### PR TITLE
qa: check if bcc module is version 0.5.0+

### DIFF
--- a/qa/common.bcc
+++ b/qa/common.bcc
@@ -15,6 +15,13 @@ _pmdabcc_check()
     $python -c "import bcc" >/dev/null 2>&1
     [ $? -eq 0 ] || _notrun "python bcc module not installed"
 
+    # python BCC module doesn't have a __version__ attribute,
+    # therefore check for the DEBUG_BPF_REGISTER_STATE attribute
+    # (added in version 0.5.0)
+    # TODO: update once __version__ attribute is available
+    $python -c "from bcc import DEBUG_BPF_REGISTER_STATE" >/dev/null 2>&1
+    [ $? -eq 0 ] || _notrun "python bcc module 0.5.0+ is required"
+
     [ -f $PCP_PMDAS_DIR/bcc/pmdabcc.python ] || _notrun "bcc PMDA not installed"
 }
 


### PR DESCRIPTION
python BCC module doesn't have a `__version__` attribute, therefore check for the DEBUG_BPF_REGISTER_STATE attribute (added in version 0.5.0)