### PR TITLE
pmrep modularization, add pcp2{es,json,xml,xlsx,zabbix}

### DIFF
--- a/qa/1068
+++ b/qa/1068
@@ -1,8 +1,8 @@
 #!/bin/sh
 # PCP QA Test No. 1068
-# Exercise pmrep Zabbix export reporting modes.
+# Exercise pcp2zabbix.
 #
-# Copyright (c) 2015 Red Hat.
+# Copyright (c) 2015-2017 Red Hat.
 #
 
 seq=`basename $0`
@@ -16,7 +16,7 @@ $python -c "from collections import OrderedDict" >/dev/null 2>&1
 [ $? -eq 0 ] || _notrun "python collections OrderedDict module not installed"
 
 which socat >/dev/null 2>&1 || _notrun "socat binary not installed"
-which pmrep >/dev/null 2>&1 || _notrun "pmrep not installed"
+which pcp2zabbix >/dev/null 2>&1 || _notrun "pcp2zabbix not installed"
 
 status=1	# failure is the default!
 signal=$PCP_BINADM_DIR/pmsignal
@@ -25,10 +25,10 @@ trap "cd $here; rm -rf $tmp.*; exit \$status" 0 1 2 3 15
 
 _seq_store()
 {
-    echo "--- pmrep stdout --" >>$seq.full
-    cat $tmp.pmrep.out >>$seq.full
-    echo "--- pmrep stderr --" >>$seq.full
-    cat $tmp.pmrep.err >>$seq.full
+    echo "--- pcp2zabbix stdout --" >>$seq.full
+    cat $tmp.pcp2zabbix.out >>$seq.full
+    echo "--- pcp2zabbix stderr --" >>$seq.full
+    cat $tmp.pcp2zabbix.err >>$seq.full
     echo "--- socat stdout --" >>$seq.full
     cat $tmp.socat.out >>$seq.full
     echo "--- socat stderr --" >>$seq.full
@@ -67,7 +67,7 @@ cat $tmp.config >>$seq.full
 socat tcp-listen:$zabbix_port,reuseaddr - >$tmp.socat.out 2>$tmp.socat.err &
 pid=$!
 sleep 2
-pmrep -t 2 -s 3 $log -c $tmp.config -o zabbix sample >$tmp.pmrep.out 2>$tmp.pmrep.err &   # will error out after socket cat dies
+pcp2zabbix -r -t 2 -s 3 $log -c $tmp.config sample >$tmp.pcp2zabbix.out 2>$tmp.pcp2zabbix.err &   # will error out after socket cat dies
 pmpid=$!
 sleep 2
 $signal $pid $pmpid 2>/dev/null

--- a/qa/1068.out
+++ b/qa/1068.out
@@ -13,7 +13,7 @@ body:
 		{
 			"host":"HOSTNAME",
 			"key":"pcp.sample.milliseconds",
-			"value":"380432147.45",
+			"value":"380432147.450",
 			"clock":957177405.57778},
 		{
 			"host":"HOSTNAME",

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -45,6 +45,7 @@ OTHER_SUBDIRS = \
 	pcp2elasticsearch \
 	pcp2graphite \
 	pcp2influxdb \
+	pcp2json \
 	pcp2xlsx \
 	pcp2xml \
 	pcp2zabbix \

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -44,6 +44,7 @@ OTHER_SUBDIRS = \
 	pcp \
 	pcp2graphite \
 	pcp2influxdb \
+	pcp2zabbix \
 	pmafm \
 	pmfind \
 	pmcpp \

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -45,6 +45,7 @@ OTHER_SUBDIRS = \
 	pcp2elasticsearch \
 	pcp2graphite \
 	pcp2influxdb \
+	pcp2xlsx \
 	pcp2xml \
 	pcp2zabbix \
 	pmafm \

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -42,6 +42,7 @@ OTHER_SUBDIRS = \
 	genpmda \
 	newhelp \
 	pcp \
+	pcp2elasticsearch \
 	pcp2graphite \
 	pcp2influxdb \
 	pcp2zabbix \

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -45,6 +45,7 @@ OTHER_SUBDIRS = \
 	pcp2elasticsearch \
 	pcp2graphite \
 	pcp2influxdb \
+	pcp2xml \
 	pcp2zabbix \
 	pmafm \
 	pmfind \

--- a/src/pcp2elasticsearch/GNUmakefile
+++ b/src/pcp2elasticsearch/GNUmakefile
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2017 Red Hat, Inc.  All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+
+TOPDIR = ../..
+include $(TOPDIR)/src/include/builddefs
+
+TARGET = pcp2elasticsearch
+#MAN_SECTION = 1
+#MAN_PAGES = $(TARGET).$(MAN_SECTION)
+#MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
+
+default: $(TARGET).py
+# $(MAN_PAGES)
+
+default:
+
+include $(BUILDRULES)
+
+install: default
+ifeq "$(HAVE_PYTHON)" "true"
+	$(INSTALL) -m 755 $(TARGET).py $(PCP_BIN_DIR)/$(TARGET)
+#	@$(INSTALL_MAN)
+endif
+
+default_pcp: default
+
+install_pcp: install

--- a/src/pcp2elasticsearch/pcp2elasticsearch.py
+++ b/src/pcp2elasticsearch/pcp2elasticsearch.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env pmpython
+#
+# Copyright (C) 2015-2017 Marko Myllynen <myllynen@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+# [write_es] Copyright (C) 2014-2015 Red Hat, based on pcp2es by Frank Ch. Eigler
+
+# pylint: disable=superfluous-parens
+# pylint: disable=invalid-name, line-too-long, no-self-use
+# pylint: disable=too-many-boolean-expressions, too-many-statements
+# pylint: disable=too-many-instance-attributes, too-many-locals
+# pylint: disable=too-many-branches, too-many-nested-blocks
+# pylint: disable=bare-except, broad-except
+
+""" PCP to Elasticsearch Bridge """
+
+# Common imports
+from collections import OrderedDict
+import errno
+import sys
+
+# Our imports
+from elasticsearch import Elasticsearch
+
+# PCP Python PMAPI
+from pcp import pmapi, pmconfig
+from cpmapi import PM_CONTEXT_ARCHIVE, PM_ERR_EOL, PM_DEBUG_APPL1
+
+if sys.version_info[0] >= 3:
+    long = int # pylint: disable=redefined-builtin
+
+# Default config
+DEFAULT_CONFIG = ["./pcp2elasticsearch.conf", "$HOME/.pcp2elasticsearch.conf", "$HOME/.pcp/pcp2elasticsearch.conf", "$PCP_SYSCONF_DIR/pcp2elasticsearch.conf"]
+
+# Defaults
+CONFVER = 1
+ES_INDEX = "pcp"
+ES_SERVER = "http://localhost:9200/"
+
+class pcp2elasticsearch(object):
+    """ PCP to Elasticsearch """
+    def __init__(self):
+        """ Construct object, prepare for command line handling """
+        self.context = None
+        self.pmconfig = pmconfig.pmConfig(self)
+        self.opts = self.options()
+
+        # Configuration directives
+        self.keys = ('source', 'output', 'derived', 'header', 'globals',
+                     'samples', 'interval', 'type', 'precision',
+                     'es_server', 'es_index', 'es_hostid',
+                     'count_scale', 'space_scale', 'time_scale', 'version',
+                     'speclocal', 'instances', 'ignore_incompat', 'omit_flat')
+
+        # The order of preference for options (as present):
+        # 1 - command line options
+        # 2 - options from configuration file(s)
+        # 3 - built-in defaults defined below
+        self.check = 0
+        self.version = CONFVER
+        self.source = "local:"
+        self.output = None # For pmrep conf file compat only
+        self.speclocal = None
+        self.derived = None
+        self.header = 1
+        self.globals = 1
+        self.samples = None # forever
+        self.interval = pmapi.timeval(60)      # 60 sec
+        self.opts.pmSetOptionInterval(str(60)) # 60 sec
+        self.delay = 0
+        self.type = 0
+        self.ignore_incompat = 0
+        self.instances = []
+        self.omit_flat = 0
+        self.precision = 3 # .3f
+        self.timefmt = "%H:%M:%S" # For compat only
+        self.interpol = 0
+        self.count_scale = None
+        self.space_scale = None
+        self.time_scale = None
+
+        self.es_server = ES_SERVER
+        self.es_index = ES_INDEX
+        self.es_hostid = None
+
+        # Internal
+        self.runtime = -1
+
+        # Performance metrics store
+        # key - metric name
+        # values - 0:label, 1:instance(s), 2:unit/scale, 3:type, 4:width, 5:pmfg item
+        self.metrics = OrderedDict()
+        self.pmfg = None
+        self.pmfg_ts = None
+
+        # Read configuration and prepare to connect
+        self.config = self.pmconfig.set_config_file(DEFAULT_CONFIG)
+        self.pmconfig.read_options()
+        self.pmconfig.read_cmd_line()
+        self.pmconfig.prepare_metrics()
+
+    def options(self):
+        """ Setup default command line argument option handling """
+        opts = pmapi.pmOptions()
+        opts.pmSetOptionCallback(self.option)
+        opts.pmSetOverrideCallback(self.option_override)
+        opts.pmSetShortOptions("a:h:LK:c:Ce:D:V?HGA:S:T:O:s:t:Z:zrIi:vP:q:b:y:g:x:X:")
+        opts.pmSetShortUsage("[option...] metricspec [...]")
+
+        opts.pmSetLongOptionHeader("General options")
+        opts.pmSetLongOptionArchive()      # -a/--archive
+        opts.pmSetLongOptionArchiveFolio() # --archive-folio
+        opts.pmSetLongOptionContainer()    # --container
+        opts.pmSetLongOptionHost()         # -h/--host
+        opts.pmSetLongOptionLocalPMDA()    # -L/--local-PMDA
+        opts.pmSetLongOptionSpecLocal()    # -K/--spec-local
+        opts.pmSetLongOption("config", 1, "c", "FILE", "config file path")
+        opts.pmSetLongOption("check", 0, "C", "", "check config and metrics and exit")
+        opts.pmSetLongOption("derived", 1, "e", "FILE|DFNT", "derived metrics definitions")
+        opts.pmSetLongOptionDebug()        # -D/--debug
+        opts.pmSetLongOptionVersion()      # -V/--version
+        opts.pmSetLongOptionHelp()         # -?/--help
+
+        opts.pmSetLongOptionHeader("Reporting options")
+        opts.pmSetLongOption("no-header", 0, "H", "", "omit headers")
+        opts.pmSetLongOption("no-globals", 0, "G", "", "omit global metrics")
+        opts.pmSetLongOptionAlign()        # -A/--align
+        opts.pmSetLongOptionStart()        # -S/--start
+        opts.pmSetLongOptionFinish()       # -T/--finish
+        opts.pmSetLongOptionOrigin()       # -O/--origin
+        opts.pmSetLongOptionSamples()      # -s/--samples
+        opts.pmSetLongOptionInterval()     # -t/--interval
+        opts.pmSetLongOptionTimeZone()     # -Z/--timezone
+        opts.pmSetLongOptionHostZone()     # -z/--hostzone
+        opts.pmSetLongOption("raw", 0, "r", "", "output raw counter values (no rate conversion)")
+        opts.pmSetLongOption("ignore-incompat", 0, "I", "", "ignore incompatible instances (default: abort)")
+        opts.pmSetLongOption("instances", 1, "i", "STR", "instances to report (default: all current)")
+        opts.pmSetLongOption("omit-flat", 0, "v", "", "omit single-valued metrics with -i (default: include)")
+        opts.pmSetLongOption("precision", 1, "P", "N", "N digits after the decimal separator (default: 3)")
+        opts.pmSetLongOption("count-scale", 1, "q", "SCALE", "default count unit")
+        opts.pmSetLongOption("space-scale", 1, "b", "SCALE", "default space unit")
+        opts.pmSetLongOption("time-scale", 1, "y", "SCALE", "default time unit")
+
+        opts.pmSetLongOption("es-host", 1, "g", "SERVER", "elasticsearch server (default: " + ES_SERVER + ")")
+        opts.pmSetLongOption("es-index", 1, "x", "INDEX", "elasticsearch index for metric names (default: " + ES_INDEX + ")")
+        opts.pmSetLongOption("es-hostid", 1, "X", "HOSTID", "elasticsearch host-id for measurements")
+
+        return opts
+
+    def option_override(self, opt):
+        """ Override standard PCP options """
+        if opt == 'H' or opt == 'K' or opt == 'g':
+            return 1
+        return 0
+
+    def option(self, opt, optarg, index): # pylint: disable=unused-argument
+        """ Perform setup for an individual command line option """
+        if opt == 'K':
+            if not self.speclocal or not self.speclocal.startswith("K:"):
+                self.speclocal = "K:" + optarg
+            else:
+                self.speclocal = self.speclocal + "|" + optarg
+        elif opt == 'c':
+            self.config = optarg
+        elif opt == 'C':
+            self.check = 1
+        elif opt == 'e':
+            self.derived = optarg
+        elif opt == 'H':
+            self.header = 0
+        elif opt == 'G':
+            self.globals = 0
+        elif opt == 'r':
+            self.type = 1
+        elif opt == 'I':
+            self.ignore_incompat = 1
+        elif opt == 'i':
+            self.instances = self.instances + self.pmconfig.parse_instances(optarg)
+        elif opt == 'v':
+            self.omit_flat = 1
+        elif opt == 'P':
+            self.precision = int(optarg)
+        elif opt == 'q':
+            self.count_scale = optarg
+        elif opt == 'b':
+            self.space_scale = optarg
+        elif opt == 'y':
+            self.time_scale = optarg
+        elif opt == 'g':
+            self.es_server = optarg
+        elif opt == 'x':
+            self.es_index = optarg
+        elif opt == 'X':
+            self.es_hostid = optarg
+        else:
+            raise pmapi.pmUsageErr()
+
+    def connect(self):
+        """ Establish a PMAPI context """
+        context, self.source = pmapi.pmContext.set_connect_options(self.opts, self.source, self.speclocal)
+
+        self.pmfg = pmapi.fetchgroup(context, self.source)
+        self.pmfg_ts = self.pmfg.extend_timestamp()
+        self.context = self.pmfg.get_context()
+
+        if pmapi.c_api.pmSetContextOptions(self.context.ctx, self.opts.mode, self.opts.delta):
+            raise pmapi.pmUsageErr()
+
+        self.pmconfig.validate_metrics()
+
+    def validate_config(self):
+        """ Validate configuration options """
+        if self.version != CONFVER:
+            sys.stderr.write("Incompatible configuration file version (read v%s, need v%d).\n" % (self.version, CONFVER))
+            sys.exit(1)
+
+        if self.es_hostid is None:
+            self.es_hostid = self.context.pmGetContextHostName()
+
+        self.pmconfig.finalize_options()
+
+    def execute(self):
+        """ Fetch and report """
+        # Debug
+        if self.context.pmDebug(PM_DEBUG_APPL1):
+            sys.stdout.write("Known config file keywords: " + str(self.keys) + "\n")
+            sys.stdout.write("Known metric spec keywords: " + str(self.pmconfig.metricspec) + "\n")
+
+        # Set delay mode, interpolation
+        if self.context.type != PM_CONTEXT_ARCHIVE:
+            self.delay = 1
+            self.interpol = 1
+
+        # Common preparations
+        pmapi.pmContext.prepare_execute(self.context, self.opts, False, self.interpol, self.interval)
+
+        # Headers
+        if self.header == 1:
+            self.header = 0
+            self.write_header()
+
+        # Just checking
+        if self.check == 1:
+            return
+
+        # Main loop
+        while self.samples != 0:
+            # Fetch values
+            try:
+                self.pmfg.fetch()
+            except pmapi.pmErr as error:
+                if error.args[0] == PM_ERR_EOL:
+                    break
+                raise error
+
+            # Watch for endtime in uninterpolated mode
+            if not self.interpol:
+                if float(self.pmfg_ts().strftime('%s')) > float(self.opts.pmGetOptionFinish()):
+                    break
+
+            # Report and prepare for the next round
+            self.report(self.pmfg_ts())
+            if self.samples and self.samples > 0:
+                self.samples -= 1
+            if self.delay and self.interpol and self.samples != 0:
+                self.context.pmtimevalSleep(self.interval)
+
+        # Allow to flush buffered values / say goodbye
+        self.report(None)
+
+    def report(self, tstamp):
+        """ Report the metric values """
+        if tstamp != None:
+            tstamp = tstamp.strftime(self.timefmt)
+
+        self.write_es(tstamp)
+
+    def write_header(self):
+        """ Write info header """
+        if self.context.type == PM_CONTEXT_ARCHIVE:
+            sys.stdout.write("Sending %d archived metrics to Elasticsearch at %s...\n(Ctrl-C to stop)\n" % (len(self.metrics), self.es_server))
+            return
+
+        sys.stdout.write("Sending %d metrics to Elasticsearch at %s every %d sec" % (len(self.metrics), self.es_server, self.interval))
+        if self.runtime != -1:
+            sys.stdout.write(":\n%s samples(s) with %.1f sec interval ~ %d sec runtime.\n" % (self.samples, float(self.interval), self.runtime))
+        elif self.samples:
+            duration = (self.samples - 1) * float(self.interval)
+            sys.stdout.write(":\n%s samples(s) with %.1f sec interval ~ %d sec runtime.\n" % (self.samples, float(self.interval), duration))
+        else:
+            sys.stdout.write("...\n(Ctrl-C to stop)\n")
+
+    def write_es(self, timestamp):
+        """ Write (send) metrics to an Elasticsearch host """
+        if timestamp is None:
+            # Silent goodbye
+            return
+
+        ts = pmapi.pmContext.convert_datetime(self.pmfg_ts(), "ms")
+
+        es = Elasticsearch(hosts=[self.es_server])
+        # pylint: disable=unexpected-keyword-arg
+        es.indices.create(index=self.es_index,
+                          ignore=[400],
+                          body={'mappings':{'pcp-metric':
+                                            {'properties':{'@timestamp':{'type':'date'},
+                                                           'host-id':{'type':'string'}}}}})
+
+        # Assemble all metrics into a single document
+        # Use @-prefixed keys for metadata not coming in from PCP metrics
+        es_doc = {'@host-id': self.es_hostid, '@timestamp': long(ts)}
+
+        insts_key = "@instances"
+        inst_key = "@id"
+
+        for metric in self.metrics:
+            try:
+                # Install value into outgoing json/dict in key1{key2{key3=value}} style:
+                # foo.bar.baz=value    =>  foo: { bar: { baz: value ...} }
+                # foo.bar.noo[0]=value =>  foo: { bar: { @instances:[{@id: 0, noo: value ...} ... ]}
+
+                pmns_parts = metric.split(".")
+
+                # Find/create the parent dictionary into which to insert the final component
+                for inst, name, val in self.metrics[metric][5](): # pylint: disable=unused-variable
+                    try:
+                        value = val()
+                        value = round(value, self.precision) if isinstance(value, float) else value
+                    except:
+                        continue
+
+                    pmns_leaf_dict = es_doc
+
+                    for pmns_part in pmns_parts[:-1]:
+                        if pmns_part not in pmns_leaf_dict:
+                            pmns_leaf_dict[pmns_part] = {}
+                        pmns_leaf_dict = pmns_leaf_dict[pmns_part]
+                    last_part = pmns_parts[-1]
+
+                    if not name:
+                        pmns_leaf_dict[last_part] = value
+                    else:
+                        if insts_key not in pmns_leaf_dict:
+                            pmns_leaf_dict[insts_key] = []
+                        insts = pmns_leaf_dict[insts_key]
+                        # Find a preexisting {@id: name} object in there, if any
+                        found = False
+                        for j in range(1, len(insts)):
+                            if insts[j][inst_key] == name:
+                                insts[j][last_part] = value
+                                found = True
+                        if not found:
+                            insts.append({inst_key: name, last_part: value})
+            except:
+                pass
+
+        # pylint: disable=unexpected-keyword-arg
+        es.index(index=self.es_index,
+                 doc_type='pcp-metric',
+                 timestamp=long(ts),
+                 body=es_doc)
+
+    def finalize(self):
+        """ Finalize and clean up """
+        return
+
+if __name__ == '__main__':
+    try:
+        P = pcp2elasticsearch()
+        P.connect()
+        P.validate_config()
+        P.execute()
+        P.finalize()
+
+    except pmapi.pmErr as error:
+        sys.stderr.write('%s: %s\n' % (error.progname(), error.message()))
+        sys.exit(1)
+    except pmapi.pmUsageErr as usage:
+        usage.message()
+        sys.exit(1)
+    except IOError as error:
+        if error.errno != errno.EPIPE:
+            sys.stderr.write("%s\n" % str(error))
+            sys.exit(1)
+    except KeyboardInterrupt:
+        sys.stdout.write("\n")
+        P.finalize()

--- a/src/pcp2json/GNUmakefile
+++ b/src/pcp2json/GNUmakefile
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2017 Red Hat, Inc.  All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+
+TOPDIR = ../..
+include $(TOPDIR)/src/include/builddefs
+
+TARGET = pcp2json
+#MAN_SECTION = 1
+#MAN_PAGES = $(TARGET).$(MAN_SECTION)
+#MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
+
+default: $(TARGET).py
+# $(MAN_PAGES)
+
+default:
+
+include $(BUILDRULES)
+
+install: default
+ifeq "$(HAVE_PYTHON)" "true"
+	$(INSTALL) -m 755 $(TARGET).py $(PCP_BIN_DIR)/$(TARGET)
+#	@$(INSTALL_MAN)
+endif
+
+default_pcp: default
+
+install_pcp: install

--- a/src/pcp2json/pcp2json.py
+++ b/src/pcp2json/pcp2json.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env pmpython
+#
+# Copyright (C) 2015-2017 Marko Myllynen <myllynen@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+# [write_json] Copyright (C) 2014-2015 Red Hat, based on pcp2es by Frank Ch. Eigler
+
+# pylint: disable=superfluous-parens
+# pylint: disable=invalid-name, line-too-long, no-self-use
+# pylint: disable=too-many-boolean-expressions, too-many-statements
+# pylint: disable=too-many-instance-attributes, too-many-locals
+# pylint: disable=too-many-branches, too-many-nested-blocks
+# pylint: disable=bare-except, broad-except
+
+""" PCP to JSON Bridge """
+
+# Common imports
+from collections import OrderedDict
+import errno
+import sys
+
+# Our imports
+try:
+    import json
+except:
+    import simplejson as json
+import socket
+import os
+
+# PCP Python PMAPI
+from pcp import pmapi, pmconfig
+from cpmapi import PM_CONTEXT_ARCHIVE, PM_ERR_EOL, PM_DEBUG_APPL1
+
+if sys.version_info[0] >= 3:
+    long = int # pylint: disable=redefined-builtin
+
+# Default config
+DEFAULT_CONFIG = ["./pcp2json.conf", "$HOME/.pcp2json.conf", "$HOME/.pcp/pcp2json.conf", "$PCP_SYSCONF_DIR/pcp2json.conf"]
+
+# Defaults
+CONFVER = 1
+INDENT = 4
+TIMEFMT = "%Y-%m-%d %H:%M:%S"
+
+class PCP2JSON(object):
+    """ PCP to JSON """
+    def __init__(self):
+        """ Construct object, prepare for command line handling """
+        self.context = None
+        self.pmconfig = pmconfig.pmConfig(self)
+        self.opts = self.options()
+
+        # Configuration directives
+        self.keys = ('source', 'output', 'derived', 'header', 'globals',
+                     'samples', 'interval', 'type', 'precision',
+                     'timefmt', 'extended', 'everything',
+                     'count_scale', 'space_scale', 'time_scale', 'version',
+                     'speclocal', 'instances', 'ignore_incompat', 'omit_flat')
+
+        # The order of preference for options (as present):
+        # 1 - command line options
+        # 2 - options from configuration file(s)
+        # 3 - built-in defaults defined below
+        self.check = 0
+        self.version = CONFVER
+        self.source = "local:"
+        self.output = None # For pmrep conf file compat only
+        self.speclocal = None
+        self.derived = None
+        self.header = 1
+        self.globals = 1
+        self.samples = None # forever
+        self.interval = pmapi.timeval(60)      # 60 sec
+        self.opts.pmSetOptionInterval(str(60)) # 60 sec
+        self.delay = 0
+        self.type = 0
+        self.ignore_incompat = 0
+        self.instances = []
+        self.omit_flat = 0
+        self.precision = 3 # .3f
+        self.timefmt = TIMEFMT
+        self.interpol = 0
+        self.count_scale = None
+        self.space_scale = None
+        self.time_scale = None
+
+        # Not in pcp2json.conf, won't overwrite
+        self.outfile = None
+
+        self.extended = 0
+        self.everything = 0
+
+        # Internal
+        self.runtime = -1
+
+        self.data = None
+        self.prev_ts = None
+        self.writer = None
+
+        # Performance metrics store
+        # key - metric name
+        # values - 0:label, 1:instance(s), 2:unit/scale, 3:type, 4:width, 5:pmfg item
+        self.metrics = OrderedDict()
+        self.pmfg = None
+        self.pmfg_ts = None
+
+        # Read configuration and prepare to connect
+        self.config = self.pmconfig.set_config_file(DEFAULT_CONFIG)
+        self.pmconfig.read_options()
+        self.pmconfig.read_cmd_line()
+        self.pmconfig.prepare_metrics()
+
+    def options(self):
+        """ Setup default command line argument option handling """
+        opts = pmapi.pmOptions()
+        opts.pmSetOptionCallback(self.option)
+        opts.pmSetOverrideCallback(self.option_override)
+        opts.pmSetShortOptions("a:h:LK:c:Ce:D:V?HGA:S:T:O:s:t:Z:zrIi:vP:q:b:y:F:f:xX")
+        opts.pmSetShortUsage("[option...] metricspec [...]")
+
+        opts.pmSetLongOptionHeader("General options")
+        opts.pmSetLongOptionArchive()      # -a/--archive
+        opts.pmSetLongOptionArchiveFolio() # --archive-folio
+        opts.pmSetLongOptionContainer()    # --container
+        opts.pmSetLongOptionHost()         # -h/--host
+        opts.pmSetLongOptionLocalPMDA()    # -L/--local-PMDA
+        opts.pmSetLongOptionSpecLocal()    # -K/--spec-local
+        opts.pmSetLongOption("config", 1, "c", "FILE", "config file path")
+        opts.pmSetLongOption("check", 0, "C", "", "check config and metrics and exit")
+        opts.pmSetLongOption("output-file", 1, "F", "OUTFILE", "output file")
+        opts.pmSetLongOption("derived", 1, "e", "FILE|DFNT", "derived metrics definitions")
+        opts.pmSetLongOptionDebug()        # -D/--debug
+        opts.pmSetLongOptionVersion()      # -V/--version
+        opts.pmSetLongOptionHelp()         # -?/--help
+
+        opts.pmSetLongOptionHeader("Reporting options")
+        opts.pmSetLongOption("no-header", 0, "H", "", "omit headers")
+        opts.pmSetLongOption("no-globals", 0, "G", "", "omit global metrics")
+        opts.pmSetLongOptionAlign()        # -A/--align
+        opts.pmSetLongOptionStart()        # -S/--start
+        opts.pmSetLongOptionFinish()       # -T/--finish
+        opts.pmSetLongOptionOrigin()       # -O/--origin
+        opts.pmSetLongOptionSamples()      # -s/--samples
+        opts.pmSetLongOptionInterval()     # -t/--interval
+        opts.pmSetLongOptionTimeZone()     # -Z/--timezone
+        opts.pmSetLongOptionHostZone()     # -z/--hostzone
+        opts.pmSetLongOption("raw", 0, "r", "", "output raw counter values (no rate conversion)")
+        opts.pmSetLongOption("ignore-incompat", 0, "I", "", "ignore incompatible instances (default: abort)")
+        opts.pmSetLongOption("instances", 1, "i", "STR", "instances to report (default: all current)")
+        opts.pmSetLongOption("omit-flat", 0, "v", "", "omit single-valued metrics with -i (default: include)")
+        opts.pmSetLongOption("timestamp-format", 1, "f", "STR", "strftime string for timestamp format")
+        opts.pmSetLongOption("precision", 1, "P", "N", "N digits after the decimal separator (default: 3)")
+        opts.pmSetLongOption("count-scale", 1, "q", "SCALE", "default count unit")
+        opts.pmSetLongOption("space-scale", 1, "b", "SCALE", "default space unit")
+        opts.pmSetLongOption("time-scale", 1, "y", "SCALE", "default time unit")
+
+        opts.pmSetLongOption("with-extended", 0, "x", "", "write extended information about metrics")
+        opts.pmSetLongOption("with-everything", 0, "X", "", "write everything, incl. internal IDs")
+
+        return opts
+
+    def option_override(self, opt):
+        """ Override standard PCP options """
+        if opt == 'H' or opt == 'K':
+            return 1
+        return 0
+
+    def option(self, opt, optarg, index): # pylint: disable=unused-argument
+        """ Perform setup for an individual command line option """
+        if opt == 'K':
+            if not self.speclocal or not self.speclocal.startswith("K:"):
+                self.speclocal = "K:" + optarg
+            else:
+                self.speclocal = self.speclocal + "|" + optarg
+        elif opt == 'c':
+            self.config = optarg
+        elif opt == 'C':
+            self.check = 1
+        elif opt == 'F':
+            if os.path.exists(optarg):
+                sys.stderr.write("File %s already exists.\n" % optarg)
+                sys.exit(1)
+            self.outfile = optarg
+        elif opt == 'e':
+            self.derived = optarg
+        elif opt == 'H':
+            self.header = 0
+        elif opt == 'G':
+            self.globals = 0
+        elif opt == 'r':
+            self.type = 1
+        elif opt == 'I':
+            self.ignore_incompat = 1
+        elif opt == 'i':
+            self.instances = self.instances + self.pmconfig.parse_instances(optarg)
+        elif opt == 'v':
+            self.omit_flat = 1
+        elif opt == 'P':
+            self.precision = int(optarg)
+        elif opt == 'f':
+            self.timefmt = optarg
+        elif opt == 'q':
+            self.count_scale = optarg
+        elif opt == 'b':
+            self.space_scale = optarg
+        elif opt == 'y':
+            self.time_scale = optarg
+        elif opt == 'x':
+            self.extended = 1
+        elif opt == 'X':
+            self.extended = 1
+            self.everything = 1
+        else:
+            raise pmapi.pmUsageErr()
+
+    def connect(self):
+        """ Establish a PMAPI context """
+        context, self.source = pmapi.pmContext.set_connect_options(self.opts, self.source, self.speclocal)
+
+        self.pmfg = pmapi.fetchgroup(context, self.source)
+        self.pmfg_ts = self.pmfg.extend_timestamp()
+        self.context = self.pmfg.get_context()
+
+        if pmapi.c_api.pmSetContextOptions(self.context.ctx, self.opts.mode, self.opts.delta):
+            raise pmapi.pmUsageErr()
+
+        self.pmconfig.validate_metrics()
+
+    def validate_config(self):
+        """ Validate configuration options """
+        if self.version != CONFVER:
+            sys.stderr.write("Incompatible configuration file version (read v%s, need v%d).\n" % (self.version, CONFVER))
+            sys.exit(1)
+
+        self.pmconfig.finalize_options()
+
+    def execute(self):
+        """ Fetch and report """
+        # Debug
+        if self.context.pmDebug(PM_DEBUG_APPL1):
+            sys.stdout.write("Known config file keywords: " + str(self.keys) + "\n")
+            sys.stdout.write("Known metric spec keywords: " + str(self.pmconfig.metricspec) + "\n")
+
+        # Set delay mode, interpolation
+        if self.context.type != PM_CONTEXT_ARCHIVE:
+            self.delay = 1
+            self.interpol = 1
+
+        # Common preparations
+        pmapi.pmContext.prepare_execute(self.context, self.opts, False, self.interpol, self.interval)
+
+        # Headers
+        if self.header == 1:
+            self.header = 0
+            self.write_header()
+
+        # Just checking
+        if self.check == 1:
+            return
+
+        # Main loop
+        while self.samples != 0:
+            # Fetch values
+            try:
+                self.pmfg.fetch()
+            except pmapi.pmErr as error:
+                if error.args[0] == PM_ERR_EOL:
+                    break
+                raise error
+
+            # Watch for endtime in uninterpolated mode
+            if not self.interpol:
+                if float(self.pmfg_ts().strftime('%s')) > float(self.opts.pmGetOptionFinish()):
+                    break
+
+            # Report and prepare for the next round
+            self.report(self.pmfg_ts())
+            if self.samples and self.samples > 0:
+                self.samples -= 1
+            if self.delay and self.interpol and self.samples != 0:
+                self.context.pmtimevalSleep(self.interval)
+
+        # Allow to flush buffered values / say goodbye
+        self.report(None)
+
+    def report(self, tstamp):
+        """ Report the metric values """
+        if tstamp != None:
+            tstamp = tstamp.strftime(self.timefmt)
+
+        self.write_json(tstamp)
+
+    def write_header(self):
+        """ Write info header """
+        output = self.outfile if self.outfile else "stdout"
+        if self.context.type == PM_CONTEXT_ARCHIVE:
+            sys.stdout.write('{ "//": "Writing %d archived metrics to %s..." }\n{ "//": "(Ctrl-C to stop)" }\n' % (len(self.metrics), output))
+            return
+
+        sys.stdout.write('{ "//": "Waiting for %d metrics to be written to %s' % (len(self.metrics), output))
+        if self.runtime != -1:
+            sys.stdout.write(':" }\n{ "//": "%s samples(s) with %.1f sec interval ~ %d sec runtime." }\n' % (self.samples, float(self.interval), self.runtime))
+        elif self.samples:
+            duration = (self.samples - 1) * float(self.interval)
+            sys.stdout.write(':" }\n{ "//": "%s samples(s) with %.1f sec interval ~ %d sec runtime." }\n' % (self.samples, float(self.interval), duration))
+        else:
+            sys.stdout.write('..." }\n{ "//": "(Ctrl-C to stop)" }\n')
+
+    def write_json(self, timestamp):
+        """ Write results in JSON format """
+        if timestamp is None:
+            # Silent goodbye, close in finalize()
+            return
+
+        ts = pmapi.pmContext.convert_datetime(self.pmfg_ts(), "sec")
+
+        if self.prev_ts is None:
+            self.prev_ts = ts
+
+        if not self.writer:
+            if self.outfile is None:
+                self.writer = sys.stdout
+            else:
+                self.writer = open(self.outfile, 'wt')
+
+        # Assemble all metrics into a single document
+        # Use @-prefixed keys for metadata not coming in from PCP metrics
+        if not self.data:
+            self.data = {'@pcp': {'@hosts': []}}
+            host = self.context.pmGetContextHostName()
+            self.data['@pcp']['@hosts'].append({'@host': host, '@source': self.source})
+            self.data['@pcp']['@hosts'][0]['@timezone'] = pmapi.pmContext.posix_tz_to_utc_offset(pmapi.pmContext.get_local_tz())
+            self.data['@pcp']['@hosts'][0]['@metrics'] = []
+
+        self.data['@pcp']['@hosts'][0]['@metrics'].append({'@timestamp': str(timestamp)})
+        self.data['@pcp']['@hosts'][0]['@metrics'][-1]['@interval'] = str(int(ts - self.prev_ts + 0.5))
+        self.prev_ts = ts
+
+        def get_type_string(desc):
+            """ Get metric type as string """
+            if desc.contents.type == pmapi.c_api.PM_TYPE_32:
+                mtype = "32-bit signed"
+            elif desc.contents.type == pmapi.c_api.PM_TYPE_U32:
+                mtype = "32-bit unsigned"
+            elif desc.contents.type == pmapi.c_api.PM_TYPE_64:
+                mtype = "64-bit signed"
+            elif desc.contents.type == pmapi.c_api.PM_TYPE_U64:
+                mtype = "64-bit unsigned"
+            elif desc.contents.type == pmapi.c_api.PM_TYPE_FLOAT:
+                mtype = "32-bit float"
+            elif desc.contents.type == pmapi.c_api.PM_TYPE_DOUBLE:
+                mtype = "64-bit float"
+            elif desc.contents.type == pmapi.c_api.PM_TYPE_STRING:
+                mtype = "string"
+            else:
+                mtype = "unknown"
+            return mtype
+
+        def create_attrs(key, value, unit, pmid, desc):
+            """ Create extra attribute string """
+            data = {key: value}
+            if unit:
+                data['@unit'] = unit
+            if self.extended:
+                # Or consider self.context.pmTypeStr(desc.contents.type)
+                data['@type'] = get_type_string(desc)
+                data['@semantics'] = self.context.pmSemStr(desc.contents.sem)
+            if self.everything:
+                data['@pmid'] = pmid
+                data['@indom'] = desc.contents.indom
+            return data
+
+        insts_key = "@instances"
+        inst_key = "@id"
+
+        for i, metric in enumerate(self.metrics):
+            try:
+                # Install value into outgoing json/dict in key1{key2{key3=value}} style:
+                # foo.bar.baz=value    =>  foo: { bar: { baz: value ...} }
+                # foo.bar.noo[0]=value =>  foo: { bar: { @instances:[{@id: 0, noo: value ...} ... ]}
+
+                pmns_parts = metric.split(".")
+
+                # Find/create the parent dictionary into which to insert the final component
+                for inst, name, val in self.metrics[metric][5](): # pylint: disable=unused-variable
+                    try:
+                        value = val()
+                        fmt = "." + str(self.precision) + "f"
+                        value = format(value, fmt) if isinstance(value, float) else str(value)
+                    except:
+                        continue
+
+                    pmns_leaf_dict = self.data['@pcp']['@hosts'][0]['@metrics'][-1]
+
+                    for pmns_part in pmns_parts[:-1]:
+                        if pmns_part not in pmns_leaf_dict:
+                            pmns_leaf_dict[pmns_part] = {}
+                        pmns_leaf_dict = pmns_leaf_dict[pmns_part]
+                    last_part = pmns_parts[-1]
+
+                    if not name:
+                        pmns_leaf_dict[last_part] = create_attrs(last_part, value, self.metrics[metric][2][0], self.pmconfig.pmids[i], self.pmconfig.descs[i])
+                    else:
+                        if insts_key not in pmns_leaf_dict:
+                            pmns_leaf_dict[insts_key] = []
+                        insts = pmns_leaf_dict[insts_key]
+                        # Find a preexisting {@id: name} object in there, if any
+                        found = False
+                        for j in range(1, len(insts)):
+                            if insts[j][inst_key] == name:
+                                insts[j][last_part] = create_attrs(last_part, value, self.metrics[metric][2][0], self.pmconfig.pmids[i], self.pmconfig.descs[i])
+                                found = True
+                        if not found:
+                            insts.append(create_attrs(last_part, value, self.metrics[metric][2][0], self.pmconfig.pmids[i], self.pmconfig.descs[i]))
+            except:
+                pass
+
+    def finalize(self):
+        """ Finalize and clean up """
+        if self.writer:
+            try:
+                self.writer.write(json.dumps(self.data,
+                                             indent=INDENT,
+                                             sort_keys=True,
+                                             ensure_ascii=False,
+                                             separators=(',', ': ')))
+                self.writer.write("\n")
+                self.writer.flush()
+            except socket.error as error:
+                if error.errno != errno.EPIPE:
+                    raise
+            self.writer.close()
+            self.writer = None
+        return
+
+if __name__ == '__main__':
+    try:
+        P = PCP2JSON()
+        P.connect()
+        P.validate_config()
+        P.execute()
+        P.finalize()
+
+    except pmapi.pmErr as error:
+        sys.stderr.write('%s: %s\n' % (error.progname(), error.message()))
+        sys.exit(1)
+    except pmapi.pmUsageErr as usage:
+        usage.message()
+        sys.exit(1)
+    except IOError as error:
+        if error.errno != errno.EPIPE:
+            sys.stderr.write("%s\n" % str(error))
+            sys.exit(1)
+    except KeyboardInterrupt:
+        sys.stdout.write("\n")
+        P.finalize()

--- a/src/pcp2xlsx/GNUmakefile
+++ b/src/pcp2xlsx/GNUmakefile
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2017 Red Hat, Inc.  All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+
+TOPDIR = ../..
+include $(TOPDIR)/src/include/builddefs
+
+TARGET = pcp2xlsx
+#MAN_SECTION = 1
+#MAN_PAGES = $(TARGET).$(MAN_SECTION)
+#MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
+
+default: $(TARGET).py
+# $(MAN_PAGES)
+
+default:
+
+include $(BUILDRULES)
+
+install: default
+ifeq "$(HAVE_PYTHON)" "true"
+	$(INSTALL) -m 755 $(TARGET).py $(PCP_BIN_DIR)/$(TARGET)
+#	@$(INSTALL_MAN)
+endif
+
+default_pcp: default
+
+install_pcp: install

--- a/src/pcp2xlsx/pcp2xlsx.py
+++ b/src/pcp2xlsx/pcp2xlsx.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env pmpython
+#
+# Copyright (C) 2015-2017 Marko Myllynen <myllynen@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+# pylint: disable=superfluous-parens
+# pylint: disable=invalid-name, line-too-long, no-self-use
+# pylint: disable=too-many-boolean-expressions, too-many-statements
+# pylint: disable=too-many-instance-attributes, too-many-locals
+# pylint: disable=too-many-branches, too-many-nested-blocks
+# pylint: disable=bare-except, broad-except
+
+""" PCP to XLSX Bridge """
+
+# Common imports
+from collections import OrderedDict
+import errno
+import sys
+
+# Our imports
+import os
+import xlsxwriter
+
+# PCP Python PMAPI
+from pcp import pmapi, pmconfig
+from cpmapi import PM_CONTEXT_ARCHIVE, PM_ERR_EOL, PM_IN_NULL, PM_DEBUG_APPL1
+
+if sys.version_info[0] >= 3:
+    long = int # pylint: disable=redefined-builtin
+
+# Default config
+DEFAULT_CONFIG = ["./pcp2xlsx.conf", "$HOME/.pcp2xlsx.conf", "$HOME/.pcp/pcp2xlsx.conf", "$PCP_SYSCONF_DIR/pcp2xlsx.conf"]
+
+# Defaults
+CONFVER = 1
+TIMEFMT = "yyyy-mm-dd hh:mm:ss"
+
+class PCP2XLSX(object):
+    """ PCP to XLSX """
+    def __init__(self):
+        """ Construct object, prepare for command line handling """
+        self.context = None
+        self.pmconfig = pmconfig.pmConfig(self)
+        self.opts = self.options()
+
+        # Configuration directives
+        self.keys = ('source', 'output', 'derived', 'header', 'globals',
+                     'samples', 'interval', 'type', 'precision',
+                     'timefmt',
+                     'count_scale', 'space_scale', 'time_scale', 'version',
+                     'speclocal', 'instances', 'ignore_incompat', 'omit_flat')
+
+        # The order of preference for options (as present):
+        # 1 - command line options
+        # 2 - options from configuration file(s)
+        # 3 - built-in defaults defined below
+        self.check = 0
+        self.version = CONFVER
+        self.source = "local:"
+        self.output = None # For pmrep conf file compat only
+        self.speclocal = None
+        self.derived = None
+        self.header = 1
+        self.globals = 1
+        self.samples = None # forever
+        self.interval = pmapi.timeval(60)      # 60 sec
+        self.opts.pmSetOptionInterval(str(60)) # 60 sec
+        self.delay = 0
+        self.type = 0
+        self.ignore_incompat = 0
+        self.instances = []
+        self.omit_flat = 0
+        self.precision = 3 # .3f
+        self.timefmt = TIMEFMT
+        self.interpol = 0
+        self.count_scale = None
+        self.space_scale = None
+        self.time_scale = None
+
+        # Not in pcp2xlsx.conf, won't overwrite
+        self.outfile = None
+
+        # Internal
+        self.runtime = -1
+
+        self.sheet = None
+        self.row = -1
+        self.ws = None
+
+        # Performance metrics store
+        # key - metric name
+        # values - 0:label, 1:instance(s), 2:unit/scale, 3:type, 4:width, 5:pmfg item
+        self.metrics = OrderedDict()
+        self.pmfg = None
+        self.pmfg_ts = None
+
+        # Read configuration and prepare to connect
+        self.config = self.pmconfig.set_config_file(DEFAULT_CONFIG)
+        self.pmconfig.read_options()
+        self.pmconfig.read_cmd_line()
+        self.pmconfig.prepare_metrics()
+
+    def options(self):
+        """ Setup default command line argument option handling """
+        opts = pmapi.pmOptions()
+        opts.pmSetOptionCallback(self.option)
+        opts.pmSetOverrideCallback(self.option_override)
+        opts.pmSetShortOptions("a:h:LK:c:Ce:D:V?HGA:S:T:O:s:t:Z:zrIi:vP:q:b:y:F:f:")
+        opts.pmSetShortUsage("[option...] metricspec [...]")
+
+        opts.pmSetLongOptionHeader("General options")
+        opts.pmSetLongOptionArchive()      # -a/--archive
+        opts.pmSetLongOptionArchiveFolio() # --archive-folio
+        opts.pmSetLongOptionContainer()    # --container
+        opts.pmSetLongOptionHost()         # -h/--host
+        opts.pmSetLongOptionLocalPMDA()    # -L/--local-PMDA
+        opts.pmSetLongOptionSpecLocal()    # -K/--spec-local
+        opts.pmSetLongOption("config", 1, "c", "FILE", "config file path")
+        opts.pmSetLongOption("check", 0, "C", "", "check config and metrics and exit")
+        opts.pmSetLongOption("output-file", 1, "F", "OUTFILE", "output file")
+        opts.pmSetLongOption("derived", 1, "e", "FILE|DFNT", "derived metrics definitions")
+        opts.pmSetLongOptionDebug()        # -D/--debug
+        opts.pmSetLongOptionVersion()      # -V/--version
+        opts.pmSetLongOptionHelp()         # -?/--help
+
+        opts.pmSetLongOptionHeader("Reporting options")
+        opts.pmSetLongOption("no-header", 0, "H", "", "omit headers")
+        opts.pmSetLongOption("no-globals", 0, "G", "", "omit global metrics")
+        opts.pmSetLongOptionAlign()        # -A/--align
+        opts.pmSetLongOptionStart()        # -S/--start
+        opts.pmSetLongOptionFinish()       # -T/--finish
+        opts.pmSetLongOptionOrigin()       # -O/--origin
+        opts.pmSetLongOptionSamples()      # -s/--samples
+        opts.pmSetLongOptionInterval()     # -t/--interval
+        opts.pmSetLongOptionTimeZone()     # -Z/--timezone
+        opts.pmSetLongOptionHostZone()     # -z/--hostzone
+        opts.pmSetLongOption("raw", 0, "r", "", "output raw counter values (no rate conversion)")
+        opts.pmSetLongOption("ignore-incompat", 0, "I", "", "ignore incompatible instances (default: abort)")
+        opts.pmSetLongOption("instances", 1, "i", "STR", "instances to report (default: all current)")
+        opts.pmSetLongOption("omit-flat", 0, "v", "", "omit single-valued metrics with -i (default: include)")
+        opts.pmSetLongOption("precision", 1, "P", "N", "N digits after the decimal separator (default: 3)")
+        opts.pmSetLongOption("timestamp-format", 1, "f", "STR", "xlsxwriter timestamp format")
+        opts.pmSetLongOption("count-scale", 1, "q", "SCALE", "default count unit")
+        opts.pmSetLongOption("space-scale", 1, "b", "SCALE", "default space unit")
+        opts.pmSetLongOption("time-scale", 1, "y", "SCALE", "default time unit")
+
+        return opts
+
+    def option_override(self, opt):
+        """ Override standard PCP options """
+        if opt == 'H' or opt == 'K':
+            return 1
+        return 0
+
+    def option(self, opt, optarg, index): # pylint: disable=unused-argument
+        """ Perform setup for an individual command line option """
+        if opt == 'K':
+            if not self.speclocal or not self.speclocal.startswith("K:"):
+                self.speclocal = "K:" + optarg
+            else:
+                self.speclocal = self.speclocal + "|" + optarg
+        elif opt == 'c':
+            self.config = optarg
+        elif opt == 'C':
+            self.check = 1
+        elif opt == 'F':
+            if os.path.exists(optarg):
+                sys.stderr.write("File %s already exists.\n" % optarg)
+                sys.exit(1)
+            self.outfile = optarg
+        elif opt == 'e':
+            self.derived = optarg
+        elif opt == 'H':
+            self.header = 0
+        elif opt == 'G':
+            self.globals = 0
+        elif opt == 'r':
+            self.type = 1
+        elif opt == 'I':
+            self.ignore_incompat = 1
+        elif opt == 'i':
+            self.instances = self.instances + self.pmconfig.parse_instances(optarg)
+        elif opt == 'v':
+            self.omit_flat = 1
+        elif opt == 'P':
+            self.precision = int(optarg)
+        elif opt == 'f':
+            self.timefmt = optarg
+        elif opt == 'q':
+            self.count_scale = optarg
+        elif opt == 'b':
+            self.space_scale = optarg
+        elif opt == 'y':
+            self.time_scale = optarg
+        else:
+            raise pmapi.pmUsageErr()
+
+    def connect(self):
+        """ Establish a PMAPI context """
+        context, self.source = pmapi.pmContext.set_connect_options(self.opts, self.source, self.speclocal)
+
+        self.pmfg = pmapi.fetchgroup(context, self.source)
+        self.pmfg_ts = self.pmfg.extend_timestamp()
+        self.context = self.pmfg.get_context()
+
+        if pmapi.c_api.pmSetContextOptions(self.context.ctx, self.opts.mode, self.opts.delta):
+            raise pmapi.pmUsageErr()
+
+        self.pmconfig.validate_metrics()
+
+    def validate_config(self):
+        """ Validate configuration options """
+        if self.version != CONFVER:
+            sys.stderr.write("Incompatible configuration file version (read v%s, need v%d).\n" % (self.version, CONFVER))
+            sys.exit(1)
+
+        if not self.outfile:
+            sys.stderr.write("Output file must be defined.\n")
+            sys.exit(1)
+
+        self.pmconfig.finalize_options()
+
+    def execute(self):
+        """ Fetch and report """
+        # Debug
+        if self.context.pmDebug(PM_DEBUG_APPL1):
+            sys.stdout.write("Known config file keywords: " + str(self.keys) + "\n")
+            sys.stdout.write("Known metric spec keywords: " + str(self.pmconfig.metricspec) + "\n")
+
+        # Set delay mode, interpolation
+        if self.context.type != PM_CONTEXT_ARCHIVE:
+            self.delay = 1
+            self.interpol = 1
+
+        # Common preparations
+        pmapi.pmContext.prepare_execute(self.context, self.opts, False, self.interpol, self.interval)
+
+        # Headers
+        if self.header == 1:
+            self.header = 0
+            self.write_header()
+
+        # Just checking
+        if self.check == 1:
+            return
+
+        # Main loop
+        while self.samples != 0:
+            # Fetch values
+            try:
+                self.pmfg.fetch()
+            except pmapi.pmErr as error:
+                if error.args[0] == PM_ERR_EOL:
+                    break
+                raise error
+
+            # Watch for endtime in uninterpolated mode
+            if not self.interpol:
+                if float(self.pmfg_ts().strftime('%s')) > float(self.opts.pmGetOptionFinish()):
+                    break
+
+            # Report and prepare for the next round
+            self.report(self.pmfg_ts())
+            if self.samples and self.samples > 0:
+                self.samples -= 1
+            if self.delay and self.interpol and self.samples != 0:
+                self.context.pmtimevalSleep(self.interval)
+
+        # Allow to flush buffered values / say goodbye
+        self.report(None)
+
+    def report(self, tstamp):
+        """ Report the metric values """
+        if tstamp != None:
+            tstamp = tstamp.strftime(self.timefmt)
+
+        self.write_xlsx(tstamp)
+
+    def write_header(self):
+        """ Write info header """
+        if self.context.type == PM_CONTEXT_ARCHIVE:
+            sys.stdout.write("Recording %d archived metrics to %s...\n(Ctrl-C to stop)\n" % (len(self.metrics), self.outfile))
+            return
+
+        sys.stdout.write("Recording %d metrics to %s" % (len(self.metrics), self.outfile))
+        if self.runtime != -1:
+            sys.stdout.write(":\n%s samples(s) with %.1f sec interval ~ %d sec runtime.\n" % (self.samples, float(self.interval), self.runtime))
+        elif self.samples:
+            duration = (self.samples - 1) * float(self.interval)
+            sys.stdout.write(":\n%s samples(s) with %.1f sec interval ~ %d sec runtime.\n" % (self.samples, float(self.interval), duration))
+        else:
+            sys.stdout.write("...\n(Ctrl-C to stop)\n")
+
+    def write_xlsx(self, timestamp):
+        """ Write results in XLSX format """
+        if timestamp is None:
+            # Complete and close
+            self.sheet.close()
+            self.sheet = None
+            return
+
+        # Current row
+        self.row += 1
+
+        # Create the sheet and write the sheet headers
+        if not self.sheet:
+            col = 0
+            self.sheet = xlsxwriter.Workbook(self.outfile, {'constant_memory': True, 'in_memory': False, 'default_date_format': self.timefmt})
+            self.ws = self.sheet.add_worksheet("PCP Metrics")
+            fmt = self.sheet.add_format({'bold': True})
+            fmt.set_align('left')
+            self.ws.set_column(col, col, 20)
+            self.ws.write_string(self.row, col, "Host", fmt)
+            col += 1
+            host = self.context.pmGetContextHostName()
+            self.ws.write_string(self.row, col, host, fmt)
+            self.row += 1
+            col = 0
+            self.ws.write_string(self.row, col, "Source", fmt)
+            col += 1
+            self.ws.write_string(self.row, col, self.source, fmt)
+            self.row += 1
+            col = 0
+            self.ws.write_string(self.row, col, "Timezone", fmt)
+            col += 1
+            timez = pmapi.pmContext.posix_tz_to_utc_offset(pmapi.pmContext.get_local_tz())
+            self.ws.write_string(self.row, col, timez, fmt)
+            self.row += 1
+            col = 0
+            self.ws.write_blank(self.row, col, None, fmt)
+            self.row += 1
+            fmt = self.sheet.add_format({'bold': True})
+            fmt.set_align('right')
+            self.ws.write_string(self.row, col, "Time", fmt)
+            # Labels, static
+            for i, metric in enumerate(self.metrics):
+                for j in range(len(self.pmconfig.insts[i][0])):
+                    col += 1
+                    key = metric
+                    if self.pmconfig.insts[i][0][0] != PM_IN_NULL and  self.pmconfig.insts[i][1][j]:
+                        key += "[" + self.pmconfig.insts[i][1][j] + "]"
+                    # Mark metrics with instance domain but without instances
+                    if self.pmconfig.descs[i].contents.indom != PM_IN_NULL and self.pmconfig.insts[i][1][0] is None:
+                        key += "[]"
+                    self.ws.write_string(self.row, col, key, fmt)
+                    l = len(key) if self.metrics[metric][4] < len(key) else self.metrics[metric][4]
+                    self.ws.set_column(col, col, l + 5)
+            self.row += 1
+            # Units, static
+            col = 0
+            for i, metric in enumerate(self.metrics):
+                unit = self.metrics[metric][2][0]
+                ins = 1 if self.pmconfig.insts[i][0][0] == PM_IN_NULL else len(self.pmconfig.insts[i][0])
+                for _ in range(ins):
+                    col += 1
+                    self.ws.write_string(self.row, col, unit, fmt)
+            self.row += 1
+            # Add empty line for readability
+            col = 0
+            fmt = self.sheet.add_format()
+            fmt.set_top(2)
+            self.ws.write_blank(self.row, col, None, fmt)
+            for i in range(len(self.metrics)):
+                for _ in range(len(self.pmconfig.insts[i][0])):
+                    col += 1
+                    self.ws.write_blank(self.row, col, None, fmt)
+            self.row += 1
+
+        # Avoid crossing the C/Python boundary more than once per metric
+        res = {}
+        for _, metric in enumerate(self.metrics):
+            try:
+                for inst, name, val in self.metrics[metric][5](): # pylint: disable=unused-variable
+                    try:
+                        value = val()
+                        if isinstance(value, float):
+                            value = round(value, self.precision)
+                        res[metric + str(inst)] = value
+                    except:
+                        pass
+            except:
+                pass
+
+        # Add corresponding values for each column in the static header
+        col = 0
+        self.ws.write_datetime(self.row, col, self.pmfg_ts())
+        for i, metric in enumerate(self.metrics):
+            for j in range(len(self.pmconfig.insts[i][0])):
+                col += 1
+                if metric + str(self.pmconfig.insts[i][0][j]) in res:
+                    value = res[metric + str(self.pmconfig.insts[i][0][j])]
+                    if value is None:
+                        self.ws.write_blank(self.row, col, None)
+                    elif isinstance(value, str):
+                        self.ws.write_string(self.row, col, value)
+                    else:
+                        self.ws.write_number(self.row, col, value)
+                else:
+                    self.ws.write_blank(self.row, col, None)
+
+    def finalize(self):
+        """ Finalize and clean up """
+        if self.sheet:
+            self.sheet.close()
+            self.sheet = None
+        return
+
+if __name__ == '__main__':
+    try:
+        P = PCP2XLSX()
+        P.connect()
+        P.validate_config()
+        P.execute()
+        P.finalize()
+
+    except pmapi.pmErr as error:
+        sys.stderr.write('%s: %s\n' % (error.progname(), error.message()))
+        sys.exit(1)
+    except pmapi.pmUsageErr as usage:
+        usage.message()
+        sys.exit(1)
+    except IOError as error:
+        if error.errno != errno.EPIPE:
+            sys.stderr.write("%s\n" % str(error))
+            sys.exit(1)
+    except KeyboardInterrupt:
+        sys.stdout.write("\n")
+        P.finalize()

--- a/src/pcp2xml/GNUmakefile
+++ b/src/pcp2xml/GNUmakefile
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2017 Red Hat, Inc.  All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+
+TOPDIR = ../..
+include $(TOPDIR)/src/include/builddefs
+
+TARGET = pcp2xml
+#MAN_SECTION = 1
+#MAN_PAGES = $(TARGET).$(MAN_SECTION)
+#MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
+
+default: $(TARGET).py
+# $(MAN_PAGES)
+
+default:
+
+include $(BUILDRULES)
+
+install: default
+ifeq "$(HAVE_PYTHON)" "true"
+	$(INSTALL) -m 755 $(TARGET).py $(PCP_BIN_DIR)/$(TARGET)
+#	@$(INSTALL_MAN)
+endif
+
+default_pcp: default
+
+install_pcp: install

--- a/src/pcp2xml/pcp2xml.py
+++ b/src/pcp2xml/pcp2xml.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env pmpython
+#
+# Copyright (C) 2015-2017 Marko Myllynen <myllynen@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+# pylint: disable=superfluous-parens
+# pylint: disable=invalid-name, line-too-long, no-self-use
+# pylint: disable=too-many-boolean-expressions, too-many-statements
+# pylint: disable=too-many-instance-attributes, too-many-locals
+# pylint: disable=too-many-branches, too-many-nested-blocks
+# pylint: disable=bare-except, broad-except
+
+""" PCP to XML Bridge """
+
+# Common imports
+from collections import OrderedDict
+import errno
+import sys
+
+# Our imports
+import socket
+import os
+
+# PCP Python PMAPI
+from pcp import pmapi, pmconfig
+from cpmapi import PM_CONTEXT_ARCHIVE, PM_ERR_EOL, PM_DEBUG_APPL1
+
+if sys.version_info[0] >= 3:
+    long = int # pylint: disable=redefined-builtin
+
+# Default config
+DEFAULT_CONFIG = ["./pcp2xml.conf", "$HOME/.pcp2xml.conf", "$HOME/.pcp/pcp2xml.conf", "$PCP_SYSCONF_DIR/pcp2xml.conf"]
+
+# Defaults
+CONFVER = 1
+TIMEFMT = "%Y-%m-%d %H:%M:%S"
+
+class PCP2XML(object):
+    """ PCP to XML """
+    def __init__(self):
+        """ Construct object, prepare for command line handling """
+        self.context = None
+        self.pmconfig = pmconfig.pmConfig(self)
+        self.opts = self.options()
+
+        # Configuration directives
+        self.keys = ('source', 'output', 'derived', 'header', 'globals',
+                     'samples', 'interval', 'type', 'precision',
+                     'timefmt', 'extended', 'everything',
+                     'count_scale', 'space_scale', 'time_scale', 'version',
+                     'speclocal', 'instances', 'ignore_incompat', 'omit_flat')
+
+        # The order of preference for options (as present):
+        # 1 - command line options
+        # 2 - options from configuration file(s)
+        # 3 - built-in defaults defined below
+        self.check = 0
+        self.version = CONFVER
+        self.source = "local:"
+        self.output = None # For pmrep conf file compat only
+        self.speclocal = None
+        self.derived = None
+        self.header = 1
+        self.globals = 1
+        self.samples = None # forever
+        self.interval = pmapi.timeval(60)      # 60 sec
+        self.opts.pmSetOptionInterval(str(60)) # 60 sec
+        self.delay = 0
+        self.type = 0
+        self.ignore_incompat = 0
+        self.instances = []
+        self.omit_flat = 0
+        self.precision = 3 # .3f
+        self.timefmt = TIMEFMT
+        self.interpol = 0
+        self.count_scale = None
+        self.space_scale = None
+        self.time_scale = None
+
+        # Not in pcp2xml.conf, won't overwrite
+        self.outfile = None
+
+        self.extended = 0
+        self.everything = 0
+
+        # Internal
+        self.runtime = -1
+
+        self.prev_ts = None
+        self.writer = None
+
+        # Performance metrics store
+        # key - metric name
+        # values - 0:label, 1:instance(s), 2:unit/scale, 3:type, 4:width, 5:pmfg item
+        self.metrics = OrderedDict()
+        self.pmfg = None
+        self.pmfg_ts = None
+
+        # Read configuration and prepare to connect
+        self.config = self.pmconfig.set_config_file(DEFAULT_CONFIG)
+        self.pmconfig.read_options()
+        self.pmconfig.read_cmd_line()
+        self.pmconfig.prepare_metrics()
+
+    def options(self):
+        """ Setup default command line argument option handling """
+        opts = pmapi.pmOptions()
+        opts.pmSetOptionCallback(self.option)
+        opts.pmSetOverrideCallback(self.option_override)
+        opts.pmSetShortOptions("a:h:LK:c:Ce:D:V?HGA:S:T:O:s:t:Z:zrIi:vP:q:b:y:F:f:xX")
+        opts.pmSetShortUsage("[option...] metricspec [...]")
+
+        opts.pmSetLongOptionHeader("General options")
+        opts.pmSetLongOptionArchive()      # -a/--archive
+        opts.pmSetLongOptionArchiveFolio() # --archive-folio
+        opts.pmSetLongOptionContainer()    # --container
+        opts.pmSetLongOptionHost()         # -h/--host
+        opts.pmSetLongOptionLocalPMDA()    # -L/--local-PMDA
+        opts.pmSetLongOptionSpecLocal()    # -K/--spec-local
+        opts.pmSetLongOption("config", 1, "c", "FILE", "config file path")
+        opts.pmSetLongOption("check", 0, "C", "", "check config and metrics and exit")
+        opts.pmSetLongOption("output-file", 1, "F", "OUTFILE", "output file")
+        opts.pmSetLongOption("derived", 1, "e", "FILE|DFNT", "derived metrics definitions")
+        opts.pmSetLongOptionDebug()        # -D/--debug
+        opts.pmSetLongOptionVersion()      # -V/--version
+        opts.pmSetLongOptionHelp()         # -?/--help
+
+        opts.pmSetLongOptionHeader("Reporting options")
+        opts.pmSetLongOption("no-header", 0, "H", "", "omit headers")
+        opts.pmSetLongOption("no-globals", 0, "G", "", "omit global metrics")
+        opts.pmSetLongOptionAlign()        # -A/--align
+        opts.pmSetLongOptionStart()        # -S/--start
+        opts.pmSetLongOptionFinish()       # -T/--finish
+        opts.pmSetLongOptionOrigin()       # -O/--origin
+        opts.pmSetLongOptionSamples()      # -s/--samples
+        opts.pmSetLongOptionInterval()     # -t/--interval
+        opts.pmSetLongOptionTimeZone()     # -Z/--timezone
+        opts.pmSetLongOptionHostZone()     # -z/--hostzone
+        opts.pmSetLongOption("raw", 0, "r", "", "output raw counter values (no rate conversion)")
+        opts.pmSetLongOption("ignore-incompat", 0, "I", "", "ignore incompatible instances (default: abort)")
+        opts.pmSetLongOption("instances", 1, "i", "STR", "instances to report (default: all current)")
+        opts.pmSetLongOption("omit-flat", 0, "v", "", "omit single-valued metrics with -i (default: include)")
+        opts.pmSetLongOption("precision", 1, "P", "N", "N digits after the decimal separator (default: 3)")
+        opts.pmSetLongOption("timestamp-format", 1, "f", "STR", "strftime string for timestamp format")
+        opts.pmSetLongOption("count-scale", 1, "q", "SCALE", "default count unit")
+        opts.pmSetLongOption("space-scale", 1, "b", "SCALE", "default space unit")
+        opts.pmSetLongOption("time-scale", 1, "y", "SCALE", "default time unit")
+
+        opts.pmSetLongOption("with-extended", 0, "x", "", "write extended information about metrics")
+        opts.pmSetLongOption("with-everything", 0, "X", "", "write everything, incl. internal IDs")
+
+        return opts
+
+    def option_override(self, opt):
+        """ Override standard PCP options """
+        if opt == 'H' or opt == 'K':
+            return 1
+        return 0
+
+    def option(self, opt, optarg, index): # pylint: disable=unused-argument
+        """ Perform setup for an individual command line option """
+        if opt == 'K':
+            if not self.speclocal or not self.speclocal.startswith("K:"):
+                self.speclocal = "K:" + optarg
+            else:
+                self.speclocal = self.speclocal + "|" + optarg
+        elif opt == 'c':
+            self.config = optarg
+        elif opt == 'C':
+            self.check = 1
+        elif opt == 'F':
+            if os.path.exists(optarg):
+                sys.stderr.write("File %s already exists.\n" % optarg)
+                sys.exit(1)
+            self.outfile = optarg
+        elif opt == 'e':
+            self.derived = optarg
+        elif opt == 'H':
+            self.header = 0
+        elif opt == 'G':
+            self.globals = 0
+        elif opt == 'r':
+            self.type = 1
+        elif opt == 'I':
+            self.ignore_incompat = 1
+        elif opt == 'i':
+            self.instances = self.instances + self.pmconfig.parse_instances(optarg)
+        elif opt == 'v':
+            self.omit_flat = 1
+        elif opt == 'P':
+            self.precision = int(optarg)
+        elif opt == 'f':
+            self.timefmt = optarg
+        elif opt == 'q':
+            self.count_scale = optarg
+        elif opt == 'b':
+            self.space_scale = optarg
+        elif opt == 'y':
+            self.time_scale = optarg
+        elif opt == 'x':
+            self.extended = 1
+        elif opt == 'X':
+            self.extended = 1
+            self.everything = 1
+        else:
+            raise pmapi.pmUsageErr()
+
+    def connect(self):
+        """ Establish a PMAPI context """
+        context, self.source = pmapi.pmContext.set_connect_options(self.opts, self.source, self.speclocal)
+
+        self.pmfg = pmapi.fetchgroup(context, self.source)
+        self.pmfg_ts = self.pmfg.extend_timestamp()
+        self.context = self.pmfg.get_context()
+
+        if pmapi.c_api.pmSetContextOptions(self.context.ctx, self.opts.mode, self.opts.delta):
+            raise pmapi.pmUsageErr()
+
+        self.pmconfig.validate_metrics()
+
+    def validate_config(self):
+        """ Validate configuration options """
+        if self.version != CONFVER:
+            sys.stderr.write("Incompatible configuration file version (read v%s, need v%d).\n" % (self.version, CONFVER))
+            sys.exit(1)
+
+        self.pmconfig.finalize_options()
+
+    def execute(self):
+        """ Fetch and report """
+        # Debug
+        if self.context.pmDebug(PM_DEBUG_APPL1):
+            sys.stdout.write("Known config file keywords: " + str(self.keys) + "\n")
+            sys.stdout.write("Known metric spec keywords: " + str(self.pmconfig.metricspec) + "\n")
+
+        # Set delay mode, interpolation
+        if self.context.type != PM_CONTEXT_ARCHIVE:
+            self.delay = 1
+            self.interpol = 1
+
+        # Common preparations
+        pmapi.pmContext.prepare_execute(self.context, self.opts, False, self.interpol, self.interval)
+
+        # Headers
+        if self.header == 1:
+            self.header = 0
+            self.write_header()
+
+        # Just checking
+        if self.check == 1:
+            return
+
+        # Main loop
+        while self.samples != 0:
+            # Fetch values
+            try:
+                self.pmfg.fetch()
+            except pmapi.pmErr as error:
+                if error.args[0] == PM_ERR_EOL:
+                    break
+                raise error
+
+            # Watch for endtime in uninterpolated mode
+            if not self.interpol:
+                if float(self.pmfg_ts().strftime('%s')) > float(self.opts.pmGetOptionFinish()):
+                    break
+
+            # Report and prepare for the next round
+            self.report(self.pmfg_ts())
+            if self.samples and self.samples > 0:
+                self.samples -= 1
+            if self.delay and self.interpol and self.samples != 0:
+                self.context.pmtimevalSleep(self.interval)
+
+        # Allow to flush buffered values / say goodbye
+        self.report(None)
+
+    def report(self, tstamp):
+        """ Report the metric values """
+        if tstamp != None:
+            tstamp = tstamp.strftime(self.timefmt)
+
+        self.write_xml(tstamp)
+
+    def write_header(self):
+        """ Write info header """
+        output = self.outfile if self.outfile else "stdout"
+
+        if not self.outfile:
+            self.header = 1
+            sys.stdout.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+
+        if self.context.type == PM_CONTEXT_ARCHIVE:
+            sys.stdout.write("<!-- Writing %d archived metrics to %s... -->\n<!-- Ctrl-C to stop -->\n" % (len(self.metrics), output))
+            return
+
+        sys.stdout.write("<!-- Writing %d metrics to %s" % (len(self.metrics), output))
+        if self.runtime != -1:
+            sys.stdout.write(": -->\n<!-- %s samples(s) with %.1f sec interval ~ %d sec runtime. -->\n" % (self.samples, float(self.interval), self.runtime))
+        elif self.samples:
+            duration = (self.samples - 1) * float(self.interval)
+            sys.stdout.write(": -->\n<!-- %s samples(s) with %.1f sec interval ~ %d sec runtime. -->\n" % (self.samples, float(self.interval), duration))
+        else:
+            sys.stdout.write("... -->\n<!-- Ctrl-C to stop -->\n")
+
+    def write_xml(self, timestamp):
+        """ Write results in XML format """
+        if timestamp is None:
+            # Silent goodbye, close in finalize()
+            return
+
+        ts = pmapi.pmContext.convert_datetime(self.pmfg_ts(), "sec")
+
+        if self.prev_ts is None:
+            self.prev_ts = ts
+
+        if not self.writer:
+            if self.outfile is None:
+                self.writer = sys.stdout
+            else:
+                self.writer = open(self.outfile, 'wt')
+            if not self.header:
+                self.writer.write('<?xml version="1.0" encoding="UTF-8"?>\n')
+            self.writer.write('<pcp>\n')
+            host = self.context.pmGetContextHostName()
+            self.writer.write('  <host nodename="%s">\n' % host)
+            self.writer.write('    <source>%s</source>\n' % self.source)
+            timez = pmapi.pmContext.posix_tz_to_utc_offset(pmapi.pmContext.get_local_tz())
+            self.writer.write('    <timezone>%s</timezone>\n' % timez)
+            self.writer.write('    <metrics>\n')
+
+        # Assemble all metrics into a single document
+        data = {}
+
+        insts_key = "@instances"
+        inst_key = "@id"
+
+        def escape_xml(string):
+            """ Escape XML special characters """
+            return string.replace("&", "&amp;").replace('"', '&quot;').replace("'", "&apos;").replace("<", "&lt;").replace(">", "&gt;")
+
+        for i, metric in enumerate(self.metrics):
+            try:
+                # Install value into dict in key1{key2{key3=value}} style:
+                # foo.bar.baz=value    =>  foo: { bar: { baz: value ...} }
+
+                pmns_parts = metric.split(".")
+
+                # Find/create the parent dictionary into which to insert the final component
+                for inst, name, val in self.metrics[metric][5](): # pylint: disable=unused-variable
+                    try:
+                        value = val()
+                        fmt = "." + str(self.precision) + "f"
+                        value = format(value, fmt) if isinstance(value, float) else str(value)
+                        value = escape_xml(value)
+                    except:
+                        continue
+
+                    pmns_leaf_dict = data
+
+                    for pmns_part in pmns_parts[:-1]:
+                        if pmns_part not in pmns_leaf_dict:
+                            pmns_leaf_dict[pmns_part] = {}
+                        pmns_leaf_dict = pmns_leaf_dict[pmns_part]
+                    last_part = pmns_parts[-1]
+
+                    if not name:
+                        pmns_leaf_dict[last_part] = [None, self.metrics[metric][2][0], value, self.pmconfig.pmids[i], self.pmconfig.descs[i]]
+                    else:
+                        if insts_key not in pmns_leaf_dict:
+                            pmns_leaf_dict[insts_key] = []
+                        insts = pmns_leaf_dict[insts_key]
+                        # Find a preexisting {@id: name} object in there, if any
+                        found = False
+                        for j in range(1, len(insts)):
+                            if insts[j][inst_key] == name:
+                                insts[j][last_part] = [name, self.metrics[metric][2][0], value, self.pmconfig.pmids[i], self.pmconfig.descs[i]]
+                                found = True
+                        if not found:
+                            insts.append({inst_key: name, last_part: [name, self.metrics[metric][2][0], value, self.pmconfig.pmids[i], self.pmconfig.descs[i]]})
+            except:
+                pass
+
+        def get_type_string(desc):
+            """ Get metric type as string """
+            if desc.contents.type == pmapi.c_api.PM_TYPE_32:
+                mtype = "32-bit signed"
+            elif desc.contents.type == pmapi.c_api.PM_TYPE_U32:
+                mtype = "32-bit unsigned"
+            elif desc.contents.type == pmapi.c_api.PM_TYPE_64:
+                mtype = "64-bit signed"
+            elif desc.contents.type == pmapi.c_api.PM_TYPE_U64:
+                mtype = "64-bit unsigned"
+            elif desc.contents.type == pmapi.c_api.PM_TYPE_FLOAT:
+                mtype = "32-bit float"
+            elif desc.contents.type == pmapi.c_api.PM_TYPE_DOUBLE:
+                mtype = "64-bit float"
+            elif desc.contents.type == pmapi.c_api.PM_TYPE_STRING:
+                mtype = "string"
+            else:
+                mtype = "unknown"
+            return mtype
+
+        def create_attrs(instance, unit, pmid, desc):
+            """ Create extra attribute string """
+            attrs = ""
+            if instance:
+                attrs += ' instance="' + instance + '"'
+            if unit:
+                attrs += ' unit="' + unit + '"'
+            if self.extended:
+                # Or consider self.context.pmTypeStr(desc.contents.type)
+                attrs += ' type="' + get_type_string(desc) + '"'
+                attrs += ' semantics="' + self.context.pmSemStr(desc.contents.sem) + '"'
+            if self.everything:
+                attrs += ' pmid="' + str(pmid) + '"'
+                if desc.contents.indom != pmapi.c_api.PM_IN_NULL:
+                    attrs += ' indom="' + str(desc.contents.indom) + '"'
+            return attrs
+
+        def iteritems(d):
+            """ Python 2/3 compatibility wrapper """
+            try:
+                return d.iteritems()
+            except AttributeError:
+                return d.items()
+
+        # Use custom XML writer to allow updates on each interval
+        def write_metric_xml(data, indent="        "):
+            """ Write metric values as XML elements """
+            for key, value in iteritems(data):
+                if isinstance(value, dict):
+                    self.writer.write('%s<%s>\n' % (indent, key))
+                    write_metric_xml(value, indent + "  ")
+                    self.writer.write('%s</%s>\n' % (indent, key))
+                else:
+                    if not isinstance(value[0], dict):
+                        self.writer.write('%s<%s%s>%s</%s>\n' % (indent, key, create_attrs(None, value[1], value[3], value[4]), value[2], key))
+                    else:
+                        for j, _ in enumerate(value):
+                            for k in value[j]:
+                                if k == inst_key:
+                                    continue
+                                self.writer.write('%s<%s%s>%s</%s>\n' % (indent, k, create_attrs(escape_xml(value[j][k][0]), value[j][k][1], value[j][k][3], value[j][k][4]), value[j][k][2], k))
+
+        # Add current values
+        interval = str(int(ts - self.prev_ts + 0.5))
+        self.writer.write('      <timestamp value="%s" interval="%s">\n' % (str(timestamp), interval))
+        self.prev_ts = ts
+        write_metric_xml(data)
+        self.writer.write('      </timestamp>\n')
+
+    def finalize(self):
+        """ Finalize and clean up """
+        if self.writer:
+            try:
+                self.writer.write("    </metrics>\n")
+                self.writer.write("  </host>\n")
+                self.writer.write("</pcp>\n")
+                self.writer.flush()
+            except socket.error as error:
+                if error.errno != errno.EPIPE:
+                    raise
+            self.writer.close()
+            self.writer = None
+        return
+
+if __name__ == '__main__':
+    try:
+        P = PCP2XML()
+        P.connect()
+        P.validate_config()
+        P.execute()
+        P.finalize()
+
+    except pmapi.pmErr as error:
+        sys.stderr.write('%s: %s\n' % (error.progname(), error.message()))
+        sys.exit(1)
+    except pmapi.pmUsageErr as usage:
+        usage.message()
+        sys.exit(1)
+    except IOError as error:
+        if error.errno != errno.EPIPE:
+            sys.stderr.write("%s\n" % str(error))
+            sys.exit(1)
+    except KeyboardInterrupt:
+        sys.stdout.write("\n")
+        P.finalize()

--- a/src/pcp2zabbix/GNUmakefile
+++ b/src/pcp2zabbix/GNUmakefile
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2017 Red Hat, Inc.  All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+
+TOPDIR = ../..
+include $(TOPDIR)/src/include/builddefs
+
+TARGET = pcp2zabbix
+#MAN_SECTION = 1
+#MAN_PAGES = $(TARGET).$(MAN_SECTION)
+#MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
+
+default: $(TARGET).py
+# $(MAN_PAGES)
+
+default:
+
+include $(BUILDRULES)
+
+install: default
+ifeq "$(HAVE_PYTHON)" "true"
+	$(INSTALL) -m 755 $(TARGET).py $(PCP_BIN_DIR)/$(TARGET)
+#	@$(INSTALL_MAN)
+endif
+
+default_pcp: default
+
+install_pcp: install

--- a/src/pcp2zabbix/pcp2zabbix.py
+++ b/src/pcp2zabbix/pcp2zabbix.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env pmpython
+#
+# Copyright (C) 2015-2017 Marko Myllynen <myllynen@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+# [zbxsend] Copyright (C) 2014 Sergey Kirillov <sergey.kirillov@gmail.com>
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# pylint: disable=superfluous-parens
+# pylint: disable=invalid-name, line-too-long, no-self-use
+# pylint: disable=too-many-boolean-expressions, too-many-statements
+# pylint: disable=too-many-instance-attributes, too-many-locals
+# pylint: disable=too-many-branches, too-many-nested-blocks
+# pylint: disable=bare-except, broad-except
+
+""" PCP to Zabbix Bridge """
+
+# Common imports
+from collections import OrderedDict
+import errno
+import sys
+
+# Our imports
+try:
+    import json
+except:
+    import simplejson as json
+import socket
+import struct
+import time
+
+# PCP Python PMAPI
+from pcp import pmapi, pmconfig
+from cpmapi import PM_CONTEXT_ARCHIVE, PM_ERR_EOL, PM_DEBUG_APPL0, PM_DEBUG_APPL1
+
+if sys.version_info[0] >= 3:
+    long = int # pylint: disable=redefined-builtin
+
+# Default config
+DEFAULT_CONFIG = ["./pcp2zabbix.conf", "$HOME/.pcp2zabbix.conf", "$HOME/.pcp/pcp2zabbix.conf", "$PCP_SYSCONF_DIR/pcp2zabbix.conf"]
+
+# Defaults
+CONFVER = 1
+ZBXSERVER = "localhost"
+ZBXPORT = 10051
+ZBXPREFIX = "pcp."
+
+class ZabbixMetric(object): # pylint: disable=too-few-public-methods
+    """ A Zabbix metric """
+    def __init__(self, host, key, value, clock):
+        self.host = host
+        self.key = key
+        self.value = value
+        self.clock = clock
+
+    def __repr__(self):
+        return 'Metric(%r, %r, %r, %r)' % (self.host, self.key, self.value, self.clock)
+
+class PCP2Zabbix(object):
+    """ PCP to Zabbix """
+    def __init__(self):
+        """ Construct object, prepare for command line handling """
+        self.context = None
+        self.pmconfig = pmconfig.pmConfig(self)
+        self.opts = self.options()
+
+        # Configuration directives
+        self.keys = ('source', 'output', 'derived', 'header', 'globals',
+                     'samples', 'interval', 'type', 'precision',
+                     'zabbix_server', 'zabbix_port', 'zabbix_host', 'zabbix_interval', 'zabbix_prefix',
+                     'count_scale', 'space_scale', 'time_scale', 'version',
+                     'speclocal', 'instances', 'ignore_incompat', 'omit_flat')
+
+        # The order of preference for options (as present):
+        # 1 - command line options
+        # 2 - options from configuration file(s)
+        # 3 - built-in defaults defined below
+        self.check = 0
+        self.version = CONFVER
+        self.source = "local:"
+        self.output = None # For pmrep conf file compat only
+        self.speclocal = None
+        self.derived = None
+        self.header = 1
+        self.globals = 1
+        self.samples = None # forever
+        self.interval = pmapi.timeval(60)      # 60 sec
+        self.opts.pmSetOptionInterval(str(60)) # 60 sec
+        self.delay = 0
+        self.type = 0
+        self.ignore_incompat = 0
+        self.instances = []
+        self.omit_flat = 0
+        self.precision = 3 # .3f
+        self.timefmt = "%H:%M:%S" # For compat only
+        self.interpol = 0
+        self.count_scale = None
+        self.space_scale = None
+        self.time_scale = None
+
+        self.zabbix_server = ZBXSERVER
+        self.zabbix_port = ZBXPORT
+        self.zabbix_host = None
+        self.zabbix_interval = None
+        self.zabbix_prefix = ZBXPREFIX
+
+        # Internal
+        self.runtime = -1
+
+        self.zabbix_prevsend = None
+        self.zabbix_metrics = []
+
+        # Performance metrics store
+        # key - metric name
+        # values - 0:label, 1:instance(s), 2:unit/scale, 3:type, 4:width, 5:pmfg item
+        self.metrics = OrderedDict()
+        self.pmfg = None
+        self.pmfg_ts = None
+
+        # Read configuration and prepare to connect
+        self.config = self.pmconfig.set_config_file(DEFAULT_CONFIG)
+        self.pmconfig.read_options()
+        self.pmconfig.read_cmd_line()
+        self.pmconfig.prepare_metrics()
+
+    def options(self):
+        """ Setup default command line argument option handling """
+        opts = pmapi.pmOptions()
+        opts.pmSetOptionCallback(self.option)
+        opts.pmSetOverrideCallback(self.option_override)
+        opts.pmSetShortOptions("a:h:LK:c:Ce:D:V?HGA:S:T:O:s:t:Z:zrIi:vP:q:b:y:g:p:X:E:x:")
+        opts.pmSetShortUsage("[option...] metricspec [...]")
+
+        opts.pmSetLongOptionHeader("General options")
+        opts.pmSetLongOptionArchive()      # -a/--archive
+        opts.pmSetLongOptionArchiveFolio() # --archive-folio
+        opts.pmSetLongOptionContainer()    # --container
+        opts.pmSetLongOptionHost()         # -h/--host
+        opts.pmSetLongOptionLocalPMDA()    # -L/--local-PMDA
+        opts.pmSetLongOptionSpecLocal()    # -K/--spec-local
+        opts.pmSetLongOption("config", 1, "c", "FILE", "config file path")
+        opts.pmSetLongOption("check", 0, "C", "", "check config and metrics and exit")
+        opts.pmSetLongOption("derived", 1, "e", "FILE|DFNT", "derived metrics definitions")
+        opts.pmSetLongOptionDebug()        # -D/--debug
+        opts.pmSetLongOptionVersion()      # -V/--version
+        opts.pmSetLongOptionHelp()         # -?/--help
+
+        opts.pmSetLongOptionHeader("Reporting options")
+        opts.pmSetLongOption("no-header", 0, "H", "", "omit headers")
+        opts.pmSetLongOption("no-globals", 0, "G", "", "omit global metrics")
+        opts.pmSetLongOptionAlign()        # -A/--align
+        opts.pmSetLongOptionStart()        # -S/--start
+        opts.pmSetLongOptionFinish()       # -T/--finish
+        opts.pmSetLongOptionOrigin()       # -O/--origin
+        opts.pmSetLongOptionSamples()      # -s/--samples
+        opts.pmSetLongOptionInterval()     # -t/--interval
+        opts.pmSetLongOptionTimeZone()     # -Z/--timezone
+        opts.pmSetLongOptionHostZone()     # -z/--hostzone
+        opts.pmSetLongOption("raw", 0, "r", "", "output raw counter values (no rate conversion)")
+        opts.pmSetLongOption("ignore-incompat", 0, "I", "", "ignore incompatible instances (default: abort)")
+        opts.pmSetLongOption("instances", 1, "i", "STR", "instances to report (default: all current)")
+        opts.pmSetLongOption("omit-flat", 0, "v", "", "omit single-valued metrics with -i (default: include)")
+        opts.pmSetLongOption("precision", 1, "P", "N", "N digits after the decimal separator (default: 3)")
+        opts.pmSetLongOption("count-scale", 1, "q", "SCALE", "default count unit")
+        opts.pmSetLongOption("space-scale", 1, "b", "SCALE", "default space unit")
+        opts.pmSetLongOption("time-scale", 1, "y", "SCALE", "default time unit")
+
+        opts.pmSetLongOption("zabbix-server", 1, "g", "SERVER", "zabbix server (default: " + ZBXSERVER + ")")
+        opts.pmSetLongOption("zabbix-port", 1, "p", "PORT", "zabbix port (default: " + str(ZBXPORT) + ")")
+        opts.pmSetLongOption("zabbix-host", 1, "X", "HOSTID", "zabbix host-id for measurements")
+        opts.pmSetLongOption("zabbix-interval", 1, "E", "INTERVAL", "interval to send collected metrics")
+        opts.pmSetLongOption("zabbix-prefix", 1, "x", "PREFOX", "prefix for metric names (default: " + ZBXPREFIX + ")")
+
+        return opts
+
+    def option_override(self, opt):
+        """ Override standard PCP options """
+        if opt == 'H' or opt == 'K' or opt == 'g':
+            return 1
+        return 0
+
+    def option(self, opt, optarg, index): # pylint: disable=unused-argument
+        """ Perform setup for an individual command line option """
+        if opt == 'K':
+            if not self.speclocal or not self.speclocal.startswith("K:"):
+                self.speclocal = "K:" + optarg
+            else:
+                self.speclocal = self.speclocal + "|" + optarg
+        elif opt == 'c':
+            self.config = optarg
+        elif opt == 'C':
+            self.check = 1
+        elif opt == 'e':
+            self.derived = optarg
+        elif opt == 'H':
+            self.header = 0
+        elif opt == 'G':
+            self.globals = 0
+        elif opt == 'r':
+            self.type = 1
+        elif opt == 'I':
+            self.ignore_incompat = 1
+        elif opt == 'i':
+            self.instances = self.instances + self.pmconfig.parse_instances(optarg)
+        elif opt == 'v':
+            self.omit_flat = 1
+        elif opt == 'P':
+            self.precision = int(optarg)
+        elif opt == 'q':
+            self.count_scale = optarg
+        elif opt == 'b':
+            self.space_scale = optarg
+        elif opt == 'y':
+            self.time_scale = optarg
+        elif opt == 'g':
+            self.zabbix_server = optarg
+        elif opt == 'p':
+            self.zabbix_port = optarg
+        elif opt == 'X':
+            self.zabbix_host = optarg
+        elif opt == 'E':
+            self.zabbix_interval = optarg
+        elif opt == 'x':
+            self.zabbix_prefix = optarg
+        else:
+            raise pmapi.pmUsageErr()
+
+    def connect(self):
+        """ Establish a PMAPI context """
+        context, self.source = pmapi.pmContext.set_connect_options(self.opts, self.source, self.speclocal)
+
+        self.pmfg = pmapi.fetchgroup(context, self.source)
+        self.pmfg_ts = self.pmfg.extend_timestamp()
+        self.context = self.pmfg.get_context()
+
+        if pmapi.c_api.pmSetContextOptions(self.context.ctx, self.opts.mode, self.opts.delta):
+            raise pmapi.pmUsageErr()
+
+        self.pmconfig.validate_metrics()
+
+    def validate_config(self):
+        """ Validate configuration options """
+        if self.version != CONFVER:
+            sys.stderr.write("Incompatible configuration file version (read v%s, need v%d).\n" % (self.version, CONFVER))
+            sys.exit(1)
+
+        if self.zabbix_host is None:
+            self.zabbix_host = self.context.pmGetContextHostName()
+
+        self.pmconfig.finalize_options()
+
+        # Adjust interval
+        if self.zabbix_interval:
+            self.zabbix_interval = float(pmapi.timeval.fromInterval(self.zabbix_interval))
+            if self.zabbix_interval < float(self.interval):
+                self.zabbix_interval = float(self.interval)
+        else:
+            self.zabbix_interval = float(self.interval)
+
+    def execute(self):
+        """ Fetch and report """
+        # Debug
+        if self.context.pmDebug(PM_DEBUG_APPL1):
+            sys.stdout.write("Known config file keywords: " + str(self.keys) + "\n")
+            sys.stdout.write("Known metric spec keywords: " + str(self.pmconfig.metricspec) + "\n")
+
+        # Set delay mode, interpolation
+        if self.context.type != PM_CONTEXT_ARCHIVE:
+            self.delay = 1
+            self.interpol = 1
+
+        # Common preparations
+        pmapi.pmContext.prepare_execute(self.context, self.opts, False, self.interpol, self.interval)
+
+        # Headers
+        if self.header == 1:
+            self.header = 0
+            self.write_header()
+
+        # Just checking
+        if self.check == 1:
+            return
+
+        # Main loop
+        while self.samples != 0:
+            # Fetch values
+            try:
+                self.pmfg.fetch()
+            except pmapi.pmErr as error:
+                if error.args[0] == PM_ERR_EOL:
+                    break
+                raise error
+
+            # Watch for endtime in uninterpolated mode
+            if not self.interpol:
+                if float(self.pmfg_ts().strftime('%s')) > float(self.opts.pmGetOptionFinish()):
+                    break
+
+            # Report and prepare for the next round
+            self.report(self.pmfg_ts())
+            if self.samples and self.samples > 0:
+                self.samples -= 1
+            if self.delay and self.interpol and self.samples != 0:
+                self.context.pmtimevalSleep(self.interval)
+
+        # Allow to flush buffered values / say goodbye
+        self.report(None)
+
+    def report(self, tstamp):
+        """ Report the metric values """
+        if tstamp != None:
+            tstamp = tstamp.strftime(self.timefmt)
+
+        self.write_zabbix(tstamp)
+
+    def write_header(self):
+        """ Write info header """
+        if self.context.type == PM_CONTEXT_ARCHIVE:
+            self.zabbix_interval = 250 # See zabbix_sender(8)
+            sys.stdout.write("Sending %d archived metrics to Zabbix server %s...\n(Ctrl-C to stop)\n" % (len(self.metrics), self.zabbix_server))
+            return
+
+        sys.stdout.write("Sending %d metrics to Zabbix server %s every %d sec" % (len(self.metrics), self.zabbix_server, self.zabbix_interval))
+        if self.runtime != -1:
+            sys.stdout.write(":\n%s samples(s) with %.1f sec interval ~ %d sec runtime.\n" % (self.samples, float(self.interval), self.runtime))
+        elif self.samples:
+            duration = (self.samples - 1) * float(self.interval)
+            sys.stdout.write(":\n%s samples(s) with %.1f sec interval ~ %d sec runtime.\n" % (self.samples, float(self.interval), duration))
+        else:
+            sys.stdout.write("...\n(Ctrl-C to stop)\n")
+
+    def recv_from_zabbix(self, sock, count):
+        """ Receive a response from a Zabbix server. """
+        buf = b''
+        while len(buf) < count:
+            chunk = sock.recv(count - len(buf))
+            if not chunk:
+                return buf
+            buf += chunk
+        return buf
+
+    def send_to_zabbix(self, metrics, zabbix_host, zabbix_port, timeout=15):
+        """ Send a set of metrics to a Zabbix server. """
+        j = json.dumps
+        # Zabbix has a very fragile JSON parser, so we cannot use json to
+        # dump the whole packet
+        metrics_data = []
+        for m in metrics:
+            clock = m.clock or time.time()
+            metrics_data.append(('\t\t{\n'
+                                 '\t\t\t"host":%s,\n'
+                                 '\t\t\t"key":%s,\n'
+                                 '\t\t\t"value":%s,\n'
+                                 '\t\t\t"clock":%.5f}') % (j(m.host), j(m.key), j(m.value), clock))
+        json_data = ('{\n'
+                     '\t"request":"sender data",\n'
+                     '\t"data":[\n%s]\n'
+                     '}') % (',\n'.join(metrics_data))
+
+        data_len = struct.pack('<Q', len(json_data))
+        packet = b'ZBXD\1' + data_len + json_data.encode('utf-8')
+        try:
+            zabbix = socket.socket()
+            zabbix.connect((zabbix_host, zabbix_port))
+            zabbix.settimeout(timeout)
+            # send metrics to zabbix
+            zabbix.sendall(packet)
+            # get response header from zabbix
+            resp_hdr = self.recv_from_zabbix(zabbix, 13)
+            if not bytes.decode(resp_hdr).startswith('ZBXD\1') or len(resp_hdr) != 13:
+                if self.context.pmDebug(PM_DEBUG_APPL0):
+                    print('Invalid Zabbix response len=%d' % len(resp_hdr))
+                return False
+            resp_body_len = struct.unpack('<Q', resp_hdr[5:])[0]
+            # get response body from zabbix
+            resp_body = zabbix.recv(resp_body_len)
+            resp = json.loads(bytes.decode(resp_body))
+            if self.context.pmDebug(PM_DEBUG_APPL0):
+                print('Got response from Zabbix: %s' % resp)
+            if resp.get('response') != 'success':
+                sys.stderr.write('Error response from Zabbix: %s', resp)
+                sys.stderr.flush()
+                return False
+            return True
+        except socket.timeout as err:
+            sys.stderr.write("Zabbix connection timed out: " + str(err))
+            sys.stderr.flush()
+            return False
+        finally:
+            zabbix.close()
+
+    def write_zabbix(self, timestamp):
+        """ Write (send) metrics to a Zabbix server """
+        if timestamp is None:
+            # Send any remaining buffered values
+            if self.zabbix_metrics:
+                self.send_to_zabbix(self.zabbix_metrics, self.zabbix_server, self.zabbix_port)
+                self.zabbix_metrics = []
+            return
+
+        ts = pmapi.pmContext.convert_datetime(self.pmfg_ts(), "sec")
+
+        if self.zabbix_prevsend is None:
+            self.zabbix_prevsend = ts
+
+        # Collect the results
+        for metric in self.metrics:
+            try:
+                for inst, name, val in self.metrics[metric][5](): # pylint: disable=unused-variable
+                    key = self.zabbix_prefix + metric
+                    if name:
+                        key += "[" + name + "]"
+                    try:
+                        value = val()
+                        fmt = "." + str(self.precision) + "f"
+                        value = format(value, fmt) if isinstance(value, float) else str(value)
+                        self.zabbix_metrics.append(ZabbixMetric(self.zabbix_host, key, value, ts))
+                    except:
+                        pass
+            except:
+                pass
+
+        # Send when needed
+        if self.context.type == PM_CONTEXT_ARCHIVE:
+            if len(self.zabbix_metrics) >= self.zabbix_interval:
+                self.send_to_zabbix(self.zabbix_metrics, self.zabbix_server, self.zabbix_port)
+                self.zabbix_metrics = []
+        elif ts - self.zabbix_prevsend > self.zabbix_interval:
+            self.send_to_zabbix(self.zabbix_metrics, self.zabbix_server, self.zabbix_port)
+            self.zabbix_metrics = []
+            self.zabbix_prevsend = ts
+
+    def finalize(self):
+        """ Finalize and clean up """
+        if self.zabbix_metrics:
+            self.send_to_zabbix(self.zabbix_metrics, self.zabbix_server, self.zabbix_port)
+            self.zabbix_metrics = []
+
+if __name__ == '__main__':
+    try:
+        P = PCP2Zabbix()
+        P.connect()
+        P.validate_config()
+        P.execute()
+        P.finalize()
+
+    except pmapi.pmErr as error:
+        sys.stderr.write('%s: %s\n' % (error.progname(), error.message()))
+        sys.exit(1)
+    except pmapi.pmUsageErr as usage:
+        usage.message()
+        sys.exit(1)
+    except IOError as error:
+        if error.errno != errno.EPIPE:
+            sys.stderr.write("%s\n" % str(error))
+            sys.exit(1)
+    except KeyboardInterrupt:
+        sys.stdout.write("\n")
+        P.finalize()

--- a/src/pmrep/pmrep.1
+++ b/src/pmrep/pmrep.1
@@ -471,14 +471,6 @@ Print metrics in CSV format (subject to formatting options).
 .TP 2
 .I stdout
 Print metrics to stdout (format subject to formatting options).
-.TP 2
-.I zabbix
-Send metrics to a Zabbix server.
-See
-.BR pmrep.conf (5)
-for the needed Zabbix configuration options.
-This target is currently
-.IR experimental .
 .RE
 .TP
 .B \-O

--- a/src/pmrep/pmrep.conf
+++ b/src/pmrep/pmrep.conf
@@ -144,18 +144,6 @@ cached = mem.util.allcache
 cached.formula = mem.util.cached + mem.util.slab
 cached.label = mem_c
 
-# Zabbix integration example - metrics will be sent with "pcp." prefix
-[zabbix]
-output = zabbix
-globals = no
-zabbix_server = 192.168.122.100
-zabbix_host = Linux-test-VM2
-zabbix_interval = 1m
-interval = 10s
-free = mem.util.free
-util = mem.util.used
-fork = kernel.all.sysfork
-
 # Per process metrics
 [proc-info]
 derived = proc.psinfo.age = kernel.all.uptime - proc.psinfo.start_time

--- a/src/pmrep/pmrep.conf.5
+++ b/src/pmrep/pmrep.conf.5
@@ -300,37 +300,6 @@ The following options are also accepted in the \fB[options]\fR
 section but are typically used only in custom sections as they are
 applicable only to certain output targets.
 .RE
-.P
-zabbix_server (string) (zabbix output target only)
-.RS 4
-Hostname or IP address of Zabbix server to send the metrics to. If a
-host is monitored by a proxy, proxy hostname or IP address should be
-used instead. Undefined by default.
-.RE
-.P
-zabbix_port (integer) (zabbix output target only)
-.RS 4
-Specify port number of server trapper running on the server.
-Default is \fB10051\fR.
-.RE
-.P
-zabbix_host (string) (zabbix output target only)
-.RS 4
-Specify agent hostname as registered in Zabbix frontend. Host IP address
-and DNS name will not work. Undefined by default.
-.RE
-.P
-zabbix_interval (string) (zabbix output target only)
-.RS 4
-Indicates the interval to send the metrics to the Zabbix server. This
-can be longer than the generic \fIinterval\fR to minimize the overhead
-when communicating with the server (as each send creates a new
-connection). Follows the time syntax described in
-.BR PCPIntro (1).
-Defaults to the generic \fIinterval\fR. Zabbix tools send at most 250
-metrics at a time. Ignored when reading metrics from PCP archives,
-in which case metrics will be sent roughly at 250 metric batches.
-.RE
 .SS The [global] section
 The
 .B [global]
@@ -499,6 +468,5 @@ System provided configuration file.
 .BR PCPIntro (1),
 .BR pmrep (1),
 .BR __pmSpecLocalPMDA (3),
-.BR pmRegisterDerived (3)
 and
-.BR zbxpcp (3).
+.BR pmRegisterDerived (3).

--- a/src/pmrep/pmrep.py
+++ b/src/pmrep/pmrep.py
@@ -21,29 +21,24 @@
 
 """ Performance Metrics Reporter """
 
+# Common imports
 from collections import OrderedDict
-from datetime import datetime
-try:
-    import ConfigParser
-except ImportError:
-    import configparser as ConfigParser
-try:
-    import json
-except:
-    import simplejson as json
-import socket
-import struct
 import errno
+import sys
+
+# Our imports
+from datetime import datetime
+import socket
 import time
 import math
-import csv
-import sys
-import os
 import re
+import os
 
-from pcp import pmapi, pmi
-from cpmapi import PM_CONTEXT_ARCHIVE, PM_CONTEXT_HOST, PM_CONTEXT_LOCAL, PM_MODE_FORW, PM_MODE_INTERP, PM_ERR_TYPE, PM_ERR_EOL, PM_ERR_NAME, PM_IN_NULL, PM_SEM_COUNTER, PM_TIME_MSEC, PM_TIME_SEC, PM_XTB_SET, PM_DEBUG_APPL1
-from cpmapi import PM_TYPE_32, PM_TYPE_U32, PM_TYPE_64, PM_TYPE_U64, PM_TYPE_FLOAT, PM_TYPE_DOUBLE, PM_TYPE_STRING
+# PCP Python PMAPI
+from pcp import pmapi, pmi, pmconfig
+from cpmapi import PM_CONTEXT_ARCHIVE, PM_CONTEXT_HOST, PM_CONTEXT_LOCAL
+from cpmapi import PM_ERR_EOL, PM_IN_NULL, PM_DEBUG_APPL1
+from cpmapi import PM_TYPE_FLOAT, PM_TYPE_DOUBLE, PM_TYPE_STRING
 from cpmi import PMI_ERR_DUPINSTNAME
 
 if sys.version_info[0] >= 3:
@@ -60,9 +55,8 @@ OUTSEP  = "  "
 OUTTIME = "%H:%M:%S"
 NO_VAL  = "N/A"
 NO_INST = "~"
-TRUNC   = "xxx"
 
-# Output targets
+# pmrep output targets
 OUTPUT_ARCHIVE = "archive"
 OUTPUT_CSV     = "csv"
 OUTPUT_STDOUT  = "stdout"
@@ -72,6 +66,7 @@ class PMReporter(object):
     def __init__(self):
         """ Construct object, prepare for command line handling """
         self.context = None
+        self.pmconfig = pmconfig.pmConfig(self)
         self.opts = self.options()
 
         # Configuration directives
@@ -83,15 +78,11 @@ class PMReporter(object):
                      'count_scale', 'space_scale', 'time_scale', 'version',
                      'speclocal', 'instances', 'ignore_incompat', 'omit_flat')
 
-        # Special command line switches
-        self.arghelp = ('-?', '--help', '-V', '--version')
-
         # The order of preference for options (as present):
         # 1 - command line options
         # 2 - options from configuration file(s)
         # 3 - built-in defaults defined below
         self.check = 0
-        self.config = self.set_config_file()
         self.version = CONFVER
         self.source = "local:"
         self.output = OUTPUT_STDOUT
@@ -102,8 +93,8 @@ class PMReporter(object):
         self.globals = 1
         self.timestamp = 0
         self.samples = None # forever
-        self.interval = pmapi.timeval(1)      # 1 sec
-        self.opts.pmSetOptionInterval(str(1)) # 1 sec
+        self.interval = pmapi.timeval(1)       # 1 sec
+        self.opts.pmSetOptionInterval(str(1))  # 1 sec
         self.delay = 0
         self.type = 0
         self.ignore_incompat = 0
@@ -138,14 +129,11 @@ class PMReporter(object):
         self.pmfg = None
         self.pmfg_ts = None
 
-        # Corresponding config file metric specifiers
-        self.metricspec = ('label', 'instances', 'unit', 'type', 'width', 'formula')
-
-        self.pmids = []
-        self.descs = []
-        self.insts = []
-
-        self.tmp = []
+        # Read configuration and prepare to connect
+        self.config = self.pmconfig.set_config_file(DEFAULT_CONFIG)
+        self.pmconfig.read_options()
+        self.pmconfig.read_cmd_line()
+        self.pmconfig.prepare_metrics()
 
     def options(self):
         """ Setup default command line argument option handling """
@@ -204,8 +192,8 @@ class PMReporter(object):
         return opts
 
     def option_override(self, opt):
-        """ Override a few standard PCP options """
-        if opt == 'H' or opt == 'p' or opt == 'K':
+        """ Override standard PCP options """
+        if opt == 'H' or opt == 'K' or opt == 'p':
             return 1
         return 0
 
@@ -255,7 +243,7 @@ class PMReporter(object):
         elif opt == 'I':
             self.ignore_incompat = 1
         elif opt == 'i':
-            self.instances = self.instances + self.parse_instances(optarg)
+            self.instances = self.instances + self.pmconfig.parse_instances(optarg)
         elif opt == 'v':
             self.omit_flat = 1
         elif opt == 'X':
@@ -283,263 +271,9 @@ class PMReporter(object):
         else:
             raise pmapi.pmUsageErr()
 
-    def set_config_file(self):
-        """ Set default config file """
-        config = None
-        for conf in DEFAULT_CONFIG:
-            conf = conf.replace("$HOME", os.getenv("HOME"))
-            conf = conf.replace("$PCP_SYSCONF_DIR", pmapi.pmContext.pmGetConfig("PCP_SYSCONF_DIR"))
-            if os.path.isfile(conf) and os.access(conf, os.R_OK):
-                config = conf
-                break
-
-        # Possibly override the default config file before
-        # parsing the rest of the command line options
-        args = iter(sys.argv[1:])
-        for arg in args:
-            if arg in self.arghelp:
-                return None
-            if arg == '-c' or arg == '--config' or arg.startswith("-c"):
-                try:
-                    if arg == '-c' or arg == '--config':
-                        config = next(args)
-                    else:
-                        config = arg.replace("-c", "", 1)
-                    if not os.path.isfile(config) or not os.access(config, os.R_OK):
-                        raise IOError("Failed to read configuration file '%s'." % config)
-                except StopIteration:
-                    break
-        return config
-
-    def parse_instances(self, instances):
-        """ Parse user-supplied instances string """
-        insts = []
-        reader = csv.reader([instances])
-        for _, inst in enumerate(list(reader)[0]):
-            if inst.startswith('"') or inst.startswith("'"):
-                inst = inst[1:]
-            if inst.endswith('"') or inst.endswith("'"):
-                inst = inst[:-1]
-            insts.append(inst)
-        return insts
-
-    def set_attr(self, name, value):
-        """ Set options read from file """
-        if value in ('true', 'True', 'y', 'yes', 'Yes'):
-            value = 1
-        if value in ('false', 'False', 'n', 'no', 'No'):
-            value = 0
-        if name == 'source':
-            self.source = value
-        if name == 'speclocal':
-            if not self.speclocal or not self.speclocal.startswith("K:"):
-                self.speclocal = value
-        elif name == 'samples':
-            self.opts.pmSetOptionSamples(value)
-            self.samples = self.opts.pmGetOptionSamples()
-        elif name == 'interval':
-            self.opts.pmSetOptionInterval(value)
-            self.interval = self.opts.pmGetOptionInterval()
-        elif name == 'type':
-            if value == 'raw':
-                self.type = 1
-            else:
-                self.type = 0
-        elif name == 'instances':
-            self.instances = value.split(",") # pylint: disable=no-member
-        else:
-            try:
-                setattr(self, name, int(value))
-            except ValueError:
-                setattr(self, name, value)
-
-    def read_config(self):
-        """ Read options from configuration file """
-        config = ConfigParser.SafeConfigParser()
-        if self.config:
-            config.read(self.config)
-        if not config.has_section('options'):
-            return
-        for opt in config.options('options'):
-            if opt in self.keys:
-                self.set_attr(opt, config.get('options', opt))
-            else:
-                sys.stderr.write("Invalid directive '%s' in %s.\n" % (opt, self.config))
-                sys.exit(1)
-
-    def read_cmd_line(self):
-        """ Read command line options """
-        pmapi.c_api.pmSetOptionFlags(pmapi.c_api.PM_OPTFLAG_DONE)  # Do later
-        if pmapi.c_api.pmGetOptionsFromList(sys.argv):
-            raise pmapi.pmUsageErr()
-
-    def parse_metric_spec_instances(self, spec):
-        """ Parse instances from metric spec """
-        insts = [None]
-        if spec.count(",") < 2:
-            return spec + ",,", insts
-        # User may supply quoted or unquoted instance specification
-        # Conf file preservers outer quotes, command line does not
-        # We need to detect which is the case here. What a mess.
-        quoted = 0
-        s = spec.split(",")[2]
-        if s and (s[1] == "'" or s[1] == '"'):
-            quoted = 1
-        if spec.count('"') or spec.count("'"):
-            inststr = spec.partition(",")[2].partition(",")[2]
-            q = inststr[0]
-            inststr = inststr[:inststr.rfind(q)+1]
-            if quoted:
-                insts = self.parse_instances(inststr[1:-1])
-            else:
-                insts = self.parse_instances(inststr)
-            spec = spec.replace(inststr, "")
-        else:
-            insts = [s]
-        if spec.count(",") < 2:
-            spec += ",,"
-        return spec, insts
-
-    def parse_metric_info(self, metrics, key, value):
-        """ Parse metric information """
-        # NB. Uses the config key, not the metric, as the dict key
-        compact = False
-        if ',' in value or ('.' in key and key.rsplit(".")[1] not in self.metricspec):
-            compact = True
-        # NB. Formulas may now contain commas, see pmRegisterDerived(3)
-        if ',' in value and ('.' in key and key.rsplit(".")[1] == "formula"):
-            compact = False
-        if compact:
-            # Compact / one-line definition
-            spec, insts = self.parse_metric_spec_instances(key + "," + value)
-            metrics[key] = spec.split(",")
-            metrics[key][2] = insts
-        else:
-            # Verbose / multi-line definition
-            if not '.' in key or key.rsplit(".")[1] not in self.metricspec:
-                # New metric
-                metrics[key] = [value]
-                for index in range(0, 6):
-                    if len(metrics[key]) <= index:
-                        metrics[key].append(None)
-            else:
-                # Additional info
-                key, spec = key.rsplit(".")
-                if key not in metrics:
-                    sys.stderr.write("Undeclared metric key %s.\n" % key)
-                    sys.exit(1)
-                if spec == "formula":
-                    if self.derived is None:
-                        self.derived = metrics[key][0] + "=" + value
-                    else:
-                        self.derived += "@" + metrics[key][0] + "=" + value
-                else:
-                    metrics[key][self.metricspec.index(spec)+1] = value
-
-    def prepare_metrics(self):
-        """ Construct and prepare the initial metrics set """
-        metrics = self.opts.pmGetOperands()
-        if not metrics:
-            sys.stderr.write("No metrics specified.\n")
-            raise pmapi.pmUsageErr()
-
-        # Read config
-        config = ConfigParser.SafeConfigParser()
-        if self.config:
-            config.read(self.config)
-
-        # First read global metrics (if not disabled already)
-        globmet = OrderedDict()
-        if self.globals == 1:
-            if config.has_section('global'):
-                parsemet = OrderedDict()
-                for key in config.options('global'):
-                    self.parse_metric_info(parsemet, key, config.get('global', key))
-                for metric in parsemet:
-                    name = parsemet[metric][:1][0]
-                    globmet[name] = parsemet[metric][1:]
-
-        # Add command line and configuration file metric sets
-        tempmet = OrderedDict()
-        for metric in metrics:
-            if metric.startswith(":"):
-                tempmet[metric[1:]] = None
-            else:
-                spec, insts = self.parse_metric_spec_instances(metric)
-                m = spec.split(",")
-                m[2] = insts
-                tempmet[m[0]] = m[1:]
-
-        # Get config and set details for configuration file metric sets
-        confmet = OrderedDict()
-        for spec in tempmet:
-            if tempmet[spec] is None:
-                if config.has_section(spec):
-                    parsemet = OrderedDict()
-                    for key in config.options(spec):
-                        if key in self.keys:
-                            self.set_attr(key, config.get(spec, key))
-                        else:
-                            self.parse_metric_info(parsemet, key, config.get(spec, key))
-                            for metric in parsemet:
-                                name = parsemet[metric][:1][0]
-                                confmet[name] = parsemet[metric][1:]
-                            tempmet[spec] = confmet
-                else:
-                    raise IOError("Metric set definition '%s' not found." % metric)
-
-        # Create the combined metrics set
-        if self.globals == 1:
-            for metric in globmet:
-                self.metrics[metric] = globmet[metric]
-        for metric in tempmet:
-            if isinstance(tempmet[metric], list):
-                self.metrics[metric] = tempmet[metric]
-            else:
-                for m in tempmet[metric]:
-                    self.metrics[m] = confmet[m]
-
     def connect(self):
         """ Establish a PMAPI context """
-        context = None
-
-        if pmapi.c_api.pmGetOptionArchives():
-            context = pmapi.c_api.PM_CONTEXT_ARCHIVE
-            self.opts.pmSetOptionContext(pmapi.c_api.PM_CONTEXT_ARCHIVE)
-            self.source = self.opts.pmGetOptionArchives()[0]
-        elif pmapi.c_api.pmGetOptionHosts():
-            context = pmapi.c_api.PM_CONTEXT_HOST
-            self.opts.pmSetOptionContext(pmapi.c_api.PM_CONTEXT_HOST)
-            self.source = self.opts.pmGetOptionHosts()[0]
-        elif pmapi.c_api.pmGetOptionLocalPMDA():
-            context = pmapi.c_api.PM_CONTEXT_LOCAL
-            self.opts.pmSetOptionContext(pmapi.c_api.PM_CONTEXT_LOCAL)
-            self.source = None
-
-        if not context:
-            if '/' in self.source:
-                context = pmapi.c_api.PM_CONTEXT_ARCHIVE
-                self.opts.pmSetOptionArchive(self.source)
-                self.opts.pmSetOptionContext(pmapi.c_api.PM_CONTEXT_ARCHIVE)
-            elif self.source != '@':
-                context = pmapi.c_api.PM_CONTEXT_HOST
-                self.opts.pmSetOptionHost(self.source)
-                self.opts.pmSetOptionContext(pmapi.c_api.PM_CONTEXT_HOST)
-            else:
-                context = pmapi.c_api.PM_CONTEXT_LOCAL
-                self.opts.pmSetOptionLocalPMDA()
-                self.opts.pmSetOptionContext(pmapi.c_api.PM_CONTEXT_LOCAL)
-                self.source = None
-
-        if context == pmapi.c_api.PM_CONTEXT_LOCAL and self.speclocal:
-            self.speclocal = self.speclocal.replace("K:", "")
-            for spec in self.speclocal.split("|"):
-                self.opts.pmSetOptionSpecLocal(spec)
-
-        # All options set, finalize configuration
-        flags = self.opts.pmGetOptionFlags()
-        self.opts.pmSetOptionFlags(flags | pmapi.c_api.PM_OPTFLAG_DONE)
-        pmapi.c_api.pmEndOptions()
+        context, self.source = pmapi.pmContext.set_connect_options(self.opts, self.source, self.speclocal)
 
         self.pmfg = pmapi.fetchgroup(context, self.source)
         self.pmfg_ts = self.pmfg.extend_timestamp()
@@ -547,6 +281,8 @@ class PMReporter(object):
 
         if pmapi.c_api.pmSetContextOptions(self.context.ctx, self.opts.mode, self.opts.delta):
             raise pmapi.pmUsageErr()
+
+        self.pmconfig.validate_metrics()
 
     def validate_config(self):
         """ Validate configuration options """
@@ -558,308 +294,25 @@ class PMReporter(object):
             sys.stderr.write("Archive must be defined with archive output.\n")
             sys.exit(1)
 
-        # Runtime overrides samples/interval
-        if self.opts.pmGetOptionFinishOptarg():
-            self.runtime = float(self.opts.pmGetOptionFinish()) - float(self.opts.pmGetOptionOrigin())
-            if self.opts.pmGetOptionSamples():
-                self.samples = self.opts.pmGetOptionSamples()
-                if self.samples < 2:
-                    self.samples = 2
-                self.interval = float(self.runtime) / (self.samples - 1)
-                self.opts.pmSetOptionInterval(str(self.interval))
-                self.interval = self.opts.pmGetOptionInterval()
-            else:
-                self.interval = self.opts.pmGetOptionInterval()
-                if not self.interval:
-                    self.interval = pmapi.timeval(0)
-                try:
-                    self.samples = int(self.runtime / float(self.interval) + 1)
-                except:
-                    pass
-        else:
-            self.samples = self.opts.pmGetOptionSamples()
-            self.interval = self.opts.pmGetOptionInterval()
-
-        if float(self.interval) <= 0:
-            sys.stderr.write("Interval must be greater than zero.\n")
-            sys.exit(1)
-
-    def check_metric(self, metric):
-        """ Validate individual metric and get its details """
-        try:
-            pmid = self.context.pmLookupName(metric)[0]
-            if pmid in self.pmids:
-                # Always ignore duplicates
-                return
-            desc = self.context.pmLookupDescs(pmid)[0]
-            try:
-                if self.context.type == PM_CONTEXT_ARCHIVE:
-                    inst = self.context.pmGetInDomArchive(desc)
-                else:
-                    inst = self.context.pmGetInDom(desc) # disk.dev.read
-                if not inst[0]:
-                    inst = ([PM_IN_NULL], [None])        # pmcd.pmie.logfile
-            except pmapi.pmErr:
-                inst = ([PM_IN_NULL], [None])            # mem.util.free
-            # Reject unsupported types
-            if not (desc.contents.type == PM_TYPE_32 or
-                    desc.contents.type == PM_TYPE_U32 or
-                    desc.contents.type == PM_TYPE_64 or
-                    desc.contents.type == PM_TYPE_U64 or
-                    desc.contents.type == PM_TYPE_FLOAT or
-                    desc.contents.type == PM_TYPE_DOUBLE or
-                    desc.contents.type == PM_TYPE_STRING):
-                raise pmapi.pmErr(PM_ERR_TYPE)
-            instances = self.instances if not self.tmp[0] else self.tmp
-            if self.omit_flat and instances and not inst[1][0]:
-                return
-            if instances and inst[1][0]:
-                found = [[], []]
-                for r in instances:
-                    cr = re.compile(r'\A' + r + r'\Z')
-                    for i, s in enumerate(inst[1]):
-                        if re.match(cr, s):
-                            found[0].append(inst[0][i])
-                            found[1].append(inst[1][i])
-                if not found[0]:
-                    return
-                inst = tuple(found)
-            self.pmids.append(pmid)
-            self.descs.append(desc)
-            self.insts.append(inst)
-        except pmapi.pmErr as error:
-            if self.ignore_incompat:
-                return
-            sys.stderr.write("Invalid metric %s (%s).\n" % (metric, str(error)))
-            sys.exit(1)
-
-    def format_metric_label(self, label):
-        """ Format a metric label """
-        # See src/libpcp/src/units.c
-        if ' / ' in label:
-            label = label.replace("nanosec", "ns").replace("microsec", "us")
-            label = label.replace("millisec", "ms").replace("sec", "s")
-            label = label.replace("min", "min").replace("hour", "h")
-            label = label.replace(" / ", "/")
-        return label
-
-    def validate_metrics(self):
-        """ Validate the metrics set """
-        # Check the metrics against PMNS, resolve non-leaf metrics
-        if self.derived:
-            if self.derived.startswith("/") or self.derived.startswith("."):
-                try:
-                    self.context.pmLoadDerivedConfig(self.derived)
-                except pmapi.pmErr as error:
-                    sys.stderr.write("Failed to register derived metric: %s.\n" % str(error))
-                    sys.exit(1)
-            else:
-                for definition in self.derived.split("@"):
-                    err = ""
-                    try:
-                        name, expr = definition.split("=", 1)
-                        self.context.pmLookupName(name.strip())
-                    except pmapi.pmErr as error:
-                        if error.args[0] != PM_ERR_NAME:
-                            err = error.message()
-                        else:
-                            try:
-                                self.context.pmRegisterDerived(name.strip(), expr.strip())
-                                continue
-                            except pmapi.pmErr as error:
-                                err = error.message()
-                    except ValueError as error:
-                        err = "Invalid syntax (expected metric=expression)"
-                    except Exception as error:
-                        err = "Unidentified error"
-                    finally:
-                        if err:
-                            sys.stderr.write("Failed to register derived metric: %s.\n" % err)
-                            sys.exit(1)
-
-        # Prepare for non-leaf metrics
-        metrics = self.metrics
-        self.metrics = OrderedDict()
-
-        for metric in metrics:
-            try:
-                l = len(self.pmids)
-                self.tmp = metrics[metric][1]
-                if not 'append' in dir(self.tmp):
-                    self.tmp = [self.tmp]
-                self.context.pmTraversePMNS(metric, self.check_metric)
-                if len(self.pmids) == l:
-                    # No compatible metrics found
-                    continue
-                elif len(self.pmids) == l + 1:
-                    # Leaf
-                    if metric in self.context.pmNameAll(self.pmids[l]):
-                        self.metrics[metric] = metrics[metric]
-                    else:
-                        # Handle single non-leaf case in an archive
-                        self.metrics[self.context.pmNameID(self.pmids[l])] = []
-                else:
-                    # Non-leaf
-                    for i in range(l, len(self.pmids)):
-                        name = self.context.pmNameID(self.pmids[i])
-                        # We ignore specs like disk.dm,,,MB on purpose, for now
-                        self.metrics[name] = []
-            except pmapi.pmErr as error:
-                sys.stderr.write("Invalid metric %s (%s).\n" % (metric, str(error)))
-                sys.exit(1)
-
-        # Exit if no metrics with specified instances found
-        if not self.insts:
-            sys.stderr.write("No matching instances found.\n")
-            # Try to help the user to get the instance specifications right
-            if self.instances:
-                print("\nRequested global instances:")
-                print(self.instances)
-            sys.exit(1)
-
-        # Finalize the metrics set
-        incompat_metrics = {}
-        for i, metric in enumerate(self.metrics):
-            # Fill in all fields for easier checking later
-            for index in range(0, 6):
-                if len(self.metrics[metric]) <= index:
-                    self.metrics[metric].append(None)
-
-            # Label
-            if not self.metrics[metric][0]:
-                # mem.util.free -> m.u.free
-                name = ""
-                for m in metric.split("."):
-                    name += m[0] + "."
-                self.metrics[metric][0] = name[:-2] + m # pylint: disable=undefined-loop-variable
-
-            # Rawness
-            if self.metrics[metric][3] == 'raw' or self.type == 1 or \
-               self.output == OUTPUT_ARCHIVE or \
-               self.output == OUTPUT_CSV:
-                self.metrics[metric][3] = 1
-            else:
-                self.metrics[metric][3] = 0
-
-            # Set unit/scale if not specified on per-metric basis
-            if not self.metrics[metric][2]:
-                unit = self.descs[i].contents.units
-                self.metrics[metric][2] = str(unit)
-                if self.count_scale and \
-                   unit.dimCount == 1 and ( \
-                   unit.dimSpace == 0 and
-                   unit.dimTime  == 0):
-                    self.metrics[metric][2] = self.count_scale
-                if self.space_scale and \
-                   unit.dimSpace == 1 and ( \
-                   unit.dimCount == 0 and
-                   unit.dimTime  == 0):
-                    self.metrics[metric][2] = self.space_scale
-                if self.time_scale and \
-                   unit.dimTime  == 1 and ( \
-                   unit.dimCount == 0 and
-                   unit.dimSpace == 0):
-                    self.metrics[metric][2] = self.time_scale
-
-            # Finalize label and unit/scale
-            try:
-                label = self.metrics[metric][2]
-                (unitstr, mult) = self.context.pmParseUnitsStr(self.metrics[metric][2])
-                if self.metrics[metric][3] == 0 and \
-                   self.descs[i].contents.type != PM_TYPE_STRING and \
-                   self.descs[i].contents.sem == PM_SEM_COUNTER and \
-                   '/' not in label:
-                    label += " / s"
-                label = self.format_metric_label(label)
-                self.metrics[metric][2] = (label, unitstr, mult)
-            except pmapi.pmErr as error:
-                sys.stderr.write("%s: %s.\n" % (str(error), self.metrics[metric][2]))
-                sys.exit(1)
-
-            # Set metric type - default to double for precision
-            mtype = PM_TYPE_DOUBLE
-            # But use native type when else was not requested
-            if str(unitstr) == str(self.descs[i].contents.units):
-                mtype = self.descs[i].contents.type
-            # However always use double for non-raw counters
-            if self.metrics[metric][3] == 0 and \
-               self.descs[i].contents.sem == PM_SEM_COUNTER:
-                mtype = PM_TYPE_DOUBLE
-            # Strings will be strings right till the end
-            if self.descs[i].contents.type == PM_TYPE_STRING:
-                mtype = self.descs[i].contents.type
-
-            # Set default width if not specified on per-metric basis
-            if self.metrics[metric][4]:
-                self.metrics[metric][4] = int(self.metrics[metric][4])
-            elif self.width != 0:
-                self.metrics[metric][4] = self.width
-            else:
-                self.metrics[metric][4] = len(self.metrics[metric][0])
-            if self.metrics[metric][4] < len(TRUNC):
-                self.metrics[metric][4] = len(TRUNC) # Forced minimum
-
-            # Add fetchgroup item
-            try:
-                scale = self.metrics[metric][2][0]
-                self.metrics[metric][5] = self.pmfg.extend_indom(metric, mtype, scale, 1024)
-            except:
-                if self.ignore_incompat:
-                    # Schedule the metric for removal
-                    incompat_metrics[metric] = i
-                else:
-                    raise
-
-        # Remove all traces of incompatible metrics
-        for metric in incompat_metrics:
-            del self.pmids[incompat_metrics[metric]]
-            del self.descs[incompat_metrics[metric]]
-            del self.insts[incompat_metrics[metric]]
-            del self.metrics[metric]
-        incompat_metrics = {}
-
-        # Verify that we have valid metrics
-        if not self.metrics:
-            sys.stderr.write("No compatible metrics found.\n")
-            sys.exit(1)
-
-    def get_local_tz(self, set_dst=-1):
-        """ Figure out the local timezone using the PCP convention """
-        dst = time.localtime().tm_isdst
-        if set_dst >= 0:
-            dst = 1 if set_dst else 0
-        offset = time.altzone if dst else time.timezone
-        currtz = time.tzname[dst]
-        if offset:
-            offset = offset/3600
-            offset = int(offset) if offset == int(offset) else offset
-            if offset >= 0:
-                offset = "+" + str(offset)
-            currtz += str(offset)
-        return currtz
-
-    def get_mode_step(self):
-        """ Get mode and step for pmSetMode """
-        if not self.interpol or self.output == OUTPUT_ARCHIVE:
-            mode = PM_MODE_FORW
-            step = 0
-        else:
-            mode = PM_MODE_INTERP
-            secs_in_24_days = 2073600
-            if self.interval.tv_sec > secs_in_24_days:
-                step = self.interval.tv_sec
-                mode |= PM_XTB_SET(PM_TIME_SEC)
-            else:
-                step = self.interval.tv_sec * 1000 + self.interval.tv_usec / 1000
-                mode |= PM_XTB_SET(PM_TIME_MSEC)
-        return (mode, int(step))
+        self.pmconfig.finalize_options()
 
     def execute(self):
         """ Fetch and report """
         # Debug
         if self.context.pmDebug(PM_DEBUG_APPL1):
             sys.stdout.write("Known config file keywords: " + str(self.keys) + "\n")
-            sys.stdout.write("Known metric spec keywords: " + str(self.metricspec) + "\n")
+            sys.stdout.write("Known metric spec keywords: " + str(self.pmconfig.metricspec) + "\n")
+
+        # Set delay mode, interpolation
+        if self.context.type != PM_CONTEXT_ARCHIVE:
+            self.delay = 1
+            self.interpol = 1
+
+        # Time
+        self.localtz = pmapi.pmContext.get_local_tz()
+
+        # Common preparations
+        pmapi.pmContext.prepare_execute(self.context, self.opts, self.output == OUTPUT_ARCHIVE, self.interpol, self.interval)
 
         # Set output primitives
         if self.delimiter is None:
@@ -868,24 +321,6 @@ class PMReporter(object):
             else:
                 self.delimiter = OUTSEP
 
-        # Time
-        self.localtz = self.get_local_tz()
-        if self.opts.pmGetOptionHostZone():
-            os.environ['TZ'] = self.context.pmWhichZone()
-            time.tzset()
-        else:
-            tz = self.localtz
-            if self.context.type == PM_CONTEXT_ARCHIVE:
-                # Determine correct local TZ based on DST of the archive
-                tz = self.get_local_tz(time.localtime(self.opts.pmGetOptionOrigin()).tm_isdst)
-            os.environ['TZ'] = tz
-            time.tzset()
-            self.context.pmNewZone(tz)
-        if self.opts.pmGetOptionTimezone():
-            os.environ['TZ'] = self.opts.pmGetOptionTimezone()
-            time.tzset()
-            self.context.pmNewZone(self.opts.pmGetOptionTimezone())
-
         if self.timefmt is None:
             if self.output == OUTPUT_CSV:
                 self.timefmt = CSVTIME
@@ -893,11 +328,6 @@ class PMReporter(object):
                 self.timefmt = OUTTIME
         if not self.timefmt:
             self.timestamp = 0
-
-        # Set delay mode, interpolation
-        if self.context.type != PM_CONTEXT_ARCHIVE:
-            self.delay = 1
-            self.interpol = 1
 
         # Print preparation
         self.prepare_writer()
@@ -914,11 +344,6 @@ class PMReporter(object):
             self.write_header()
         else:
             self.repeat_header = 0
-
-        # Archive fetching mode
-        if self.context.type == PM_CONTEXT_ARCHIVE:
-            (mode, step) = self.get_mode_step()
-            self.context.pmSetMode(mode, self.opts.pmGetOptionOrigin(), step)
 
         # Just checking
         if self.check == 1:
@@ -1001,7 +426,7 @@ class PMReporter(object):
             self.format += "{" + str(index) + "}"
             index += 1
         for i, metric in enumerate(self.metrics):
-            for _ in range(len(self.insts[i][0])):
+            for _ in range(len(self.pmconfig.insts[i][0])):
                 l = str(self.metrics[metric][4])
                 #self.format += "{:>" + l + "." + l + "}{}"
                 self.format += "{" + str(index) + ":>" + l + "." + l + "}"
@@ -1057,7 +482,7 @@ class PMReporter(object):
         if self.context.type == PM_CONTEXT_LOCAL:
             host = "localhost, using DSO PMDAs"
 
-        timezone = self.get_local_tz()
+        timezone = pmapi.pmContext.get_local_tz()
         if timezone != self.localtz:
             timezone += " (reporting, current is " + self.localtz + ")"
 
@@ -1118,12 +543,12 @@ class PMReporter(object):
         if self.output == OUTPUT_CSV:
             self.writer.write("Time")
             for i, metric in enumerate(self.metrics):
-                for j in range(len(self.insts[i][0])):
+                for j in range(len(self.pmconfig.insts[i][0])):
                     name = metric
-                    if self.insts[i][0][0] != PM_IN_NULL and self.insts[i][1][j]:
-                        name += "-" + self.insts[i][1][j]
+                    if self.pmconfig.insts[i][0][0] != PM_IN_NULL and self.pmconfig.insts[i][1][j]:
+                        name += "-" + self.pmconfig.insts[i][1][j]
                     # Mark metrics with instance domain but without instances
-                    if self.descs[i].contents.indom != PM_IN_NULL and self.insts[i][1][0] is None:
+                    if self.pmconfig.descs[i].contents.indom != PM_IN_NULL and self.pmconfig.insts[i][1][0] is None:
                         name += "-"
                     name = name.replace(self.delimiter, " ").replace("\n", " ").replace("\"", " ")
                     self.writer.write(self.delimiter + "\"" + name + "\"")
@@ -1144,14 +569,14 @@ class PMReporter(object):
                     units.append(self.metrics[metric][2][0])
                     units.append(self.delimiter)
                     continue
-                prnti = 1 if self.insts[i][0][0] != PM_IN_NULL else prnti
-                for j in range(len(self.insts[i][0])):
+                prnti = 1 if self.pmconfig.insts[i][0][0] != PM_IN_NULL else prnti
+                for j in range(len(self.pmconfig.insts[i][0])):
                     names.append(self.metrics[metric][0])
                     names.append(self.delimiter)
                     units.append(self.metrics[metric][2][0])
                     units.append(self.delimiter)
-                    if prnti == 1 and self.insts[i][1][j]:
-                        insts.append(self.insts[i][1][j])
+                    if prnti == 1 and self.pmconfig.insts[i][1][j]:
+                        insts.append(self.pmconfig.insts[i][1][j])
                     else:
                         insts.append(self.delimiter)
                     insts.append(self.delimiter)
@@ -1181,18 +606,18 @@ class PMReporter(object):
                 self.pmi.pmiSetTimezone(self.context.pmGetArchiveLabel().tz)
             for i, metric in enumerate(self.metrics):
                 self.pmi.pmiAddMetric(metric,
-                                      self.pmids[i],
-                                      self.descs[i].contents.type,
-                                      self.descs[i].contents.indom,
-                                      self.descs[i].contents.sem,
-                                      self.descs[i].contents.units)
-                ins = 0 if self.insts[i][0][0] == PM_IN_NULL else len(self.insts[i][0])
+                                      self.pmconfig.pmids[i],
+                                      self.pmconfig.descs[i].contents.type,
+                                      self.pmconfig.descs[i].contents.indom,
+                                      self.pmconfig.descs[i].contents.sem,
+                                      self.pmconfig.descs[i].contents.units)
+                ins = 0 if self.pmconfig.insts[i][0][0] == PM_IN_NULL else len(self.pmconfig.insts[i][0])
                 for j in range(ins):
                     if metric not in self.recorded:
                         self.recorded[metric] = []
