### PR TITLE
libpcp_pmda: Fixed a memory leak detected by valgrind.

### DIFF
--- a/src/libpcp_pmda/src/mainloop.c
+++ b/src/libpcp_pmda/src/mainloop.c
@@ -213,7 +213,7 @@ __pmdaMainPDU(pmdaInterface *dispatch)
 		/* Not INTERFACE_4 or later */
 		sts = PM_ERR_NAME;
 	    }
-	    __pmUnpinPDUBuf(namelist);
+	    free(namelist);
 	}
 	if (sts < 0)
 	    __pmSendError(pmda->e_outfd, FROM_ANON, sts);


### PR DESCRIPTION
Original issue created at: https://github.com/performancecopilot/pcp/issues/19

pmdaproc has memory leaks using the following python monitor client to collect process list at 1 second interval. 

/proc/pmdaproc_pid/smaps: (Heap size hits 18Mb after 5 days run)
02416000-035a1000 rw-p 00000000 00:00 0                                  [heap]
Size:              17964 kB
Rss:               17852 kB
Pss:               17852 kB
Shared_Clean:          0 kB
Shared_Dirty:          0 kB
Private_Clean:         0 kB
Private_Dirty:     17852 kB
Referenced:        17852 kB
Anonymous:         17852 kB
AnonHugePages:         0 kB
Swap:                  0 kB
KernelPageSize:        4 kB
MMUPageSize:           4 kB
Locked:                0 kB
VmFlags: rd wr mr mw me ac

Valgrind output:
<error>
  <unique>0x42</unique>
  <tid>1</tid>
  <kind>Leak_DefinitelyLost</kind>
  <xwhat>
    <text>615,463 bytes in 25,293 blocks are definitely lost in loss record 65 of 65</text>
    <leakedbytes>615463</leakedbytes>
    <leakedblocks>25293</leakedblocks>
  </xwhat>
  <stack>
    <frame>
      <ip>0x4C2741D</ip>
      <obj>/usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so</obj>
      <fn>malloc</fn>
    </frame>
    <frame>
      <ip>0x505C48D</ip>
      <obj>/usr/local/lib/libpcp.so.3</obj>
      <fn>__pmDecodeNameList</fn>
      <dir>/home/ec2-user/pcp/src/libpcp/src</dir>
      <file>p_pmns.c</file>
      <line>344</line>
    </frame>
    <frame>
      <ip>0x4E38277</ip>
      <obj>/usr/lib64/libpcp_pmda.so.3</obj>
      <fn>__pmdaMainPDU</fn>
      <dir>/home/ec2-user/pcp/src/libpcp_pmda/src</dir>
      <file>mainloop.c</file>
      <line>201</line>
    </frame>
    <frame>
      <ip>0x4E386D7</ip>
      <obj>/usr/lib64/libpcp_pmda.so.3</obj>
      <fn>pmdaMain</fn>
      <dir>/home/ec2-user/pcp/src/libpcp_pmda/src</dir>
      <file>mainloop.c</file>
      <line>428</line>
    </frame>
    <frame>
      <ip>0x402CA6</ip>
      <obj>/var/lib/pcp/pmdas/proc/pmdaproc</obj>
      <fn>main</fn>
      <dir>/home/ec2-user/pcp/src/pmdas/linux_proc</dir>
      <file>pmda.c</file>
      <line>3153</line>
    </frame>
  </stack>
</error>

Python client used to repro the issue:

#!/usr/bin/python

from cpmapi import PM_TYPE_U32, PM_TYPE_FLOAT, PM_TYPE_STRING, PM_TYPE_U64
from pcp import pmapi

import json
import sys
import time

class Prototype(object):

    def __init__(self):
        self.context = None
        self.opts = pmapi.pmOptions()
        self.opts.pmSetShortOptions("V?")
        self.opts.pmSetLongOptionHeader("Options")
        self.opts.pmSetLongOptionVersion()
        self.opts.pmSetLongOptionHelp()

    def execute(self):
        metrics = ('proc.psinfo.pid', 'proc.psinfo.cmd', 'proc.psinfo.nice')
        pmids = self.context.pmLookupName(metrics)
        descs = self.context.pmLookupDescs(pmids)
        result = self.context.pmFetch(pmids)
        process_list = []
        for inst in range(result.contents.get_numval(0)):
            pid_value = self.context.pmExtractValue(
                        result.contents.get_valfmt(0),
                        result.contents.get_vlist(0, inst),
                        descs[0].contents.type, descs[0].contents.type)
            pid =  pid_value.ull
            process_list.append(pid)

        self.context.pmFreeResult(result)
        print json.dumps(process_list)

    def connect(self):
        self.context = pmapi.pmContext.fromOptions(self.opts, sys.argv)

if __name__ == '__main__':
    testApp = Prototype()
    testApp.connect()
    while True:
        testApp.execute()
        time.sleep(1)
