### PR TITLE
Fix conditional scope for pmlogger-timefmt change

### DIFF
--- a/src/pmmgr/pmmgr.cxx
+++ b/src/pmmgr/pmmgr.cxx
@@ -1436,8 +1436,10 @@ pmmgr_pmlogger_daemon::daemon_command_line()
       char timestr2[100];
       int rc = strftime(timestr2, sizeof(timestr2), pmlogger_timefmt.c_str(), now);
       if (rc > 0)
-        timestr += "-";
-	timestr += timestr2; // no sh_quote required
+        {
+          timestr += "-";
+          timestr += timestr2; // no sh_quote required
+        }
     }
 
   // last argument


### PR DESCRIPTION
Fix a scoping issue in one of my recent commits.  Thanks to Frank for pointing this out.