-                    self.recorded[metric].append(self.insts[i][0][j])
+                    self.recorded[metric].append(self.pmconfig.insts[i][0][j])
                     try:
-                        self.pmi.pmiAddInstance(self.descs[i].contents.indom, self.insts[i][1][j], self.insts[i][0][j])
+                        self.pmi.pmiAddInstance(self.pmconfig.descs[i].contents.indom, self.pmconfig.insts[i][1][j], self.pmconfig.insts[i][0][j])
                     except pmi.pmiErr as error:
                         if error.args[0] == PMI_ERR_DUPINSTNAME:
                             pass
@@ -1201,20 +626,20 @@ class PMReporter(object):
         data = 0
         for i, metric in enumerate(self.metrics):
             try:
-                for inst, name, val in self.metrics[metric][5]():
+                for inst, name, val in self.metrics[metric][5](): # pylint: disable=unused-variable
                     try:
                         value = val()
                         if inst != PM_IN_NULL and inst not in self.recorded[metric]:
                             self.recorded[metric].append(inst)
                             try:
-                                self.pmi.pmiAddInstance(self.descs[i].contents.indom, name, inst)
+                                self.pmi.pmiAddInstance(self.pmconfig.descs[i].contents.indom, name, inst)
                             except pmi.pmiErr as error:
                                 if error.args[0] == PMI_ERR_DUPINSTNAME:
                                     pass
