### PR TITLE
All environment variables must be PCP_

### DIFF
--- a/src/pmdas/unbound/pmdaunbound.python
+++ b/src/pmdas/unbound/pmdaunbound.python
@@ -1352,7 +1352,7 @@ class UnboundPMDA(PMDA):
         PMDA.__init__(self, name, domain)
         self.patherrors = 0
         self.fileerrors = 0
-        ctl = getenv('UNBOUND_STATS', '/usr/sbin/unbound-control stats_noreset')
+        ctl = getenv('PCP_UNBOUND_STATS', '/usr/sbin/unbound-control stats_noreset')
         self.unboundctl = shlex.split(ctl)
 
         self.values = {}


### PR DESCRIPTION
In order to override the default UNBOUND_STATS command, it must be set as an environment variable but pcp.env clearly states that any variable set in pcp.conf will be ignored if not prefixed by PCP_.