### PR TITLE
rc_pmcd: Wait for pmcd to be ready before reporting success.

### DIFF
--- a/src/pmcd/rc_pmcd
+++ b/src/pmcd/rc_pmcd
@@ -485,6 +485,7 @@ Error: pmcd control file '"$PCP_PMCDCONF_PATH"' is missing, cannot start pmcd.'
 		    | tr '\012' ' ' `
 
 	    $PMCD $OPTS
+            _start_pmcheck
 	    $RC_STATUS -v
 
 	    $PCP_BINADM_DIR/pmpost "start pmcd from $prog"


### PR DESCRIPTION
The old rc_pcp used to call pmcd_wait before starting pmlogger, but
this seems to have been lost when it was split into rc_pmcd and
rc_pmlogger.