### PR TITLE
first wave of diffs to compile on OpenBSD

### DIFF
--- a/configure
+++ b/configure
@@ -3099,6 +3099,15 @@ $as_echo "#define IS_NETBSD 1" >>confdefs.h
     export CFLAGS="-fPIC -fno-strict-aliasing -D_GNU_SOURCE -D_NETBSD_SOURCE"
     pcp_platform_paths='/usr/pkg/bin'
     pcp_ps_all_flags=auxww
+elif test $target_os = openbsd
+then
+    target_os=openbsd
+
+$as_echo "#define IS_OPENBSD 1" >>confdefs.h
+
+    export CFLAGS="-fPIC -fno-strict-aliasing -D_GNU_SOURCE"
+    pcp_platform_paths='/usr/local/bin'
+    pcp_ps_all_flags=auxww
 else
     echo
     echo "FATAL ERROR: need platform-specific customization for \"$target_os\""
@@ -16294,5 +16303,3 @@ if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
 $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
-
-

--- a/configure.ac
+++ b/configure.ac
@@ -2,17 +2,17 @@ dnl
 dnl Copyright (c) 2012-2015 Red Hat.
 dnl Copyright (c) 2008 Aconex.  All Rights Reserved.
 dnl Copyright (c) 2000-2004,2008 Silicon Graphics, Inc.  All Rights Reserved.
-dnl 
+dnl
 dnl This program is free software; you can redistribute it and/or modify it
 dnl under the terms of the GNU General Public License as published by the
 dnl Free Software Foundation; either version 2 of the License, or (at your
 dnl option) any later version.
-dnl 
+dnl
 dnl This program is distributed in the hope that it will be useful, but
 dnl WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 dnl or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 dnl for more details.
-dnl 
+dnl
 
 dnl unpacking check - this file must exist
 AC_INIT(src/include/pcp/pmapi.h)
@@ -214,7 +214,7 @@ else
     build_os=`echo $build_os | sed '[s/^\([^-][^-]*\)-.*$/\1/]'`
 fi
 
-echo Building on $build for $target 
+echo Building on $build for $target
 echo "Build: os=$build_os cpu=$build_cpu"
 echo "Target: os=$target_os cpu=$target_cpu"
 
@@ -309,6 +309,12 @@ then
     AC_DEFINE(IS_NETBSD, [1], [Platform is NetBSD])
     export CFLAGS="-fPIC -fno-strict-aliasing -D_GNU_SOURCE -D_NETBSD_SOURCE"
     pcp_platform_paths='/usr/pkg/bin'
+    pcp_ps_all_flags=auxww
+elif test $target_os = openbsd
+then
+    AC_DEFINE(IS_OPENBSD, [1], [Platform is OpenBSD])
+    export CFLAGS="-fPIC -fno-strict-aliasing -D_GNU_SOURCE"
+    pcp_platform_paths='/usr/local/bin'
     pcp_ps_all_flags=auxww
 else
     echo
