### PR TITLE
pmwebd: improve graphite archive-cache performance w.r.t. syscalls

### DIFF
--- a/man/man1/pmwebd.1
+++ b/man/man1/pmwebd.1
@@ -95,6 +95,8 @@ protocols, if possible.
 .TP
 \f3\-A\f1 \f2archdir\f1
 Limit remote access to archives to only those beneath the given directory.
+For performance, symbolic links to other directories may not
+be followed.
 By default, only files beneath the initial
 .B pmwebd
 working directory may


### PR DESCRIPTION
It was reported that on a large collection of pcp archives, which
included a number of corrupt (0-byte ones), the graphite
metric-enumeration query took too long.  One source of this was
excessive effort on
- frequently retrying opening corrupt archives, and
- fstat'ing all files under -A $DIR

We no longer do either.  Corrupt archives are treated as though they
were fresh at the moment of pmwebd startup, but containing no content.
The -A directory's transitive contents are no longer routinely
fstat()d, only readdir() enumerated.  This costs us the ability to
follow subdirectory symlinks, but it's a pretty big win otherwise.
No QA impact, only performance.