### PR TITLE
pmrep.conf: Add sar-n-SOCK config

### DIFF
--- a/src/pmrep/pmrep.conf
+++ b/src/pmrep/pmrep.conf
@@ -609,7 +609,22 @@ network.interface.out.fifo    = txfifo/s,,,,
 
 #[sar-n-NFS]
 #[sar-n-NFSD]
-#[sar-n-SOCK]
+
+[sar-n-SOCK]
+header = yes
+unitinfo = no
+globals = no
+timestamp = yes
+width = 9
+precision = 2
+delimiter = " "
+network.sockstat.total        = totsck,,,,
+network.sockstat.tcp.inuse    = tcpsck,,,,
+network.sockstat.udp.inuse    = udpsck,,,,
+network.sockstat.raw.inuse    = rawsck,,,,
+network.sockstat.frag.inuse   = ip-frag,,,,
+network.sockstat.tcp.tw       = tcp-tw,,,,
+
 #[sar-n-TCP-ETCP]
 
 [sar-q]

--- a/src/pmrep/pmrep.conf
+++ b/src/pmrep/pmrep.conf
@@ -618,12 +618,12 @@ timestamp = yes
 width = 9
 precision = 2
 delimiter = " "
-network.sockstat.total        = totsck,,,,
-network.sockstat.tcp.inuse    = tcpsck,,,,
-network.sockstat.udp.inuse    = udpsck,,,,
-network.sockstat.raw.inuse    = rawsck,,,,
-network.sockstat.frag.inuse   = ip-frag,,,,
-network.sockstat.tcp.tw       = tcp-tw,,,,
+network.sockstat.total      = totsck,,,,12
+network.sockstat.tcp.inuse  = tcpsck,,,,
+network.sockstat.udp.inuse  = udpsck,,,,
+network.sockstat.raw.inuse  = rawsck,,,,
+network.sockstat.frag.inuse = ip-frag,,,,
+network.sockstat.tcp.tw     = tcp-tw,,,,
 
 #[sar-n-TCP-ETCP]
 


### PR DESCRIPTION
Add a equivalent configuration for pmrep for "sar -n SOCK".  The "pmrep :sar-n-SOCK" metrics output matches up with the sar command that it modeled after.