### PR TITLE
Add a pmrep configuration for numa hint faults metrics

### DIFF
--- a/src/pmrep/pmrep.conf
+++ b/src/pmrep/pmrep.conf
@@ -936,3 +936,35 @@ steal.label = st
 steal.formula = 100 * kernel.all.cpu.steal / hinv.ncpu
 steal.unit = s
 steal.width = 4
+
+[numa-hint-faults]
+header = yes
+unitinfo = no
+globals = no
+timestamp = yes
+width = 15
+precision = 2
+delimiter = " "
+mem.vmstat.numa_hint_faults = faults/s,,,,
+mem.vmstat.numa_hint_faults_local = faults_local/s,,,,
+local = mem.vmstat.numa_hint_faults_local_percent
+local.label = %%local
+local.formula = 100 *
+  (rate(mem.vmstat.numa_hint_faults)
+  ?
+    rate(mem.vmstat.numa_hint_faults_local)/rate(mem.vmstat.numa_hint_faults)
+  :
+    mkconst(1, type="double", semantics="instant") )
+local.width = 7
+faults_remote = mem.vmstat.numa_hint_faults_remote
+faults_remote.formula = mem.vmstat.numa_hint_faults - mem.vmstat.numa_hint_faults_local
+faults_remote.label = faults_remote/s
+remote = mem.vmstat.numa_hint_faults_remote_percent
+remote.formula = 100 *
+  (rate(mem.vmstat.numa_hint_faults)
+  ?
+    (1 - rate(mem.vmstat.numa_hint_faults_local)/rate(mem.vmstat.numa_hint_faults))
+  :
+    mkconst(0, type="double", semantics="instant") )
+remote.label = %%remote
+remote.width = 7


### PR DESCRIPTION
PCP metrics were recently added for numa_hint_faults and
numa_hint_faults_local information from /proc/vmstat.  This pmrep
configuration computes a derived metric numa_hint_faults_remote. The
three numa hint fault metrics are displayed with percentages for the
local and remote faults to provide an indicatation whether there is a
problem with page locality on NUMA machines.