### PR TITLE
perfevent_pmda: Fixes a sigsegv for test_dynamic_events_config

### DIFF
--- a/src/pmdas/perfevent/parse_events.h
+++ b/src/pmdas/perfevent/parse_events.h
@@ -83,8 +83,7 @@ struct software_event {
 char dev_dir[PATH_MAX];   /* Optional path prefix for the PMU devices */
 
 int init_dynamic_events(struct pmu **pmu_list);
-void setup_cpu_config(struct pmu *pmu_ptr, int *ncpus, int **cpuarr,
-		      cpulist_t *cpus);
+void setup_cpu_config(struct pmu *pmu_ptr, int *ncpus, int **cpuarr);
 int get_file_string(char *path, char *buf);
 void cleanup_pmu_list(struct pmu *pmu);
 

--- a/src/pmdas/perfevent/perfinterface.c
+++ b/src/pmdas/perfevent/perfinterface.c
@@ -710,8 +710,7 @@ static int perf_setup_dynamic_events(perfdata_t *inst,
                 return -E_PERFEVENT_REALLOC;
             }
 
-            setup_cpu_config(pmu_ptr, &ncpus, &cpuarr,
-                             &archinfo->cpus);
+            setup_cpu_config(pmu_ptr, &ncpus, &cpuarr);
 
             if (ncpus <= 0) { /* Assume default cpu set */
                 cpuarr = archinfo->cpus.index;


### PR DESCRIPTION
The perfevent pmda code initializes/parses a cpumask for each
PMU. Previously, it used to allocate a memory block with max available
cpus from archinfo->cpulist. And, then, it finds out the list of
allowable cpus on which events of a certain PMU can be monitored. That
causes an issue with the test case test_dynamic_events_config, in which,
the archinfo->cpulist initialized (from the system) may be less than the
cpumask available for a pmu in this test case. If that's the case, it
will cause a sigsegv, since, it tries to parse more cpus than the
allocated space.

This PR fixes this issue by allocating the appropriate space by first
looking at the cpumask and then parsing it.