### PR TITLE
series.h: avoid redefining sds type

### DIFF
--- a/src/include/pcp/series.h
+++ b/src/include/pcp/series.h
@@ -15,8 +15,8 @@
 #define PCP_SERIES_H
 
 #include <stdio.h>
+#include "sds.h" /* define typedef sds */
 
-typedef char *sds;	/* simple dynamic strings */
 typedef sds pmSeriesID;	/* external 40-byte form of series identifier */
 typedef sds pmSourceID;	/* external 40-byte form of source identifier */
 


### PR DESCRIPTION
On C < ISO 2011, the repeated typedef of the same identifier is invalid.
To make series.h compilable on pre-std=c11 such as rhel6, add a 
#include "sds.h" and drop the duplicate typedef.