### PR TITLE
[linux_pmda] Added extended disk partition stats for kernel 2.6.25 and above

### DIFF
--- a/src/pmdas/linux/help
+++ b/src/pmdas/linux/help
@@ -329,6 +329,34 @@ Cumulative number of bytes read and written since system boot time
 (subject to counter wrap) for individual disk partitions or logical
 volumes.
 
+@ disk.partitions.read_merge per-disk-partition count of merged read requests
+
+@ disk.partitions.write_merge per-disk-partition count of merged write requests
+
+@ disk.partitions.avactive per-disk-partition device count of active time
+
+@ disk.partitions.aveq per-disk-partition device time averaged count of request queue length
+
+@ disk.partitions.read_rawactive per-disk-partition raw count of active read time
+When converted to a rate, this metric represents the raw utilization of
+the device during the sampling interval as a result of reads.  Accounting for
+this metric is only done on I/O completion and can thus result in more than a
+second's worth of IO being accounted for within any one second, leading to
+>100% utilisation.  It is suitable mainly for use in calculations with other
+metrics, e.g. mirroring the results from existing performance tools:
+
+ iostat.partitions.r_await = delta(disk.partitions.read_rawactive) / delta(disk.partitions.read)
+
+@ disk.partitions.write_rawactive per-disk-partition raw count of active write time
+When converted to a rate, this metric represents the raw utilization of
+the device during the sampling interval as a result of writes.  Accounting for
+this metric is only done on I/O completion and can thus result in more than a
+second's worth of IO being accounted for within any one second, leading to
+>100% utilisation.  It is suitable mainly for use in calculations with other
+metrics, e.g. mirroring the results from existing performance tools:
+
+ iostat.partitions.w_await = delta(disk.partitions.write_rawactive) / delta(disk.partitions.write)
+
 @ swap.pagesin pages read from swap devices due to demand for physical memory
 @ swap.pagesout pages written to swap devices due to demand for physical memory
 @ swap.in number of swap in operations

--- a/src/pmdas/linux/pmda.c
+++ b/src/pmdas/linux/pmda.c
@@ -1871,6 +1871,35 @@ static pmdaMetric metrictab[] = {
       { PMDA_PMID(CLUSTER_PARTITIONS,8), PM_TYPE_U32, PARTITIONS_INDOM, PM_SEM_COUNTER, 
       PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0) }, },
 
