### PR TITLE
pmda_perfevent: Add null checks for pmc_settings

### DIFF
--- a/src/pmdas/perfevent/configparser.l
+++ b/src/pmdas/perfevent/configparser.l
@@ -289,6 +289,10 @@ static void set_pmcsetting_derived_scale(configuration_t *config,  double scale,
     if (context_derived)
     {
         setting_lists = config->derivedArr[config->nDerivedEntries-1].setting_lists;
+        if (NULL == setting_lists)
+        {
+            return;
+        }
         while (setting_lists->next)
         {
             setting_lists = setting_lists->next;
@@ -317,6 +321,10 @@ static void set_pmcsetting_cpuconfig(configuration_t *config, int cpuconfig)
 
     if (context_derived)
     {
+        if (NULL == setting_lists)
+        {
+            return;
+        }
         setting_lists = config->derivedArr[config->nDerivedEntries-1].setting_lists;
         while (setting_lists->next)
         {


### PR DESCRIPTION
Fixes segfaults in case of empty pmc_settings.