### PR TITLE
qa: add test 1116 for BCC PMDA biotop tool

### DIFF
--- a/qa/1116
+++ b/qa/1116
@@ -1,0 +1,113 @@
+#!/bin/sh
+# PCP QA Test No. 1116
+# Exercise the BCC PMDA - install, remove and values.
+#
+# Copyright (c) 2018 Andreas Gerstmayr.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+. ./common.python
+
+$python -c "from pcp import pmda" >/dev/null 2>&1
+[ $? -eq 0 ] || _notrun "python pcp pmda module not installed"
+$python -c "import bcc" >/dev/null 2>&1
+[ $? -eq 0 ] || _notrun "python bcc module not installed"
+
+[ -f $PCP_PMDAS_DIR/bcc/pmdabcc.python ] || _notrun "bcc PMDA not installed"
+
+status=1       # failure is the default!
+signal=$PCP_BINADM_DIR/pmsignal
+username=`id -u -n`
+$sudo rm -rf $tmp.* $seq.full
+write_size=$((3*1024*1024)) # number of bytes to write into testfile
+
+_install_filter()
+{
+    sed \
+	-e "s/.*pmdabcc.* Info/Info/g" \
+  -e "s/1 metrics and [0-9]\+ values/1 metrics and X values/g" \
+    #end
+}
+
+_value_filter()
+{
+    grep "value ${write_size}" | \
+    sed -e 's/\[[0-9]\+ or ".\+"\]/[X or "DEV::PID"]/g'
+    #end
+}
+
+pmdabcc_remove()
+{
+    echo
+    echo "=== remove bcc agent ==="
+    $sudo ./Remove >$tmp.out 2>&1
+    _filter_pmda_remove <$tmp.out
+}
+
+pmdabcc_install()
+{
+    # start from known starting points
+    cd $PCP_PMDAS_DIR/bcc
+    $sudo ./Remove >/dev/null 2>&1
+
+    cat <<EOF >$tmp.config
+[pmda]
+modules = biotop
+prefix = bcc.
+[biotop]
+module = biotop
+cluster = 2
+EOF
+    echo "pmdabcc config:" >> $here/$seq.full
+    cat $tmp.config >> $here/$seq.full
+
+    [ -f $PCP_PMDAS_DIR/bcc/bcc.conf ] && \
+    $sudo cp $PCP_PMDAS_DIR/bcc/bcc.conf $tmp.backup
+    $sudo cp $tmp.config $PCP_PMDAS_DIR/bcc/bcc.conf
+
+    echo
+    echo "=== bcc agent installation ==="
+    $sudo ./Install </dev/null >$tmp.out 2>&1
+    cat $tmp.out | _filter_pmda_install | _install_filter
+}
+
+pmdabcc_cleanup()
+{
+    [ "X$spid" != X ] && (( $signal $spid )&) >/dev/null 2>&1
+    if [ -f $tmp.backup ]; then
+        $sudo cp $tmp.backup $PCP_PMDAS_DIR/bcc/bcc.conf
+        $sudo rm $tmp.backup
+    else
+        $sudo rm -f $PCP_PMDAS_DIR/bcc/bcc.conf
+    fi
+    # note: _restore_auto_restart pmcd done in _cleanup_pmda()
+    _cleanup_pmda bcc
+}
+
+_prepare_pmda bcc
+trap "pmdabcc_cleanup; exit \$status" 0 1 2 3 15
+
+_stop_auto_restart pmcd
+
+# real QA test starts here
+pmdabcc_install
+echo
+
+# Generate system activity for the BCC biotop module
+# block device required here, no tmpfs (e.g. /tmp)
+dd if=/dev/zero of=/var/tmp/pcp_qa_1116 bs=${write_size} count=1 oflag=direct 2>/dev/null
+
+echo "=== report metric values ==="
+pminfo -dfmtT bcc.proc.io.perdev 2>&1 | _value_filter \
+| tee -a $here/$seq.full
+
+echo "=== verify metric values ==="
+pminfo -v bcc 2>&1 \
+| tee -a $here/$seq.full
+
+pmdabcc_remove
+
+status=0
+exit

--- a/qa/1116.out
+++ b/qa/1116.out
@@ -1,0 +1,52 @@
+QA output created by 1116
+
+=== bcc agent installation ===
+Info: Enabled modules:
+Info: ['biotop']
+Info: Configuring modules:
+Info: biotop
+Info: Modules configured.
+Info: Initializing modules:
+Info: biotop
+Info: biotop: Initialized.
+Info: Modules initialized.
+Info: Registering metrics:
+Info: biotop
+Info: Metrics registered.
+Info: Registering helpers:
+Info: biotop
+Info: Helpers registered.
+Info: Enabled modules:
+Info: ['biotop']
+Info: Configuring modules:
+Info: biotop
+Info: Modules configured.
+Info: Initializing modules:
+Info: biotop
+Info: biotop: Initialized.
+Info: Modules initialized.
+Info: Registering metrics:
+Info: biotop
+Info: Metrics registered.
+Info: Registering helpers:
+Info: biotop
+Info: Helpers registered.
+Updating the Performance Metrics Name Space (PMNS) ...
+Terminate PMDA if already installed ...
+[...install files, make output...]
+Updating the PMCD control file, and notifying PMCD ...
+Check bcc metrics have appeared ... 1 metrics and X values
+
+=== report metric values ===
+    inst [X or "DEV::PID"] value 3145728
+=== verify metric values ===
+
+=== remove bcc agent ===
+Culling the Performance Metrics Name Space ...
+bcc ... done
+Updating the PMCD control file, and notifying PMCD ...
+[...removing files...]
+Check bcc metrics have gone away ... OK
+Waiting for pmcd to terminate ...
+Starting pmcd ... 
+Starting pmlogger ... 

--- a/qa/group
+++ b/qa/group
@@ -1432,6 +1432,7 @@ pmlogsize
 1113 pcp python local
 1114 archive pmval multi-archive local pmlogextract
 1115 pmda.bcc local
+1116 pmda.bcc local
 1119 pmlogsummary archive multi-archive decompress-xz local pmlogextract
 1120 pmda.prometheus local
 1121 pmda.linux local


### PR DESCRIPTION
this test writes a testfile to `/var/tmp/pcp_qa_1116`, because a block device is required for the bcc tool (`/tmp` is tmpfs)
is this ok, or should I use another location for the testfile?