### PR TITLE
pidstat: fix failing unit tests

### DIFF
--- a/src/pcp/pidstat/pcp-pidstat.py
+++ b/src/pcp/pidstat/pcp-pidstat.py
@@ -414,9 +414,7 @@ class CpuProcessStackUtilReporter:
         self.pidstat_options = pidstat_options
 
     def print_report(self, timestamp, header_indentation, value_indentation):
-        indentation = "        " if len(timestamp)<9 else (len(timestamp)-7)*" "
         self.printer ("Timestamp" + header_indentation + "UID\tPID\tStkSize\tCommand")
-        indentation = ((len(indentation)+9)-len(timestamp))*" "
         processes = self.process_filter.filter_processes(self.process_stack_util.get_processes())
         for process in processes:
             if self.pidstat_options.show_process_user:

--- a/src/pcp/pidstat/test/cpu_usage_reporter_test.py
+++ b/src/pcp/pidstat/test/cpu_usage_reporter_test.py
@@ -42,9 +42,9 @@ class TestCpuUsageReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuUsageReporter(cpu_usage, process_filter, 1, printer, self.options)
 
-        reporter.print_report(123, 4)
+        reporter.print_report(123, 4, "  ", "    ")
 
-        printer.assert_called_with("123\t1000\t1\t2.43\t1.24\t0.0\t3.67\t1\tprocess_1")
+        printer.assert_called_with("123    1000\t1\t2.43\t1.24\t0.0\t3.67\t1\tprocess_1")
 
     def test_print_report_with_user_name(self):
         self.options.show_process_user = 'pcp'
@@ -54,9 +54,9 @@ class TestCpuUsageReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuUsageReporter(cpu_usage, process_filter, 1, printer, self.options)
 
-        reporter.print_report(123, 4)
+        reporter.print_report(123, 4, "  ", "    ")
 
-        printer.assert_called_with("123\tpcp\t1\t2.43\t1.24\t0.0\t3.67\t1\tprocess_1")
+        printer.assert_called_with("123    pcp\t1\t2.43\t1.24\t0.0\t3.67\t1\tprocess_1")
 
     def test_print_report_with_per_processor_usage(self):
         self.options.per_processor_usage = True
@@ -66,9 +66,9 @@ class TestCpuUsageReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuUsageReporter(cpu_usage, process_filter, 1, printer, self.options)
 
-        reporter.print_report(123, 4)
+        reporter.print_report(123, 4, "  ", "    ")
 
-        printer.assert_called_with("123\t1000\t1\t2.43\t1.24\t0.0\t0.92\t1\tprocess_1")
+        printer.assert_called_with("123    1000\t1\t2.43\t1.24\t0.0\t0.92\t1\tprocess_1")
 
     def test_print_report_with_user_percent_none(self):
         cpu_usage = Mock()
@@ -78,9 +78,9 @@ class TestCpuUsageReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuUsageReporter(cpu_usage, process_filter, 1, printer, self.options)
 
-        reporter.print_report(123, 4)
+        reporter.print_report(123, 4, "  ", "    ")
 
-        printer.assert_called_with("123\t1000\t1\tNone\t1.24\t0.0\t3.67\t1\tprocess_1")
+        printer.assert_called_with("123    1000\t1\tNone\t1.24\t0.0\t3.67\t1\tprocess_1")
 
     def test_print_report_with_guest_percent_none(self):
         cpu_usage = Mock()
@@ -90,9 +90,9 @@ class TestCpuUsageReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuUsageReporter(cpu_usage, process_filter, 1, printer, self.options)
 
-        reporter.print_report(123, 4)
+        reporter.print_report(123, 4, "  ", "    ")
 
-        printer.assert_called_with("123\t1000\t1\t2.43\t1.24\tNone\t3.67\t1\tprocess_1")
+        printer.assert_called_with("123    1000\t1\t2.43\t1.24\tNone\t3.67\t1\tprocess_1")
 
     def test_print_report_with_system_percent_none(self):
         cpu_usage = Mock()
@@ -102,9 +102,9 @@ class TestCpuUsageReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuUsageReporter(cpu_usage, process_filter, 1, printer, self.options)
 
-        reporter.print_report(123, 4)
+        reporter.print_report(123, 4, "  ", "    ")
 
