### PR TITLE
perfevent_pmda: Add PMU events exported from kernel

### DIFF
--- a/man/man1/pmdaperfevent.1
+++ b/man/man1/pmdaperfevent.1
@@ -46,6 +46,11 @@ The configuration
 file allows different counters to be programmed on different CPUs and supports
 round-robin assignment of uncore counters needed for some AMD chips.
 .PP
+The PMDA also counts for events exposed in the kernel via
+/sys/bus/event_source/devices directory. The PMU device name and the event
+name must be mentioned in the configuration file. Otherwise, the metric won't
+be available to monitor through this PMDA.
+.PP
 The PMDA configures the counters to count events in both user and kernel mode.
 This means that the hardware counters are unavailable to use by normal
 unprivileged user applications when they are in use by the PMDA.

--- a/qa/perfevent/GNUmakefile
+++ b/qa/perfevent/GNUmakefile
@@ -32,6 +32,7 @@ SRCS = perf_event_test.c \
        rapl-interface.c \
        configparser.yytest.c \
        $(SRCDIR)/perfinterface.c \
+	$(SRCDIR)/parse_events.c
 
 THREAD_SRCS = threadtest.c \
 	      $(SRCDIR)/perfmanager.c \

--- a/qa/perfevent/config/test_dynamic_counters.txt
+++ b/qa/perfevent/config/test_dynamic_counters.txt
@@ -1,0 +1,8 @@
+[pmuname ]
+INSTRUCTIONS_RETIRED cpu
+UNHALTED_REFERENCE_CYCLES cpu_rr
+
+[dynamic]
+pmu1.bar
+pmu2.cm_event1
+pmu2.cm_event3

--- a/src/pmdas/perfevent/GNUmakefile
+++ b/src/pmdas/perfevent/GNUmakefile
@@ -24,10 +24,11 @@ CMDTARGET	= pmda$(IAM)
 PMDADIR		= $(PCP_PMDAS_DIR)/$(IAM)
 
 CFILES	= pmda.c perfmanager.c perfinterface.c architecture.c \
-		  rapl-interface.c configparser.yy.c perflock.c
+		  rapl-interface.c configparser.yy.c perflock.c \
+		  parse_events.c
 
 HFILES  = architecture.h configparser.h perfinterface.h perfmanager.h \
-		  rapl-interface.h perflock.h
+		  rapl-interface.h perflock.h parse_events.h
 
 SCRIPTS		= Install Remove perfevent-makerewrite.pl
 

--- a/src/pmdas/perfevent/architecture.c
+++ b/src/pmdas/perfevent/architecture.c
@@ -54,7 +54,7 @@ static void free_cpulist(cpulist_t *del)
  *
  * \returns number of parsed indices or -1 on failure.
  */
