### PR TITLE
Fix typo: /etc/pcp/pmmgr/target-discovery

### DIFF
--- a/man/html/guide.html
+++ b/man/html/guide.html
@@ -134,8 +134,8 @@
 <br> $ sudo update-rc.d pmmgr defaults
 <br> # Common:
 <br> # echo acme.com >> /etc/pcp/pmmgr/target-host
-<br> # echo avahi >> /etc/pcp/pmmgr/target-discover
-<br> # echo probe=<FONT COLOR="#cc0000">ip.addr.tup.le/netmask</FONT> >> /etc/pcp/pmmgr/target-discover
+<br> # echo avahi >> /etc/pcp/pmmgr/target-discovery
+<br> # echo probe=<FONT COLOR="#cc0000">ip.addr.tup.le/netmask</FONT> >> /etc/pcp/pmmgr/target-discovery
 <br> # service pmmgr restart
 <br> # find /var/log/pcp/pmmgr
 </B></TD></TR>


### PR DESCRIPTION
The docs were telling users to write to /etc/pcp/pmmgr/target-discover

Signed-off-by: Zack Cerza <zack@redhat.com>