### PR TITLE
libpcp: unlock context before returning

### DIFF
--- a/src/libpcp/src/logutil.c
+++ b/src/libpcp/src/logutil.c
@@ -2268,8 +2268,12 @@ pmGetArchiveLabel(pmLogLabel *lp)
 {
     __pmContext		*ctxp;
     ctxp = __pmHandleToPtr(pmWhichContext());
-    if (ctxp == NULL || ctxp->c_type != PM_CONTEXT_ARCHIVE)
+    if (ctxp == NULL) 
 	return PM_ERR_NOCONTEXT;
+    if (ctxp->c_type != PM_CONTEXT_ARCHIVE) {
+	PM_UNLOCK(ctxp->c_lock);
+	return PM_ERR_NOCONTEXT;
+    }
     else {
 	__pmLogLabel	*rlp;
 	/*


### PR DESCRIPTION
If called in a non-archive context, the context ctxp->lock c_lock is
never unlocked.