-                        if self.descs[i].contents.type == PM_TYPE_STRING:
+                        if self.pmconfig.descs[i].contents.type == PM_TYPE_STRING:
                             self.pmi.pmiPutValue(metric, name, value)
-                        elif self.descs[i].contents.type == PM_TYPE_FLOAT or \
-                             self.descs[i].contents.type == PM_TYPE_DOUBLE:
+                        elif self.pmconfig.descs[i].contents.type == PM_TYPE_FLOAT or \
+                             self.pmconfig.descs[i].contents.type == PM_TYPE_DOUBLE:
                             self.pmi.pmiPutValue(metric, name, "%f" % value)
                         else:
                             self.pmi.pmiPutValue(metric, name, "%d" % value)
@@ -1234,6 +659,7 @@ class PMReporter(object):
             # Silent goodbye
             return
 
+        # Print the results
         line = timestamp
 
         # Avoid crossing the C/Python boundary more than once per metric
@@ -1253,16 +679,15 @@ class PMReporter(object):
 
         # Add corresponding values for each column in the static header
         for i, metric in enumerate(self.metrics):
-            for j in range(len(self.insts[i][0])):
+            for j in range(len(self.pmconfig.insts[i][0])):
                 line += self.delimiter
-                if metric + str(self.insts[i][0][j]) in res:
-                    value = res[metric + str(self.insts[i][0][j])]
+                if metric + str(self.pmconfig.insts[i][0][j]) in res:
+                    value = res[metric + str(self.pmconfig.insts[i][0][j])]
                     if isinstance(value, str):
                         value = value.replace(self.delimiter, " ").replace("\n", " ").replace('"', " ")
                         line += str('"' + value + '"')
                     else:
                         line += str(value)
