### PR TITLE
Uninitialised variable & resource leak.

### DIFF
--- a/src/pmdas/perfevent/parse_events.c
+++ b/src/pmdas/perfevent/parse_events.c
@@ -725,7 +725,7 @@ static int populate_pmus(struct pmu **pmus)
 void setup_cpu_config(struct pmu *pmu_ptr, int *ncpus, int **cpuarr)
 {
     FILE *cpulist;
-    char cpumask_path[PATH_MAX], *line;
+    char cpumask_path[PATH_MAX], *line = NULL;
     int *on_cpus = NULL;
     size_t len = 0;
 
@@ -750,6 +750,7 @@ void setup_cpu_config(struct pmu *pmu_ptr, int *ncpus, int **cpuarr)
                 return;
             }
         } else {
+            fclose(cpulist);
             *cpuarr = NULL;
             return;
         }


### PR DESCRIPTION
I noticed these two errors while inspecting the code to track down the
cause of the problem in #331.

The real question is why valgrind didn't find the uninitialised *line. I (temporarily) changed the compiler flags to -O2 for the test harness and low-and-behold valgrind noticed the uninitialized variable in the original code:
```
==28987== Conditional jump or move depends on uninitialised value(s)
==28987==    at 0x51ABF32: getdelim (iogetdelim.c:63)
==28987==    by 0x40AFF6: getline (stdio.h:117)
==28987==    by 0x40AFF6: setup_cpu_config (parse_events.c:743)
==28987==    by 0x4087ED: perf_setup_dynamic_events (perfinterface.c:714)
==28987==    by 0x40A030: perf_event_create (perfinterface.c:1236)
==28987==    by 0x40445B: test_dynamic_events_config (perf_event_test.c:822)
==28987==    by 0x40481C: runtest (perf_event_test.c:955)
==28987==    by 0x4015D9: main (perf_event_test.c:971)
```