@@ -995,7 +1001,7 @@ enable_qt=false
 qt_release=release
 AS_IF([test "x$do_qt" != "xno"], [
     enable_qt=true
-    
+
     if test -z "$QMAKE"
     then
 	AC_PATH_PROGS(QMAKE, [qmake-qt5 qmake-qt4 qmake],, [$QTDIR/bin:/usr/bin:/usr/lib64/qt5/bin:/usr/lib/qt5/bin:/usr/lib64/qt4/bin:/usr/lib/qt4/bin])
@@ -1045,7 +1051,7 @@ dnl note: all makefiles in this package use the gmake syntax
 if test -z "$MAKE"
 then
     AC_PATH_PROG(MAKE, gmake)
-    if test -z "$MAKE" 
+    if test -z "$MAKE"
     then
 	# look elsewhere ...
 	AC_MSG_CHECKING([for GNU make elsewhere])
@@ -1074,7 +1080,7 @@ then
 	    fi
 	fi
 	AC_MSG_RESULT($MAKE)
-    fi 
+    fi
 fi
 make=$MAKE
 AC_SUBST(make)
@@ -1197,7 +1203,7 @@ then
 	    AC_MSG_WARN([PackageMaker not found, mac packages will not be made])
 	fi
     else
-	AC_MSG_RESULT([ no])	
+	AC_MSG_RESULT([ no])
     fi
 else
     package_maker="$PACKAGE_MAKER"
@@ -1440,8 +1446,8 @@ AC_CHECK_HEADERS(sys/statvfs.h sys/statfs.h sys/mount.h)
 dnl Check if we have <sys/endian.h> ... standard way
 AC_MSG_CHECKING([for sys/endian.h ])
 AC_TRY_COMPILE(
-[  
-    #include <sys/endian.h> 
+[
+    #include <sys/endian.h>
 ],
 [
 ], AC_DEFINE(HAVE_SYS_ENDIAN_H, [1], [sys/endian.h]) AC_MSG_RESULT(yes), AC_MSG_RESULT(no))
@@ -1449,8 +1455,8 @@ AC_TRY_COMPILE(
 dnl Check if we have <machine/endian.h> ... MacOSX way
 AC_MSG_CHECKING([for machine/endian.h ])
 AC_TRY_COMPILE(
-[  
-    #include <machine/endian.h> 
+[
+    #include <machine/endian.h>
 ],
 [
 ], AC_DEFINE(HAVE_MACHINE_ENDIAN_H, [1], [machine/endian.h]) AC_MSG_RESULT(yes), AC_MSG_RESULT(no))
@@ -1458,9 +1464,9 @@ AC_TRY_COMPILE(
 dnl Check if we have <sys/endian.h> ... IRIX strangeness
 AC_MSG_CHECKING([for sys/endian.h (IRIX variant) ])
 AC_TRY_COMPILE(
-[  
+[
     #include <standards.h>
-    #include <sys/endian.h> 
+    #include <sys/endian.h>
 ],
 [
 ], AC_DEFINE(HAVE_SYS_ENDIAN_H, [1], [IRIX sys/endian.h]) AC_MSG_RESULT(yes), AC_MSG_RESULT(no))
@@ -1759,9 +1765,9 @@ fi
 dnl check if we have a type for the pointer's size integer (__psint_t)
 AC_MSG_CHECKING([for __psint_t ])
 AC_TRY_COMPILE(
-[  
+[
     #include <sys/types.h>
-    #include <stdlib.h> 
+    #include <stdlib.h>
     #include <stddef.h>
 ], [ __psint_t psint; ],
 AC_DEFINE(HAVE___PSINT_T, [1], [__psint_t type]) AC_MSG_RESULT(yes), AC_MSG_RESULT(no))
@@ -2205,7 +2211,7 @@ then
     AC_MSG_CHECKING([where pthread_create() is defined])
     for cand in "" pthreads pthread ; do
 	savedLIBS=$LIBS
-	if test -n "$cand" 
+	if test -n "$cand"
 	then
 	    LIBS=`echo $LIBS -l$cand`
 	fi
@@ -2567,7 +2573,7 @@ AC_TRY_LINK([#include <sys/wait.h>],
 ], AC_DEFINE(HAVE_WAIT_INCLUDES_SIGNAL, [1], [indirect signal.h]))
 
 dnl check for name and type of time fields in struct stat
-dnl IRIX example	timespec_t st_mtim;	
+dnl IRIX example	timespec_t st_mtim;
 dnl Linux example 	struct timespec st_mtim;
 dnl Darwin example 	struct timespec st_mtimespec;
 dnl Solaris example	timestruc_t st_mtim;
@@ -2882,7 +2888,7 @@ AC_ARG_WITH(demosdir,[AC_HELP_STRING([--with-demosdir],[run directory [DATADIR/p
                    [pcp_demos_dir=$pcp_share_dir/demos])
 AC_SUBST(pcp_demos_dir)
 
-if test -z "$XCONFIRM" 
+if test -z "$XCONFIRM"
 then
     AC_PATH_PROG(ac_xconfirm_prog, xconfirm, $pcp_bin_dir/pmconfirm)
 else
@@ -3066,7 +3072,7 @@ AC_TRY_COMPILE([
 ], [ struct timespec foo; ],
 AC_DEFINE(HAVE_STRUCT_TIMESPEC, [1], [timespec type]) AC_MSG_RESULT(yes), AC_MSG_RESULT(no))
 
-dnl check if we have IRIX style altzone 
+dnl check if we have IRIX style altzone
 AC_MSG_CHECKING([for altzone in time.h])
 AC_TRY_COMPILE([
     #include <time.h>
@@ -3135,7 +3141,7 @@ AC_SUBST(HAVE_ZLIB, [$have_zlib])
 dnl Check if we have AI_ADDRCONFIG
 AC_MSG_CHECKING([for AI_ADDRCONFIG])
 AC_TRY_COMPILE(
-[  
+[
     #include <netdb.h>
     int test = AI_ADDRCONFIG;
 ],

--- a/src/include/pcp/config.h.in
+++ b/src/include/pcp/config.h.in
@@ -38,7 +38,7 @@ extern "C" {
 #undef HAVE_ST_MTIME_WITH_E
 
 /* if your compiler supports LL sufix on 64 bit int constants */
-#undef HAVE_CONST_LONGLONG 
+#undef HAVE_CONST_LONGLONG
 
 /*
  * HAVE_UNDERBAR_ENVIRON if extern char **_environ is defined
@@ -325,11 +325,11 @@ extern "C" {
 #undef HAVE_PORT_PERFORMANCE_QUERY_VIA
 #undef HAVE_PMA_QUERY_VIA
 
-#ifndef ULONGLONG_MAX 
+#ifndef ULONGLONG_MAX
 #define ULONGLONG_MAX (__uint64_t)18446744073709551615ULL
 #endif
 
-#ifndef LONGLONG_MAX 
+#ifndef LONGLONG_MAX
 #define LONGLONG_MAX (__int64_t)9223372036854775807LL
 #endif
 
@@ -342,7 +342,7 @@ extern "C" {
 
 /* Check if __psint_t is set to something meaningful */
 #undef HAVE___PSINT_T
-#ifndef HAVE___PSINT_T 
+#ifndef HAVE___PSINT_T
 #ifdef HAVE_32BIT_PTR
 typedef int __psint_t;
 #elif defined HAVE_64BIT_PTR
@@ -538,6 +538,9 @@ typedef void (*SIG_PF) (int);
 
 /* Determine if we are on a NetBSD box */
 #undef IS_NETBSD
+
+/* Determine if we are on a NetBSD box */
+#undef IS_OPENBSD
 
 /* Determine if we are on a Mac OS X box */
 #undef IS_DARWIN

--- a/src/libpcp/src/auxserver.c
+++ b/src/libpcp/src/auxserver.c
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2013-2015 Red Hat.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published
  * by the Free Software Foundation; either version 2.1 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
  * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
  * License for more details.
  */
 
-#include <sys/stat.h> 
+#include <sys/stat.h>
 
 #include "pmapi.h"
 #include "impl.h"
@@ -20,6 +20,11 @@
 #include "internal.h"
 #if defined(HAVE_GETPEERUCRED)
 #include <ucred.h>
+#endif
+
+/* OpenBSD doesn't have EPROTO */
+#ifndef EPROTO
+#define EPROTO EINTR
 #endif
 
 #define STRINGIFY(s)	#s

--- a/src/libpcp/src/pdubuf.c
+++ b/src/libpcp/src/pdubuf.c
@@ -1,17 +1,16 @@
 /*
  * Copyright (c) 1995 Silicon Graphics, Inc.  All Rights Reserved.
  * Copyright (c) 2015 Red Hat, Inc.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published
  * by the Free Software Foundation; either version 2.1 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
  * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
  * License for more details.
- *
  * Thread-safe notes
  *
  * To avoid buffer trampling, on success __pmFindPDUBuf() now returns
@@ -24,6 +23,9 @@
 #include "compiler.h"
 #include <assert.h>
 #include <search.h>
+#ifdef __OpenBSD__
+#include <sys/stdint.h>
+#endif
 
 typedef struct bufctl
 {

--- a/src/libpcp/src/util.c
+++ b/src/libpcp/src/util.c
@@ -4,12 +4,12 @@
  * Copyright (c) 2012-2015 Red Hat.
  * Copyright (c) 2009 Aconex.  All Rights Reserved.
  * Copyright (c) 1995-2002,2004 Silicon Graphics, Inc.  All Rights Reserved.
- * 
+ *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published
  * by the Free Software Foundation; either version 2.1 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
  * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
@@ -27,7 +27,7 @@
  */
 
 #include <stdarg.h>
-#include <sys/stat.h> 
+#include <sys/stat.h>
 #include <inttypes.h>
 #include <limits.h>
 #include <ctype.h>
@@ -41,7 +41,7 @@
 #include <sys/times.h>
 #endif
 #if defined(HAVE_SYS_MMAN_H)
-#include <sys/mman.h> 
+#include <sys/mman.h>
 #endif
 #if defined(HAVE_IEEEFP_H)
 #include <ieeefp.h>
@@ -506,7 +506,7 @@ __pmStringListAdd(char *item, int numElements, char ***list)
     }
 
     /*
-     * Now allocate a new buffer for the expanded list. 
+     * Now allocate a new buffer for the expanded list.
      * We need room for a new pointer and for the new item.
      */
     newSize = ptrSize + sizeof(**list) + dataSize + strlen(item) + 1;
@@ -639,9 +639,9 @@ dump_valueset(FILE *f, pmValueSet *vsp)
 	    pmPrintValue(f, vsp->valfmt, desc.type, vp, 1);
 	else {
 	    if (vsp->valfmt == PM_VAL_INSITU)
-		pmPrintValue(f, vsp->valfmt, PM_TYPE_UNKNOWN, vp, 1); 
+		pmPrintValue(f, vsp->valfmt, PM_TYPE_UNKNOWN, vp, 1);
 	    else
-		pmPrintValue(f, vsp->valfmt, (int)vp->value.pval->vtype, vp, 1); 
+		pmPrintValue(f, vsp->valfmt, (int)vp->value.pval->vtype, vp, 1);
 	}
 	fputc('\n', f);
     }
@@ -1452,7 +1452,7 @@ pmflush(void)
 	    while ((len = (int)read(fileno(fptr), outbuf, MSGBUFLEN)) > 0) {
 		sts = write(fileno(stderr), outbuf, len);
 		if (sts != len) {
-		    fprintf(stderr, "pmflush: write() failed: %s\n", 
+		    fprintf(stderr, "pmflush: write() failed: %s\n",
 			osstrerror_r(errmsg, sizeof(errmsg)));
 		}
 		sts = 0;
@@ -1480,7 +1480,7 @@ pmflush(void)
 	    while ((len = (int)read(fileno(fptr), outbuf, MSGBUFLEN)) > 0) {
 		sts = write(fileno(eptr), outbuf, len);
 		if (sts != len) {
-		    fprintf(stderr, "pmflush: write() failed: %s\n", 
+		    fprintf(stderr, "pmflush: write() failed: %s\n",
 			osstrerror_r(errmsg, sizeof(errmsg)));
 		}
 		sts = 0;
@@ -1550,7 +1550,7 @@ __pmSetClientId(const char *id)
 	/* Did we get a name? */
 	if (servInfoName == NULL) {
 	    char	errmsg[PM_MAXERRMSGLEN];
-	    fprintf(stderr, "__pmSetClientId: __pmGetNameInfo() failed: %s\n", 
+	    fprintf(stderr, "__pmSetClientId: __pmGetNameInfo() failed: %s\n",
 		    osstrerror_r(errmsg, sizeof(errmsg)));
 	}
 	else {
@@ -1566,7 +1566,7 @@ __pmSetClientId(const char *id)
 	    __pmSockAddrFree(addr);
 	    if (ipaddr == NULL) {
 		char	errmsg[PM_MAXERRMSGLEN];
-		fprintf(stderr, "__pmSetClientId: __pmSockAddrToString() failed: %s\n", 
+		fprintf(stderr, "__pmSetClientId: __pmSockAddrToString() failed: %s\n",
 			osstrerror_r(errmsg, sizeof(errmsg)));
 	    }
 	    else
@@ -1788,7 +1788,7 @@ scandir(const char *dirname, struct dirent ***namelist,
     return n;
 }
 
-/* 
+/*
  * Alphabetical sort for default use
  */
 int
@@ -1808,7 +1808,7 @@ alphasort(const_dirent **p, const_dirent **q)
  * Copyright (C) 2003 by Sun Microsystems, Inc. All rights reserved.
  *
  * Permission to use, copy, modify, and distribute this
- * software is freely granted, provided that this notice 
+ * software is freely granted, provided that this notice
  * is preserved.
  * ====================================================
  */
@@ -1842,7 +1842,7 @@ bozo!
  *	1. Compute and return log2(x) in two pieces:
  *		log2(x) = w1 + w2,
  *	   where w1 has 53-24 = 29 bit trailing zeros.
- *	2. Perform y*log2(x) = n+y' by simulating muti-precision 
+ *	2. Perform y*log2(x) = n+y' by simulating muti-precision
  *	   arithmetic, where |y'|<=0.5.
  *	3. Return x**y = 2**n*exp(y'*log2)
  *
@@ -1870,17 +1870,17 @@ bozo!
  * Accuracy:
  *	pow(x,y) returns x**y nearly rounded. In particular
  *			pow(integer,integer)
- *	always returns the correct integer provided it is 
+ *	always returns the correct integer provided it is
  *	representable.
  *
  * Constants :
- * The hexadecimal values are the intended ones for the following 
- * constants. The decimal values may be used, provided that the 
- * compiler will convert from decimal to binary accurately enough 
+ * The hexadecimal values are the intended ones for the following
+ * constants. The decimal values may be used, provided that the
+ * compiler will convert from decimal to binary accurately enough
  * to produce the hexadecimal values shown.
  */
 
-static const double 
+static const double
 bp[] = {1.0, 1.5,},
 dp_h[] = { 0.0, 5.84962487220764160156e-01,}, /* 0x3FE2B803, 0x40000000 */
 dp_l[] = { 0.0, 1.35003920212974897128e-08,}, /* 0x3E4CFDEB, 0x43CFD006 */
@@ -1927,12 +1927,12 @@ pow(double x, double y)
 	ix = hx&0x7fffffff;  iy = hy&0x7fffffff;
 
     /* y==zero: x**0 = 1 */
-	if((iy|ly)==0) return one; 	
+	if((iy|ly)==0) return one;
 
     /* +-NaN return x+y */
 	if(ix > 0x7ff00000 || ((ix==0x7ff00000)&&(lx!=0)) ||
-	   iy > 0x7ff00000 || ((iy==0x7ff00000)&&(ly!=0))) 
-		return x+y;	
+	   iy > 0x7ff00000 || ((iy==0x7ff00000)&&(ly!=0)))
+		return x+y;
 
     /* determine if y is an odd int when x < 0
      * yisint = 0	... y is not an integer
@@ -1940,7 +1940,7 @@ pow(double x, double y)
      * yisint = 2	... y is an even int
      */
 	yisint  = 0;
-	if(hx<0) {	
+	if(hx<0) {
 	    if(iy>=0x43400000) yisint = 2; /* even integer y */
 	    else if(iy>=0x3ff00000) {
 		k = (iy>>20)-0x3ff;	   /* exponent */
@@ -1951,11 +1951,11 @@ pow(double x, double y)
 		    j = iy>>(20-k);
 		    if((j<<(20-k))==iy) yisint = 2-(j&1);
 		}
-	    }		
-	} 
+	    }
+	}
 
     /* special value of y */
-	if(ly==0) { 	
+	if(ly==0) {
 	    if (iy==0x7ff00000) {	/* y is +-inf */
 	        if(((ix-0x3ff00000)|lx)==0)
 		    return  y - y;	/* inf**+-1 is NaN */
@@ -1963,14 +1963,14 @@ pow(double x, double y)
 		    return (hy>=0)? y: zero;
 	        else			/* (|x|<1)**-,+inf = inf,0 */
 		    return (hy<0)?-y: zero;
-	    } 
+	    }
 	    if(iy==0x3ff00000) {	/* y is  +-1 */
 		if(hy<0) return one/x; else return x;
 	    }
 	    if(hy==0x40000000) return x*x; /* y is  2 */
 	    if(hy==0x3fe00000) {	/* y is  0.5 */
 		if(hx>=0)	/* x >= +0 */
-		return sqrt(x);	
+		return sqrt(x);
 	    }
 	}
 
@@ -1983,13 +1983,13 @@ pow(double x, double y)
 		if(hx<0) {
 		    if(((ix-0x3ff00000)|yisint)==0) {
 			z = (z-z)/(z-z); /* (-1)**non-int is NaN */
-		    } else if(yisint==1) 
+		    } else if(yisint==1)
 			z = -z;		/* (x<0)**odd = -(|x|**odd) */
 		}
 		return z;
 	    }
 	}
-    
+
 	n = (hx>>31)+1;
 
     /* (x<0)**(non-int) is NaN */
@@ -2007,7 +2007,7 @@ pow(double x, double y)
 	/* over/underflow if x is not close to one */
 	    if(ix<0x3fefffff) return (hy<0)? s*huge*huge:s*tiny*tiny;
 	    if(ix>0x3ff00000) return (hy>0)? s*huge*huge:s*tiny*tiny;
-	/* now |1-x| is tiny <= 2**-20, suffice to compute 
+	/* now |1-x| is tiny <= 2**-20, suffice to compute
  	   log(x) by x-x^2/2+x^3/3-x^4/4 */
 	    t = ax-one;		/* t has 20 trailing zeros */
 	    w = (t*t)*(0.5-t*(0.3333333333333333333333-t*0.25));
@@ -2039,7 +2039,7 @@ pow(double x, double y)
 	    __LO(s_h) = 0;
 	/* t_h=ax+bp[k] High */
 	    t_h = zero;
-	    __HI(t_h)=((ix>>1)|0x20000000)+0x00080000+(k<<18); 
+	    __HI(t_h)=((ix>>1)|0x20000000)+0x00080000+(k<<18);
 	    t_l = ax - (t_h-bp[k]);
 	    s_l = v*((u-s_h*t_h)-s_h*t_l);
 	/* compute log(ax) */
@@ -2101,7 +2101,7 @@ pow(double x, double y)
 	    n = ((n&0x000fffff)|0x00100000)>>(20-k);
 	    if(j<0) n = -n;
 	    p_h -= t;
-	} 
+	}
 	t = p_l+p_h;
 	__LO(t) = 0;
 	u = t*lg2_h;
@@ -2138,8 +2138,8 @@ __pmProcessExists(pid_t pid)
        return 0;
     return (len > 0);
 }
-#elif defined(IS_FREEBSD)
-int 
+#elif defined(IS_FREEBSD) || defined(IS_OPENBSD)
+int
 __pmProcessExists(pid_t pid)
 {
     /*
@@ -2153,7 +2153,7 @@ __pmProcessExists(pid_t pid)
 #elif defined(HAVE_PROCFS)
 #define PROCFS			"/proc"
 #define PROCFS_PATH_SIZE	(sizeof(PROCFS)+PROCFS_ENTRY_SIZE)
-int 
+int
 __pmProcessExists(pid_t pid)
 {
     char proc_buf[PROCFS_PATH_SIZE];


### PR DESCRIPTION
It passed configure, gmake compiles but it still fails later on linking...

```
...
gcc -L/usr/local/lib -L/usr/X11R6/lib -L/usr/local/lib -L/usr/X11R6/lib -Wall -L./src/libpcp/src -L./src/libpcp_pmda/src  -L/usr/local/lib -L/usr/X11R6/lib -Wall -L../src/libpcp/src -L../src/libpcp_pmda/src  -L/usr/local/lib -L/usr/X11R6/lib -Wall -L../../src/libpcp/src -L../../src/libpcp_pmda/src  -L/usr/local/lib -L/usr/X11R6/lib -Wall -L../../../src/libpcp/src -L../../../src/libpcp_pmda/src  -Wl,--version-script=exports -o libpcp..3  connect.o context.o desc.o err.o fetch.o fetchgroup.o freeresult.o help.o instance.o p_desc.o p_error.o p_fetch.o p_instance.o p_profile.o p_result.o p_text.o p_pmns.o p_creds.o p_attr.o pdu.o pdubuf.o pmns.o profile.o store.o units.o util.o ipc.o sortinst.o logmeta.o logportmap.o logutil.o tz.o interp.o checksum.o rtime.o tv.o spec.o fetchlocal.o optfetch.o AF.o stuffvalue.o endian.o config.o auxconnect.o auxserver.o discovery.o p_lcontrol.o p_lrequest.o p_lstatus.o logconnect.o logcontrol.o connectlocal.o derive.o derive_fetch.o events.o lock.o hash.o fault.o access.o getopt.o probe.o avahi.o accounts.o    getdate.tab.o -lavahi-common -lavahi-client -lm -lpthread      
instance.o: In function `inresult_to_lists':
/home/jirib/tmp/moje/pcp/src/libpcp/src/instance.c:200: warning: warning: strcpy() is almost always misused, please use strlcpy()
/usr/local/lib/libavahi-common.so.0.0: warning: warning: rand() may return deterministic values, is that what you want?
pmns.o: In function `attach':
/home/jirib/tmp/moje/pcp/src/libpcp/src/pmns.c:651: warning: warning: strcat() is almost always misused, please use strlcat()
logportmap.o: In function `__pmLogFindPort':
/home/jirib/tmp/moje/pcp/src/libpcp/src/logportmap.c:403: warning: warning: sprintf() is often misused, please use snprintf()
/usr/local/lib/libdbus-1.so.11.1: warning: warning: vsprintf() is often misused, please use vsnprintf()
/usr/lib/crt0.o: In function `_start':
(.text+0x9d): undefined reference to `main'
collect2: ld returned 1 exit status
../../../src/include/buildrules:86: recipe for target 'libpcp..3' failed
gmake[3]: *** [libpcp..3] Error 1
GNUmakefile:24: recipe for target 'default' failed
gmake[2]: *** [default] Error 2
GNUmakefile:117: recipe for target 'default_pcp' failed
gmake[1]: *** [default_pcp] Error 2
gmake[1]: Leaving directory '/home/jirib/tmp/moje/pcp/src'
GNUmakefile:49: recipe for target 'default_pcp' failed
gmake: *** [default_pcp] Error 2
```