### PR TITLE
pcp2zabbix: fix python typo for formatting zabbix server error

### DIFF
--- a/src/pcp2zabbix/pcp2zabbix.py
+++ b/src/pcp2zabbix/pcp2zabbix.py
@@ -430,7 +430,7 @@ class PCP2Zabbix(object):
             if self.context.pmDebug(PM_DEBUG_APPL0):
                 print('Got response from Zabbix: %s' % resp)
             if resp.get('response') != 'success':
-                sys.stderr.write('Error response from Zabbix: %s', resp)
+                sys.stderr.write('Error response from Zabbix: %s' % resp)
                 sys.stderr.flush()
                 return False
             return True


### PR DESCRIPTION
stderr.write takes ("foo %s" % bar)  rather than ("foo %s", bar).