### PR TITLE
pmwebd file service: add/check ETag header for 304 Not Modified results

### DIFF
--- a/qa/661
+++ b/qa/661
@@ -52,7 +52,7 @@ echo "crashers"
 _filter_curl_i()
 {
     tr -d '\r' |                      # drop ^M from httpd results
-    sed -e 's,^Date:.*$,Date: XXX,' -e 's/302 Moved Temporarily/302 Found/' |
+    sed -e 's,^Date:.*$,Date: XXX,' -e 's/302 Moved Temporarily/302 Found/' -e 's/^ETag: .*/ETAG/' |
     grep -v 'Connection:.*Alive'      # some microhttpd versions add this
 }
 
@@ -73,6 +73,7 @@ echo "the catalog"
 curl -s -i "http://localhost:$webport/?zoo=goo&phantasm" | _filter_curl_i
 curl -s -i "http://localhost:$webport/blinkenlights" | _filter_curl_i
 curl -s -i "http://localhost:$webport/blinkenlights/" | _filter_curl_i
+curl -s -i "http://localhost:$webport/graphite/index.html" | _filter_curl_i | grep -i etag
 curl -s -S "http://localhost:$webport/graphite/index.html?foo=bar&ectoplasm=egon"
 
 echo

--- a/qa/661.out
+++ b/qa/661.out
@@ -21,6 +21,7 @@ Access-Control-Allow-Origin: *
 Location: /blinkenlights/index.html
 Date: XXX
 
+ETAG
 <!-- Copyright 2008 Orbitz WorldWide
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -175,6 +176,11 @@ metric tree iteration
         {
             "name": "all",
             "path": "archives/naslog.kernel.all.",
+            "is_leaf": 0
+        },
+        {
+            "name": "cpu",
+            "path": "archives/naslog.kernel.cpu.",
             "is_leaf": 0
         }
     ]


### PR DESCRIPTION
When pmwebd is used for ordinary file service, it's desirable to allow
web browsers to cache those files.  This patch introduces simple
tagging of these files with the ETag: header (with some readily
available fstat(2) values as keys).  It now sends a 304 result code
instead of a 200 and a whole new copy of unmodified files.