### PR TITLE
pmconfig.py: handle option priorities correctly

### DIFF
--- a/qa/1069
+++ b/qa/1069
@@ -21,6 +21,13 @@ status=1	# failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 trap "cd $here; rm -rf $tmp.*; exit \$status" 0 1 2 3 15
 
+_filename_filter()
+{
+    sed \
+	-e '/Invalid directive/s/ in .*/ in the config file./' \
+    #end
+}
+
 _live_filter()
 {
     sed \
@@ -90,6 +97,7 @@ pmrep -s 1 -t 1 -b GB -w 3x mem.util.free
 pmrep -s 1 -t 1 -i '('      disk.dev.read
 pmrep -s 1 -t 1 -i '.[]*'   disk.dev.read
 pmrep -s 1 -t 1 -i '.[z-a]' disk.dev.read
+pmrep -s 1 -t 1 :nosuchset
 
 echo "== exercise non-integer options"
 pmrep -T 2.5s -t 0.5 -p $log -c $tmp.config -x sample | _archive_filter
@@ -283,15 +291,35 @@ pmrep -C $log2 -u -U -q MB -I mem.util
 pmrep -C $log2 -u    -i sda mem.util.free disk.dev mem.util
 pmrep -C $log2 -u -v -i sda mem.util.free disk.dev mem.util
 
+echo "== handle empty/invalid/multiple metricsets in config file"
+echo '[fail]' > $tmp.econfig
+echo 'failure = yes' >> $tmp.econfig
+pmrep -s 1 -x -C -H -U $log2 -c $tmp.econfig :fail
+echo '[options]' > $tmp.econfig
+echo 'mem.util.free = freemem' >> $tmp.econfig
+pmrep -s 1 -x -C -H -U $log2 -c $tmp.econfig hinv.machine 2>&1 | _filename_filter
+echo '[empty]' > $tmp.econfig
+echo 'interval = 2s' >> $tmp.econfig
+echo '[metric]' >> $tmp.econfig
+echo 'mem.util.free = freemem' >> $tmp.econfig
+echo 'interval = 3s' >> $tmp.econfig
+pmrep -s 1 -x -C -H -U $log2 -c $tmp.econfig :empty | _archive_filter
+pmrep -s 1 -x -C -H -U $log2 -c $tmp.econfig :metric | _archive_filter
+pmrep -s 1 -x -C -H -U $log2 -c $tmp.econfig :empty :metric | _archive_filter
+pmrep -s 1 -x -C -H -U $log2 -c $tmp.econfig :metric :empty | _archive_filter
+
 echo "== exercise option priority"
 echo '[options]' > $tmp.pconfig
 echo 'header = yes' >> $tmp.pconfig
 echo 'unitinfo = no' >> $tmp.pconfig
 echo 'interval = 2s' >> $tmp.pconfig
+# Use built-in defaults for header/unitinfo/interval
 pmrep -s 5 $log2 -p mem.util.free
 echo "---"
+# Override built-in defaults of unitinfo/interval
 pmrep -s 5 $log2 -p -c $tmp.pconfig mem.util.free
 echo "---"
+# Override built-in defaults / config of header/interval
 pmrep -s 5 $log2 -t 3s -p -H -c $tmp.pconfig mem.util.free
 echo "---"
 echo '[options]' > $tmp.pconfig
@@ -299,24 +327,38 @@ echo "source = $here/archives/no-such-archive" >> $tmp.pconfig
 echo '[source]' >> $tmp.pconfig
 echo "source = $here/archives/rep" >> $tmp.pconfig
 echo 'kernel.all.uptime = uptime,,,,8' >> $tmp.pconfig
+# Override generic option with metricset specific option
 pmrep -s 5 -c $tmp.pconfig -z -p -u :source
 echo "---"
 echo '[source]' > $tmp.pconfig
 echo 'source = wrong.example.com' >> $tmp.pconfig
 echo 'kernel.all.uptime = uptime,,,,8' >> $tmp.pconfig
+# Override config file source with command line option
 pmrep -s 5 $log2 -c $tmp.pconfig -p -u :source
 echo "---"
 echo '[source]' > $tmp.pconfig
 echo 'source = @' >> $tmp.pconfig
 echo "speclocal = clear|add,29,sample/pmda_sample.$DSO_SUFFIX,sample_init" >> $tmp.pconfig
 echo 'sample.long.one = one,,,,8' >> $tmp.pconfig
+# Test speclocal from config file
 pmrep -s 1 -c $tmp.pconfig -p -u :source | _live_filter
 echo "---"
 echo '[source]' > $tmp.pconfig
 echo 'source = @' >> $tmp.pconfig
 echo 'speclocal = fail' >> $tmp.pconfig
 echo 'sample.long.one = one,,,,8' >> $tmp.pconfig
+# Test speclocal override from command line
 pmrep -s 1 -K clear -K add,29,sample/pmda_sample.$DSO_SUFFIX,sample_init -c $tmp.pconfig -p -u :source | _live_filter
+echo "---"
+echo '[options]' > $tmp.pconfig
+echo 'interval = 4s' >> $tmp.pconfig
+echo '[testing]' >> $tmp.pconfig
+echo 'unitinfo = yes' >> $tmp.pconfig
+echo 'timestamp = no' >> $tmp.pconfig
+echo 'interval = 3s' >> $tmp.pconfig
+echo 'mem.util.free = freemem' >> $tmp.pconfig
+# Test overriding metricset specific settings (#357)
+pmrep -s 3 $log2 -p -c $tmp.pconfig -U -t 2s :testing
 
 # success, all done
 echo "== done"

--- a/qa/1069.out
+++ b/qa/1069.out
@@ -249,6 +249,7 @@ Error while parsing options: Integer expected.
 Invalid regex '(': unbalanced parenthesis.
 Invalid regex '.[]*': unexpected end of regular expression.
 Invalid regex '.[z-a]': bad character range.
+Metricset definition ':nosuchset' not found.
 == exercise non-integer options
 
   archive: QAPATH/archives/sample-secs
@@ -763,6 +764,43 @@ pmrep: Impossible value or scale conversion
   d.d.avactive  d.d.read  d.d.write  d.d.total  d.d.read_bytes  d.d.write_bytes
            sda       sda        sda        sda             sda              sda
           ms/s   count/s    count/s    count/s         Kbyte/s          Kbyte/s
+== handle empty/invalid/multiple metricsets in config file
+Invalid metric yes (PM_ERR_NAME Unknown metric name).
+Invalid directive [options]/mem.util.free in the config file.
+No metrics specified.
+
+  archive: QAPATH/archives/20130706
+     host: billing02
+ timezone: UTC+10
+    start: Sat Jul  6 00:47:01 2013
+      end: Sun Jul  7 00:15:43 2013
+  metrics: 1 (1 instance)
+  samples: 1
+ interval: 3.0 sec
+ duration: 00:00:00
+
+
+  archive: QAPATH/archives/20130706
+     host: billing02
+ timezone: UTC+10
+    start: Sat Jul  6 00:47:01 2013
+      end: Sun Jul  7 00:15:43 2013
+  metrics: 1 (1 instance)
+  samples: 1
+ interval: 3.0 sec
+ duration: 00:00:00
+
+
+  archive: QAPATH/archives/20130706
+     host: billing02
+ timezone: UTC+10
+    start: Sat Jul  6 00:47:01 2013
+      end: Sun Jul  7 00:15:43 2013
+  metrics: 1 (1 instance)
+  samples: 1
+ interval: 2.0 sec
+ duration: 00:00:00
+
 == exercise option priority
           m.u.free
              Kbyte
@@ -808,4 +846,9 @@ HH:MM:SS         1
                one
                   
 HH:MM:SS         1
+---
+          freemem
+00:47:01    38220
+00:47:03    38220
+00:47:05    38220
 == done

--- a/src/python/pcp/pmconfig.py
+++ b/src/python/pcp/pmconfig.py
@@ -120,23 +120,30 @@ class pmConfig(object):
             except ValueError:
                 setattr(self.util, name, value)
 
+    def read_section_options(self, config, section):
+        """ Read options from a configuration file section """
+        if not config.has_section(section):
+            return
+        for opt in config.options(section):
+            if opt in self.util.keys:
+                self.set_attr(opt, config.get(section, opt))
+            elif section == 'options':
+                sys.stderr.write("Invalid directive [%s]/%s in %s.\n" % (section, opt, self.util.config))
+                sys.exit(1)
+
     def read_options(self):
         """ Read options from configuration file """
         config = ConfigParser.SafeConfigParser()
         if self.util.config:
             config.read(self.util.config)
-        if not config.has_section('options'):
-            return
-        for opt in config.options('options'):
-            if opt in self.util.keys:
-                self.set_attr(opt, config.get('options', opt))
-            else:
-                sys.stderr.write("Invalid directive '%s' in %s.\n" % (opt, self.util.config))
-                sys.exit(1)
+        self.read_section_options(config, 'options')
+        for arg in iter(sys.argv[1:]):
+            if arg.startswith(":") and arg[1:] in config.sections():
+                self.read_section_options(config, arg[1:])
 
     def read_cmd_line(self):
         """ Read command line options """
-        pmapi.c_api.pmSetOptionFlags(pmapi.c_api.PM_OPTFLAG_DONE)  # Do later
+        pmapi.c_api.pmSetOptionFlags(pmapi.c_api.PM_OPTFLAG_DONE)
         if pmapi.c_api.pmGetOptionsFromList(sys.argv):
             raise pmapi.pmUsageErr()
 
@@ -238,7 +245,7 @@ class pmConfig(object):
                     name = parsemet[metric][:1][0]
                     globmet[name] = parsemet[metric][1:]
 
-        # Add command line and configuration file metric sets
+        # Add command line and configuration file metricsets
         tempmet = OrderedDict()
         for metric in metrics:
             if metric.startswith(":"):
@@ -249,23 +256,21 @@ class pmConfig(object):
                 m[2] = insts
                 tempmet[m[0]] = m[1:]
 
-        # Get config and set details for configuration file metric sets
+        # Get config and set details for configuration file metricsets
         confmet = OrderedDict()
         for spec in tempmet:
             if tempmet[spec] is None:
                 if config.has_section(spec):
                     parsemet = OrderedDict()
                     for key in config.options(spec):
-                        if key in self.util.keys:
-                            self.set_attr(key, config.get(spec, key))
-                        else:
+                        if key not in self.util.keys:
                             self.parse_metric_info(parsemet, key, config.get(spec, key))
                             for metric in parsemet:
                                 name = parsemet[metric][:1][0]
                                 confmet[name] = parsemet[metric][1:]
                             tempmet[spec] = confmet
                 else:
-                    raise IOError("Metric set definition '%s' not found." % metric)
+                    raise IOError("Metricset definition '%s' not found." % metric)
 
         # Create the combined metrics set
         if self.util.globals == 1:
@@ -275,8 +280,12 @@ class pmConfig(object):
             if isinstance(tempmet[metric], list):
                 self.util.metrics[metric] = tempmet[metric]
             else:
-                for m in tempmet[metric]:
-                    self.util.metrics[m] = confmet[m]
+                if tempmet[metric]:
+                    for m in tempmet[metric]:
+                        self.util.metrics[m] = confmet[m]
+
+        if not self.util.metrics:
+            raise IOError("No metrics specified.")
 
     def check_metric(self, metric):
         """ Validate individual metric and get its details """


### PR DESCRIPTION
Make sure command line options always override config file values.

Fixes #357.