### PR TITLE
Prometheus: add auto metadata refresh and indom cache fixes

### DIFF
--- a/qa/1192
+++ b/qa/1192
@@ -11,22 +11,16 @@ echo "QA output created by $seq"
 . ./common.product
 . ./common.filter
 . ./common.check
-. ./common.docker
+. ./common.python
 
-_check_containers
-_check_docker_images "quay.io/prometheus/prometheus"
-count=`_count_docker_containers`
-[ "$count" -gt 0 ] && \
-    _notrun "Needs quay.io/prometheus/prometheus docker setup ($count running containers found)"
-
+$python -c "import prometheus_client"
+[ $? -eq 0 ] || _notrun "python prometheus_client module not installed"
 
 _cleanup()
 {
-    if [ -n "$container" ]
+    if [ -n "$pid" ]
     then
-        echo "== removing container"
-        _remove_docker_containers $container
-        container=""
+        kill -9 $pid
     fi
     $sudo rm -rf $tmp.* $tmp.*
 }
@@ -55,7 +49,7 @@ pmdaprometheus_install()
 generate_config()
 {
 	cd $PCP_PMDAS_DIR/prometheus
-	$sudo ./pmdaprometheus.python -g -n "test" -u "http://127.0.0.1:9090/metrics"
+	$sudo ./pmdaprometheus.python -g -n "test" -u "http://127.0.0.1:9090"
 }
 
 status=1	# failure is the default!
