### PR TITLE
python: add errno attribute to pmErr class

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -127,7 +127,7 @@ install_pcp : $(SUBDIRS)
 
 check :: check_pcp
  
-check_pcp : pcp
+check_pcp : pcp python
 	$(SUBDIRS_MAKERULE)
 
 $(LIBPCP_SUBDIR): $(INCLUDE_SUBDIR)

--- a/src/python/GNUmakefile
+++ b/src/python/GNUmakefile
@@ -66,3 +66,8 @@ endif
 include $(BUILDRULES)
 
 install_pcp install: install_python2 install_python3
+
+check :: check_pcp
+
+check_pcp:
+	pmpython -m unittest discover -s test -p '*_test.py'

--- a/src/python/pcp/pmapi.py
+++ b/src/python/pcp/pmapi.py
@@ -146,10 +146,14 @@ def pyFileToCFile(fileObj):
 #
 
 class pmErr(Exception):
+    def __init__(self, *args):
+        super(pmErr, self).__init__(*args)
+        self.errno = args[0]
+
     def __str__(self):
         errSym = None
         try:
-            errSym = c_api.pmErrSymDict[self.args[0]]
+            errSym = c_api.pmErrSymDict[self.errno]
         except KeyError:
             pass
         if errSym == None:
@@ -158,7 +162,7 @@ class pmErr(Exception):
 
     def message(self):
         errStr = create_string_buffer(c_api.PM_MAXERRMSGLEN)
-        errStr = LIBPCP.pmErrStr_r(self.args[0], errStr, c_api.PM_MAXERRMSGLEN)
+        errStr = LIBPCP.pmErrStr_r(self.errno, errStr, c_api.PM_MAXERRMSGLEN)
         result = str(errStr.decode())
         for index in range(1, len(self.args)):
             result += " " + str(self.args[index])

--- a/src/python/test/pmerr_test.py
+++ b/src/python/test/pmerr_test.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env pmpython
+#
+# Copyright (C) 2016 Ryan Doyle
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+import unittest
+import cpmapi
+from pcp import pmapi
+
+class TestPmErr(unittest.TestCase):
+
+    def test_errno_returns_the_error_number_that_caused_the_exception(self):
+        error = pmapi.pmErr(cpmapi.PM_ERR_PMID)
+
+        self.assertEqual(error.errno, cpmapi.PM_ERR_PMID)
+
+    def test_message_returns_the_string_representation_of_the_error(self):
+        error = pmapi.pmErr(cpmapi.PM_ERR_PMID)
+
+        self.assertEqual(error.message(), "Unknown or illegal metric identifier")
+
+    def test_message_with_additional_arguments_appends_the_arguments_to_the_message(self):
+        error = pmapi.pmErr(cpmapi.PM_ERR_PMID, "arg1", "arg2")
+
+        self.assertEqual(error.message(), "Unknown or illegal metric identifier arg1 arg2")


### PR DESCRIPTION
Exposes the error code that the exception was raised with via the `errno` attribute. This follows the convention of Python built-in exceptions.