### PR TITLE
pmlogger: Ensure that pmlogger starts after pmcd.

### DIFF
--- a/src/pmlogger/pmlogger.service.in
+++ b/src/pmlogger/pmlogger.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Performance Metrics Archive Logger
 Documentation=man:pmlogger(1)
-After=local-fs.target network.target
+After=local-fs.target network.target pmcd.service
 
 [Service]
 Type=oneshot

--- a/src/pmlogger/pmlogger.service.in
+++ b/src/pmlogger/pmlogger.service.in
@@ -2,12 +2,12 @@
 Description=Performance Metrics Archive Logger
 Documentation=man:pmlogger(1)
 After=local-fs.target network.target
- 
+
 [Service]
 Type=oneshot
 ExecStart=@path@/pmlogger start
 ExecStop=@path@/pmlogger stop
-RemainAfterExit=yes 
- 
+RemainAfterExit=yes
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When pmlogger and pmcd are started at the same time by systemd (as
happens during system boot), we need to make sure that pmlogger is not
activated before pmcd is ready to accept connections from clients.