### PR TITLE
pmmgr: tolerate pmcds with empty hostname

### DIFF
--- a/man/man1/pmmgr.1
+++ b/man/man1/pmmgr.1
@@ -147,7 +147,7 @@ instances, how to uniquely identify them, and where state
 such as log files should be kept for each.  Ideally, a persistent and
 unique hostid string is computed for each potential target pmcd from
 specified metric values.  This hostid is also used as a subdirectory
-name for locating daemon data.
+name for locating daemon data.  The rare empty hostid is mapped to "-".
 .TP
 .I hostid\-static
 This file contains one or more lines specifying the static string that

--- a/src/pmmgr/pmmgr.cxx
+++ b/src/pmmgr/pmmgr.cxx
@@ -458,6 +458,9 @@ pmmgr_job_spec::compute_hostids (const pcp_context_spec& ctx) const
 	}
     }
 
+  if (sanitized == "") // treat empty hostid as '-', from hostid-metrics separator
+    sanitized = "-";
+
   hostids.insert(pmmgr_hostid (sanitized));
   return hostids;
 }


### PR DESCRIPTION
An assertion failure was formerly triggered, possibly by pmcds
advertising a blank hostname.  This code now assigns them a
hostid of "-".