-
         self.writer.write(line + "\n")
 
     def write_stdout(self, timestamp):
@@ -1307,27 +732,27 @@ class PMReporter(object):
         k = 0
         for i, metric in enumerate(self.metrics):
             l = self.metrics[metric][4]
-            for j in range(len(self.insts[i][0])):
+            for j in range(len(self.pmconfig.insts[i][0])):
                 k += 1
-                if metric + str(self.insts[i][0][j]) in res:
-                    value = res[metric + str(self.insts[i][0][j])]
+                if metric + str(self.pmconfig.insts[i][0][j]) in res:
+                    value = res[metric + str(self.pmconfig.insts[i][0][j])]
                     # Make sure the value fits
                     if isinstance(value, (int, long)):
                         if len(str(value)) > l:
-                            value = TRUNC
+                            value = pmconfig.TRUNC
                         else:
                             #fmt[k] = "{:" + str(l) + "d}"
                             fmt[k] = "{X:" + str(l) + "d}"
                     elif isinstance(value, str):
                         if len(value) > l:
-                            value = TRUNC
+                            value = pmconfig.TRUNC
 
                     if isinstance(value, float) and not math.isinf(value):
                         c = self.precision
                         s = len(str(int(value)))
                         if s > l:
                             c = -1
-                            value = TRUNC
+                            value = pmconfig.TRUNC
                         #for _ in reversed(range(c+1)):
                             #t = "{:" + str(l) + "." + str(c) + "f}"
                         for f in reversed(range(c+1)):