@@ -69,11 +63,8 @@ $sudo rm -f $PCP_PMDAS_DIR/prometheus/metadata/*
 
 # real QA test starts here
 
-echo "== starting container"
-container=`$docker run -d -p 127.0.0.1:9090:9090 quay.io/prometheus/prometheus`
-echo "== container: $container" >> $here/$seq.full
-# Wait for the prometheus container to complete setup
-sleep 5
+$python $here/prometheus/prometheus_client_server.python &
+pid=$!
 
 generate_config
 
@@ -87,17 +78,25 @@ else
 	cat $tmp.out
 fi
 
-if pminfo -f prometheus.test.go_goroutines > $tmp.info 2> $tmp.err
+if pminfo -f prometheus.test.queue_size > $tmp.info 2> $tmp.err
 then
-	echo "Fetch prometheus.go_goroutines: success"
-	pminfo -d prometheus.test.go_goroutines
+	echo "Fetch prometheus.test.queue_size: success"
+	pminfo -f prometheus.test.queue_size
 else
-	echo "Fetch prometheus.go_goroutines: failed"
+	echo "Fetch prometheus.test.queue_size: failed"
 	cat $tmp.err
 fi
 
-pmdaprometheus_remove
+if pminfo -f prometheus.test.requests_total > $tmp.info 2> $tmp.err
+then
+    echo "Fetch prometheus.test.requests_total: success"
+    pminfo -f prometheus.test.requests_total
+else
+    echo "Fetch prometheus.test.requests_total: failed"
+    cat $tmp.err
+fi
 
+pmdaprometheus_remove
 _restore_config $PCP_PMDAS_DIR/prometheus/metadata
 # success, all done
 status=0

--- a/qa/1192.out
+++ b/qa/1192.out
@@ -1,14 +1,18 @@
 QA output created by 1192
-== starting container
 Waiting for pmcd to terminate ...
 
 === prometheus agent installation ===
 Installation ok
-Fetch prometheus.go_goroutines: success
+Fetch prometheus.test.queue_size: success
 
-prometheus.test.go_goroutines
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+prometheus.test.queue_size
+    value 90
+Fetch prometheus.test.requests_total: success
+
+prometheus.test.requests_total
+    inst [1 or "agent="prometheus"::type="fetch""] value 1
+    inst [2 or "agent="json"::type="store""] value 1
+    inst [3 or "agent="docker"::type="oneline""] value 1
 
 === remove prometheus agent ===
 Culling the Performance Metrics Name Space ...
@@ -16,7 +20,5 @@ prometheus ... done
 Updating the PMCD control file, and notifying PMCD ...
 [...removing files...]
 Check prometheus metrics have gone away ... OK
-== removing container
-Waiting for pmcd to terminate ...
 Starting pmcd ... 
 Starting pmlogger ... 

--- a/qa/GNUmakefile
+++ b/qa/GNUmakefile
@@ -21,7 +21,7 @@ ifeq "$(PMDA_PERFEVENT)" "true"
 SUBDIRS += perfevent
 endif
 ifeq "$(HAVE_PYTHON)" "true"
-SUBDIRS += secure mic haproxy lio
+SUBDIRS += secure mic haproxy lio prometheus
 endif
 LCONFIG = localconfig
 

--- a/qa/GNUmakefile.install
+++ b/qa/GNUmakefile.install
@@ -20,7 +20,7 @@ ifeq "$(PMDA_PERFEVENT)" "true"
 SUBDIRS += perfevent
 endif
 ifeq "$(HAVE_PYTHON)" "true"
-SUBDIRS += secure mic haproxy lio
+SUBDIRS += secure mic haproxy lio prometheus
 endif
 
 default default_pcp setup: $(SUBDIRS) localconfig new remake check qa_hosts

--- a/qa/prometheus/GNUmakefile
+++ b/qa/prometheus/GNUmakefile
@@ -1,0 +1,16 @@
+#!gmake
+
+TOPDIR = ../..
+include $(TOPDIR)/src/include/builddefs
+
+TESTDIR = $(PCP_VAR_DIR)/testsuite/prometheus
+SERVER = prometheus_client_server.python
+
+default default_pcp setup: prometheus_client_server.python
+
+install install_pcp:
+	$(INSTALL) -m 755 -d $(TESTDIR)
+	$(INSTALL) -m 755 $(SERVER) $(TESTDIR)/$(SERVER)
+	$(INSTALL) -m 644 GNUmakefile.install $(TESTDIR)/GNUmakefile
+
+include $(BUILDRULES)

--- a/qa/prometheus/GNUmakefile.install
+++ b/qa/prometheus/GNUmakefile.install
@@ -1,0 +1,17 @@
+#!gmake
+
+ifdef PCP_CONF
+include $(PCP_CONF)
+else
+include $(PCP_DIR)/etc/pcp.conf
+endif
+PATH	= $(shell . $(PCP_DIR)/etc/pcp.env; echo $$PATH)
+include $(PCP_INC_DIR)/builddefs
+
+TESTDIR = $(PCP_VAR_DIR)/testsuite/prometheus
+
+default default_pcp setup: prometheus_client_server.python
+
+install install_pcp:
+
+include $(BUILDRULES)

--- a/qa/prometheus/prometheus_client_server.python
+++ b/qa/prometheus/prometheus_client_server.python
@@ -1,3 +1,21 @@
+#!/usr/bin/env pmpython
+'''
+Performance Metrics Domain Agent exporting Prometheus endpoint metrics.
+'''
+#
+# Copyright (c) 2017 Ronak Jain.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+
 from prometheus_client import start_http_server, Summary, \
 	Counter, Gauge, Histogram
 import time
@@ -20,7 +38,7 @@ summary.observe(4.7)
 
 
 if __name__ == '__main__':
-	start_http_server(8000)
+	start_http_server(9090)
 	try:
 		time.sleep(1000)
 	except:

--- a/src/pmdas/prometheus/acme.py
+++ b/src/pmdas/prometheus/acme.py
@@ -1,0 +1,27 @@
+from prometheus_client import start_http_server, Summary, \
+	Counter, Gauge, Histogram
+import time
+import sys
+
+requests = Counter('requests_total', 'Total requests', ['type', 'agent'])
+requests.labels(type='fetch', agent='prometheus').inc()
+requests.labels(type='store', agent='json').inc()
+requests.labels(type='oneline', agent='docker').inc()
+
+histogram = Histogram('request_latency_seconds', 'Sample histogram')
+histogram.observe(4.7)
+
+queue = Gauge('queue_size', 'Sample Gauge of queue size')
+queue.set(100)
+queue.dec(10)
+
+summary = Summary('summary_requests', 'Sample summary of requests')
+summary.observe(4.7)
+
+
+if __name__ == '__main__':
+	start_http_server(8000)
+	try:
+		time.sleep(1000)
+	except:
+		sys.exit(0)

--- a/src/pmdas/prometheus/pmdaprometheus.python
+++ b/src/pmdas/prometheus/pmdaprometheus.python
@@ -45,7 +45,7 @@ INSTANT = "instantaneous"
 TYPES = { DOUBLE: c_api.PM_TYPE_DOUBLE, UINT: c_api.PM_TYPE_U64 }
 SEMANTICS = { COUNTER: c_api.PM_SEM_COUNTER, INSTANT: c_api.PM_SEM_INSTANT }
 
-def diffMetadata(self, new_metrics, old_metrics):
+def diffMetadata(new_metrics, old_metrics):
 	''' diffMetadata finds new/removed metrics by diffing'''
 	if old_metrics is None:
 		old_metrics = []
@@ -80,11 +80,12 @@ def diffMetadata(self, new_metrics, old_metrics):
 				changes_map[name] = True
 				old_instances.append(instance)
 
+	removed_names = []
 	# Find remove metrics/instances
 	for name in old_metrics_map:
 		if name not in new_metrics_map:
 			changes_map[name] = True
-			old_metrics_map.pop(name)
+			removed_names.append(name)
 			continue
 		old_metric = old_metrics_map[name]
 		old_instances = old_metric.get("instances")
@@ -95,6 +96,7 @@ def diffMetadata(self, new_metrics, old_metrics):
 		if instances is None or len(instances) == 0:
 			changes_map[name] = True
 			old_metric["instances"] = None
+			old_metric["prometheus_name"] = name
 			continue
 		removed_instances = []
 		for instance in old_instances:
@@ -105,12 +107,14 @@ def diffMetadata(self, new_metrics, old_metrics):
 			for instance in removed_instances:
 				old_instances.remove(instance)
 
+	for name in removed_names:
+		old_metrics_map.pop(name)
 	# Flatten map into array
 	metrics_arr = []
 	for i in old_metrics_map:
 		metrics_arr.append(old_metrics_map[i])
 
-	return (changes_map, metrics_arr)
+	return (changes_map, metrics_arr, old_metrics_map)
 
 
 class ScanPrometheus(object):
@@ -297,8 +301,10 @@ class Metric(object):
 	@indom_cache.setter
 	def indom_cache(self, indom):
 		''' Adds the instances to the indom assigned '''
+		indom.load()
 		self.__indom_cache = indom
 		for inst in self.instances:
+			self.log("instance add hoing --> %s"%(inst["name"]))
 			try:
 				id = self.__indom_cache.lookup_name(inst["name"])
 			except KeyError:
@@ -383,8 +389,8 @@ class Metric(object):
 				prometheus_name = self.instance_by_name[name]
 				return [values[prometheus_name], 1]
 			except Exception as e:
-				self.log("Invalid instance given for metric on fetch: %s" \
-					% self.name)
+				self.log("Invalid instance given for metric on fetch: %s %d" \
+					% (self.name, inst))
 				return [c_api.PM_ERR_INST, 0]
 		else:
 			if inst != c_api.PM_INDOM_NULL:
@@ -538,13 +544,14 @@ class PrometheusSource(object):
 		self.metrics = []
 		self.metrics_by_id = {}
 		self.metrics_value = {}
+		self.metrics_by_name = {}
 		self.fetch_failed = False
 		self.numfetch = 0
 		self.metrics_cache = None
 		self.metadata = None
 		self.endpoint = None
 		self.filepath = None
-		self.load_metrics_metadata()
+		self.metadata = self.load_metrics_metadata()
 		self.prepare_passed = self.prepare_metrics_metadata()
 
 		if not self.prepare_passed:
@@ -563,7 +570,7 @@ class PrometheusSource(object):
 		self.__metric_cache = IndomCache(self.__cluster,
 										 MAX_METRIC, self.pmda)
 		self.__metric_cache.load()
-		self.metrics = self.parse_metrics_metadata(self.metadata)
+		self.metrics = self.parse_metrics_metadata(self.metadata.get("metrics"))
 		self.load_instance_domains(self.metrics)
 		self.load_metrics_idx(self.metrics)
 
@@ -589,7 +596,7 @@ class PrometheusSource(object):
 					 % self.path)
 			return
 		fobj.close()
-		self.metadata = metadata
+		return metadata
 
 	def prepare_metrics_metadata(self):
 		''' Parses the basic metadata of the source'''
@@ -610,9 +617,8 @@ class PrometheusSource(object):
 		self.filepath = metadata.get("filepath")
 		return True
 
-	def parse_metrics_metadata(self, metadata):
+	def parse_metrics_metadata(self, metrics_meta):
 		''' Parses, initializes and stores the metrics from metadata '''
-		metrics_meta = metadata.get("metrics")
 		if not metrics_meta:
 			self.log("Empty metadata for PrometheusPmda cofnig with path: %s"
 					 % self.path)
@@ -635,6 +641,7 @@ class PrometheusSource(object):
 			# Skip metrics without instances
 			if not metric.instances:
 				continue
+
 			# Indoms are stored as cluster_name.metric_name
 			full_name = "%s.%s" % (self.name, metric.name)
 			indom_idx = None
@@ -694,6 +701,15 @@ class PrometheusSource(object):
 								   metric.description)
 		self.metrics_by_id[metric.idx] = metric
 
+	def __remove_metric(self, name):
+		try:
+			id = self.__metric_cache.lookup_name(name)
+			metric = self.metrics_by_id[id]
+			self.pmda.remove_metric(metric.full_name, metric.obj)
+			self.metrics_by_id.pop(id)
+		except KeyError:
+			self.log("Attempting to remove metric which does not exist")
+
 	def parse_metrics_values(self, raw_data):
 		''' Parses the metric values from the raw data '''
 		lines = raw_data.splitlines()
@@ -719,13 +735,31 @@ class PrometheusSource(object):
 		except:
 			self.fetch_failed = True
 
+	def reload_metadata(self):
+		''' add/remove metrics by diffing metadatas '''
+		new_metadata = self.load_metrics_metadata()
+		old_metrics = self.metadata.get("metrics")
+		new_metrics = new_metadata.get("metrics")
+		(changes, metrics_meta_list, metrics_meta_map) \
+			 = diffMetadata(new_metrics, old_metrics)
+		if len(changes) == 0:
+			return
+		new_metrics_meta = []
+		for name in changes:
+			if name in metrics_meta_map:
+				new_metrics_meta.append(metrics_meta_map[name])
+			self.__remove_metric(name)
+		metrics = self.parse_metrics_metadata(new_metrics_meta)
+		self.load_instance_domains(metrics)
+		self.load_metrics_idx(metrics)
+		self.metadata = new_metadata
+
 	def fetch(self, item, inst):
 		''' Fetch called to fetch values of metrics of this cluster'''
 		# Refresh the metric values if the cluster is not refreshed recently
 		# Fetch fails when the metrics value could be refreshed
 		if self.fetch_failed:
 			return [c_api.PM_ERR_INST, 0]
-
 		if item not in self.metrics_by_id:
 			return [c_api.PM_ERR_PMID, 0]
 		return self.metrics_by_id[item].fetch(inst, self.metrics_value)
@@ -735,7 +769,7 @@ class PrometheusPMDA(PMDA):
 	def __init__(self, pmda_name, domain):
 		''' Initialize the PMDA'''
 		self.pmda_name = pmda_name
-		self.debug = ('PCP_PYTHON_DEBUG' in os.environ)
+		self.debug = True #('PCP_PYTHON_DEBUG' in os.environ)
 		PMDA.__init__(self, pmda_name, domain)
 		self.connect_pmcd()
 		self.numfetch = 0
@@ -743,6 +777,9 @@ class PrometheusPMDA(PMDA):
 		self.metadata_refresh_frequency = 60
 		self.endpoint_fetch_timeout = .5
 		self.last_refresh_time = 0
+		self.last_reload_time = 0
+		# delay the reload after metadata refresh
+		self.reload_delay = 60
 		self.refresh_process = None
 
 		pmdaDir = "%s/%s/metadata/" % (pmContext.pmGetConfig('PCP_PMDAS_DIR'), pmda_name)
@@ -758,6 +795,7 @@ class PrometheusPMDA(PMDA):
 		self.cluster_cache = IndomCache(0, MAX_CLUSTER, self, 2)
 		''' Indom 1 is reserved for storing the instance domains'''
 		self.indom_cache = IndomCache(1, MAX_INDOM, self, MAX_CLUSTER + 1)
+		self.indom_cache.load()
 
 		self.cluster_cache.load()
 		if self.cluster_cache.len() == 0:
@@ -768,6 +806,7 @@ class PrometheusPMDA(PMDA):
 		self.load_prometheus_sources()
 		self.set_fetch(self.prometheus_fetch)
 		self.set_refresh_all(self.refresh_all)
+		self.set_refresh_metrics(self.refresh_metrics)
 		self.set_fetch_callback(self.prometheus_fetch_callback)
 		self.set_store_callback(self.prometheus_store_callback)
 
@@ -890,8 +929,8 @@ class PrometheusPMDA(PMDA):
 		return c_api.PM_ERR_PMID
 
 	def refresh_metadata_helper(self):
-		currTime = time.time()
-		if (currTime - self.last_refresh_time) >= self.metadata_refresh_frequency:
+		curr_time = time.time()
+		if (curr_time - self.last_refresh_time) >= self.metadata_refresh_frequency:
 			if self.refresh_process is not None and \
 				self.refresh_process.is_alive() is True:
 				return
@@ -917,8 +956,8 @@ class PrometheusPMDA(PMDA):
 			scanner.raw_metrics = req.text
 			scanner.parse_raw()
 			new_metrics = scanner.exportMetrics()
-			(changes, metrics) = diffMetadata(self, new_metrics, \
-				 metadata.get('metrics'))
+			(changes, metrics, metrics_map) = diffMetadata(new_metrics, \
+				metadata.get('metrics'))
 
 			if len(changes) > 0:
 				metadata["metrics"] = metrics
@@ -956,6 +995,13 @@ class PrometheusPMDA(PMDA):
 		# Wait for all the threads to terminate
 		for t in threads:
 			t.join()
+
+	def refresh_metrics(self):
+		curr_time = time.time()
+		if (curr_time - self.last_reload_time) >= self.reload_delay:
+			self.last_reload_time = curr_time
+			for i in self.source_by_cluster:
+				self.source_by_cluster[i].reload_metadata()
 
 if __name__ == '__main__':
 	'''

--- a/src/pmdas/prometheus/pmdaprometheus.python
+++ b/src/pmdas/prometheus/pmdaprometheus.python
@@ -49,72 +49,38 @@ def diffMetadata(new_metrics, old_metrics):
 	''' diffMetadata finds new/removed metrics by diffing'''
 	if old_metrics is None:
 		old_metrics = []
-	changes_map = {}
+	changed_names = {}
 	old_metrics_map = {}
 	new_metrics_map = {}
+	final_metrics = {}
+
 	# Map old_metrics array into `name:metric`
 	for metric in old_metrics:
 		old_metrics_map[metric.get("name")] = metric
+
 	# Map new metrics array into `name:metrics`
 	for metric in new_metrics:
 		new_metrics_map[metric.get("name")] = metric
 
-	# Find newly added metrics/instances
+	# Find removed and instances updated metrics
+	for name in old_metrics_map:
+		metric = old_metrics_map[name]
+		if name not in new_metrics_map:
+			changed_names[name] = True
+			continue
+
+		if metric.get("instances") != new_metrics_map[name].get("instances"):
+			metric["instances"] = new_metrics_map[name].get("instances")
+			changed_names[name] = True
+
+		final_metrics[name] = metric
+
+	# Find newly added metrics
 	for name in new_metrics_map:
 		if name not in old_metrics_map:
-			changes_map[name] = True
-			old_metrics_map[name] = new_metrics_map[name]
-			continue
-		metric = new_metrics_map[name]
-		instances = metric.get("instances")
-		if instances is None:
-			continue
-		old_metric = old_metrics_map[name]
-		old_instances = old_metric.get("instances")
-		if old_instances is None or len(old_instances) == 0:
-			changes_map[name] = True
-			old_metric["instances"] = instances
-			continue
-		for instance in instances:
-			if instance not in old_instances:
-				changes_map[name] = True
-				old_instances.append(instance)
-
-	removed_names = []
-	# Find remove metrics/instances
-	for name in old_metrics_map:
-		if name not in new_metrics_map:
-			changes_map[name] = True
-			removed_names.append(name)
-			continue
-		old_metric = old_metrics_map[name]
-		old_instances = old_metric.get("instances")
-		if old_instances is None:
-			continue
-		metric = new_metrics_map[name]
-		instances = metric.get("instances")
-		if instances is None or len(instances) == 0:
-			changes_map[name] = True
-			old_metric["instances"] = None
-			old_metric["prometheus_name"] = name
-			continue
-		removed_instances = []
-		for instance in old_instances:
-			if instance not in instances:
-				removed_instances.append(instance)
-		if len(removed_instances) > 0:
-			changes_map[name] = True
-			for instance in removed_instances:
-				old_instances.remove(instance)
-
-	for name in removed_names:
-		old_metrics_map.pop(name)
-	# Flatten map into array
-	metrics_arr = []
-	for i in old_metrics_map:
-		metrics_arr.append(old_metrics_map[i])
-
-	return (changes_map, metrics_arr, old_metrics_map)
+			changed_names[name] = True
+			final_metrics[name] = new_metrics_map[name]
+	return (changed_names, final_metrics)
 
 
 class ScanPrometheus(object):
@@ -574,6 +540,7 @@ class PrometheusSource(object):
 		self.metadata = None
 		self.endpoint = None
 		self.filepath = None
+		self.metadata_mtime = os.stat(path).st_mtime
 		self.metadata = self.load_metrics_metadata()
 		self.prepare_passed = self.prepare_metrics_metadata()
 
@@ -615,8 +582,8 @@ class PrometheusSource(object):
 		try:
 			metadata = json.load(fobj)
 		except ValueError:
-			self.log("Couldn't parse Prometheus metadata from %s"
-					 % self.path)
+			self.log("Couldn't parse Prometheus metadata from %s %s"
+					 % (self.path, str(e)))
 			return
 		fobj.close()
 		return metadata
@@ -642,9 +609,8 @@ class PrometheusSource(object):
 
 	def parse_metrics_metadata(self, metrics_meta):
 		''' Parses, initializes and stores the metrics from metadata '''
-		if not metrics_meta:
-			self.log("Empty metadata for PrometheusPmda cofnig with path: %s"
-					 % self.path)
+		if metrics_meta is None:
+			self.log("Invalid metadata")
 			return
 		metrics = []
 		full_name = "%s.%s" % (self.pmda.pmda_name, self.name)
@@ -754,26 +720,32 @@ class PrometheusSource(object):
 				data = open(self.filepath,'r').read()
 				self.parse_metrics_values(data)
 				self.fetch_failed = False
-		except:
+		except Exception as e:
+			self.log(str(e))
 			self.fetch_failed = True
 
 	def reload_metadata(self):
 		''' add/remove metrics by diffing metadatas '''
+		if os.stat(self.path).st_mtime <= self.metadata_mtime:
+			return
+		self.metadata_mtime = os.stat(self.path).st_mtime
 		new_metadata = self.load_metrics_metadata()
 		old_metrics = self.metadata.get("metrics")
 		new_metrics = new_metadata.get("metrics")
-		(changes, metrics_meta_list, metrics_meta_map) \
-			 = diffMetadata(new_metrics, old_metrics)
+		(changes, metrics) = diffMetadata(new_metrics, old_metrics)
 		if len(changes) == 0:
 			return
-		new_metrics_meta = []
+		self.metadata = new_metadata
+		updated_metrics = []
 		for name in changes:
-			if name in metrics_meta_map:
-				new_metrics_meta.append(metrics_meta_map[name])
-		metrics = self.parse_metrics_metadata(new_metrics_meta)
+			self.__remove_metric(name)
+			if name in metrics:
+				updated_metrics.append(metrics[name])
+		if len(updated_metrics) == 0:
+			return
+		metrics = self.parse_metrics_metadata(updated_metrics)
 		self.load_instance_domains(metrics)
 		self.load_metrics_idx(metrics)
-		self.metadata = new_metadata
 
 	def fetch(self, item, inst):
 		''' Fetch called to fetch values of metrics of this cluster'''
@@ -790,13 +762,12 @@ class PrometheusPMDA(PMDA):
 	def __init__(self, pmda_name, domain):
 		''' Initialize the PMDA'''
 		self.pmda_name = pmda_name
-		self.debug = True #('PCP_PYTHON_DEBUG' in os.environ)
+		self.debug = ('PCP_PYTHON_DEBUG' in os.environ)
 		PMDA.__init__(self, pmda_name, domain)
 		self.connect_pmcd()
 		self.numfetch = 0
 		self.num_threads = 8
 		self.metadata_refresh_frequency = 120
-		self.metadata_reload_delay = 10
 		self.endpoint_fetch_timeout = .5
 		self.last_refresh_time = 0
 		self.last_reload_time = 0
@@ -851,22 +822,11 @@ class PrometheusPMDA(PMDA):
 		self.add_metric(metric_info.full_name, metric_info.obj,
 						metric_info.description)
 
-
-		metric_info = Metric(self.pmda_name + '.config', 0, self)
-		metric_info.name = 'metadata_reload_delay'
-		metric_info.type = c_api.PM_TYPE_FLOAT
-		metric_info.description = 'Delay in reloading metadata after \
-			refreshing metadata in seconds'
-		metric_info.idx = 2
-		metric_info.create()
-		self.add_metric(metric_info.full_name, metric_info.obj,
-						metric_info.description)
-
 		metric_info = Metric(self.pmda_name + '.config', 0, self)
 		metric_info.name = 'endpoint_fetch_timeout'
 		metric_info.type = c_api.PM_TYPE_FLOAT
 		metric_info.description = 'Timeout on endpoint fetch in seconds'
-		metric_info.idx = 3
+		metric_info.idx = 2
 		metric_info.create()
 		self.add_metric(metric_info.full_name, metric_info.obj,
 						metric_info.description)
@@ -936,8 +896,6 @@ class PrometheusPMDA(PMDA):
 			elif item == 1:
 				return [self.metadata_refresh_frequency, 1]
 			elif item == 2:
-				return [self.metadata_reload_delay, 1]
-			elif item == 3:
 				return [self.endpoint_fetch_timeout, 1]
 			else:
 				return [c_api.PM_ERR_PMID, 0]
@@ -955,9 +913,6 @@ class PrometheusPMDA(PMDA):
 				return 1
 			elif item == 2:
 				self.metadata_reload_delay = value
-				return 1
-			elif item == 3:
-				self.endpoint_fetch_timeout = value
 				return 1
 			else:
 				return c_api.PM_ERR_PMID
@@ -991,11 +946,14 @@ class PrometheusPMDA(PMDA):
 			scanner.raw_metrics = req.text
 			scanner.parse_raw()
 			new_metrics = scanner.exportMetrics()
-			(changes, metrics, metrics_map) = diffMetadata(new_metrics, \
+			(changes, metrics) = diffMetadata(new_metrics, \
 				metadata.get('metrics'))
 
 			if len(changes) > 0:
-				metadata["metrics"] = metrics
+				metrics_arr = []
+				for name in metrics:
+					metrics_arr.append(metrics[name])
+				metadata["metrics"] = metrics_arr
 				with open(source.path, "w") as f:
 					f.write(json.dumps(metadata, indent=2))
 					f.close()
@@ -1033,7 +991,10 @@ class PrometheusPMDA(PMDA):
 
 	def refresh_metrics(self):
 		''' Reload metadata of each source'''
-		if (self.last_refresh_time - self.last_reload_time) >= self.metadata_reload_delay:
+		if self.refresh_process is not None and \
+				self.refresh_process.is_alive() is True:
+				return
+		if  self.last_refresh_time >= self.last_reload_time:
 			self.last_reload_time = time.time()
 			for i in self.source_by_cluster:
 				try:

--- a/src/pmdas/prometheus/pmdaprometheus.python
+++ b/src/pmdas/prometheus/pmdaprometheus.python
@@ -698,6 +698,12 @@ class PrometheusSource(object):
 		except KeyError:
 			pass
 
+	def remove_all(self):
+		for id in self.metrics_by_id:
+			metric = self.metrics_by_id[id]
+			self.pmda.remove_metric(metric.full_name, metric.obj)
+		self.metrics_by_id = {}
+
 	def parse_metrics_values(self, raw_data):
 		''' Parses the metric values from the raw data '''
 		lines = raw_data.splitlines()
@@ -778,6 +784,7 @@ class PrometheusPMDA(PMDA):
 		self.dir_mtime = os.stat(self.dir).st_mtime
 		self.source_by_cluster = {}
 		self.source_by_name = {}
+		self.source_by_path = {}
 
 		# Cluster cache stores the indoms of clusters
 		# Indom values start from 2 as Indom 1 is reserved for internal metrics
@@ -833,10 +840,14 @@ class PrometheusPMDA(PMDA):
 
 	def load_prometheus_sources(self):
 		''' Initializes the PrometheusSource for all the Prometheus sources '''
+		paths_seen = []
 		new_source_seen = False
 		for root, dirs, files in os.walk(self.dir):
 			for file in files:
 				path = os.path.join(root, file)
+				paths_seen.append(path)
+				if path in self.source_by_path:
+					continue
 				source = PrometheusSource(path, self)
 				if not source.name:
 					continue
@@ -867,9 +878,18 @@ class PrometheusPMDA(PMDA):
 				source.cluster = cluster_idx
 				self.source_by_cluster[cluster_idx] = source
 				self.source_by_name[source.name] = source
+				self.source_by_path[path] = source
 				new_source_seen = True
 		if new_source_seen:
 			self.cluster_cache.refresh()
+		# Remove sources whose metadata has been deleted
+		for path in self.source_by_path:
+			if path not in paths_seen:
+				source = self.source_by_path[path]
+				source.remove_all()
+				self.source_by_path.pop(path)
+				self.source_by_cluster.pop(source.cluster)
+				self.source_by_name.pop(source.name)
 
 	def prometheus_fetch(self):
 		''' Called once before calling prometheus_fetch_callback '''
@@ -877,10 +897,7 @@ class PrometheusPMDA(PMDA):
 		# Lookup the metadata directory for any new source
 		if self.dir_mtime < os.stat(self.dir).st_mtime:
 			self.dir_mtime = os.stat(self.dir).st_mtime
-			self.reset_metrics()
-			self.add_static_metrics()
 			self.load_prometheus_sources()
-			self.pmns_refresh()
 		# Count the number of times fetch called
 		self.numfetch += 1
 

--- a/src/pmdas/prometheus/pmdaprometheus.python
+++ b/src/pmdas/prometheus/pmdaprometheus.python
@@ -509,8 +509,12 @@ class IndomCache(pmdaIndom):
 			self.cache_load()
 		except pmErr:
 			return
-		for (inst, name) in self.get_all_instances():
+		self.cache_mark_active()
+
+		for (inst, name) in self:
 			self.add_value_inactive(name)
+
+		self.cache_mark_inactive()
 
 	def next_value(self):
 		''' Return next value to be allocated. '''

--- a/src/pmdas/prometheus/pmdaprometheus.python
+++ b/src/pmdas/prometheus/pmdaprometheus.python
@@ -25,10 +25,12 @@ from collections import OrderedDict
 from ctypes import c_int
 import copy
 import errno
+import math
 import json
 import os
 import re
 import requests
+import threading
 
 MAX_CLUSTER = 0xfff
 MAX_METRIC = 0x3ff
@@ -641,10 +643,6 @@ class PrometheusSource(object):
 	def fetch(self, item, inst):
 		''' Fetch called to fetch values of metrics of this cluster'''
 		# Refresh the metric values if the cluster is not refreshed recently
-		if self.pmda.numfetch > self.numfetch:
-			self.refresh_metrics()
-			self.numfetch = self.pmda.numfetch
-
 		# Fetch fails when the metrics value could be refreshed
 		if self.fetch_failed:
 			return [c_api.PM_ERR_INST, 0]
@@ -662,6 +660,7 @@ class PrometheusPMDA(PMDA):
 		PMDA.__init__(self, pmda_name, domain)
 		self.connect_pmcd()
 		self.numfetch = 0
+		self.num_threads = 8
 
 		pmdaDir = "%s/%s/metadata/" % (pmContext.pmGetConfig('PCP_PMDAS_DIR'), pmda_name)
 		self.dir = pmdaDir
@@ -685,6 +684,7 @@ class PrometheusPMDA(PMDA):
 		self.add_static_metrics()
 		self.load_prometheus_sources()
 		self.set_fetch(self.prometheus_fetch)
+		self.set_refresh_all(self.refresh_all)
 		self.set_fetch_callback(self.prometheus_fetch_callback)
 
 	def add_static_metrics(self):
@@ -756,7 +756,7 @@ class PrometheusPMDA(PMDA):
 	def prometheus_fetch_callback(self, cluster, item, inst):
 		''' Main fetch callback which returns the value of the metric '''
 		# cluster 0 is reserved for the static metrics
-		self.log("requesting " + str(item) + " cluster" + str(cluster))
+		# self.log("requesting " + str(item) + " cluster" + str(cluster))
 		if cluster == 0:
 			if item != 0 or inst != c_api.PM_IN_NULL:
 				return [c_api.PM_ERR_PMID, 0]
@@ -765,6 +765,29 @@ class PrometheusPMDA(PMDA):
 		elif cluster in self.source_by_cluster:
 			return self.source_by_cluster[cluster].fetch(item, inst)
 		return [c_api.PM_ERR_PMID, 1]
+
+	def refresh_worker(self, *clusters):
+		for i in clusters:
+			if i==0:
+				continue
+			self.source_by_cluster[i].refresh_metrics()
+
+	def refresh_all(self, clusters):
+		self.log("Here")
+		slicelen = math.ceil(len(clusters)/float(self.num_threads))
+		index = 0
+		threads = []
+		for i in range(self.num_threads):
+			if index >= len(clusters):
+				break
+			t = threading.Thread(target=self.refresh_worker,
+					args = clusters[index:index + slicelen])
+			index += slicelen
+			threads.append(t)
+			t.daemon = True
+			t.start()
+		for t in threads:
+			t.join()
 
 if __name__ == '__main__':
 	'''

--- a/src/pmdas/prometheus/pmdaprometheus.python
+++ b/src/pmdas/prometheus/pmdaprometheus.python
@@ -304,7 +304,6 @@ class Metric(object):
 		indom.load()
 		self.__indom_cache = indom
 		for inst in self.instances:
-			self.log("instance add hoing --> %s"%(inst["name"]))
 			try:
 				id = self.__indom_cache.lookup_name(inst["name"])
 			except KeyError:
@@ -430,6 +429,7 @@ class IndomCache(pmdaIndom):
 		# active state from python is a bit tricky. '__active_values'
 		# contains a dictionary of active values.
 		self.__active_values = OrderedDict()
+		self.__inactive_values = OrderedDict()
 
 		pmdaIndom.__init__(self, pmda.indom(self.serial), self.__values)
 		try:
@@ -441,6 +441,7 @@ class IndomCache(pmdaIndom):
 		self.__maxval = max_value
 		self.cache_resize(max_value)
 		self.__nextval = min_value
+		self.min_value = min_value
 
 	@property
 	def indom(self):
@@ -468,6 +469,22 @@ class IndomCache(pmdaIndom):
 			self.__nextval = value + 1
 		self.__names_by_values[value] = name
 
+	def add_value_if_not_exists(self, name, value):
+		''' Add a value to the indom if it does not exist already'''
+		if name in self.__inactive_values:
+			value = self.__inactive_values[name]
+			self.__values[name] = c_int(value)
+			self.__names_by_values[value] = name
+			self.__inactive_values.pop(name)
+		elif name not in self.__values:
+			self.add_value(name, value)
+
+	def add_value_inactive(self, name):
+		'''Add a value to the inactive dict'''
+		# Used to store all the inactive values on cache load
+		value = self.next_value()
+		self.__inactive_values[name] = value
+
 	def set_active(self, name):
 		''' Mark a indom as active. '''
 		if name not in self.__values:
@@ -477,7 +494,14 @@ class IndomCache(pmdaIndom):
 	def lookup_name(self, name):
 		'''
 		Lookup name in an indom cache and return its associated value.
+		If name found in inactive values, add it to values and return it's value.
 		'''
+		if name in self.__inactive_values:
+			value = self.__inactive_values[name]
+			self.__values[name] = c_int(value)
+			self.__names_by_values[value] = name
+			self.__inactive_values.pop(name)
+			return value
 		if name not in self.__values:
 			raise KeyError(name)
 		valueobj = self.__values[name]
@@ -519,8 +543,8 @@ class IndomCache(pmdaIndom):
 			self.cache_load()
 		except pmErr:
 			return
-		for (inst, name) in self:
-			self.add_value(name, inst)
+		for (inst, name) in self.get_all_instances():
+			self.add_value_inactive(name)
 
 	def next_value(self):
 		''' Return next value to be allocated. '''
@@ -544,7 +568,6 @@ class PrometheusSource(object):
 		self.metrics = []
 		self.metrics_by_id = {}
 		self.metrics_value = {}
-		self.metrics_by_name = {}
 		self.fetch_failed = False
 		self.numfetch = 0
 		self.metrics_cache = None
@@ -657,7 +680,6 @@ class PrometheusSource(object):
 					self.log("Skipping instance domain in '%s' -"
 						" max instance domains reached" % full_name)
 					break
-
 			indom = IndomCache(indom_idx, MAX_INDOM, self.pmda)
 			metric.indom_cache = indom
 		# Stores the cached indoms
@@ -708,7 +730,7 @@ class PrometheusSource(object):
 			self.pmda.remove_metric(metric.full_name, metric.obj)
 			self.metrics_by_id.pop(id)
 		except KeyError:
-			self.log("Attempting to remove metric which does not exist")
+			pass
 
 	def parse_metrics_values(self, raw_data):
 		''' Parses the metric values from the raw data '''
@@ -748,7 +770,6 @@ class PrometheusSource(object):
 		for name in changes:
 			if name in metrics_meta_map:
 				new_metrics_meta.append(metrics_meta_map[name])
-			self.__remove_metric(name)
 		metrics = self.parse_metrics_metadata(new_metrics_meta)
 		self.load_instance_domains(metrics)
 		self.load_metrics_idx(metrics)
@@ -774,12 +795,11 @@ class PrometheusPMDA(PMDA):
 		self.connect_pmcd()
 		self.numfetch = 0
 		self.num_threads = 8
-		self.metadata_refresh_frequency = 60
+		self.metadata_refresh_frequency = 120
+		self.metadata_reload_delay = 10
 		self.endpoint_fetch_timeout = .5
 		self.last_refresh_time = 0
 		self.last_reload_time = 0
-		# delay the reload after metadata refresh
-		self.reload_delay = 60
 		self.refresh_process = None
 
 		pmdaDir = "%s/%s/metadata/" % (pmContext.pmGetConfig('PCP_PMDAS_DIR'), pmda_name)
@@ -792,15 +812,14 @@ class PrometheusPMDA(PMDA):
 		# Indom values start from 2 as Indom 1 is reserved for internal metrics
 		# Indom 2 is reserved for caching  the indoms metrics with indoms
 		# across all the clusters
-		self.cluster_cache = IndomCache(0, MAX_CLUSTER, self, 2)
+		self.cluster_cache = IndomCache(0, MAX_CLUSTER, self, 0)
+		self.cluster_cache.load()
 		''' Indom 1 is reserved for storing the instance domains'''
 		self.indom_cache = IndomCache(1, MAX_INDOM, self, MAX_CLUSTER + 1)
 		self.indom_cache.load()
 
-		self.cluster_cache.load()
-		if self.cluster_cache.len() == 0:
-			self.cluster_cache.add_value('__internal__', 0)
-			self.cluster_cache.add_value('__indom_cache__', 1)
+		self.cluster_cache.add_value_if_not_exists('__internal__', 0)
+		self.cluster_cache.add_value_if_not_exists('__indom_cache__', 1)
 
 		self.add_static_metrics()
 		self.load_prometheus_sources()
@@ -832,11 +851,22 @@ class PrometheusPMDA(PMDA):
 		self.add_metric(metric_info.full_name, metric_info.obj,
 						metric_info.description)
 
+
+		metric_info = Metric(self.pmda_name + '.config', 0, self)
+		metric_info.name = 'metadata_reload_delay'
+		metric_info.type = c_api.PM_TYPE_FLOAT
+		metric_info.description = 'Delay in reloading metadata after \
+			refreshing metadata in seconds'
+		metric_info.idx = 2
+		metric_info.create()
+		self.add_metric(metric_info.full_name, metric_info.obj,
+						metric_info.description)
+
 		metric_info = Metric(self.pmda_name + '.config', 0, self)
 		metric_info.name = 'endpoint_fetch_timeout'
 		metric_info.type = c_api.PM_TYPE_FLOAT
 		metric_info.description = 'Timeout on endpoint fetch in seconds'
-		metric_info.idx = 2
+		metric_info.idx = 3
 		metric_info.create()
 		self.add_metric(metric_info.full_name, metric_info.obj,
 						metric_info.description)
@@ -906,6 +936,8 @@ class PrometheusPMDA(PMDA):
 			elif item == 1:
 				return [self.metadata_refresh_frequency, 1]
 			elif item == 2:
+				return [self.metadata_reload_delay, 1]
+			elif item == 3:
 				return [self.endpoint_fetch_timeout, 1]
 			else:
 				return [c_api.PM_ERR_PMID, 0]
@@ -922,6 +954,9 @@ class PrometheusPMDA(PMDA):
 				self.metadata_refresh_frequency = value
 				return 1
 			elif item == 2:
+				self.metadata_reload_delay = value
+				return 1
+			elif item == 3:
 				self.endpoint_fetch_timeout = value
 				return 1
 			else:
@@ -997,11 +1032,14 @@ class PrometheusPMDA(PMDA):
 			t.join()
 
 	def refresh_metrics(self):
-		curr_time = time.time()
-		if (curr_time - self.last_reload_time) >= self.reload_delay:
-			self.last_reload_time = curr_time
+		''' Reload metadata of each source'''
+		if (self.last_refresh_time - self.last_reload_time) >= self.metadata_reload_delay:
+			self.last_reload_time = time.time()
 			for i in self.source_by_cluster:
-				self.source_by_cluster[i].reload_metadata()
+				try:
+					self.source_by_cluster[i].reload_metadata()
+				except:
+					pass
 
 if __name__ == '__main__':
 	'''

--- a/src/pmdas/prometheus/pmdaprometheus.python
+++ b/src/pmdas/prometheus/pmdaprometheus.python
@@ -630,7 +630,8 @@ class PrometheusSource(object):
 		''' Refreshes the metric values of this cluster'''
 		try:
 			if self.endpoint:
-				req = requests.get(self.endpoint)
+				req = requests.get(self.endpoint, \
+					timeout=self.pmda.endpoint_fetch_timeout)
 				self.parse_metrics_values(req.text)
 				self.fetch_failed = False
 			else:
@@ -661,6 +662,8 @@ class PrometheusPMDA(PMDA):
 		self.connect_pmcd()
 		self.numfetch = 0
 		self.num_threads = 8
+		self.metadata_refresh_frequency = 120
+		self.endpoint_fetch_timeout = .5
 
 		pmdaDir = "%s/%s/metadata/" % (pmContext.pmGetConfig('PCP_PMDAS_DIR'), pmda_name)
 		self.dir = pmdaDir
@@ -686,6 +689,7 @@ class PrometheusPMDA(PMDA):
 		self.set_fetch(self.prometheus_fetch)
 		self.set_refresh_all(self.refresh_all)
 		self.set_fetch_callback(self.prometheus_fetch_callback)
+		self.set_store_callback(self.prometheus_store_callback)
 
 	def add_static_metrics(self):
 		'''
@@ -696,6 +700,24 @@ class PrometheusPMDA(PMDA):
 		metric_info.type = c_api.PM_TYPE_64
 		metric_info.description = 'Number of times data fetched'
 		metric_info.idx = 0
+		metric_info.create()
+		self.add_metric(metric_info.full_name, metric_info.obj,
+						metric_info.description)
+
+		metric_info = Metric(self.pmda_name + '.config', 0, self)
+		metric_info.name = 'metadata_refresh_frequency'
+		metric_info.type = c_api.PM_TYPE_64
+		metric_info.description = 'Frequency of refreshing  metadata in seconds'
+		metric_info.idx = 1
+		metric_info.create()
+		self.add_metric(metric_info.full_name, metric_info.obj,
+						metric_info.description)
+
+		metric_info = Metric(self.pmda_name + '.config', 0, self)
+		metric_info.name = 'endpoint_fetch_timeout'
+		metric_info.type = c_api.PM_TYPE_FLOAT
+		metric_info.description = 'Timeout on endpoint fetch in seconds'
+		metric_info.idx = 2
 		metric_info.create()
 		self.add_metric(metric_info.full_name, metric_info.obj,
 						metric_info.description)
@@ -758,13 +780,34 @@ class PrometheusPMDA(PMDA):
 		# cluster 0 is reserved for the static metrics
 		# self.log("requesting " + str(item) + " cluster" + str(cluster))
 		if cluster == 0:
-			if item != 0 or inst != c_api.PM_IN_NULL:
+			if inst != c_api.PM_IN_NULL:
 				return [c_api.PM_ERR_PMID, 0]
-			else:
+			elif item == 0:
 				return [self.numfetch, 1]
+			elif item == 1:
+				return [self.metadata_refresh_frequency, 1]
+			elif item == 2:
+				return [self.endpoint_fetch_timeout, 1]
+			else:
+				return [c_api.PM_ERR_PMID, 0]
 		elif cluster in self.source_by_cluster:
 			return self.source_by_cluster[cluster].fetch(item, inst)
 		return [c_api.PM_ERR_PMID, 1]
+
+	def prometheus_store_callback(self, cluster, item, inst, value):
+		''' Main store callback which stores the value of the metric'''
+		if inst != c_api.PM_IN_NULL:
+			return c_api.PM_ERR_PMID
+		if cluster == 0:
+			if item == 1:
+				self.metadata_refresh_frequency = value
+				return 1
+			elif item == 2:
+				self.endpoint_fetch_timeout = value
+				return 1
+			else:
+				return c_api.PM_ERR_PMID
+		return c_api.PM_ERR_PMID
 
 	def refresh_worker(self, *clusters):
 		for i in clusters:
@@ -773,10 +816,14 @@ class PrometheusPMDA(PMDA):
 			self.source_by_cluster[i].refresh_metrics()
 
 	def refresh_all(self, clusters):
-		self.log("Here")
+		''' Called once before fetch callbacks
+			Creates threads to parallely update the metric values
+		'''
+		# slicelen defines the number of clusters each thread should handle
 		slicelen = math.ceil(len(clusters)/float(self.num_threads))
 		index = 0
 		threads = []
+
 		for i in range(self.num_threads):
 			if index >= len(clusters):
 				break
@@ -786,6 +833,8 @@ class PrometheusPMDA(PMDA):
 			threads.append(t)
 			t.daemon = True
 			t.start()
+
+		# Wait for all the threads to terminate
 		for t in threads:
 			t.join()
 

--- a/src/pmdas/prometheus/pmdaprometheus.python
+++ b/src/pmdas/prometheus/pmdaprometheus.python
@@ -29,8 +29,10 @@ import math
 import json
 import os
 import re
+import time
 import requests
 import threading
+from multiprocessing import Process
 
 MAX_CLUSTER = 0xfff
 MAX_METRIC = 0x3ff
@@ -43,6 +45,74 @@ INSTANT = "instantaneous"
 TYPES = { DOUBLE: c_api.PM_TYPE_DOUBLE, UINT: c_api.PM_TYPE_U64 }
 SEMANTICS = { COUNTER: c_api.PM_SEM_COUNTER, INSTANT: c_api.PM_SEM_INSTANT }
 
+def diffMetadata(self, new_metrics, old_metrics):
+	''' diffMetadata finds new/removed metrics by diffing'''
+	if old_metrics is None:
+		old_metrics = []
+	changes_map = {}
+	old_metrics_map = {}
+	new_metrics_map = {}
+	# Map old_metrics array into `name:metric`
+	for metric in old_metrics:
+		old_metrics_map[metric.get("name")] = metric
+	# Map new metrics array into `name:metrics`
+	for metric in new_metrics:
+		new_metrics_map[metric.get("name")] = metric
+
+	# Find newly added metrics/instances
+	for name in new_metrics_map:
+		if name not in old_metrics_map:
+			changes_map[name] = True
+			old_metrics_map[name] = new_metrics_map[name]
+			continue
+		metric = new_metrics_map[name]
+		instances = metric.get("instances")
+		if instances is None:
+			continue
+		old_metric = old_metrics_map[name]
+		old_instances = old_metric.get("instances")
+		if old_instances is None or len(old_instances) == 0:
+			changes_map[name] = True
+			old_metric["instances"] = instances
+			continue
+		for instance in instances:
+			if instance not in old_instances:
+				changes_map[name] = True
+				old_instances.append(instance)
+
+	# Find remove metrics/instances
+	for name in old_metrics_map:
+		if name not in new_metrics_map:
+			changes_map[name] = True
+			old_metrics_map.pop(name)
+			continue
+		old_metric = old_metrics_map[name]
+		old_instances = old_metric.get("instances")
+		if old_instances is None:
+			continue
+		metric = new_metrics_map[name]
+		instances = metric.get("instances")
+		if instances is None or len(instances) == 0:
+			changes_map[name] = True
+			old_metric["instances"] = None
+			continue
+		removed_instances = []
+		for instance in old_instances:
+			if instance not in instances:
+				removed_instances.append(instance)
+		if len(removed_instances) > 0:
+			changes_map[name] = True
+			for instance in removed_instances:
+				old_instances.remove(instance)
+
+	# Flatten map into array
+	metrics_arr = []
+	for i in old_metrics_map:
+		metrics_arr.append(old_metrics_map[i])
+
+	return (changes_map, metrics_arr)
+
+
 class ScanPrometheus(object):
 	''' Scans Prometheus Endpoint to Generate Metadata for the given endpoint'''
 
@@ -52,6 +122,8 @@ class ScanPrometheus(object):
 		self.filepath = filepath
 		self.raw_metrics = None
 		self.metrics_by_name = {}
+
+	def run(self):
 		self.fetch_raw_metrics()
 		self.parse_raw()
 		self.save_metadata()
@@ -82,15 +154,19 @@ class ScanPrometheus(object):
 					metadata[key] = self.__dict__[key]
 			return metadata
 
+	def exportMetrics(self):
+		metrics = []
+		for k in self.metrics_by_name:
+			metrics.append(self.metrics_by_name[k].export())
+		return metrics
+
 	def save_metadata(self):
 		# Saves the metadata of the Prometheus endpoint in PCP_PMDAS_DIR
-		config = { "name": self.name, "metrics": [] }
+		config = { "name": self.name, "metrics": self.exportMetrics() }
 		if self.filepath:
 			config["filepath"] = os.path.abspath(self.filepath)
 		else:
 			config["endpoint"] = self.endpoint
-		for k in self.metrics_by_name:
-			config["metrics"].append(self.metrics_by_name[k].export())
 		raw_config = json.dumps(config, indent=2)
 		filename = os.getenv('PCP_PMDAS_DIR') + \
 					"/prometheus/metadata/" + self.name + ".json"
@@ -171,7 +247,8 @@ class ScanPrometheus(object):
 		lines = self.raw_metrics.splitlines()
 		lineIter = 0
 		while lineIter<len(lines):
-			if lines[lineIter][0] != "#" or lines[lineIter+1][0] != '#':
+			if len(lines[lineIter]) == 0 or lines[lineIter][0] != "#" \
+				or lines[lineIter+1][0] != '#':
 				raise ValueError("Invalid format of Prometheus metrics metadata"
 					"\n%s" %(lines[lineIter]))
 			metricLines = [lines[lineIter], lines[lineIter+1]]
@@ -486,9 +563,9 @@ class PrometheusSource(object):
 		self.__metric_cache = IndomCache(self.__cluster,
 										 MAX_METRIC, self.pmda)
 		self.__metric_cache.load()
-		self.parse_metrics_metadata()
-		self.load_instance_domains()
-		self.load_metrics_idx()
+		self.metrics = self.parse_metrics_metadata(self.metadata)
+		self.load_instance_domains(self.metrics)
+		self.load_metrics_idx(self.metrics)
 
 	def log(self, string):
 		''' Log an informational message '''
@@ -533,9 +610,9 @@ class PrometheusSource(object):
 		self.filepath = metadata.get("filepath")
 		return True
 
-	def parse_metrics_metadata(self):
+	def parse_metrics_metadata(self, metadata):
 		''' Parses, initializes and stores the metrics from metadata '''
-		metrics_meta = self.metadata.get("metrics")
+		metrics_meta = metadata.get("metrics")
 		if not metrics_meta:
 			self.log("Empty metadata for PrometheusPmda cofnig with path: %s"
 					 % self.path)
@@ -550,11 +627,11 @@ class PrometheusSource(object):
 			except Exception as e:
 				self.log("Unable to parse metric for Prometheus PMDA: %s"
 						% meta)
-		self.metrics = metrics
+		return metrics
 
-	def load_instance_domains(self):
+	def load_instance_domains(self, metrics):
 		''' Assigns indoms to the metrics with instances '''
-		for metric in self.metrics:
+		for metric in metrics:
 			# Skip metrics without instances
 			if not metric.instances:
 				continue
@@ -579,9 +656,9 @@ class PrometheusSource(object):
 		# Stores the cached indoms
 		self.pmda.indom_cache.refresh()
 
-	def load_metrics_idx(self):
+	def load_metrics_idx(self, metrics):
 		''' Loads the metrics with pmid and adds them to the PMDA'''
-		for metric in self.metrics:
+		for metric in metrics:
 			name = metric.name
 
 			# Assigns the id to a metric and stores in the metric cache
@@ -620,6 +697,7 @@ class PrometheusSource(object):
 	def parse_metrics_values(self, raw_data):
 		''' Parses the metric values from the raw data '''
 		lines = raw_data.splitlines()
+		self.metrics_value = {}
 		for line in lines:
 			tokens = line.split(' ')
 			if tokens[0] == '#':
@@ -662,8 +740,10 @@ class PrometheusPMDA(PMDA):
 		self.connect_pmcd()
 		self.numfetch = 0
 		self.num_threads = 8
-		self.metadata_refresh_frequency = 120
+		self.metadata_refresh_frequency = 60
 		self.endpoint_fetch_timeout = .5
+		self.last_refresh_time = 0
+		self.refresh_process = None
 
 		pmdaDir = "%s/%s/metadata/" % (pmContext.pmGetConfig('PCP_PMDAS_DIR'), pmda_name)
 		self.dir = pmdaDir
@@ -764,7 +844,7 @@ class PrometheusPMDA(PMDA):
 
 	def prometheus_fetch(self):
 		''' Called once before calling prometheus_fetch_callback '''
-
+		self.refresh_metadata_helper()
 		# Lookup the metadata directory for any new source
 		if self.dir_mtime < os.stat(self.dir).st_mtime:
 			self.dir_mtime = os.stat(self.dir).st_mtime
@@ -809,7 +889,46 @@ class PrometheusPMDA(PMDA):
 				return c_api.PM_ERR_PMID
 		return c_api.PM_ERR_PMID
 
+	def refresh_metadata_helper(self):
+		currTime = time.time()
+		if (currTime - self.last_refresh_time) >= self.metadata_refresh_frequency:
+			if self.refresh_process is not None and \
+				self.refresh_process.is_alive() is True:
+				return
+			self.refresh_process = Process(target=self.refresh_metadata)
+			self.refresh_process.start()
+			self.last_refresh_time = time.time()
+
+
+	def refresh_metadata(self):
+		if len(self.source_by_cluster) == 0:
+			return
+		for i in self.source_by_cluster:
+			source = self.source_by_cluster[i]
+			metadata = source.metadata
+			data = None
+			try:
+				req = requests.get(source.endpoint, \
+					timeout=self.endpoint_fetch_timeout)
+				data = req.text
+			except:
+				continue
+			scanner = ScanPrometheus('')
+			scanner.raw_metrics = req.text
+			scanner.parse_raw()
+			new_metrics = scanner.exportMetrics()
+			(changes, metrics) = diffMetadata(self, new_metrics, \
+				 metadata.get('metrics'))
+
+			if len(changes) > 0:
+				metadata["metrics"] = metrics
+				with open(source.path, "w") as f:
+					f.write(json.dumps(metadata, indent=2))
+					f.close()
+
+
 	def refresh_worker(self, *clusters):
+		''' Worker targeted by refresh_all() to refresh metrics values'''
 		for i in clusters:
 			if i==0:
 				continue
@@ -856,6 +975,7 @@ if __name__ == '__main__':
 		if not ( args.url or args.filepath ) or not args.name:
 			parser.error("Name and url or filepath of the endpoint required")
 			os.exit(1)
-		ScanPrometheus(args.name, args.url, args.filepath)
+		scan = ScanPrometheus(args.name, args.url, args.filepath)
+		scan.run()
 	else:
 		PrometheusPMDA('prometheus', 144).run()

--- a/src/python/pcp/pmda.py
+++ b/src/python/pcp/pmda.py
@@ -446,6 +446,10 @@ class PMDA(MetricDispatch):
         return cpmda.set_store_callback(store_callback)
 
     @staticmethod
+    def set_refresh_all(refresh_all):
+        return cpmda.set_refresh_all(refresh_all)
+
+    @staticmethod
     def set_refresh_metrics(refresh_metrics):
         return cpmda.set_refresh_metrics(refresh_metrics)
 

--- a/src/python/pcp/pmda.py
+++ b/src/python/pcp/pmda.py
@@ -108,7 +108,7 @@ class pmdaIndom(Structure):
 
     def __iter__(self):
         # Generates an iterator for the cache.
-        if self.it_numinst < 0:
+        if self.it_numinst <= 0:
             LIBPCP_PMDA.pmdaCacheOp(self.it_indom,
                                     cpmda.PMDA_CACHE_WALK_REWIND)
             while 1:
@@ -127,7 +127,7 @@ class pmdaIndom(Structure):
                     yield (inst, name)
 
     def inst_name_lookup(self, instance):
-        if self.it_numinst < 0:
+        if self.it_numinst <= 0:
             name = (c_char_p)()
             sts = LIBPCP_PMDA.pmdaCacheLookup(self.it_indom, instance,
                                               byref(name), None)
@@ -156,6 +156,7 @@ class pmdaIndom(Structure):
             key8 = key.encode('utf-8')
             LIBPCP_PMDA.pmdaCacheStore(indom, cpmda.PMDA_CACHE_ADD, key8, byref(insts[key]))
         LIBPCP_PMDA.pmdaCacheOp(indom, cpmda.PMDA_CACHE_SAVE)
+        self.it_numinst = -1
 
     def set_instances(self, indom, insts):
         if (insts == None):

--- a/src/python/pcp/pmda.py
+++ b/src/python/pcp/pmda.py
@@ -296,6 +296,21 @@ class MetricDispatch(object):
         self._metric_helptext[pmid] = text
         cpmda.set_need_refresh()
 
+    def remove_metric(self, name, metric):
+        pmid = metric.m_desc.pmid
+        if (name not in self._metric_names_map):
+            raise KeyError('attempt to remove_metric which does not existing')
+        if (pmid not in self._metrics):
+            raise KeyError('attempt to add_metric with an existing PMID')
+
+        self._metrictable.remove(metric)
+        self._metrics.pop(pmid)
+        self._metric_names.pop(pmid)
+        self._metric_names_map.pop(name)
+        self._metric_oneline.pop(pmid)
+        self._metric_helptext.pop(pmid)
+        cpmda.set_need_refresh()
+
     def add_indom(self, indom, oneline = '', text = ''):
         indomid = indom.it_indom
         for entry in self._indomtable:

--- a/src/python/pmda.c
+++ b/src/python/pmda.c
@@ -60,6 +60,7 @@ static PyObject *refresh_func;
 static PyObject *instance_func;
 static PyObject *store_cb_func;
 static PyObject *fetch_cb_func;
+static PyObject *refresh_all_func;
 static PyObject *refresh_metrics_func;
 
 static Py_ssize_t nindoms;
@@ -370,6 +371,35 @@ refresh_cluster(int cluster)
 }
 
 static int
+refresh_all_clusters(int numclusters, int *clusters)
+{
+    PyObject *arglist, *result, *list;
+    list = PyList_New(numclusters);
+    if (list == NULL){
+        __pmNotifyErr(LOG_ERR, "refresh: Unable to allocate memory");
+        return 1;
+    }
+    for (int i = 0; i < numclusters; i++) {
+        PyObject *num = PyLong_FromLong(clusters[i]);
+        PyList_SET_ITEM(list, i, num);
+    }
+
+    arglist = Py_BuildValue("(N)", list);
+    if (arglist == NULL){
+        return -ENOMEM;
+    }
+    result = PyEval_CallObject(refresh_all_func, arglist);
+    Py_DECREF(list);
+    Py_DECREF(arglist);
+    if (result == NULL) {
+        PyErr_Print();
+        return -EAGAIN; /* exception thrown */
+    }
+    Py_DECREF(result);
+    return 0;
+}
+
+static int
 refresh(int numpmid, pmID *pmidlist)
 {
     size_t need;
@@ -395,8 +425,13 @@ refresh(int numpmid, pmID *pmidlist)
         if (j == count)
             clusters[count++] = cluster;
     }
