### PR TITLE
integrate Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: required
+
+services:
+  - docker
+
+language: c
+
+before_install:
+  - docker build -f build/containers/travis-ci/Dockerfile -t pcp-qa .
+
+before_script:
+  - docker run -d --privileged --name pcp-qa pcp-qa
+  - docker exec pcp-qa bash -c 'cd /pcp && ./Makepkgs'
+  - docker exec pcp-qa bash -c 'cd /pcp/pcp-*/build/rpm && VER=$(pwd | cut -d- -f2 | cut -d/ -f1) && dnf -y install pcp{,-conf,-libs,-libs-devel,-devel,-testsuite}-$VER-1.x86_64.rpm'
+  - docker exec pcp-qa systemctl start pmcd
+
+script:
+  - docker exec pcp-qa bash -c 'cd /var/lib/pcp/testsuite && ./check -g sanity'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![PCP](images/pcpicon.png)
 
+[![Build Status](https://travis-ci.org/performancecopilot/pcp.svg?branch=master)](https://travis-ci.org/performancecopilot/pcp)
+
 Performance Co-Pilot (PCP) provides a framework and services to support
 system-level performance monitoring and management. It presents a unifying
 abstraction for all of the performance data in a system, and many tools

--- a/build/containers/travis-ci/Dockerfile
+++ b/build/containers/travis-ci/Dockerfile
@@ -1,0 +1,9 @@
+FROM fedora:27
+
+RUN dnf -y install which sudo hostname findutils bc git \
+                   pkg-config make gcc gcc-c++ perl flex bison \
+                   rpm-build redhat-rpm-config \
+                   initscripts man ncurses-devel procps readline-devel zlib-devel
+
+COPY . /pcp
+CMD ["/usr/sbin/init"]


### PR DESCRIPTION
This PR integrates Travis CI.
It builds the PCP rpm packages inside a Docker image (Fedora 27) and executes the testsuite (with the `sanity` group).

Reason for using Docker inside the Travis CI VM is independence over the Travis CI VM image (at the moment Ubuntu 12.04 and Ubuntu 14.04 are available) and reproducibility.

Example build: https://travis-ci.org/andihit/pcp/builds/354788103
To enable the build on Travis CI, somebody with enough privileges of the GitHub pcp repo has to enable it on Travis CI.

The part where the generated RPM filenames is determined is a bit hacky, maybe somebody has a better idea?