### PR TITLE
pmdabcc: disable ext4dist per default, add xfsdist and zfsdist sections

### DIFF
--- a/src/pmdas/bcc/bcc.conf
+++ b/src/pmdas/bcc/bcc.conf
@@ -13,8 +13,9 @@
 # Cluster IDs 200-299 are reserved for possible site-local modules.
 
 [pmda]
-modules = biolatency,sysfork,tcplife,runqlat,ext4dist
+modules = biolatency,sysfork,tcplife,runqlat
 #modules = biotop
+#modules = ext4dist,xfsdist,zfsdist
 #modules = tracepoint_hits,usdt_hits,uprobe_hits
 #modules = usdt_jvm_threads,usdt_jvm_alloc
 prefix = bcc.
@@ -49,6 +50,13 @@ cluster = 4
 module = fs.ext4dist
 cluster = 5
 
+[xfsdist]
+module = fs.xfsdist
+cluster = 6
+
+[zfsdist]
+module = fs.zfsdist
+cluster = 7
 
 [tracepoint_hits]
 module = tracepoint_hits

--- a/src/pmdas/bcc/modules/usdt_jvm_threads.python
+++ b/src/pmdas/bcc/modules/usdt_jvm_threads.python
@@ -102,7 +102,7 @@ class PCPBCCModule(PCPBCCBase):
     def refresh(self):
         """ Refresh BPF data """
         if self.bpf is None:
-            return None
+            return
 
         self.stats[0] = self.bpf["stats"][c_int(0)].value
         self.stats[1] = self.bpf["stats"][c_int(1)].value


### PR DESCRIPTION
ext4dist, xfsdist and zfsdist modules only work if the respective
filesystem kernel module is loaded, therefore disable all fs modules
per default