### PR TITLE
Additional slave metrics for MySQL PMDA

### DIFF
--- a/src/pmdas/mysql/pmdamysql.pl
+++ b/src/pmdas/mysql/pmdamysql.pl
@@ -1801,6 +1801,12 @@ $pmda->add_metric(pmda_pmid(3,33), PM_TYPE_U32, PM_INDOM_NULL,
 $pmda->add_metric(pmda_pmid(3,34), PM_TYPE_U32, PM_INDOM_NULL,
 		  PM_SEM_DISCRETE, pmda_units(0,0,0,0,0,0),
 		  'mysql.slave_status.master_ssl_allowed_num', '','');
+$pmda->add_metric(pmda_pmid(3,35), PM_TYPE_U32, PM_INDOM_NULL,
+		  PM_SEM_DISCRETE, pmda_units(0,0,0,0,0,0),
+		  'mysql.slave_status.sql_delay', '','');
+$pmda->add_metric(pmda_pmid(3,36), PM_TYPE_U32, PM_INDOM_NULL,
+		  PM_SEM_DISCRETE, pmda_units(0,0,0,0,0,0),
+		  'mysql.slave_status.sql_remaining_delay', '','');
 		  
 $pmda->add_indom($process_indom, \@process_instances,
 		 'Instance domain exporting each MySQL process', '');


### PR DESCRIPTION
Corresponding lines from SHOW SLAVE STATUS:
```
SQL_Delay: 0
SQL_Remaining_Delay: NULL
```

One problem i noticed is that SQL_Delay and SQL_Remaining_Delay can be both int and NULL.
This also applies to Seconds_Behind_Master which is PM_TYPE_U32 right now.