### PR TITLE
GH#439: add low-level-discovery support to pcp2zabbix

### DIFF
--- a/qa/1068
+++ b/qa/1068
@@ -64,14 +64,16 @@ EOF
 
 cat $tmp.config >>$seq.full
 
-socat tcp-listen:$zabbix_port,reuseaddr - >$tmp.socat.out 2>$tmp.socat.err &
+# start a longer-lived copy of socat we can use for consecutive tests
+socat tcp-listen:$zabbix_port,reuseaddr,fork - >>$tmp.socat.out 2>$tmp.socat.err &
 pid=$!
 sleep 2
+
+echo "== Zabbix Archive ==="
 pcp2zabbix -r -t 2 -s 3 $log -c $tmp.config sample >$tmp.pcp2zabbix.out 2>$tmp.pcp2zabbix.err &   # will error out after socket cat dies
 pmpid=$!
 sleep 2
-$signal $pid $pmpid 2>/dev/null
-wait
+$signal $pmpid 2>/dev/null
 _seq_store
 
 echo "== Zabbix server input ==="
@@ -81,6 +83,28 @@ echo "header: $header"
 echo "body:"
 echo '{' # ate this from the header
 sed -n '1!p' $tmp.socat.out
+echo #}
+# truncate the file so we get separate results for the second run
+true > $tmp.socat.out
+
+sleep 2
+echo "== Zabbix LLD ==="
+pcp2zabbix -r --lld -t 2 -s 3 -c $tmp.config sample.float.bin >$tmp.pcp2zabbix.out 2>$tmp.pcp2zabbix.err &
+pmpid=$!
+sleep 2
+$signal $pmpid 2>/dev/null
+
+$signal $pid 2>/dev/null
+wait
+_seq_store
+
+echo "== Zabbix server input ==="
+# check the first line has the initial ZBXD preamble (before JSON)
+header=`_zbx_header $tmp.socat.out`
+echo "header: $header"
+echo "body:"
+echo '{' # ate this from the header
+sed -n '1!p' $tmp.socat.out | sed -e 's,"clock":[0-9]*,"clock":CLOCK,'
 echo #}
 
 # success, all done

--- a/qa/1068.out
+++ b/qa/1068.out
@@ -1,4 +1,5 @@
 QA output created by 1068
+== Zabbix Archive ===
 == Zabbix server input ===
 header: 0000000   Z   B   X   D
 body:
@@ -35,4 +36,62 @@ body:
 			"key":"pcp.sample.milliseconds",
 			"value":"380436166.949",
 			"clock":957177409}]
+}
+== Zabbix LLD ===
+== Zabbix server input ===
+header: 0000000   Z   B   X   D
+body:
+{
+	"request":"sender data",
+	"data":[
+		{
+			"host":"HOSTNAME",
+			"key":"pcp.sample.float.bin[bin-100]",
+			"value":"100.000",
+			"clock":CLOCK},
+		{
+			"host":"HOSTNAME",
+			"key":"pcp.sample.float.bin[bin-200]",
+			"value":"200.000",
+			"clock":CLOCK},
+		{
+			"host":"HOSTNAME",
+			"key":"pcp.sample.float.bin[bin-300]",
+			"value":"300.000",
+			"clock":CLOCK},
+		{
+			"host":"HOSTNAME",
+			"key":"pcp.sample.float.bin[bin-400]",
+			"value":"400.000",
+			"clock":CLOCK},
+		{
+			"host":"HOSTNAME",
+			"key":"pcp.sample.float.bin[bin-500]",
+			"value":"500.000",
+			"clock":CLOCK},
+		{
+			"host":"HOSTNAME",
+			"key":"pcp.sample.float.bin[bin-600]",
+			"value":"600.000",
+			"clock":CLOCK},
+		{
+			"host":"HOSTNAME",
+			"key":"pcp.sample.float.bin[bin-700]",
+			"value":"700.000",
+			"clock":CLOCK},
+		{
+			"host":"HOSTNAME",
+			"key":"pcp.sample.float.bin[bin-800]",
+			"value":"800.000",
+			"clock":CLOCK},
+		{
+			"host":"HOSTNAME",
+			"key":"pcp.sample.float.bin[bin-900]",
+			"value":"900.000",
+			"clock":CLOCK},
+		{
+			"host":"HOSTNAME",
+			"key":"pcp.discovery[pcp.sample.float.bin]",
+			"value":"{ \"data\": [{ \"{#PCP.SAMPLE.FLOAT.BIN}\":\"bin-100\"},{ \"{#PCP.SAMPLE.FLOAT.BIN}\":\"bin-200\"},{ \"{#PCP.SAMPLE.FLOAT.BIN}\":\"bin-300\"},{ \"{#PCP.SAMPLE.FLOAT.BIN}\":\"bin-400\"},{ \"{#PCP.SAMPLE.FLOAT.BIN}\":\"bin-500\"},{ \"{#PCP.SAMPLE.FLOAT.BIN}\":\"bin-600\"},{ \"{#PCP.SAMPLE.FLOAT.BIN}\":\"bin-700\"},{ \"{#PCP.SAMPLE.FLOAT.BIN}\":\"bin-800\"},{ \"{#PCP.SAMPLE.FLOAT.BIN}\":\"bin-900\"}] }",
+			"clock":CLOCK}]
 }

--- a/src/pcp2zabbix/pcp2zabbix.1
+++ b/src/pcp2zabbix/pcp2zabbix.1
@@ -19,7 +19,7 @@
 \f3pcp2zabbix\f1 \- pcp-to-zabbix metrics exporter
 .SH SYNOPSIS
 \fBpcp2zabbix\fP
-[\fB\-CGHIjLnrRvV?\fP]
+[\fB\-CGHIjLnrRlvV?\fP]
 [\fB\-8\fP|\fB\-9\fP \fIlimit\fP]
 [\fB\-a\fP \fIarchive\fP]
 [\fB\-\-archive\-folio\fP \fIfolio\fP]
@@ -110,6 +110,7 @@ The following options are common with
 .BR ignore_incompat ,
 .BR instances ,
 .BR live_filter ,
+.BR lld ,
 .BR rank ,
 .BR limit_filter ,
 .BR limit_filter_force ,
@@ -333,6 +334,25 @@ With this option all incompatible metrics are silently omitted
 from reporting.
 This may be especially useful when requesting
 non-leaf nodes of the PMNS tree for reporting.
+.TP
+\fB\-l\fR, \fB\-\-lld\fR
+Add low-level discovery metrics.  This allows pcp metric instance
+domains to be sent to Zabbix, so that prototype items/triggers/graphs
+may be automatically constructed by Zabbix.  
+For each pcp metric with an instance domain, the key
+.hy 0
+\fBpcp.discovery[pcp.met.ric]\fR
+.hy
+is sent periodically.
+This symbol should be added to a discovery rule, and 
+will define the
+.hy 0
+\fB{#PCP.MET.RIC}\fR
+.hy
+LLD macro.  This macro can in
+turn be used to define prototype items/triggers/graphs.
+The names are adjusted if \fB\-x\fR was given to override the \fBpcp.\fR
+prefix.
 .TP
 \fB\-j\fR, \fB\-\-live\-filter\fR
 Perform instance live filtering.


### PR DESCRIPTION
Add new option --ldd = -l, to set a mode whereby pcp2zabbix
sends zabbix lld metrics for each pcp metric that has an indom.
This lld metric allows zabbix admins to configure templates
that grow automatically with pcp instance domains.  doc, qa++.