### PR TITLE
add qa-notes.txt to webapps files, fix #53

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -2281,6 +2281,7 @@ cd
 @pcp_share_dir@/webapps/*.png
 @pcp_share_dir@/webapps/*.ico
 @pcp_share_dir@/webapps/*.html
+@pcp_share_dir@/webapps/*.txt
 @pcp_share_dir@/webapps/blinkenlights
 
 %files webapp-grafana


### PR DESCRIPTION
- build breakage occurs when executing Makepkgs
- FIX: "Installed (but unpackaged) file(s) found: /usr/share/pcp/webapps/qa-notes.txt"

- FIXES: https://github.com/performancecopilot/pcp/issues/53