### PR TITLE
[bintray] add Debian repo HTTP headers

### DIFF
--- a/scripts/bintray-upload
+++ b/scripts/bintray-upload
@@ -51,6 +51,8 @@ deb_upload()
     curl \
 	-T ${file} -u ${user}:${apikey} \
 	-H "X-GPG-PASSPHRASE: ${gpgpass}" \
+	-H "X-Bintray-Debian-Distribution: ${distro}" \
+	-H "X-Bintray-Debian-Component: main" \
 	"${url};${deb};bt_package=pcp;bt_version=${vers};publish=1"
     echo
 }


### PR DESCRIPTION
Bintray provide a "Set Me Up" button which provides copy-paste commands to install a Debian repo into apt.

However, the current instructions don't work, they currently suggest to paste "deb https://dl.bintray.com/pcp/trusty {distribution} {components}" but apt requires the last to fields to be something like "trusty main" or "jessie main".

This patch sets the "distribution" and "components" Debian repo properties using the Bintray HTTP headers as documented at https://bintray.com/docs/api/#_debian_upload and so should correct the "Set Me Up" commands so users can copy-paste the provided instructions.