### PR TITLE
GH#451: fix fetchgroup vs derivedmetric instance profile kumite

### DIFF
--- a/man/man3/pmfetchgroup.3
+++ b/man/man3/pmfetchgroup.3
@@ -1,6 +1,6 @@
 '\"macro stdmacro
 .\"
-.\" Copyright (c) 2014-2016 Red Hat, Inc.  All Rights Reserved.
+.\" Copyright (c) 2014-2018 Red Hat, Inc.  All Rights Reserved.
 .\" 
 .\" This program is free software; you can redistribute it and/or modify it
 .\" under the terms of the GNU General Public License as published by the
@@ -86,7 +86,8 @@ Rate conversions between consecutive samples may be requested.
 .PP
 Each fetchgroup is associated with a private PMAPI context, so it can
 manipulate instance profiles and other such state without disrupting
-other contexts.
+other contexts.  The instance profile is manipulated to optimize
+fetches of individual items, even if some are derived metrics.
 This private PMAPI context belongs to the fetchgroup,
 is used for all of its internal operations, and will be destroyed.
 .PP

--- a/qa/1069
+++ b/qa/1069
@@ -295,6 +295,11 @@ EOF
 pmrep -C -H -U -a $here/archives/proc -c $tmp.derived-test.conf :derived-test
 echo "No output expected."
 
+echo "== derived metrics v. instance profiles"  # GH#451
+pmrep -s 1 -w 8 -H -U -e 'y = sum(sample.bucket)' y sample.bucket
+pmrep -s 1 -w 8 -H -U -e 'y = sum(sample.bucket)' y
+# first column should have same values
+
 echo "== extended existing sample configuration"
 cat > $tmp.dconfig <<EOF
 [global]

--- a/qa/1069.out
+++ b/qa/1069.out
@@ -1106,6 +1106,9 @@ No output expected.
 No output expected.
 No output expected.
 No output expected.
+== derived metrics v. instance profiles
+      4500       100       200       300       400       500       600       700       800       900
+      4500
 == extended existing sample configuration
   s.combo  s.seconds  s.milliseconds
       s/s        s/s            ms/s


### PR DESCRIPTION
The fetchgroup facility tries to optimize the instance profile to
minimize fetching of unnecessary instances.  The presence of
derived metrics (with opaque indom requirements of their own)
makes this optimization harmful.  New code disables it when
an IS_DERIVED() metric is added to the fetchgroup.  qa/1069 tests.