### PR TITLE
pmrep: fix now unneeded workaround

### DIFF
--- a/src/pmrep/pmrep.py
+++ b/src/pmrep/pmrep.py
@@ -907,8 +907,6 @@ class PMReporter(object):
             # Add fetchgroup item
             try:
                 scale = self.metrics[metric][2][0]
-                if scale.endswith("/h"):
-                    scale += "r"
                 self.metrics[metric][5] = self.pmfg.extend_indom(metric, mtype, scale, 1024)
             except:
                 if self.ignore_incompat:


### PR DESCRIPTION
654d0c0 addressed this properly in libpcp so drop the Python workaround.