@@ -1370,7 +795,7 @@ class PMReporter(object):
         # Collect the instances in play
         insts = []
         for i in range(len(self.metrics)):
-            for instance in self.insts[i][1]:
+            for instance in self.pmconfig.insts[i][1]:
                 if instance not in insts:
                     insts.append(instance)
 
@@ -1379,7 +804,7 @@ class PMReporter(object):
         for _, metric in enumerate(self.metrics):
             res[metric] = []
             try:
-                for inst, name, val in self.metrics[metric][5]():
+                for inst, name, val in self.metrics[metric][5](): # pylint: disable=unused-variable
                     try:
                         res[metric].append([inst, name, val()])
                     except:
@@ -1440,7 +865,7 @@ class PMReporter(object):
                 # Make sure the value fits
                 if isinstance(value, (int, long)):
                     if len(str(value)) > l:
-                        value = TRUNC
+                        value = pmconfig.TRUNC
                     else:
                         fmt[k] = "{X:" + str(l) + "d}"
 
@@ -1449,7 +874,7 @@ class PMReporter(object):
                     s = len(str(int(value)))
                     if s > l:
                         c = -1
-                        value = TRUNC
+                        value = pmconfig.TRUNC
                     for f in reversed(range(c+1)):
                         r = "{X:" + str(l) + "." + str(c) + "f}"
                         t = "{0:" + str(l) + "." + str(c) + "f}"
