### PR TITLE
Document default pmwebd context timeout

### DIFF
--- a/man/man1/pmwebd.1
+++ b/man/man1/pmwebd.1
@@ -143,7 +143,7 @@ Set the maximum timeout (in seconds) after the last operation on a pmapi web
 context, before it is closed by
 .BR pmwebd .
 A smaller timeout may be requested
-by the web client.
+by the web client. The default is 300.
 .TP
 \f3\-c\f1 \f2number\f1
 Reset the next PMWEBAPI permanent context identifier as given.


### PR DESCRIPTION
The default pmwebd context timeout of 300 seconds is not documented in the manpage.