### PR TITLE
Fixes #454 - Enable daemons on debian based systems

### DIFF
--- a/debian/pcp-manager.postinst
+++ b/debian/pcp-manager.postinst
@@ -5,7 +5,10 @@
 chown pcp:pcp /var/log/pcp/pmmgr
 chmod 775 /var/log/pcp/pmmgr
 
-if which update-rc.d >/dev/null 2>&1
+if which deb-systemd-helper >/dev/null 2>&1
+then
+   deb-systemd-helper enable pmmgr.service >/dev/null
+elif which update-rc.d >/dev/null 2>&1
 then
     update-rc.d -f pmmgr remove >/dev/null
     update-rc.d pmmgr defaults >/dev/null

--- a/debian/pcp-webapi.postinst
+++ b/debian/pcp-webapi.postinst
@@ -5,7 +5,10 @@
 chown pcp:pcp /var/log/pcp/pmwebd
 chmod 775 /var/log/pcp/pmwebd
 
-if which update-rc.d >/dev/null 2>&1
+if which deb-systemd-helper >/dev/null 2>&1
+then
+    deb-systemd-helper enable pmwebd.service >/dev/null
+elif which update-rc.d >/dev/null 2>&1
 then
     update-rc.d -f pmwebd remove >/dev/null
     update-rc.d pmwebd defaults >/dev/null

--- a/debian/pcp.postinst.tail
+++ b/debian/pcp.postinst.tail
@@ -71,7 +71,13 @@ then
     chmod 644 /var/lib/pcp/config/pmlogger/config.default
 fi
 
-if which update-rc.d >/dev/null 2>&1
+if which deb-systemd-helper >/dev/null 2>&1
+then
+    deb-systemd-helper enable pmcd.service >/dev/null
+    deb-systemd-helper enable pmlogger.service >/dev/null
+    deb-systemd-helper enable pmie.service >/dev/null
+    deb-systemd-helper enable pmproxy.service >/dev/null
+elif which update-rc.d >/dev/null 2>&1
 then
     update-rc.d -f pmcd remove >/dev/null
     update-rc.d pmcd defaults >/dev/null


### PR DESCRIPTION
On debian based systems, update-rc.d has different behavior for unit files generated via the sysv-generator versus native systemd units. As a result, PCP daemons are not enabled automatically. With this patch, deb-systemd-helper is used instead of update-rc.d, if it exists.