### PR TITLE
Fixes SIGSEGV, 64-bit format specifiers, dlsym bug and IPC on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -11317,13 +11317,21 @@ $2 == "bozo"	{ t = $1
 	_fmt='"ld"'
 	;;
     'long long'|'long long int')
-	_fmt='"lld"'
+        if test $target_os = mingw; then
+            _fmt='"I64d"'
+        else
+	    _fmt='"lld"'
+        fi
 	;;
     'unsigned long'|'unsigned long int'|'long unsigned int')
 	_fmt='"lu"'
 	;;
     'unsigned long long')
-	_fmt='"llu"'
+        if test $target_os = mingw; then
+            _fmt='"I64u"'
+        else
+	    _fmt='"llu"'
+        fi
 	;;
     *\*)	# pointer to a something
 	_fmt='"p"'

--- a/configure.ac
+++ b/configure.ac
@@ -1821,13 +1821,21 @@ $2 == "bozo"	{ t = $1
 	_fmt='"ld"'
 	;;
     'long long'|'long long int')
-	_fmt='"lld"'
+        if test $target_os = mingw; then
+            _fmt='"I64d"'
+        else
+	    _fmt='"lld"'
+        fi
 	;;
     'unsigned long'|'unsigned long int'|'long unsigned int')
 	_fmt='"lu"'
 	;;
     'unsigned long long')
-	_fmt='"llu"'
+        if test $target_os = mingw; then
+            _fmt='"I64u"'
+        else
+	    _fmt='"llu"'
+        fi
 	;;
     *\*)	# pointer to a something
 	_fmt='"p"'

--- a/src/include/pcp/config.h.in
+++ b/src/include/pcp/config.h.in
@@ -570,12 +570,6 @@ extern const char *wsastrerror(int);
 #define SIGHUP		(NSIG+1)
 #define SIGUSR1		(NSIG+2)
 #define SIGBUS		(NSIG+3)
-#define S_IRGRP		0
-#define S_IWGRP		0
-#define S_IROTH		0
-#define S_IWOTH		0
-#define S_IRWXG		0
-#define S_IRWXO		0
 #define S_ISVTX		0
 
 #define fcntl(f, cmd, ...) 0

--- a/src/libpcp/src/auxserver.c
+++ b/src/libpcp/src/auxserver.c
@@ -630,6 +630,7 @@ OpenRequestPorts(__pmFdSet *fdset, int backlog)
 	}
     }
 
+#ifndef IS_MINGW
     /* Open a local unix domain socket, if specified, and supported. */
     if (localSocketPath != NULL) {
 #if defined(HAVE_STRUCT_SOCKADDR_UN)
@@ -644,6 +645,7 @@ OpenRequestPorts(__pmFdSet *fdset, int backlog)
 		      pmProgname);
 #endif
     }
+#endif
 
     if (success)
 	return maximum;

--- a/src/libpcp/src/win32.c
+++ b/src/libpcp/src/win32.c
@@ -89,7 +89,7 @@ __pmSetSignalHandler(int sig, __pmSignalHandler func)
     char *signame, evname[64];
     HANDLE eventhdl, waithdl;
 
-    if ((signame = MapSignals(sig, &index)) < 0)
+    if ((signame = MapSignals(sig, &index)) == NULL)
 	return index;
 
     if (signals[index].callback) {	/* remove old handler */

--- a/src/pmcd/src/config.c
+++ b/src/pmcd/src/config.c
@@ -1995,8 +1995,8 @@ GetAgentDso(AgentInfo *aPtr)
 #if defined(HAVE_DLOPEN)
     dlerror();
     dso->initFn = (void (*)(pmdaInterface*))dlsym(dso->dlHandle, dso->entryPoint);
-    dlerrstr = dlerror();
-    if (dlerrstr != NULL) {
+    if (dso->initFn == NULL) {
+        dlerrstr = dlerror();
 	fprintf(stderr, "Couldn't find init function `%s' in %s DSO: %s\n",
 		     dso->entryPoint, aPtr->pmDomainLabel, dlerrstr);
 	dlclose(dso->dlHandle);


### PR DESCRIPTION
This patch makes it actually possible to run PCP on Windows platform by cross-compiling from Fedora with mingw64.

1 - The format specifier for printing 64-bit signed and unsigned numbers is incorrect for Windows platform. It should be %I64d and %I64u as opposed to %lld and %llu.

2 - The MinGW on Windows already correctly defines the macros S_IRGRP, S_IWGRP, S_IROTH, S_IWOTH, S_IRWXG, and S_IRWXO but the current code incorrectly redefines all of them to 0 (zero).

3 - The current code tries to use Unix Domain Sockets for IPC communication with plugins. This is not supported on Windows platform.

4 - Fixed a SIGSEGV which happened when an error returned from setting up signal handlers. Instead of comparing the return to NULL it compared to < 0, which is a classic arithmetic to pointer comparison error.

5 - Fixed a bug of error handling when dynamic loading a shared library (DLL in case of Windows).