### PR TITLE
pmdabcc: rename runqlat metric name

### DIFF
--- a/qa/1118
+++ b/qa/1118
@@ -45,11 +45,11 @@ _pmdabcc_wait_for_metric
 dd if=/dev/urandom bs=`expr 20 \* 1024 \* 1024` count=1 2>/dev/null | bzip2 -9 >> /dev/null
 
 echo "=== report metric values ==="
-pminfo -dfmtT bcc.kernel.all.runnable 2>&1 | tee -a $here/$seq.full \
+pminfo -dfmtT bcc.runq.latency 2>&1 | tee -a $here/$seq.full \
 | _value_filter
 
 echo "=== check metric labels ==="
-pminfo -l bcc.kernel.all.runnable 2>&1 | tee -a $here/$seq.full \
+pminfo -l bcc.runq.latency 2>&1 | tee -a $here/$seq.full \
 | _label_filter
 
 _pmdabcc_remove

--- a/src/pmdas/bcc/modules/runqlat.python
+++ b/src/pmdas/bcc/modules/runqlat.python
@@ -31,7 +31,7 @@ bpf_src = "modules/runqlat.bpf"
 # PCP BCC PMDA constants
 #
 MODULE = 'runqlat'
-METRIC = 'kernel.all.runnable'
+METRIC = 'runq.latency'
 units_count = pmUnits(0, 0, 1, 0, 0, PM_COUNT_ONE)
 
 #


### PR DESCRIPTION
as `bcc.kernel.all.runnable` is inconsistent with the current `kernel.all.runnable` metric from PCP, I renamed it.

@natoscott do you have any better suggestions for the name?
The tool 
> measures the time a task spends waiting on a run queue for a turn on-CPU, and shows this time as a histogram. This time should be small, but a task may need to wait its turn due to CPU load.

(https://github.com/iovisor/bcc/blob/master/tools/runqlat.py)