### PR TITLE
Have the PMDA JSON create a default place for json metrics

### DIFF
--- a/src/pmdas/json/Install
+++ b/src/pmdas/json/Install
@@ -22,6 +22,13 @@ iam=json
 python_opt=true
 daemon_opt=false
 
+if [ ! -e "$PCP_TMP_DIR/json" ]
+then
+    echo "creating $PCP_TMP_DIR/json"
+    mkdir -p -m 1777 "$PCP_TMP_DIR/json"
+fi
+chown $PCP_USER:$PCP_GROUP "$PCP_TMP_DIR/json"
+
 pmdaSetup
 pmdaInstall
 exit

--- a/src/pmdas/json/config.json
+++ b/src/pmdas/json/config.json
@@ -1,6 +1,6 @@
 {
     "directory_list" : [
-	"/proc/systemtap"
+	"/proc/systemtap", "/var/lib/pcp/tmp/json"
     ],
     "trusted_directory_list" : [
     ]


### PR DESCRIPTION
To make it easier to use the PMDA JSON for dynamically created metrics
it creates a default directory ($PCP_TMP_DIR/json) for other
applications to place their metrics coded as json files in.  PMDA JSON
scans that directory for json files and it will pick up any new
metrics in the default directory automatically.