### PR TITLE
Fixed memory leak in python module pmsubsys.py

### DIFF
--- a/src/python/pcp/pmsubsys.py
+++ b/src/python/pcp/pmsubsys.py
@@ -220,7 +220,7 @@ class Subsystem(object):
                         self.metric_values[j] = 0
                 elif metric_result.contents.get_numval(j) > 1:
                     self.metric_values[j] = copy.copy(value)
-
+        pcp.pmFreeResult(metric_result)
 
 # Processor  --------------------------------------------------------------
 


### PR DESCRIPTION
Found memory leaks in python pmsubsys module. pmFreeResult needs to be called to release metric_result previously allocated by pmFetch.