-    for (j = 0; j < count; j++)
-        sts |= refresh_cluster(clusters[j]);
+    if (refresh_all_func){
+        sts |= refresh_all_clusters(count, clusters);
+    }
+    if (refresh_func){
+        for (j = 0; j < count; j++)
+            sts |= refresh_cluster(clusters[j]);
+    }
     free(clusters);
     return sts;
 }
@@ -409,7 +444,8 @@ fetch(int numpmid, pmID *pmidlist, pmResult **rp, pmdaExt *pmda)
     maybe_refresh_all();
     if (fetch_func && (sts = prefetch()) < 0)
         return sts;
-    if (refresh_func && (sts = refresh(numpmid, pmidlist)) < 0)
+    if ( (refresh_func || refresh_all_func)
+            && (sts = refresh(numpmid, pmidlist)) < 0)
         return sts;
     return pmdaFetch(numpmid, pmidlist, rp, pmda);
 }
@@ -536,9 +572,9 @@ fetch_callback(pmdaMetric *metric, unsigned int inst, pmAtomValue *atom)
     return sts;
 }
 
-int 
+int
 store_callback(__pmID_int *pmid, unsigned int inst, pmAtomValue av, int type)
-{       
+{
     int rc, code;
     int item = pmid->item;
     int cluster = pmid->cluster;
@@ -928,7 +964,7 @@ pmda_refresh_metrics(void)
 	dispatch.version.any.ext->e_nindoms = nindoms;
 	pmdaRehash(dispatch.version.any.ext, metric_buffer, nmetrics);
     }
-    return;  
+    return;
 }
 
 static PyObject *