-        printer.assert_called_with("123\t1000\t1\t2.43\tNone\t0.0\t3.67\t1\tprocess_1")
+        printer.assert_called_with("123    1000\t1\t2.43\tNone\t0.0\t3.67\t1\tprocess_1")
 
     def test_print_report_with_total_percent_none(self):
         cpu_usage = Mock()
@@ -114,9 +114,33 @@ class TestCpuUsageReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuUsageReporter(cpu_usage, process_filter, 1, printer, self.options)
 
-        reporter.print_report(123, 4)
+        reporter.print_report(123, 4, "  ", "    ")
 
-        printer.assert_called_with("123\t1000\t1\t2.43\t1.24\t0.0\tNone\t1\tprocess_1")
+        printer.assert_called_with("123    1000\t1\t2.43\t1.24\t0.0\tNone\t1\tprocess_1")
+
+    def test_print_report_header_without_process_user(self):
+        cpu_usage = Mock()
+        process_filter = Mock()
+        printer = Mock()
+        process_filter.filter_processes = Mock(return_value=self.processes)
+        reporter = CpuUsageReporter(cpu_usage, process_filter, 1, printer, self.options)
+
+        reporter.print_report(123, 4, "  ", "    ")
+
+        printer.assert_any_call("Timestamp  UID\tPID\tusr\tsystem\tguest\t%CPU\tCPU\tCommand")
+
+    def test_print_report_header_with_process_user(self):
+        self.options.show_process_user = 'pcp'
+        cpu_usage = Mock()
+        process_filter = Mock()
+        printer = Mock()
+        process_filter.filter_processes = Mock(return_value=self.processes)
+        reporter = CpuUsageReporter(cpu_usage, process_filter, 1, printer, self.options)
+
+        reporter.print_report(123, 4, "  ", "    ")
+
+        printer.assert_any_call("Timestamp  UName\tPID\tusr\tsystem\tguest\t%CPU\tCPU\tCommand")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/pcp/pidstat/test/process_memory_util_reporter_test.py
+++ b/src/pcp/pidstat/test/process_memory_util_reporter_test.py
@@ -41,9 +41,9 @@ class TestProcessMemoryUtilReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuProcessMemoryUtilReporter(process_memory_util, process_filter, 1, printer, self.options)
 
-        reporter.print_report(123)
+        reporter.print_report(123, "  ", "    ")
 
-        printer.assert_called_with("123\t1000\t1\t9.1\t\t5.34\t\t100\t200\t1.23\tprocess_1")
+        printer.assert_called_with("123    1000\t1\t9.1\t\t5.34\t\t100\t200\t1.23\tprocess_1")
 
     def test_print_report_with_min_flt_None(self):
         process_memory_util = Mock()
@@ -53,9 +53,9 @@ class TestProcessMemoryUtilReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuProcessMemoryUtilReporter(process_memory_util, process_filter, 1, printer, self.options)
 
-        reporter.print_report(123)
+        reporter.print_report(123, "  ", "    ")
 
-        printer.assert_called_with("123\t1000\t1\tNone\t\t5.34\t\t100\t200\t1.23\tprocess_1")
+        printer.assert_called_with("123    1000\t1\tNone\t\t5.34\t\t100\t200\t1.23\tprocess_1")
 
     def test_print_report_with_maj_flt_None(self):
         process_memory_util = Mock()
@@ -65,9 +65,9 @@ class TestProcessMemoryUtilReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuProcessMemoryUtilReporter(process_memory_util, process_filter, 1, printer, self.options)
 
-        reporter.print_report(123)
+        reporter.print_report(123, "  ", "    ")
 
-        printer.assert_called_with("123\t1000\t1\t9.1\t\tNone\t\t100\t200\t1.23\tprocess_1")
+        printer.assert_called_with("123    1000\t1\t9.1\t\tNone\t\t100\t200\t1.23\tprocess_1")
 
     def test_print_report_with_user_name(self):
         self.options.show_process_user = 'pcp'
@@ -77,9 +77,20 @@ class TestProcessMemoryUtilReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuProcessMemoryUtilReporter(process_memory_util, process_filter, 1, printer, self.options)
 
