### PR TITLE
Rearrange pmcsetting list check

### DIFF
--- a/src/pmdas/perfevent/configparser.l
+++ b/src/pmdas/perfevent/configparser.l
@@ -321,11 +321,11 @@ static void set_pmcsetting_cpuconfig(configuration_t *config, int cpuconfig)
 
     if (context_derived)
     {
+        setting_lists = config->derivedArr[config->nDerivedEntries-1].setting_lists;
         if (NULL == setting_lists)
         {
             return;
         }
-        setting_lists = config->derivedArr[config->nDerivedEntries-1].setting_lists;
         while (setting_lists->next)
         {
             setting_lists = setting_lists->next;


### PR DESCRIPTION
setting_lists has to be assigned before the NULL check.