@@ -1090,7 +1126,7 @@ pmda_uptime(PyObject *self, PyObject *args, PyObject *keywords)
     if (!PyArg_ParseTupleAndKeywords(args, keywords,
                         "i:pmda_uptime", keyword_list, &now))
         return NULL;
-    
+
     days = now / (60 * 60 * 24);
     now %= (60 * 60 * 24);
     hours = now / (60 * 60);
@@ -1166,6 +1202,13 @@ set_fetch_callback(PyObject *self, PyObject *args)
 }
 
 static PyObject *
+set_refresh_all(PyObject *self, PyObject *args)
+{
+    return set_callback(self, args, "O:set_refresh_all", &refresh_all_func);
+}
+
+
+static PyObject *
 set_refresh_metrics(PyObject *self, PyObject *args)
 {
     return set_callback(self, args, "O:set_refresh_metrics",
@@ -1216,6 +1259,9 @@ static PyMethodDef methods[] = {
     { .ml_name = "set_refresh_metrics",
       .ml_meth = (PyCFunction)set_refresh_metrics,
       .ml_flags = METH_VARARGS|METH_KEYWORDS },
+    {   .ml_name = "set_refresh_all", .ml_meth = (PyCFunction)set_refresh_all,
+        .ml_flags = METH_VARARGS | METH_KEYWORDS
+    },
     { .ml_name = "pmda_log", .ml_meth = (PyCFunction)pmda_log,
         .ml_flags = METH_VARARGS|METH_KEYWORDS },
     { .ml_name = "pmda_err", .ml_meth = (PyCFunction)pmda_err,
@@ -1236,7 +1282,7 @@ pmda_dict_add(PyObject *dict, char *sym, long val)
     Py_XDECREF(pyVal);
 }
 
-/* called when the module is initialized. */ 
+/* called when the module is initialized. */
 MOD_INIT(cpmda)
 {
     PyObject *module, *dict;


### PR DESCRIPTION
For parallel http fetches, multiple threads are used when the context is with the python interpreter, which I believe fixes #313. Sub-process watches for any changes in the endpoint metrics metadata and uses diffing strategy to add/remove only changed metrics, which fixes #308. 

Thanks!