-static int parse_delimited_list(const char *line, int *output) { const char
+int parse_delimited_list(const char *line, int *output) { const char
     *start = line; char *end = NULL; long res = 0; int count = 0;
 
     long i;

--- a/src/pmdas/perfevent/architecture.h
+++ b/src/pmdas/perfevent/architecture.h
@@ -49,4 +49,6 @@ archinfo_t *get_architecture();
 
 void free_architecture(archinfo_t *);
 
+int parse_delimited_list(const char *line, int *output);
+
 #endif /* ARCHITECTURE_H_ */

--- a/src/pmdas/perfevent/configparser.h
+++ b/src/pmdas/perfevent/configparser.h
@@ -56,15 +56,22 @@ typedef struct pmcderived {
     /* pmcsetting_t *derivedSettingList; */
 } pmcderived_t;
 
+typedef struct pmcdynamic {
+    char *name;
+    pmcsetting_t *dynamicSettingList;
+} pmcdynamic_t;
+
 typedef struct configuration {
     pmcconfiguration_t *configArr;
     size_t nConfigEntries;
     pmcderived_t *derivedArr;
     size_t nDerivedEntries;
+    pmcdynamic_t *dynamicpmc;
 } configuration_t;
 
 int context_newpmc;
 int context_derived;        /* A flag to check the current pmc */
+int context_dynamic;        /* check the current dynamic pmc */
 
 /* \brief parse the perf event configuration file
  * This function allocates memory. The returned object should be passed to

--- a/src/pmdas/perfevent/configparser.l
+++ b/src/pmdas/perfevent/configparser.l
@@ -32,6 +32,13 @@ static int is_derived(char *name)
     return 0;
 }
 
+static int is_dynamic(char *name)
+{
+    if (!strcmp(name, "dynamic"))
+       return 1;
+    return 0;
+}
+
 static void add_derived(configuration_t *config, char *name)
 {
     pmcderived_t *entry;
@@ -60,6 +67,26 @@ static void add_derived(configuration_t *config, char *name)
     context_derived = 1;
 }
 
+static void add_dynamic(configuration_t *config, char *name)
+{
+    pmcdynamic_t *entry;
+
+    if (!name)
+         return;
+
+    config->dynamicpmc = realloc(config->dynamicpmc, sizeof *config->dynamicpmc);
+
+    if(NULL == config->dynamicpmc)
+    {
+        return;
+    }
+
+    entry = config->dynamicpmc;
+    entry->dynamicSettingList = NULL;
+    entry->name = strdup(name);
+    context_dynamic = 1;
+}
+
 static void add_pmctype(configuration_t *config, char *name)
 {
     pmcconfiguration_t *entry;
@@ -71,6 +98,9 @@ static void add_pmctype(configuration_t *config, char *name)
     }
     if (is_derived(name))
         return add_derived(config, name);
+
+    if (is_dynamic(name))
+        return add_dynamic(config, name);
 
     if (context_newpmc)
     {
@@ -90,6 +120,7 @@ static void add_pmctype(configuration_t *config, char *name)
     newpmctype->next = entry->pmcTypeList;
     entry->pmcTypeList = newpmctype;
     context_derived = 0;
+    context_dynamic = 0;
     context_newpmc = 0;
 }
 
@@ -149,6 +180,38 @@ static void add_pmc_setting_name_derived(configuration_t *config, char *name)
     setting_lists->nsettings++;
 }
 
+static void add_pmc_setting_name_dynamic(configuration_t *config, char *name)
+{
+    pmcdynamic_t *entry;;
+    pmcsetting_t *slist, *newpmcdynamicsetting;
+
+    entry = config->dynamicpmc;
+    if (NULL == entry)
+    {
+        return;
+    }
+    newpmcdynamicsetting = calloc(1, sizeof *newpmcdynamicsetting);
+    newpmcdynamicsetting->name = strdup(name);
+    newpmcdynamicsetting->cpuConfig = 0;
+    newpmcdynamicsetting->scale = 1.0;
+    newpmcdynamicsetting->need_perf_scale = 0;
+    newpmcdynamicsetting->next = NULL;
+
+    slist = entry->dynamicSettingList;
+    if (NULL == slist)
+    {
+        entry->dynamicSettingList = newpmcdynamicsetting;
+    }
+    else
+    {
+        while(slist->next)
+        {
+            slist = slist->next;
+        }
+        slist->next = newpmcdynamicsetting;
+    }
+}
+
 static void start_alternate_pmcsetting(configuration_t *config)
 {
     pmcderived_t *entry;
@@ -197,7 +260,9 @@ static void add_pmcsetting_name(configuration_t *config, char *name)
     }
 
     if (context_derived)
-         return add_pmc_setting_name_derived(config, name);
+        return add_pmc_setting_name_derived(config, name);
+    else if (context_dynamic)
+        return add_pmc_setting_name_dynamic(config, name);
 
     entry = &config->configArr[config->nConfigEntries-1];
 
@@ -344,6 +409,17 @@ void free_configuration(configuration_t *config)
             config->configArr[i].pmcSettingList = pmcSettingDel->next;
             free(pmcSettingDel->name);
             free(pmcSettingDel);
+        }
+    }
+
+    if (config->dynamicpmc)
+    {
+    tmp = pmcSettingDel = config->dynamicpmc->dynamicSettingList;
+        while(tmp != NULL)
+        {
+            tmp = tmp->next;
+            free(pmcSettingDel);
+            pmcSettingDel = tmp;
         }
     }
 

--- a/src/pmdas/perfevent/configparser.l
+++ b/src/pmdas/perfevent/configparser.l
@@ -513,6 +513,7 @@ configuration_t *parse_configfile(const char *filename)
     config->nConfigEntries = 0;
     config->derivedArr = NULL;
     config->nDerivedEntries = 0;
+    config->dynamicpmc = NULL;
 
     yylex_init(&scanner);
     yyset_extra(config, scanner);

--- a/src/pmdas/perfevent/parse_events.c
+++ b/src/pmdas/perfevent/parse_events.c
@@ -1,0 +1,760 @@
+/*
+ * Copyright (C) 2017 IBM Corp.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <dirent.h>
+#include <malloc.h>
+#include <stdlib.h>
+
+#include "parse_events.h"
+#include "perfinterface.h"
+
+static void cleanup_property(struct property *prop)
+{
+    if (!prop)
+        return;
+    if (prop->name)
+        free(prop->name);
+    free(prop);
+}
+
+static void cleanup_property_list(struct property *prop)
+{
+    struct property *prop_del, *curr_prop;
+
+    if (!prop)
+        return;
+    for (curr_prop = prop; curr_prop; curr_prop = prop_del) {
+        prop_del = curr_prop->next;
+        cleanup_property(curr_prop);
+    }
+}
+
+static void cleanup_event(struct pmu_event *event)
+{
+    if (!event)
+        return;
+    if (event->name)
+        free(event->name);
+    free(event);
+}
+
+static void cleanup_event_list(struct pmu_event *event)
+{
+    struct pmu_event *event_del, *curr_ev;
+
+    if (!event)
+        return;
+    for (curr_ev = event; curr_ev; curr_ev = event_del) {
+        event_del = curr_ev->next;
+        cleanup_event(curr_ev);
+    }
+}
+
+static void cleanup_pmu(struct pmu *pmu)
+{
+    if (!pmu)
+        return;
+
+    cleanup_event_list(pmu->ev);
+    cleanup_property_list(pmu->prop);
+
+    /* Now, clean up the pmu */
+    if (pmu->name)
+        free(pmu->name);
+    free(pmu);
+}
+
+static void cleanup_pmu_list(struct pmu *pmu)
+{
+    struct pmu *pmu_del, *curr_pmu;
+
+    if (!pmu)
+        return;
+
+    for (curr_pmu = pmu; curr_pmu; curr_pmu = pmu_del) {
+        pmu_del = curr_pmu->next;
+        cleanup_pmu(pmu_del);
+    }
+}
+
+/*
+ * We need to statically set these up since, these software
+ * events are not exposed via the kernel /sys/devices/
+ * interface. However, these events are defined in
+ * linux/perf_event.h.
+ */
+static struct software_event sw_events[] =
+{
+    {
+        .name = "cpu-clock",
+        .config = PERF_COUNT_SW_CPU_CLOCK,
+    },
+    {
+        .name = "task-clock",
+        .config = PERF_COUNT_SW_TASK_CLOCK,
+    },
+    {
+        .name = "page-faults",
+        .config = PERF_COUNT_SW_PAGE_FAULTS,
+    },
+    {
+        .name = "context-switches",
+        .config = PERF_COUNT_SW_CONTEXT_SWITCHES,
+    },
+    {
+        .name = "cpu-migrations",
+        .config = PERF_COUNT_SW_CPU_MIGRATIONS,
+    },
+    {
+        .name = "minor-faults",
+        .config = PERF_COUNT_SW_PAGE_FAULTS_MIN,
+    },
+    {
+        .name = "major-faults",
+        .config = PERF_COUNT_SW_PAGE_FAULTS_MAJ,
+    },
+    {
+        .name = "alignment-faults",
+        .config = PERF_COUNT_SW_ALIGNMENT_FAULTS,
+    },
+    {
+        .name = "emulation-faults",
+        .config = PERF_COUNT_SW_EMULATION_FAULTS,
+    },
+};
+
+/*
+ * Sets up the software events.
+ */
+static int setup_sw_events(struct pmu_event **events, struct pmu *pmu)
+{
+    struct pmu_event *head = NULL, *tmp, *ptr;
+    int i, sw_elems;
+
+    sw_elems = sizeof(sw_events) / sizeof(struct software_event);
+
+    for (i = 0; i < sw_elems; i++) {
+        tmp = calloc(1, sizeof(*tmp));
+        if (!tmp)
+            return -1;
+        tmp->next = NULL;
+        tmp->name = strdup(sw_events[i].name);
+        if (!tmp->name) {
+            cleanup_event_list(head);
+            cleanup_event(tmp);
+            return -E_PERFEVENT_REALLOC;
+        }
+        tmp->config = sw_events[i].config;
+        tmp->pmu = pmu;
+        if (!head) {
+            head = tmp;
+            ptr = head;
+        } else {
+            ptr->next = tmp;
+            ptr = ptr->next;
+        }
+    }
+    *events = head;
+    return 0;
+}
+
+/*
+ * Sets up the software PMU.
+ */
+static int setup_sw_pmu(struct pmu *pmu)
+{
+    struct pmu *tmp, *ptr;
+    int ret;
+
+    tmp = calloc(1, sizeof(*tmp));
+    if (!tmp)
+        return -1;
+    tmp->next = NULL;
+
+    tmp->name = strdup("software");
+    if (!tmp->name) {
+        ret = -1;
+        goto err_ret;
+    }
+
+    tmp->type = PERF_TYPE_SOFTWARE;
+    ret = setup_sw_events(&tmp->ev, pmu);
+    if (ret) {
+        ret = -1;
+        goto err_ret;
+    }
+
+    /* add the sw pmu to the end of the pmu list */
+    for (ptr = pmu; ptr->next; ptr = ptr->next);
+
+    ptr->next = tmp;
+    return 0;
+ err_ret:
+    cleanup_pmu(tmp);
+    return ret;
+}
+
+/*
+ * Utility function to fetch the contents of a
+ * file(in "path") to "buf"
+ */
+int get_file_string(char *path, char *buf)
+{
+    FILE *fp;
+    int ret;
+    size_t size = BUF_SIZE;
+    char *ptr;
+
+    fp = fopen(path, "r");
+    if (!fp) {
+        fprintf(stderr, "Can't open %s\n", path);
+        return -1;
+    }
+
+    ret = getline(&buf, &size, fp);
+    if (ret < 0) {
+        fclose(fp);
+        return ret;
+    }
+
+    /* Strip off the new line character (if found) */
+    ptr = strchr(buf, '\n');
+    if (ptr)
+        *ptr = '\0';
+    fclose(fp);
+    return 0;
+}
+
+/*
+ * Fetches the format properties for a pmu. The format directory is
+ * basically a provider of the syntax definitions for a PMU. This syntax
+ * defines how an event string should be parsed.
+ */
+static int fetch_format_properties(char *format_path, struct property **prop)
+{
+    DIR *format_dir;
+    struct dirent *dir;
+    char *buf, property_path[PATH_MAX], *ptr, *start;
+    int ret;
+    struct property *pp = NULL, *tmp, *head = NULL;
+
+    format_dir = opendir(format_path);
+    if (!format_dir) {
+        fprintf(stderr, "Error opening %s\n", format_path);
+        return -1;
+    }
+
+    while ((dir = readdir(format_dir)) != NULL) {
+        if (!strncmp(dir->d_name, ".", 1) ||
+            !strncmp(dir->d_name, "..", 2)) {
+            continue;
+        }
+        buf = calloc(BUF_SIZE, sizeof(*buf));
+        if (!buf) {
+            ret = -E_PERFEVENT_REALLOC;
+            goto free_prop_list;
+        }
+        snprintf(property_path, PATH_MAX, "%s/%s", format_path,
+                 dir->d_name);
+        ret = get_file_string(property_path, buf);
+        if (ret)
+            goto free_buf;
+
+        ptr = strchr(buf, ':');
+        if (!ptr) {
+            free(buf);
+            continue;
+        }
+        *ptr = '\0';
+        ptr++;
+        tmp = calloc(1, sizeof(*tmp));
+        if (!tmp) {
+            ret = -E_PERFEVENT_REALLOC;
+            goto free_buf;
+        }
+        tmp->next = NULL;
+
+        if (!strncmp(buf, "config1", strlen("config1"))) {
+            tmp->belongs_to = CONFIG1;
+        } else if (!strncmp(buf, "config2", strlen("config2"))) {
+            tmp->belongs_to = CONFIG2;
+        } else
+            tmp->belongs_to = CONFIG;
+
+        tmp->name = strdup(dir->d_name);
+        if (!tmp->name) {
+            ret = -E_PERFEVENT_REALLOC;
+            goto free_property;
+        }
+
+        start = ptr;
+        ptr = strchr(ptr, '-');
+        if (!ptr) {
+            /* Not a range */
+            tmp->lo_bit = tmp->hi_bit = atoi(start);
+        } else {
+            /* ptr points to '-' */
+            *ptr = '\0';
+            ptr++;
+            tmp->lo_bit = atoi(start);
+            tmp->hi_bit = atoi(ptr);
+        }
+
+        if (!pp) {
+            pp = tmp;
+            head = pp;
+        } else {
+            pp->next = tmp;
+            pp = pp->next;
+        }
+    }
+
+    *prop = head;
+    return 0;
+ free_property:
+    cleanup_property(tmp);
+ free_buf:
+    free(buf);
+ free_prop_list:
+    cleanup_property_list(head);
+    return ret;
+}
+
+/*
+ * Based on the property_info, each event's config(s) are calculated.
+ * It also checks if config1 or config2 needs to be set for each of
+ * these events and accordingly sets them.
+ */
+static int fetch_event_config(struct property_info *head,
+                              struct pmu_event *event,
+                              struct pmu *pmu)
+{
+    struct property *pp;
+    struct property_info *pi;
+
+    for (pi = head; pi; pi = pi->next) {
+        pp = pmu->prop;
+        while (pp) {
+            if (!strncmp(pp->name, pi->name,
+                         strlen(pp->name))) {
+                switch (pp->belongs_to) {
+                case CONFIG:
+                    event->config = event->config |
+                        (pi->value << pp->lo_bit);
+                    break;
+                case CONFIG1:
+                    event->config1 = event->config1 |
+                        (pi->value << pp->lo_bit);
+                    break;
+                case CONFIG2:
+                    event->config2 = event->config2 |
+                        (pi->value << pp->lo_bit);
+                    break;
+                }
+            }
+            pp = pp->next;
+        }
+    }
+
+    return 0;
+}
+
+static void cleanup_property_info(struct property_info *pi)
+{
+    struct property_info *pi_curr, *pi_del;
+
+    if (!pi)
+        return;
+    for (pi_curr = pi; pi_curr; pi_curr = pi_del) {
+        pi_del = pi_curr->next;
+        if (pi_curr->name)
+            free(pi_curr->name);
+        free(pi_curr);
+    }
+}
+
+/*
+ * Parses each event string and finds out the properties each event string
+ * contains.
+ */
+static int parse_event_string(char *buf, struct pmu_event *event,
+                              struct pmu *pmu)
+{
+    struct property_info *pi, *head = NULL, *tmp;
+    char *start, *ptr, *nptr, **endptr, *str;
+    int ret = 0;
+
+    start = buf;
+
+    while (1) {
+        ptr = strchr(start, '=');
+        if (!ptr)
+            break;
+
+        /* Found a property */
+        *ptr = '\0';
+        ptr++;   /* ptr now points to the value */
+        pi = calloc(1, sizeof(*pi));
+        if (!pi) {
+            cleanup_property_info(head);
+            return -E_PERFEVENT_REALLOC;
+        }
+        pi->next = NULL;
+
+        pi->name = strdup(start);
+        if (!pi->name) {
+            free(pi);
+            cleanup_property_info(head);
+            return -E_PERFEVENT_REALLOC;
+        }
+
+        /* Find next property */
+        start = strchr(ptr, ',');
+        if (!start) {
+            str = buf + strlen(buf) - 1;
+            endptr = &str;
+            nptr = ptr;
+            pi->value = strtoull(nptr, endptr, 16);
+            if (!head) {
+                head = pi;
+                pi = pi->next;
+            } else {
+                tmp->next = pi;
+                tmp = tmp->next;
+            }
+            break;
+        } else {
+            /* We found the next property */
+            *start = '\0';
+            str = buf + strlen(buf) - 1;
+            endptr = &str;
+            start++;
+            nptr = ptr;
+            pi->value = strtoul(nptr, endptr, 16);
+        }
+
+        if (!head) {
+            head = pi;
+            tmp = head;
+        } else {
+            tmp->next = pi;
+            tmp = tmp->next;
+        }
+    }
+
+    if (ret)
+        return ret;
+
+    ret = fetch_event_config(head, event, pmu);
+    return ret;
+}
+
+/*
+ * Fetches all the events(exposed by the kernel) for a PMU. It also
+ * initializes the config(s) for each event based on the PMU's property
+ * list.
+ */
+static int fetch_events(DIR *events_dir, struct pmu_event **events,
+                        struct pmu *pmu, char *events_path)
+{
+    struct dirent *dir;
+    struct pmu_event *ev = NULL, *tmp, *head = NULL;
+    char event_path[PATH_MAX], *buf;
+    int ret = 0;
+
+    if (!events_dir)
+        return -1;
+
+    while ((dir = readdir(events_dir)) != NULL) {
+        if (!strncmp(dir->d_name, ".", 1) ||
+            !strncmp(dir->d_name, "..", 2))
+            continue;
+
+        /* Ignoring .scale and .unit for now */
+        if (strstr(dir->d_name, ".scale") || strstr(dir->d_name, ".unit"))
+            continue;
+
+        tmp = calloc(1, sizeof(*tmp));
+        if (!tmp) {
+            cleanup_event_list(head);
+            ret = -E_PERFEVENT_REALLOC;
+            goto free_event_list;
+        }
+        tmp->next = NULL;
+        tmp->name = strdup(dir->d_name);
+        if (!tmp->name) {
+            ret = -E_PERFEVENT_REALLOC;
+            goto free_event;
+        }
+
+        /* Now, we have to find the config value for this event */
+        buf = calloc(BUF_SIZE, sizeof(*buf));
+        if (!buf) {
+            ret = -E_PERFEVENT_REALLOC;
+            goto free_event;
+        }
+
+        memset(event_path, '\0', PATH_MAX);
+        snprintf(event_path, PATH_MAX, "%s/%s", events_path, dir->d_name);
+        ret = get_file_string(event_path, buf);
+        if (ret) {
+            ret = -E_PERFEVENT_RUNTIME;
+            goto free_buf;
+        }
+
+        ret = parse_event_string(buf, tmp, pmu);
+        if (ret) {
+            ret = -E_PERFEVENT_RUNTIME;
+            goto free_buf;
+        }
+
+        tmp->pmu = pmu;
+
+        if (!ev) {
+            ev = tmp;
+            head = ev;
+        } else {
+            ev->next = tmp;
+            ev = ev->next;
+        }
+    }
+
+    *events = head;
+    return 0;
+ free_buf:
+    free(buf);
+ free_event:
+    cleanup_event(tmp);
+ free_event_list:
+    cleanup_event_list(head);
+    return ret;
+}
+
+/*
+ * Fetches the PMU type which is in "type_path".
+ */
+static int fetch_pmu_type(char *type_path, struct pmu *pmu)
+{
+    char *buf;
+    int ret;
+
+    buf = calloc(1, sizeof(BUF_SIZE));
+    if (!buf)
+        return -1;
+
+    ret = get_file_string(type_path, buf);
+    if (ret < 0) {
+        free(buf);
+        return ret;
+    }
+
+    pmu->type = (int)strtoul(buf, NULL, 10);
+    free(buf);
+    return 0;
+}
+
+/*
+ * For a PMU "pmu", its "events" directory is looked up, if not
+ * present, then we will not count that in the list of pmus. If the
+ * "events" directory is present, we proceed to read the "format"
+ * directory which helps in parsing the event string. We also fetch
+ * the type of the pmu.
+ */
+static int fetch_format_and_events(char *pmu_path, struct pmu *pmu)
+{
+    DIR *events_dir;
+    char format_path[PATH_MAX], events_path[PATH_MAX];
+    char type_path[PATH_MAX];
+    struct property *tmp = NULL;
+    struct pmu_event *ev = NULL;
+    int ret;
+
+    snprintf(type_path, PATH_MAX, "%s/%s", pmu_path, PMU_TYPE);
+    snprintf(format_path, PATH_MAX, "%s/%s", pmu_path, FORMAT);
+    snprintf(events_path, PATH_MAX, "%s/%s", pmu_path, EVENTS);
+    events_dir = opendir(events_path);
+    if (!events_dir)
+        return -E_PERFEVENT_RUNTIME;
+
+    ret = fetch_format_properties(format_path, &tmp);
+    if (ret)
+        goto close_dir;
+
+    pmu->prop = tmp;
+    ret = fetch_pmu_type(type_path, pmu);
+    if (ret) {
+        cleanup_property_list(tmp);
+        goto close_dir;
+    }
+
+    ret = fetch_events(events_dir, &ev, pmu, events_path);
+    if (ret) {
+        cleanup_property_list(tmp);
+        goto close_dir;
+    }
+
+    pmu->ev = ev;
+    ret = 0;
+ close_dir:
+    closedir(events_dir);
+    return ret;
+}
+
+/*
+ * Populates the entire list of available PMUs in pmus.
+ */
+static int populate_pmus(struct pmu **pmus)
+{
+    DIR *pmus_dir;
+    struct pmu *tmp, *head = NULL, *ptr = NULL;
+    struct dirent *dir;
+    char pmu_path[PATH_MAX];
+    int ret = -1;
+
+    pmus_dir = opendir(DEV_DIR);
+    if (!pmus_dir)
+        return ret;
+
+    while ((dir = readdir(pmus_dir)) != NULL) {
+        /* Ignore the . and .. */
+        if (!strncmp(dir->d_name, ".", 1) ||
+            !strncmp(dir->d_name, "..", 2)) {
+            continue;
+        }
+
+        memset(pmu_path, '\0', PATH_MAX);
+        snprintf(pmu_path, PATH_MAX, "%s%s", DEV_DIR, dir->d_name);
+        tmp = calloc(1, sizeof(*tmp));
+        if (!tmp) {
+            ret = -E_PERFEVENT_REALLOC;
+            goto free_pmulist;
+        }
+        tmp->next = NULL;
+        ret = fetch_format_and_events(pmu_path, tmp);
+        if (ret) {
+            /*
+             * If there was in issue initializing any event
+             * for this pmu, we should free up this pmu.
+             * However, we should continue looking for other
+             * pmus. Clear the entire list only for allocation
+             * errors.
+             */
+            if (ret == -E_PERFEVENT_REALLOC) {
+                /*
+                 * Only in this case, we would clean up the entire
+                 * list.
+                 */
+                goto free_pmu;
+            }
+            cleanup_pmu(tmp);
+            continue;
+        }
+
+        tmp->name = strdup(dir->d_name);
+        if (!tmp->name) {
+            ret = -E_PERFEVENT_REALLOC;
+            goto free_pmu;
+        }
+
+        if (!head) {
+            head = tmp;
+            ptr = head;
+        } else {
+            ptr->next = tmp;
+            ptr = ptr->next;
+        }
+    }
+
+    closedir(pmus_dir);
+
+    *pmus = head;
+    return 0;
+ free_pmu:
+    cleanup_pmu(tmp);
+ free_pmulist:
+    cleanup_pmu_list(head);
+    closedir(pmus_dir);
+    return ret;
+}
+
+/*
+ * Finds the cpumask related to a pmu. If no cpumask file is present,
+ * it assumes the default mask, i.e., the set of all cpus.
+ */
+void setup_cpu_config(struct pmu *pmu_ptr, int *ncpus, int **cpuarr,
+                      cpulist_t *cpus)
+{
+    FILE *cpulist;
+    char cpumask_path[PATH_MAX], *line;
+    int *on_cpus;
+    size_t len = 0;
+
+    memset(cpumask_path, '\0', PATH_MAX);
+    snprintf(cpumask_path, PATH_MAX, "%s%s/%s", DEV_DIR, pmu_ptr->name,
+             PMU_CPUMASK);
+    cpulist = fopen(cpumask_path, "r");
+    /*
+     * If this file is not available, then the cpumask is the set of all
+     * available cpus.
+     */
+    if (!cpulist)
+        return;
+
+    on_cpus = calloc(cpus->count, sizeof(int));
+    if (!on_cpus) {
+        fclose(cpulist);
+        return;
+    }
+
+    if (getline(&line, &len, cpulist) > 0) {
+        *ncpus = parse_delimited_list(line, on_cpus);
+        if (*ncpus > -1)
+            *cpuarr = on_cpus;
+        else
+            *cpuarr = NULL;
+    }
+
+    fclose(cpulist);
+}
+
+/*
+ * Setup the dynamic events taken from /sys/bus/event_source/devices
+ * pmu_list contains the list of all the PMUs and their events upon
+ * execution of this function.
+ */
+int init_dynamic_events(struct pmu **pmu_list) {
+    int ret = -1;
+    struct pmu *pmus = NULL;
+
+    ret = populate_pmus(&pmus);
+    if (ret)
+        return ret;
+
+    /*
+     * setup the software pmu separately, since, it needs to be
+     * setup with a set of static events.
+     */
+    ret = setup_sw_pmu(pmus);
+    if (ret)
+        return ret;
+
+    *pmu_list = pmus;
+    return 0;
+}

--- a/src/pmdas/perfevent/parse_events.h
+++ b/src/pmdas/perfevent/parse_events.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2017 IBM Corp.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef PARSE_EVENTS_H_
+#define PARSE_EVENTS_H_
+
+#include "architecture.h"
+
+#define CONFIG  0
+#define CONFIG1 1     /* Extension of config1 */
+#define CONFIG2 2     /* Extension of config2 */
+
+#define DEV_DIR "/sys/bus/event_source/devices/"
+
+#define EVENTS "events"
+#define FORMAT "format"
+#define PMU_TYPE "type"
+#define PMU_CPUMASK "cpumask"
+
+#define BUF_SIZE 1024
+
+/*
+ * Event name and configs are the things that we need for any event.
+ */
+struct pmu_event {
+    char *name;
+    unsigned long long config;
+    unsigned long long config1;
+    unsigned long long config2;
+    double scale;
+    struct pmu *pmu;                  /* Back pointer to its pmu */
+    struct pmu_event *next;
+};
+
+struct property_info {
+    char *name;
+    unsigned long long value;
+    struct property_info *next;
+};
+
+/*
+ * name : name of the format property.
+ * lo_bit : from where this property starts.
+ * hi_bit : highest bit where the property finishes.
+ */
+struct property {
+    char *name;
+    int lo_bit;
+    int hi_bit;
+    int belongs_to;
+    struct property *next;
+};
+
+struct pmu {
+    char *name;
+    int type;
+    struct property *prop;
+    struct pmu_event *ev;
+    struct pmu *next;
+};
+
+struct software_event {
+    char *name;
+    unsigned long long config;
+};
+
+int init_dynamic_events(struct pmu **pmu_list);
+void setup_cpu_config(struct pmu *pmu_ptr, int *ncpus, int **cpuarr,
+		      cpulist_t *cpus);
+int get_file_string(char *path, char *buf);
+
+#endif /* PARSE_EVENTS_H_ */

--- a/src/pmdas/perfevent/parse_events.h
+++ b/src/pmdas/perfevent/parse_events.h
@@ -19,13 +19,14 @@
 #ifndef PARSE_EVENTS_H_
 #define PARSE_EVENTS_H_
 
+#include <linux/limits.h>
 #include "architecture.h"
 
 #define CONFIG  0
 #define CONFIG1 1     /* Extension of config1 */
 #define CONFIG2 2     /* Extension of config2 */
 
-#define DEV_DIR "/sys/bus/event_source/devices/"
+#define DEV_DIR "/bus/event_source/devices/"
 
 #define EVENTS "events"
 #define FORMAT "format"
@@ -79,9 +80,12 @@ struct software_event {
     unsigned long long config;
 };
 
+char dev_dir[PATH_MAX];   /* Optional path prefix for the PMU devices */
+
 int init_dynamic_events(struct pmu **pmu_list);
 void setup_cpu_config(struct pmu *pmu_ptr, int *ncpus, int **cpuarr,
 		      cpulist_t *cpus);
 int get_file_string(char *path, char *buf);
+void cleanup_pmu_list(struct pmu *pmu);
 
 #endif /* PARSE_EVENTS_H_ */

--- a/src/pmdas/perfevent/perfevent.conf
+++ b/src/pmdas/perfevent/perfevent.conf
@@ -11,6 +11,21 @@
 #
 # if the CPU option is absent it defaults to all cpus.
 #
+# Kernel exported PMUs can be specified in this file too under [dynamic]
+# section. The PMUs exported from the kernel can be found in
+# /sys/bus/event_source/devices
+# and its corresponding event can be found under "events" directory inside
+# the PMU directory.
+# For e.g., if an event "bar"  is desired to monitored which is found here :
+# /sys/bus/event_source/devices/foo/events/bar
+# Then, it needs to be mentioned under [dynamic] as :
+# [dynamic]
+# foo.bar
+#
+# If not specified like above, a user will continue to see the event but
+# will not be able to monitor it.
+#
+#
 # For derived events :
 # [event:derived]
 #   EVENT_NAME [CPU OPTION] [scale|perf_scale]
@@ -271,6 +286,12 @@ UNHALTED_CORE_CYCLES
 INSTRUCTION_RETIRED
 UNHALTED_REFERENCE_CYCLES
 LLC_MISSES
+
+[dynamic]
+cpu.branch-misses
+cpu.cache-references
+software.page-faults
+software.context-switches
 
 [current_bandwidth:derived]
 snbep_unc_imc0::UNC_M_CAS_COUNT:RD node perf_scale

--- a/src/pmdas/perfevent/perfinterface.h
+++ b/src/pmdas/perfevent/perfinterface.h
@@ -32,6 +32,7 @@ typedef struct perf_data_t_
 typedef struct perf_counter_t_
 {
     char *name;
+    int counter_disabled;
     perf_data *data;
     int ninstances;
 } perf_counter;
@@ -70,6 +71,7 @@ typedef struct eventcpuinfo_t_ {
 
 typedef struct event_t_ {
     char *name;
+    int disable_event;
     eventcpuinfo_t *info;
     int ncpus;
 } event_t;
@@ -84,6 +86,12 @@ typedef struct derived_event_t_ {
     char *name;
     event_list_t *event_list;
 } derived_event_t;
+
+typedef struct dynamic_event_t_ {
+    char *pmu;
+    char *event;
+    struct dynamic_event_t_ *next;
+} dynamic_event_t;
 
 typedef struct perfdata_t_
 {

--- a/src/pmdas/perfevent/pmda.c
+++ b/src/pmdas/perfevent/pmda.c
@@ -240,6 +240,8 @@ static int perfevent_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomV
 
     if (idp->cluster >= NUM_STATIC_DERIVED_CLUSTERS + NUM_STATIC_CLUSTERS + nhwcounters)
         pddata = &(pinfo->derived_counter->data[inst]);
+    else if (pinfo->hwcounter->counter_disabled)
+	return PM_ERR_VALUE;
     else
         pdata = &(pinfo->hwcounter->data[inst]);
 
@@ -543,7 +545,7 @@ static char *normalize_metric_name(const char *name)
     {
         for(p = res; *p != '\0'; p++)
         {
-            if( !isalnum((int)*p) && *p != '_')
+            if( !isalnum((int)*p) && *p != '_' && *p != '.' && *p != '-')
             {
                 *p = '_'; /* "underscore" - new name */
             }

--- a/src/pmdas/perfevent/pmda.c
+++ b/src/pmdas/perfevent/pmda.c
@@ -545,7 +545,7 @@ static char *normalize_metric_name(const char *name)
     {
         for(p = res; *p != '\0'; p++)
         {
-            if( !isalnum((int)*p) && *p != '_' && *p != '.' && *p != '-')
+            if( !isalnum((int)*p) && *p != '_' && *p != '.')
             {
                 *p = '_'; /* "underscore" - new name */
             }


### PR DESCRIPTION
The perfevent pmda gets the event definitions from the libpfm
library. So, to add a new platform counter, we need to add its
definition to the libpfm library and use it here. This patch is the
first step towards removing that dependency. It parses the kernel
exported PMUs and their events from /sys/bus/event_source/devices, and
calculates the config values for each of these events. However, we don't
want to open all the events at once. Only the events which are mentioned
in perfevent.conf under [dynamic] section will be opened. But, all the
dynamic events will be listed with pminfo.
For e.g. :
 $ pminfo
[...]
perfevent.hwcounters.software.context-switches.dutycycle
perfevent.hwcounters.software.context-switches.value
perfevent.hwcounters.software.page-faults.dutycycle
perfevent.hwcounters.software.page-faults.value
[...]
perfevent.hwcounters.power.energy-cores.dutycycle
perfevent.hwcounters.power.energy-cores.value
perfevent.hwcounters.power.energy-ram.dutycycle
perfevent.hwcounters.power.energy-ram.value
[...]
perfevent.hwcounters.msr.mperf.dutycycle
perfevent.hwcounters.msr.mperf.value
perfevent.hwcounters.msr.aperf.dutycycle
perfevent.hwcounters.msr.aperf.value
[...]
perfevent.hwcounters.cpu.mem-stores.dutycycle
perfevent.hwcounters.cpu.mem-stores.value
perfevent.hwcounters.cpu.tx-capacity.dutycycle
perfevent.hwcounters.cpu.tx-capacity.value
perfevent.hwcounters.cpu.mem-loads.dutycycle
perfevent.hwcounters.cpu.mem-loads.value
perfevent.hwcounters.cpu.branch-misses.dutycycle
perfevent.hwcounters.cpu.branch-misses.value
[...]

Now, say only the event cpu.branch-instructions is mentioned under
[dynamic] section in the perfevent.conf file. In this case, we can only
read the values for this event, all other dynamic events are disabled
and will return invalid value.

$ pmval perfevent.hwcounters.cpu.branch-misses.value

metric:    perfevent.hwcounters.cpu.branch-misses.value
host:      <>
semantics: cumulative counter (converting to rate)
units:     count (converting to count / sec)
samples:   all

              cpu0                  cpu1                  cpu2                  cpu3
            3.028E+05             3.772E+05             3.757E+05             2.638E+05
            4.382E+05             2.716E+05             2.888E+05

cpu.mem-loads is not added in the perfevent.conf file, so we won't be
able to get any values out of it, even though, we can see it under pminfo.

$ pmval perfevent.hwcounters.cpu.mem-loads.value

metric:    perfevent.hwcounters.cpu.mem-loads.value
host:      <>
semantics: cumulative counter (converting to rate)
units:     count (converting to count / sec)
samples:   all
No values available
No values available

This patch also adds software events whose configuration values are
available under linux/perf_event.h :
[...]
perfevent.hwcounters.software.cpu-migrations.dutycycle
perfevent.hwcounters.software.cpu-migrations.value
perfevent.hwcounters.software.context-switches.dutycycle
perfevent.hwcounters.software.context-switches.value
perfevent.hwcounters.software.page-faults.dutycycle
perfevent.hwcounters.software.page-faults.value
[...]