@@ -1498,12 +923,8 @@ class PMReporter(object):
 if __name__ == '__main__':
     try:
         P = PMReporter()
-        P.read_config()
-        P.read_cmd_line()
-        P.prepare_metrics()
         P.connect()
         P.validate_config()
-        P.validate_metrics()
         P.execute()
         P.finalize()
 

--- a/src/python/pcp/__init__.py
+++ b/src/python/pcp/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["pmapi", "pmcc", "pmda", "pmgui", "pmi", "pmsubsys", "mmv", "cpmapi", "cpmda", "cpmgui", "cpmi", "cmmv"]
+__all__ = ["pmapi", "pmcc", "pmconfig", "pmda", "pmgui", "pmi", "pmsubsys", "mmv", "cpmapi", "cpmda", "cpmgui", "cpmi", "cmmv"]

--- a/src/python/pcp/pmconfig.py
+++ b/src/python/pcp/pmconfig.py
@@ -1,0 +1,543 @@
+# Copyright (C) 2015-2017 Marko Myllynen <myllynen@redhat.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+# pylint: disable=superfluous-parens
+# pylint: disable=invalid-name, line-too-long, no-self-use
+# pylint: disable=too-many-boolean-expressions, too-many-statements
+# pylint: disable=too-many-instance-attributes, too-many-locals
+# pylint: disable=too-many-branches, too-many-nested-blocks
+# pylint: disable=bare-except, broad-except
+
+""" PCP Python Utils Config Routines """
+
+from collections import OrderedDict
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
+import csv
+import sys
+import os
+import re
+
+from pcp import pmapi
+
+# Common defaults (for applicable utils)
+TRUNC = "xxx"
+VERSION = 1
+
+class pmConfig(object):
+    """ Config reader and validator """
+    def __init__(self, util):
+        # Common special command line switches
+        self.arghelp = ('-?', '--help', '-V', '--version')
+
+        # Supported metricset specifiers
+        self.metricspec = ('label', 'instances', 'unit', 'type', 'width', 'formula')
+
+        # Main utility reference
+        self.util = util
+
+        # Metric details
+        self.pmids = []
+        self.descs = []
+        self.insts = []
+
+        # Pass data with pmTraversePMNS
+        self.tmp = []
+
+    def set_config_file(self, default_config):
+        """ Set default config file """
+        config = None
+        for conf in default_config:
+            conf = conf.replace("$HOME", os.getenv("HOME"))
+            conf = conf.replace("$PCP_SYSCONF_DIR", pmapi.pmContext.pmGetConfig("PCP_SYSCONF_DIR"))
+            if os.path.isfile(conf) and os.access(conf, os.R_OK):
+                config = conf
+                break
+
+        # Possibly override the default config file before
+        # parsing the rest of the command line options
+        args = iter(sys.argv[1:])
+        for arg in args:
+            if arg in self.arghelp:
+                return None
+            if arg == '-c' or arg == '--config' or arg.startswith("-c"):
+                try:
+                    if arg == '-c' or arg == '--config':
+                        config = next(args)
+                    else:
+                        config = arg.replace("-c", "", 1)
+                    if not os.path.isfile(config) or not os.access(config, os.R_OK):
+                        raise IOError("Failed to read configuration file '%s'." % config)
+                except StopIteration:
+                    break
+
+        return config
+
+    def set_attr(self, name, value):
+        """ Set options read from file """
+        if value in ('true', 'True', 'y', 'yes', 'Yes'):
+            value = 1
+        if value in ('false', 'False', 'n', 'no', 'No'):
+            value = 0
+        if name == 'source':
+            self.util.source = value
+        if name == 'speclocal':
+            if not self.util.speclocal or not self.util.speclocal.startswith("K:"):
+                self.util.speclocal = value
+        elif name == 'samples':
+            self.util.opts.pmSetOptionSamples(value)
+            self.util.samples = self.util.opts.pmGetOptionSamples()
+        elif name == 'interval':
+            self.util.opts.pmSetOptionInterval(value)
+            self.util.interval = self.util.opts.pmGetOptionInterval()
+        elif name == 'type':
+            if value == 'raw':
+                self.util.type = 1
+            else:
+                self.util.type = 0
+        elif name == 'instances':
+            self.util.instances = value.split(",") # pylint: disable=no-member
+        else:
+            try:
+                setattr(self.util, name, int(value))
+            except ValueError:
+                setattr(self.util, name, value)
+
+    def read_options(self):
+        """ Read options from configuration file """
+        config = ConfigParser.SafeConfigParser()
+        if self.util.config:
+            config.read(self.util.config)
+        if not config.has_section('options'):
+            return
+        for opt in config.options('options'):
+            if opt in self.util.keys:
+                self.set_attr(opt, config.get('options', opt))
+            else:
+                sys.stderr.write("Invalid directive '%s' in %s.\n" % (opt, self.util.config))
+                sys.exit(1)
+
+    def read_cmd_line(self):
+        """ Read command line options """
+        pmapi.c_api.pmSetOptionFlags(pmapi.c_api.PM_OPTFLAG_DONE)  # Do later
+        if pmapi.c_api.pmGetOptionsFromList(sys.argv):
+            raise pmapi.pmUsageErr()
+
+    def parse_instances(self, instances):
+        """ Parse user-supplied instances string """
+        insts = []
+        reader = csv.reader([instances])
+        for _, inst in enumerate(list(reader)[0]):
+            if inst.startswith('"') or inst.startswith("'"):
+                inst = inst[1:]
+            if inst.endswith('"') or inst.endswith("'"):
+                inst = inst[:-1]
+            insts.append(inst)
+        return insts
+
+    def parse_metric_spec_instances(self, spec):
+        """ Parse instances from metric spec """
+        insts = [None]
+        if spec.count(",") < 2:
+            return spec + ",,", insts
+        # User may supply quoted or unquoted instance specification
+        # Conf file preservers outer quotes, command line does not
+        # We need to detect which is the case here. What a mess.
+        quoted = 0
+        s = spec.split(",")[2]
+        if s and (s[1] == "'" or s[1] == '"'):
+            quoted = 1
+        if spec.count('"') or spec.count("'"):
+            inststr = spec.partition(",")[2].partition(",")[2]
+            q = inststr[0]
+            inststr = inststr[:inststr.rfind(q)+1]
+            if quoted:
+                insts = self.parse_instances(inststr[1:-1])
+            else:
+                insts = self.parse_instances(inststr)
+            spec = spec.replace(inststr, "")
+        else:
+            insts = [s]
+        if spec.count(",") < 2:
+            spec += ",,"
+        return spec, insts
+
+    def parse_metric_info(self, metrics, key, value):
+        """ Parse metric information """
+        # NB. Uses the config key, not the metric, as the dict key
+        compact = False
+        if ',' in value or ('.' in key and key.rsplit(".")[1] not in self.metricspec):
+            compact = True
+        # NB. Formulas may now contain commas, see pmRegisterDerived(3)
+        if ',' in value and ('.' in key and key.rsplit(".")[1] == "formula"):
+            compact = False
+        if compact:
+            # Compact / one-line definition
+            spec, insts = self.parse_metric_spec_instances(key + "," + value)
+            metrics[key] = spec.split(",")
+            metrics[key][2] = insts
+        else:
+            # Verbose / multi-line definition
+            if not '.' in key or key.rsplit(".")[1] not in self.metricspec:
+                # New metric
+                metrics[key] = [value]
+                for index in range(0, 6):
+                    if len(metrics[key]) <= index:
+                        metrics[key].append(None)
+            else:
+                # Additional info
+                key, spec = key.rsplit(".")
+                if key not in metrics:
+                    sys.stderr.write("Undeclared metric key %s.\n" % key)
+                    sys.exit(1)
+                if spec == "formula":
+                    if self.util.derived is None:
+                        self.util.derived = metrics[key][0] + "=" + value
+                    else:
+                        self.util.derived += "@" + metrics[key][0] + "=" + value
+                else:
+                    metrics[key][self.metricspec.index(spec)+1] = value
+
+    def prepare_metrics(self):
+        """ Construct and prepare the initial metrics set """
+        metrics = self.util.opts.pmGetOperands()
+        if not metrics:
+            sys.stderr.write("No metrics specified.\n")
+            raise pmapi.pmUsageErr()
+
+        # Read config
+        config = ConfigParser.SafeConfigParser()
+        if self.util.config:
+            config.read(self.util.config)
+
+        # First read global metrics (if not disabled already)
+        globmet = OrderedDict()
+        if self.util.globals == 1:
+            if config.has_section('global'):
+                parsemet = OrderedDict()
+                for key in config.options('global'):
+                    self.parse_metric_info(parsemet, key, config.get('global', key))
+                for metric in parsemet:
+                    name = parsemet[metric][:1][0]
+                    globmet[name] = parsemet[metric][1:]
+
+        # Add command line and configuration file metric sets
+        tempmet = OrderedDict()
+        for metric in metrics:
+            if metric.startswith(":"):
+                tempmet[metric[1:]] = None
+            else:
+                spec, insts = self.parse_metric_spec_instances(metric)
+                m = spec.split(",")
+                m[2] = insts
+                tempmet[m[0]] = m[1:]
+
+        # Get config and set details for configuration file metric sets
+        confmet = OrderedDict()
+        for spec in tempmet:
+            if tempmet[spec] is None:
+                if config.has_section(spec):
+                    parsemet = OrderedDict()
+                    for key in config.options(spec):
+                        if key in self.util.keys:
+                            self.set_attr(key, config.get(spec, key))
+                        else:
+                            self.parse_metric_info(parsemet, key, config.get(spec, key))
+                            for metric in parsemet:
+                                name = parsemet[metric][:1][0]
+                                confmet[name] = parsemet[metric][1:]
+                            tempmet[spec] = confmet
+                else:
+                    raise IOError("Metric set definition '%s' not found." % metric)
+
+        # Create the combined metrics set
+        if self.util.globals == 1:
+            for metric in globmet:
+                self.util.metrics[metric] = globmet[metric]
+        for metric in tempmet:
+            if isinstance(tempmet[metric], list):
+                self.util.metrics[metric] = tempmet[metric]
+            else:
+                for m in tempmet[metric]:
+                    self.util.metrics[m] = confmet[m]
+
+    def check_metric(self, metric):
+        """ Validate individual metric and get its details """
+        try:
+            pmid = self.util.context.pmLookupName(metric)[0]
+            if pmid in self.pmids:
+                # Always ignore duplicates
+                return
+            desc = self.util.context.pmLookupDescs(pmid)[0]
+            try:
+                if self.util.context.type == pmapi.c_api.PM_CONTEXT_ARCHIVE:
+                    inst = self.util.context.pmGetInDomArchive(desc)
+                else:
+                    inst = self.util.context.pmGetInDom(desc) # disk.dev.read
+                if not inst[0]:
+                    inst = ([pmapi.c_api.PM_IN_NULL], [None]) # pmcd.pmie.logfile
+            except pmapi.pmErr:
+                inst = ([pmapi.c_api.PM_IN_NULL], [None])     # mem.util.free
+            # Reject unsupported types
+            if not (desc.contents.type == pmapi.c_api.PM_TYPE_32 or
+                    desc.contents.type == pmapi.c_api.PM_TYPE_U32 or
+                    desc.contents.type == pmapi.c_api.PM_TYPE_64 or
+                    desc.contents.type == pmapi.c_api.PM_TYPE_U64 or
+                    desc.contents.type == pmapi.c_api.PM_TYPE_FLOAT or
+                    desc.contents.type == pmapi.c_api.PM_TYPE_DOUBLE or
+                    desc.contents.type == pmapi.c_api.PM_TYPE_STRING):
+                raise pmapi.pmErr(pmapi.c_api.PM_ERR_TYPE)
+            instances = self.util.instances if not self.tmp[0] else self.tmp
+            if self.util.omit_flat and instances and not inst[1][0]:
+                return
+            if instances and inst[1][0]:
+                found = [[], []]
+                for r in instances:
+                    cr = re.compile(r'\A' + r + r'\Z')
+                    for i, s in enumerate(inst[1]):
+                        if re.match(cr, s):
+                            found[0].append(inst[0][i])
+                            found[1].append(inst[1][i])
+                if not found[0]:
+                    return
+                inst = tuple(found)
+            self.pmids.append(pmid)
+            self.descs.append(desc)
+            self.insts.append(inst)
+        except pmapi.pmErr as error:
+            if hasattr(self.util, 'ignore_incompat') and self.util.ignore_incompat:
+                return
+            sys.stderr.write("Invalid metric %s (%s).\n" % (metric, str(error)))
+            sys.exit(1)
+
+    def format_metric_label(self, label):
+        """ Format a metric label """
+        # See src/libpcp/src/units.c
+        if ' / ' in label:
+            label = label.replace("nanosec", "ns").replace("microsec", "us")
+            label = label.replace("millisec", "ms").replace("sec", "s")
+            label = label.replace("min", "min").replace("hour", "h")
+            label = label.replace(" / ", "/")
+        return label
+
+    def validate_metrics(self, instances=1024):
+        """ Validate the metrics set """
+        # Check the metrics against PMNS, resolve non-leaf metrics
+        if self.util.derived:
+            if self.util.derived.startswith("/") or self.util.derived.startswith("."):
+                try:
+                    self.util.context.pmLoadDerivedConfig(self.util.derived)
+                except pmapi.pmErr as error:
+                    sys.stderr.write("Failed to register derived metric: %s.\n" % str(error))
+                    sys.exit(1)
+            else:
+                for definition in self.util.derived.split("@"):
+                    err = ""
+                    try:
+                        name, expr = definition.split("=", 1)
+                        self.util.context.pmLookupName(name.strip())
+                    except pmapi.pmErr as error:
+                        if error.args[0] != pmapi.c_api.PM_ERR_NAME:
+                            err = error.message()
+                        else:
+                            try:
+                                self.util.context.pmRegisterDerived(name.strip(), expr.strip())
+                                continue
+                            except pmapi.pmErr as error:
+                                err = error.message()
+                    except ValueError as error:
+                        err = "Invalid syntax (expected metric=expression)"
+                    except Exception as error:
+                        err = "Unidentified error"
+                    finally:
+                        if err:
+                            sys.stderr.write("Failed to register derived metric: %s.\n" % err)
+                            sys.exit(1)
+
+        # Prepare for non-leaf metrics
+        metrics = self.util.metrics
+        self.util.metrics = OrderedDict()
+
+        for metric in metrics:
+            try:
+                l = len(self.pmids)
+                self.tmp = metrics[metric][1]
+                if not 'append' in dir(self.tmp):
+                    self.tmp = [self.tmp]
+                self.util.context.pmTraversePMNS(metric, self.check_metric)
+                if len(self.pmids) == l:
+                    # No compatible metrics found
+                    continue
+                elif len(self.pmids) == l + 1:
+                    # Leaf
+                    if metric in self.util.context.pmNameAll(self.pmids[l]):
+                        self.util.metrics[metric] = metrics[metric]
+                    else:
+                        # Handle single non-leaf case in an archive
+                        self.util.metrics[self.util.context.pmNameID(self.pmids[l])] = []
+                else:
+                    # Non-leaf
+                    for i in range(l, len(self.pmids)):
+                        name = self.util.context.pmNameID(self.pmids[i])
+                        # We ignore specs like disk.dm,,,MB on purpose, for now
+                        self.util.metrics[name] = []
+            except pmapi.pmErr as error:
+                sys.stderr.write("Invalid metric %s (%s).\n" % (metric, str(error)))
+                sys.exit(1)
+
+        # Exit if no metrics with specified instances found
+        if not self.insts:
+            sys.stderr.write("No matching instances found.\n")
+            # Try to help the user to get the instance specifications right
+            if self.util.instances:
+                print("\nRequested global instances:")
+                print(self.util.instances)
+            sys.exit(1)
+
+        # Finalize the metrics set
+        incompat_metrics = {}
+        for i, metric in enumerate(self.util.metrics):
+            # Fill in all fields for easier checking later
+            for index in range(0, 6):
+                if len(self.util.metrics[metric]) <= index:
+                    self.util.metrics[metric].append(None)
+
+            # Label
+            if not self.util.metrics[metric][0]:
+                # mem.util.free -> m.u.free
+                name = ""
+                for m in metric.split("."):
+                    name += m[0] + "."
+                self.util.metrics[metric][0] = name[:-2] + m # pylint: disable=undefined-loop-variable
+
+            # Rawness
+            # As a special service for pmrep(1) utility we hardcode
+            # support for its two output modes, archive and csv.
+            if (hasattr(self.util, 'type') and self.util.type == 1) or \
+               self.util.metrics[metric][3] == 'raw' or \
+               self.util.output == 'archive' or \
+               self.util.output == 'csv':
+                self.util.metrics[metric][3] = 1
+            else:
+                self.util.metrics[metric][3] = 0
+
+            # Set unit/scale if not specified on per-metric basis
+            if not self.util.metrics[metric][2]:
+                unit = self.descs[i].contents.units
+                self.util.metrics[metric][2] = str(unit)
+                if self.util.count_scale and \
+                   unit.dimCount == 1 and ( \
+                   unit.dimSpace == 0 and \
+                   unit.dimTime == 0):
+                    self.util.metrics[metric][2] = self.util.count_scale
+                if self.util.space_scale and \
+                   unit.dimSpace == 1 and ( \
+                   unit.dimCount == 0 and \
+                   unit.dimTime == 0):
+                    self.util.metrics[metric][2] = self.util.space_scale
+                if self.util.time_scale and \
+                   unit.dimTime == 1 and ( \
+                   unit.dimCount == 0 and \
+                   unit.dimSpace == 0):
+                    self.util.metrics[metric][2] = self.util.time_scale
+
+            # Finalize label and unit/scale
+            try:
+                label = self.util.metrics[metric][2]
+                (unitstr, mult) = self.util.context.pmParseUnitsStr(self.util.metrics[metric][2])
+                if self.util.metrics[metric][3] == 0 and \
+                   self.descs[i].contents.type != pmapi.c_api.PM_TYPE_STRING and \
+                   self.descs[i].sem == pmapi.c_api.PM_SEM_COUNTER and \
+                   '/' not in label:
+                       label += " / s"
+                label = self.format_metric_label(label)
+                self.util.metrics[metric][2] = (label, unitstr, mult)
+            except pmapi.pmErr as error:
+                sys.stderr.write("%s: %s.\n" % (str(error), self.util.metrics[metric][2]))
+                sys.exit(1)
+
+            # Set metric type - default to double for precision
+            mtype = pmapi.c_api.PM_TYPE_DOUBLE
+            # But use native type when else was not requested
+            if str(unitstr) == str(self.descs[i].contents.units):
+                mtype = self.descs[i].contents.type
+            # However always use double for non-raw counters
+            if self.util.metrics[metric][3] == 0 and \
+               self.descs[i].contents.sem == pmapi.c_api.PM_SEM_COUNTER:
+                mtype = pmapi.c_api.PM_TYPE_DOUBLE
+            # Strings will be strings right till the end
+            if self.descs[i].contents.type == pmapi.c_api.PM_TYPE_STRING:
+                mtype = self.descs[i].contents.type
+
+            # Set default width if not specified on per-metric basis
+            if self.util.metrics[metric][4]:
+                self.util.metrics[metric][4] = int(self.util.metrics[metric][4])
+            elif hasattr(self.util, 'width') and self.util.width != 0:
+                self.util.metrics[metric][4] = self.util.width
+            else:
+                self.util.metrics[metric][4] = len(self.util.metrics[metric][0])
+            if self.util.metrics[metric][4] < len(TRUNC):
+                self.util.metrics[metric][4] = len(TRUNC) # Forced minimum
+
+            # Add fetchgroup item
+            try:
+                scale = self.util.metrics[metric][2][0]
+                self.util.metrics[metric][5] = self.util.pmfg.extend_indom(metric, mtype, scale, instances)
+            except:
+                if hasattr(self.util, 'ignore_incompat') and self.util.ignore_incompat:
+                    # Schedule the metric for removal
+                    incompat_metrics[metric] = i
+                else:
+                    raise
+
+        # Remove all traces of incompatible metrics
+        for metric in incompat_metrics:
+            del self.pmids[incompat_metrics[metric]]
+            del self.descs[incompat_metrics[metric]]
+            del self.insts[incompat_metrics[metric]]
+            del self.util.metrics[metric]
+        incompat_metrics = {}
+
+        # Verify that we have valid metrics
+        if not self.util.metrics:
+            sys.stderr.write("No compatible metrics found.\n")
+            sys.exit(1)
+
+    def finalize_options(self):
+        """ Finalize util options """
+        # Runtime overrides samples/interval
+        if self.util.opts.pmGetOptionFinishOptarg():
+            self.util.runtime = float(self.util.opts.pmGetOptionFinish()) - float(self.util.opts.pmGetOptionOrigin())
+            if self.util.opts.pmGetOptionSamples():
+                self.util.samples = self.util.opts.pmGetOptionSamples()
+                if self.util.samples < 2:
+                    self.util.samples = 2
+                self.util.interval = float(self.util.runtime) / (self.util.samples - 1)
+                self.util.opts.pmSetOptionInterval(str(self.util.interval))
+                self.util.interval = self.util.opts.pmGetOptionInterval()
+            else:
+                self.util.interval = self.util.opts.pmGetOptionInterval()
+                if not self.util.interval:
+                    self.util.interval = pmapi.timeval(0)
+                try:
+                    self.util.samples = int(self.util.runtime / float(self.util.interval) + 1)
+                except:
+                    pass
+        else:
+            self.util.samples = self.util.opts.pmGetOptionSamples()
+            self.util.interval = self.util.opts.pmGetOptionInterval()
+
+        if float(self.util.interval) <= 0:
+            sys.stderr.write("Interval must be greater than zero.\n")
+            sys.exit(1)


### PR DESCRIPTION
A new tightly coupled PMConfig class for Python utilities is introduced (perhaps think of C++ friend classes) which will take care of reading the configuration file, populating the metrics data for the utility, reading command line (remember that this required quite some effort earlier to get it right for all cases), registering derived metrics, and validating the metrics in the PMNS. Utilities will use the "standard" pmrep config file format and remain mostly compatible with pmrep and each other (utility specific options are of course not recognized by other tools, e.g., zabbix_port makes only sense with pcp2zabbix).

Another module with methods that can be called directly is added to set timezone, step mode, and PMAPI context connection. There seems to be little in this area which would be different for most Python utilities.

Zabbix output support is dropped from pmrep (it was marked as experimental in the man page so should be fine) and a set of new utilities are being added to demonstrate how straightforward it becomes to add new bridge/connector utilities feeding PCP metrics data to external systems:

 * pcp2es
 * pcp2json
 * pcp2xml
 * pcp2xlsx
 * pcp2zabbix