### PR TITLE
relaxing the specificity of the cpu_cycle metric's documentation

### DIFF
--- a/src/pmdas/libvirt/pmdalibvirt.python
+++ b/src/pmdas/libvirt/pmdalibvirt.python
@@ -247,7 +247,7 @@ class LibvirtPMDA(PMDA):
             [ 'domstats.perf.cmt',               None,                       PM_TYPE_U64,    PM_SEM_INSTANT,  units_bytes, 'VM perf stats, cmt'                ],
             [ 'domstats.perf.mbmt',              None,                       PM_TYPE_U64,    PM_SEM_INSTANT,  units_bpers, 'VM perf stats, mbmt'               ],
             [ 'domstats.perf.mbml',              None,                       PM_TYPE_U64,    PM_SEM_INSTANT,  units_bpers, 'VM perf stats, mbml'               ],
-            [ 'domstats.perf.cpu_cycles',        None,                       PM_TYPE_U64,    PM_SEM_COUNTER,  units_count, 'VM perf stats, CPU cycles/instr'   ],
+            [ 'domstats.perf.cpu_cycles',        None,                       PM_TYPE_U64,    PM_SEM_COUNTER,  units_count, 'VM perf stats, CPU cycles'         ],
             [ 'domstats.perf.instructions',      None,                       PM_TYPE_U64,    PM_SEM_COUNTER,  units_count, 'VM perf stats, instructions count' ],
             [ 'domstats.perf.cache_references',  None,                       PM_TYPE_U64,    PM_SEM_COUNTER,  units_count, 'VM perf stats, cache references'   ],
             [ 'domstats.perf.cache_misses',      None,                       PM_TYPE_U64,    PM_SEM_COUNTER,  units_count, 'VM perf stats, cache misses'       ],


### PR DESCRIPTION
... considering that it's likely in error in the libvirt upstream.