### PR TITLE
Correct the semantics for proc_fs_nfsd.th_cnt and proc_fs_nfsd.pool_cnt

### DIFF
--- a/src/pmdas/linux/pmda.c
+++ b/src/pmdas/linux/pmda.c
@@ -2041,12 +2041,12 @@ static pmdaMetric metrictab[] = {
 
 /* nfs.server.threads.total */
   { &proc_fs_nfsd.th_cnt,
-    { PMDA_PMID(CLUSTER_NET_NFS,71), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+    { PMDA_PMID(CLUSTER_NET_NFS,71), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
     PMDA_PMUNITS(0,0,1,0,0,PM_COUNT_ONE) } },
 
 /* nfs.server.threads.pools */
   { &proc_fs_nfsd.pool_cnt,
-    { PMDA_PMID(CLUSTER_NET_NFS,72), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_COUNTER,
+    { PMDA_PMID(CLUSTER_NET_NFS,72), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT,
     PMDA_PMUNITS(0,0,1,0,0,PM_COUNT_ONE) } },
 
 /* nfs.server.threads.requests */


### PR DESCRIPTION
The proc_fs_nfsd.th_cnt and proc_fs_nfsd.pool_cnt were incorrectly
configured with counter semantics.  Both of the metrics should have
instanteneous semantics.