### PR TITLE
mingw64: Python pmapi on Windows - prevent crash when free()'ing resources

### DIFF
--- a/src/python/pcp/pmapi.py
+++ b/src/python/pcp/pmapi.py
@@ -89,16 +89,17 @@ from ctypes.util import find_library
 #
 # dynamic library loads
 #
+import sys
 
 LIBPCP = CDLL(find_library("pcp"))
-LIBC = CDLL(find_library("c"))
+libc_name = "c" if sys.platform != "win32" else "msvcrt"
+LIBC = CDLL(find_library(libc_name))
 
 
 ##############################################################################
 #
 # python version information and compatibility
 #
-import sys
 
 if sys.version >= '3':
     integer_types = (int,)


### PR DESCRIPTION
When calling Python pmapi functions such as ```pmGetChildren```, ```pmGetInDom```, etc. these functions internally allocate resources using ```malloc```. Unfortunately the current code on Windows crashes when ```free```'ing these resources because the ```free``` function used doesn't always belong to the correct ```msvcrt.dll``` version.

AFAIK artifacts (.exe's, .dll's, etc) compiled using mingw64 are always linked with ```\Windows\System32\msvcrt.dll```, but Python is not necessarily. E.g:

```
C:\>\Python27\python
Python 2.7.10 (default, May 23 2015, 09:44:00) [MSC v.1500 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from ctypes import CDLL
>>> from ctypes.util import find_library
>>> LIBC_OK = CDLL(find_library("msvcrt"))
>>> LIBC_ERR = CDLL(find_library("c"))
>>> LIBC_OK
<CDLL 'C:\Windows\system32\msvcrt.dll', handle cdc40000 at 1db5e80>
>>> LIBC_ERR
<CDLL 'msvcr90.dll', handle 65a70000 at 1e61d68>
>>>
```
That means that ```libpcp.dll``` (used by pmapi Python module) is using the ```malloc``` function from ```msvcrt.dll``` while Python is using the ```free``` function from ```msvcrt90.dll``` and thus it crashes.

This fix ensures that if we're on Windows platform, we always use ```msvcrt.dll```. On other platforms it's unchanged and keeps using the platform's libc.