### PR TITLE
Python bindings: Fixing bug where name isn't set in mmv_metric

### DIFF
--- a/src/python/pcp/mmv.py
+++ b/src/python/pcp/mmv.py
@@ -10,7 +10,7 @@
 # under the terms of the GNU General Public License as published by the
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
@@ -148,6 +148,7 @@ class mmv_metric(Structure):
         self.typeof = typeof
         self.indom = indom
         self.item = item
+        self.name = name
 
 ##
 # PCP Memory Mapped Value Services


### PR DESCRIPTION
Fixes problem at https://github.com/performancecopilot/pcp/issues/90