+/* disk.partitions.read_merge*/
+    { NULL,
+      { PMDA_PMID(CLUSTER_PARTITIONS,9), KERNEL_ULONG, PARTITIONS_INDOM, PM_SEM_COUNTER,
+      PMDA_PMUNITS(0,0,1,0,0,PM_COUNT_ONE) }, },
+
+/* disk.partitions.write_merge */
+    { NULL,
+      { PMDA_PMID(CLUSTER_PARTITIONS,10), KERNEL_ULONG, PARTITIONS_INDOM, PM_SEM_COUNTER,
+      PMDA_PMUNITS(0,0,1,0,0,PM_COUNT_ONE) }, },
+
+/* disk.partitions.avactive */
+    { NULL,
+      { PMDA_PMID(CLUSTER_PARTITIONS,11), PM_TYPE_U32, PARTITIONS_INDOM, PM_SEM_COUNTER,
+      PMDA_PMUNITS(0,1,0,0,PM_TIME_MSEC,0) }, },
+
+/* disk.partitions.aveq */
+    { NULL,
+      { PMDA_PMID(CLUSTER_PARTITIONS,12), PM_TYPE_U32, PARTITIONS_INDOM, PM_SEM_COUNTER,
+      PMDA_PMUNITS(0,1,0,0,PM_TIME_MSEC,0) }, },
+
+/* disk.partitions.read_rawactive */
+    { NULL,
+      { PMDA_PMID(CLUSTER_PARTITIONS,13), PM_TYPE_U32, PARTITIONS_INDOM, PM_SEM_COUNTER,
+      PMDA_PMUNITS(0,1,0,0,PM_TIME_MSEC,0) }, },
+
+/* disk.partitions.write_rawactive */
+    { NULL,
+      { PMDA_PMID(CLUSTER_PARTITIONS,14), PM_TYPE_U32, PARTITIONS_INDOM, PM_SEM_COUNTER,
+      PMDA_PMUNITS(0,1,0,0,PM_TIME_MSEC,0) }, },
 		
 /* disk.dev.read_bytes */
     { NULL, 

--- a/src/pmdas/linux/proc_partitions.c
+++ b/src/pmdas/linux/proc_partitions.c
@@ -29,6 +29,8 @@
 #include "indom.h"
 #include "proc_partitions.h"
 
+int _pm_have_kernel_2_6_partition_stats;
+
 extern int _pm_numdisks;
 
 /*
@@ -353,6 +355,9 @@ refresh_proc_partitions(pmInDom disk_indom, pmInDom partitions_indom, pmInDom dm
 		&p->wr_ios, &p->wr_merges, &p->wr_sectors, &p->wr_ticks,
 		&p->ios_in_flight, &p->io_ticks, &p->aveq);
 	    if (n != 14) {
+                /* In 2.6.25, the full statistic set is again available for partitions and
+                   disk and partition statistics are consistent again. */
+                _pm_have_kernel_2_6_partition_stats = 1;
 		p->rd_merges = p->wr_merges = p->wr_ticks =
 			p->ios_in_flight = p->io_ticks = p->aveq = 0;
 		/* Linux source: block/genhd.c::diskstats_show(2) */
@@ -445,6 +450,13 @@ static pmID disk_metric_table[] = {
     /* disk.partitions.read_bytes */ PMDA_PMID(CLUSTER_PARTITIONS,6),
     /* disk.partitions.write_bytes */PMDA_PMID(CLUSTER_PARTITIONS,7),
     /* disk.partitions.total_bytes */PMDA_PMID(CLUSTER_PARTITIONS,8),
+    /* disk.partitions.read_merge */ PMDA_PMID(CLUSTER_PARTITIONS,9),
+    /* disk.partitions.write_merge */PMDA_PMID(CLUSTER_PARTITIONS,10),
+    /* disk.partitions.avactive */   PMDA_PMID(CLUSTER_PARTITIONS,11),
+    /* disk.partitions.aveq */       PMDA_PMID(CLUSTER_PARTITIONS,12),
+    /* disk.partitions.read_rawactive */  PMDA_PMID(CLUSTER_PARTITIONS,13),
+    /* disk.partitions.write_rawactive */ PMDA_PMID(CLUSTER_PARTITIONS,14),
+
 
     /* hinv.ndisk */                 PMDA_PMID(CLUSTER_STAT,33),
 
@@ -735,6 +747,42 @@ proc_partitions_fetch(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
 		atom->ul = (p->rd_sectors +
 			   p->wr_sectors) / 2;
 		break;
+            case 9: /* disk.partitions.read_merge */
+                if (_pm_have_kernel_2_6_partition_stats)
+                    return PM_ERR_APPVERSION; /* no read_merge for partition in 2.6 */
+                else
+                    _pm_assign_ulong(atom, p->rd_merges);
+                break;
+            case 10: /* disk.partitions.write_merge */
+                if (_pm_have_kernel_2_6_partition_stats)
+                    return PM_ERR_APPVERSION; /* no write_merge for partition in 2.6 */
+                else
+                    _pm_assign_ulong(atom, p->wr_merges);
+                break;
+            case 11: /* disk.partitions.avactive */
+                if (_pm_have_kernel_2_6_partition_stats)
+                    return PM_ERR_APPVERSION; /* no avactive for partition in 2.6 */
+                else
+                    atom->ull = p->io_ticks;
+                break;
+            case 12: /* disk.partitions.aveq */
+                if (_pm_have_kernel_2_6_partition_stats)
+                    return PM_ERR_APPVERSION; /* no aveq for partition in 2.6 */
+                else
+                    atom->ull = p->aveq;
+                break;
+            case 13: /* disk.partitions.read_rawactive */
+                if (_pm_have_kernel_2_6_partition_stats)
+                    return PM_ERR_APPVERSION; /* no read_rawactive for partition in 2.6 */
+                else
+                    atom->ul = p->rd_ticks;
+                break;
+            case 14: /* disk.partitions.write_rawactive */
+                if (_pm_have_kernel_2_6_partition_stats)
+                    return PM_ERR_APPVERSION; /* no write_rawactive for partition in 2.6 */
+                else
+                    atom->ul = p->wr_ticks;
+                break;
 	    default:
 	    return PM_ERR_PMID;
 	}

--- a/src/pmdas/linux/root_linux
+++ b/src/pmdas/linux/root_linux
@@ -300,6 +300,12 @@ disk.partitions {
     read_bytes		60:10:6
     write_bytes		60:10:7
     total_bytes		60:10:8
+    read_merge          60:10:9
+    write_merge         60:10:10
+    avactive            60:10:11
+    aveq                60:10:12
+    read_rawactive      60:10:13
+    write_rawactive     60:10:14
 }
 
 mem {


### PR DESCRIPTION
Linux pmda reports less disk IO stats for disk.partitions comparing to disk.dev and disk.dm. Added the following metrics which are currently missing for kernel 2.6.25 and above:

disk.partitions.read_merge
disk.partitions.write_merge
disk.partitions.avactive
disk.partitions.aveq
disk.partitions.read_rawactive
disk.partitions.write_rawactive 

Reference: 
https://www.kernel.org/doc/Documentation/iostats.txt (Disks vs Partitions)