-        reporter.print_report(123)
+        reporter.print_report(123, "  ", "    ")
 
-        printer.assert_called_with('123\tpcp\t1\t9.1\t\t5.34\t\t100\t200\t1.23\tprocess_1')
+        printer.assert_called_with('123    pcp\t1\t9.1\t\t5.34\t\t100\t200\t1.23\tprocess_1')
+
+    def test_print_report_header(self):
+        process_memory_util = Mock()
+        process_filter = Mock()
+        printer = Mock()
+        process_filter.filter_processes = Mock(return_value=self.processes)
+        reporter = CpuProcessMemoryUtilReporter(process_memory_util, process_filter, 1, printer, self.options)
+
+        reporter.print_report(123, "  ", "    ")
+
+        printer.assert_any_call("Timestamp  UID\tPID\tMinFlt/s\tMajFlt/s\tVSize\tRSS\t%Mem\tCommand")
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/pcp/pidstat/test/process_priority_reporter_test.py
+++ b/src/pcp/pidstat/test/process_priority_reporter_test.py
@@ -38,9 +38,9 @@ class TestProcessPriorityReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuProcessPrioritiesReporter(process_priority, process_filter, printer, self.options)
 
-        reporter.print_report(123)
+        reporter.print_report(123, "  ", "    ")
 
-        printer.assert_called_with("123\t1000\t1\t99\tFIFO\tprocess_1")
+        printer.assert_called_with("123    1000\t1\t99\tFIFO\tprocess_1")
 
     def test_print_report_with_user_name(self):
         self.options.show_process_user = 'pcp'
@@ -50,9 +50,20 @@ class TestProcessPriorityReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuProcessPrioritiesReporter(process_priority, process_filter, printer, self.options)
 
-        reporter.print_report(123)
+        reporter.print_report(123, "  ", "    ")
 
-        printer.assert_called_with("123\tpcp\t1\t99\tFIFO\tprocess_1")
+        printer.assert_called_with("123    pcp\t1\t99\tFIFO\tprocess_1")
+
+    def test_print_report_header(self):
+        process_priority = Mock()
+        process_filter = Mock()
+        printer = Mock()
+        process_filter.filter_processes = Mock(return_value=self.processes)
+        reporter = CpuProcessPrioritiesReporter(process_priority, process_filter, printer, self.options)
+
+        reporter.print_report(123, "  ", "    ")
+
+        printer.assert_any_call("Timestamp  UID\tPID\tprio\tpolicy\tCommand")
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/pcp/pidstat/test/process_stack_util_reporter_test.py
+++ b/src/pcp/pidstat/test/process_stack_util_reporter_test.py
@@ -37,9 +37,9 @@ class TestProcessStackUtilReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuProcessStackUtilReporter(process_stack_util, process_filter, printer, self.options)
 
-        reporter.print_report(123)
+        reporter.print_report(123, "  ", "    ")
 
-        printer.assert_called_with("123\t1000\t1\t136\tprocess_1")
+        printer.assert_called_with("123    1000\t1\t136\tprocess_1")
 
     def test_print_report_with_user_name(self):
         self.options.show_process_user = 'pcp'
@@ -49,9 +49,20 @@ class TestProcessStackUtilReporter(unittest.TestCase):
         process_filter.filter_processes = Mock(return_value=self.processes)
         reporter = CpuProcessStackUtilReporter(process_stack_util, process_filter, printer, self.options)
 
-        reporter.print_report(123)
+        reporter.print_report(123, "  ", "    ")
 
-        printer.assert_called_with("123\tpcp\t1\t136\tprocess_1")
+        printer.assert_called_with("123    pcp\t1\t136\tprocess_1")
+
+    def test_print_report_header(self):
+        process_stack_util = Mock()
+        process_filter = Mock()
+        printer = Mock()
+        process_filter.filter_processes = Mock(return_value=self.processes)
+        reporter = CpuProcessStackUtilReporter(process_stack_util, process_filter, printer, self.options)
+
+        reporter.print_report(123, "  ", "    ")
+
+        printer.assert_any_call("Timestamp  UID\tPID\tStkSize\tCommand")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As per #blockprocs channel, fix for the unit tests. Don't worry about merging the PR through the github workflow (assuming thats still the case), just grab the branch from our fork.