### PR TITLE
Windows: Fix Performance Counter for mem.cache.bytes

### DIFF
--- a/src/pmdas/windows/pmda.c
+++ b/src/pmdas/windows/pmda.c
@@ -817,12 +817,12 @@ pdh_metric_t metricdesc[] = {
       "\\Memory\\Free System Page Table Entries"
     },
 /* mem.cache.bytes */
-    { { PMDA_PMID(0,148), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+    { { PMDA_PMID(0,148), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 	PMDA_PMUNITS(1,0,0,PM_SPACE_BYTE,0,0) }, M_NONE, 0, 0, 0, NULL,
-      "\\Memory\\Page Faults/sec"
+      "\\Memory\\Cache Bytes"
     },
 /* mem.cache.bytes_peak */
-    { { PMDA_PMID(0,149), PM_TYPE_64, PM_INDOM_NULL, PM_SEM_INSTANT,
+    { { PMDA_PMID(0,149), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_INSTANT,
 	PMDA_PMUNITS(1,0,0,PM_SPACE_BYTE,0,0) }, M_NONE, 0, 0, 0, NULL,
       "\\Memory\\Cache Bytes Peak"
     },


### PR DESCRIPTION
The ```mem.cache.bytes``` metric is collecting data from an incorrect Performance Counter: ```\Memory\Pages Faults/sec```. This patch fixes that by pointing to ```\Memory\Cache Bytes```. Also fixed the data types (U32 -> U64) and semantic interpretation (COUNTER -> INSTANT). For consistency, changed ```\Metric\Cache Bytes Peak``` data type (64 -> U64) as well.