### PR TITLE
[python-pcp] Fix a bug in pmsubsys which causes timestamp to reset.

### DIFF
--- a/src/python/pcp/pmsubsys.py
+++ b/src/python/pcp/pmsubsys.py
@@ -173,7 +173,7 @@ class Subsystem(object):
 
         try:
             metric_result = pcp.pmFetch(self.metric_pmids)
-            self._timestamp = metric_result.contents.timestamp
+            self._timestamp = copy.deepcopy(metric_result.contents.timestamp)
         except pmErr as e:
             self._timestamp = timeval(0, 0)
             raise e


### PR DESCRIPTION
Problem:
pmFreeResult is used to free memory allocated by metric_result. However, it will corrupt memory and reset self._timestamp for diff calculation. So, all subsequent collections will have huge aggregated values instead of rate between intervals.

Fix: 
Use copy.deepcopy to assign values for _timestamp which will survive from pmFreeResult call.  