### PR TITLE
pmda_perfevent: Fix non-showup of dynamic events

### DIFF
--- a/qa/perfevent/config/test_only_dynamic_events.txt
+++ b/qa/perfevent/config/test_only_dynamic_events.txt
@@ -1,0 +1,4 @@
+[dynamic]
+pmu1.bar
+pmu2.cm_event1
+pmu2.cm_event3

--- a/src/pmdas/perfevent/configparser.l
+++ b/src/pmdas/perfevent/configparser.l
@@ -254,6 +254,10 @@ static void add_pmcsetting_name(configuration_t *config, char *name)
     {
         return;
     }
+
+    if (context_dynamic)
+        return add_pmc_setting_name_dynamic(config, name);
+
     if(0 == config->nConfigEntries) 
     {
         return;
@@ -261,8 +265,6 @@ static void add_pmcsetting_name(configuration_t *config, char *name)
 
     if (context_derived)
         return add_pmc_setting_name_derived(config, name);
-    else if (context_dynamic)
-        return add_pmc_setting_name_dynamic(config, name);
 
     entry = &config->configArr[config->nConfigEntries-1];
 


### PR DESCRIPTION
When the entire perfevent.conf file is empty and only the
[dynamic] section is present, configparser.l doesn't parse
this section because of the given check for pmc settings.
This patch moves the parsing before the check.