### PR TITLE
pmdabcc: order histogram instances ascending

### DIFF
--- a/src/pmdas/bcc/modules/pcpbcc.python
+++ b/src/pmdas/bcc/modules/pcpbcc.python
@@ -15,6 +15,7 @@
 
 import ctypes as ct
 from os import kill
+from collections import OrderedDict
 from bcc.table import log2_index_max
 
 # pylint: disable=too-many-instance-attributes
@@ -148,10 +149,11 @@ class PCPBCCBase(object):
                 cache[section] = {}
             cls.read_log2_histogram_section(hist_data, cache[section])
 
-        all_insts = set()
+        all_cache_keys = set()
         for section_cache in cache.values():
-            all_insts.update(section_cache.keys())
-        return {key: ct.c_int(1) for key in all_insts}
+            all_cache_keys.update(section_cache.keys())
+        sorted_cache_keys = sorted(all_cache_keys, key=lambda k: int(k.split('-')[0]))
+        return OrderedDict([(key, ct.c_int(1)) for key in sorted_cache_keys])
 
     @classmethod
     def read_log2_histogram(cls, table, cache):
@@ -163,7 +165,8 @@ class PCPBCCBase(object):
         for k, v in table.items(): # pylint: disable=invalid-name
             hist_data[k.value] = v.value
         cls.read_log2_histogram_section(hist_data, cache)
-        return {key: ct.c_int(1) for key in cache.keys()}
+        sorted_cache_keys = sorted(cache.keys(), key=lambda k: int(k.split('-')[0]))
+        return OrderedDict([(key, ct.c_int(1)) for key in sorted_cache_keys])
 
     @staticmethod
     def read_probe_conf(conf):


### PR DESCRIPTION
cosmetic change to get ascending sorted histogram buckets:
```
ext4 open latency distribution
    inst [0 or "0-1"] value 140636
    inst [1 or "2-3"] value 15512
    inst [2 or "4-7"] value 696
    inst [3 or "8-15"] value 106
    inst [4 or "16-31"] value 285
    inst [5 or "32-63"] value 87
    inst [6 or "64-127"] value 27
    inst [7 or "128-255"] value 11
    inst [8 or "256-511"] value 11
```