### PR TITLE
pmdabcc: tcplife: track sessions independently, add more metrics + QA

### DIFF
--- a/qa/1155
+++ b/qa/1155
@@ -1,0 +1,100 @@
+#!/bin/sh
+# PCP QA Test No. 1155
+# Exercise the BCC PMDA tcplife module - install, remove and values.
+#
+# Copyright (c) 2018 Andreas Gerstmayr.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+. ./common.bcc
+
+_pmdabcc_check
+which curl >/dev/null 2>&1 || _notrun "No curl binary installed"
+
+status=1       # failure is the default!
+signal=$PCP_BINADM_DIR/pmsignal
+$sudo rm -rf $tmp.* $seq.full
+
+_install_filter()
+{
+    sed \
+    -e "s/Using BPF source file .\+/Using BPF source file X/g" \
+    #end
+}
+
+_value_filter_any()
+{
+    awk '/value .+/ {print "OK"; exit}'
+}
+
+_value_filter_nonzero()
+{
+    awk '/value [1-9]\d*/ {print "OK"; exit}'
+}
+
+_value_filter_exact()
+{
+    awk -v val=$1 '/value .+/ && $NF == val {print "OK"; exit}'
+}
+
+_prepare_pmda bcc
+trap "_pmdabcc_cleanup; exit \$status" 0 1 2 3 15
+_stop_auto_restart pmcd
+
+cat <<EOF | _pmdabcc_install | _install_filter
+[pmda]
+modules = tcplife
+prefix = bcc.
+[tcplife]
+module = tcplife
+cluster = 3
+EOF
+
+_pmdabcc_wait_for_metric
+
+# Generate system activity for the BCC tcplife module
+curl -s http://1.1.1.1
+sleep 1 # wait for async poller thread in tcplife; TODO: better solution?
+
+echo "=== report metric values for pid ==="
+pminfo -dfmtT bcc.proc.io.net.tcp.pid 2>&1 | tee -a $here/$seq.full \
+| _value_filter_nonzero
+
+echo "=== report metric values for comm ==="
+pminfo -dfmtT bcc.proc.io.net.tcp.comm 2>&1 | tee -a $here/$seq.full \
+| _value_filter_exact '"curl"'
+
+echo "=== report metric values for laddr ==="
+pminfo -dfmtT bcc.proc.io.net.tcp.laddr 2>&1 | tee -a $here/$seq.full \
+| _value_filter_any
+
+echo "=== report metric values for lport ==="
+pminfo -dfmtT bcc.proc.io.net.tcp.lport 2>&1 | tee -a $here/$seq.full \
+| _value_filter_nonzero
+
+echo "=== report metric values for daddr ==="
+pminfo -dfmtT bcc.proc.io.net.tcp.daddr 2>&1 | tee -a $here/$seq.full \
+| _value_filter_exact '"1.1.1.1"'
+
+echo "=== report metric values for dport ==="
+pminfo -dfmtT bcc.proc.io.net.tcp.dport 2>&1 | tee -a $here/$seq.full \
+| _value_filter_exact 80
+
+echo "=== report metric values for tx ==="
+pminfo -dfmtT bcc.proc.io.net.tcp.tx 2>&1 | tee -a $here/$seq.full \
+| _value_filter_nonzero
+
+echo "=== report metric values for rx ==="
+pminfo -dfmtT bcc.proc.io.net.tcp.rx 2>&1 | tee -a $here/$seq.full \
+| _value_filter_nonzero
+
+echo "=== report metric values for duration ==="
+pminfo -dfmtT bcc.proc.io.net.tcp.duration 2>&1 | tee -a $here/$seq.full \
+| _value_filter_nonzero
+
+_pmdabcc_remove
+
+status=0
+exit

--- a/qa/1155.out
+++ b/qa/1155.out
@@ -1,0 +1,73 @@
+QA output created by 1155
+
+=== bcc agent installation ===
+Info: Initializing, currently in 'notready' state.
+Info: Enabled modules:
+Info: ['tcplife']
+Info: Configuring modules:
+Info: tcplife
+Info: Modules configured.
+Info: Initializing modules:
+Info: tcplife
+Info: tcplife: Using BPF source file X
+Info: tcplife: Initialized.
+Info: Modules initialized.
+Info: Registering metrics:
+Info: tcplife
+Info: Metrics registered.
+Info: Registering helpers:
+Info: tcplife
+Info: Helpers registered.
+Info: Ready to process requests.
+Info: Initializing, currently in 'notready' state.
+Info: Enabled modules:
+Info: ['tcplife']
+Info: Configuring modules:
+Info: tcplife
+Info: Modules configured.
+Info: Initializing modules:
+Info: tcplife
+Info: tcplife: Using BPF source file X
+Info: tcplife: Initialized.
+Info: Modules initialized.
+Info: Registering metrics:
+Info: tcplife
+Info: Metrics registered.
+Info: Registering helpers:
+Info: tcplife
+Info: Helpers registered.
+Info: Ready to process requests.
+Updating the Performance Metrics Name Space (PMNS) ...
+Terminate PMDA if already installed ...
+[...install files, make output...]
+Updating the PMCD control file, and notifying PMCD ...
+Check bcc metrics have appeared ... X metrics and X values
+
+=== report metric values for pid ===
+OK
+=== report metric values for comm ===
+OK
+=== report metric values for laddr ===
+OK
+=== report metric values for lport ===
+OK
+=== report metric values for daddr ===
+OK
+=== report metric values for dport ===
+OK
+=== report metric values for tx ===
+OK
+=== report metric values for rx ===
+OK
+=== report metric values for duration ===
+OK
+
+=== remove bcc agent ===
+Culling the Performance Metrics Name Space ...
+bcc ... done
+Updating the PMCD control file, and notifying PMCD ...
+[...removing files...]
+Check bcc metrics have gone away ... OK
+Waiting for pmcd to terminate ...
+Starting pmcd ... 
+Starting pmlogger ... 

--- a/qa/group
+++ b/qa/group
@@ -1490,6 +1490,7 @@ BAD
 1152 pmda.bcc local python
 1153 pmda.bcc local python
 1154 pmda.bcc local python
+1155 pmda.bcc local python
 1159 pmlogger local pmdumplog
 1164 pmda.linux local
 1166 libpcp local

--- a/src/pmdas/bcc/bcc.conf
+++ b/src/pmdas/bcc/bcc.conf
@@ -42,6 +42,8 @@ cluster = 3
 #process = java
 #lport = 8443
 #dport = 80,443
+#session_count = 20
+#buffer_page_count = 64
 
 [runqlat]
 module = runqlat

--- a/src/pmdas/bcc/modules/tcplife.python
+++ b/src/pmdas/bcc/modules/tcplife.python
@@ -1,5 +1,6 @@
 #
 # Copyright (C) 2017-2018 Marko Myllynen <myllynen@redhat.com>
+# Copyright (C) 2018 Andreas Gerstmayr <andreas@gerstmayr.me>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,21 +17,26 @@
 # Configuration options
 # Name - type - default
 #
-# process - string - unset : list of names/pids or regex of processes to monitor
-# dport   - int    - unset : list of remote ports to monitor
-# lport   - int    - unset : list of local ports to monitor
+# process           - string - unset : list of names/pids or regex of processes to monitor
+# dport             - int    - unset : list of remote ports to monitor
+# lport             - int    - unset : list of local ports to monitor
+# session_count     - int    - 20    : number of closed TCP sessions to keep in the cache
+# buffer_page_count - int    - 64    : number of pages for the perf ring buffer (must be a
+#                                      power of two)
 
 # pylint: disable=invalid-name,too-few-public-methods,too-many-instance-attributes
 
 import ctypes as ct
+from collections import deque
 from threading import Lock, Thread
+from socket import inet_ntop, AF_INET, AF_INET6
+from struct import pack
 from os import path
-
 from bcc import BPF
 
 from pcp.pmapi import pmUnits
-from cpmapi import PM_TYPE_U64, PM_SEM_COUNTER, PM_SPACE_BYTE
-from cpmapi import PM_ERR_AGAIN
+from cpmapi import PM_TYPE_U32, PM_TYPE_U64, PM_TYPE_STRING, PM_SEM_DISCRETE
+from cpmapi import PM_SPACE_BYTE, PM_TIME_USEC, PM_ERR_AGAIN
 
 from modules.pcpbcc import PCPBCCBase
 
@@ -54,6 +60,8 @@ if not path.exists(TRACEFS + "/events/sock/inet_sock_set_state"):
 MODULE = 'tcplife'
 BASENS = 'proc.io.net.tcp.'
 units_bytes = pmUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0)
+units_usecs = pmUnits(0, 1, 0, 0, PM_TIME_USEC, 0)
+units_none = pmUnits(0, 0, 0, 0, 0, 0)
 
 TASK_COMM_LEN = 16      # linux/sched.h
 
@@ -97,9 +105,8 @@ class PCPBCCModule(PCPBCCBase):
         self.pids = []
         self.dports = []
         self.lports = []
-
-        self.ipv4_stats = {}
-        self.ipv6_stats = {}
+        self.session_count = 20
+        self.buffer_page_count = 64
 
         for opt in self.config.options(MODULE):
             if opt == 'dport':
@@ -116,6 +123,13 @@ class PCPBCCModule(PCPBCCBase):
                 for proc in procs:
                     self.log("Tracing PID %s: %s %s." % (str(proc[0]), proc[1], proc[2]))
                     self.pids.append(proc[0])
+            if opt == 'session_count':
+                self.session_count = int(self.config.get(MODULE, opt))
+            if opt == 'buffer_page_count':
+                self.buffer_page_count = int(self.config.get(MODULE, opt))
+
+        self.cache = {}
+        self.cache_instances = deque(maxlen=self.session_count)
 
         self.lock = Lock()
         self.thread = Thread(name="bpfpoller", target=self.poller)
@@ -142,39 +156,65 @@ class PCPBCCModule(PCPBCCBase):
             self.err("BPF kprobe poll failed!")
         self.log("Poller thread exiting.")
 
+    def handle_ip_event(self, data, version):
+        """ IP event handler """
+        if version == 4:
+            event = ct.cast(data, ct.POINTER(Data_ipv4)).contents
+            laddr = inet_ntop(AF_INET, pack("I", event.saddr))
+            raddr = inet_ntop(AF_INET, pack("I", event.daddr))
+        else:
+            event = ct.cast(data, ct.POINTER(Data_ipv6)).contents
+            laddr = inet_ntop(AF_INET6, event.saddr)
+            raddr = inet_ntop(AF_INET6, event.daddr)
+
+        instance = "%s::%s" % (str(event.pid).zfill(6), str(event.ts_us))
+        self.lock.acquire()
+        self.cache[instance] = [
+            event.pid,
+            event.task.decode(),
+            laddr,
+            event.ports >> 32,
+            raddr,
+            event.ports & 0xffffffff,
+            event.tx_b,
+            event.rx_b,
+            event.span_us
+        ]
+        if len(self.cache_instances) == self.session_count:
+            del self.cache[self.cache_instances[0]]
+        self.cache_instances.append(instance)
+        self.lock.release()
+
     def handle_ipv4_event(self, _cpu, data, _size):
         """ IPv4 event handler """
-        event = ct.cast(data, ct.POINTER(Data_ipv4)).contents
-        pid = str(event.pid).zfill(6)
-        self.lock.acquire()
-        if pid not in self.ipv4_stats:
-            self.ipv4_stats[pid] = [int(event.tx_b), int(event.rx_b)]
-        else:
-            self.ipv4_stats[pid][0] += int(event.tx_b)
-            self.ipv4_stats[pid][1] += int(event.rx_b)
-        self.lock.release()
+        self.handle_ip_event(data, 4)
 
     def handle_ipv6_event(self, _cpu, data, _size):
         """ IPv6 event handler """
-        event = ct.cast(data, ct.POINTER(Data_ipv6)).contents
-        pid = str(event.pid).zfill(6)
-        self.lock.acquire()
-        if pid not in self.ipv6_stats:
-            self.ipv6_stats[pid] = [int(event.tx_b), int(event.rx_b)]
-        else:
-            self.ipv6_stats[pid][0] += int(event.tx_b)
-            self.ipv6_stats[pid][1] += int(event.rx_b)
-        self.lock.release()
+        self.handle_ip_event(data, 6)
 
     def metrics(self):
         """ Get metric definitions """
         name = BASENS
         self.items = (
             # Name - reserved - type - semantics - units - help
-            (name + 'tx', None, PM_TYPE_U64, PM_SEM_COUNTER, units_bytes, 'tcp tx per pid'),
-            (name + 'rx', None, PM_TYPE_U64, PM_SEM_COUNTER, units_bytes, 'tcp rx per pid'),
+            (name + 'pid', None, PM_TYPE_U32, PM_SEM_DISCRETE, units_none, 'PID'),
+            (name + 'comm', None, PM_TYPE_STRING, PM_SEM_DISCRETE, units_none, 'command'),
+            (name + 'laddr', None, PM_TYPE_STRING, PM_SEM_DISCRETE, units_none, 'local address'),
+            (name + 'lport', None, PM_TYPE_U32, PM_SEM_DISCRETE, units_none, 'local port'),
+            (name + 'daddr', None, PM_TYPE_STRING, PM_SEM_DISCRETE, units_none, 'destination ' \
+                'address'),
+            (name + 'dport', None, PM_TYPE_U32, PM_SEM_DISCRETE, units_none, 'destination port'),
+            (name + 'tx', None, PM_TYPE_U64, PM_SEM_DISCRETE, units_bytes, 'tcp tx per pid'),
+            (name + 'rx', None, PM_TYPE_U64, PM_SEM_DISCRETE, units_bytes, 'tcp rx per pid'),
+            (name + 'duration', None, PM_TYPE_U32, PM_SEM_DISCRETE, units_usecs, 'duration of ' \
+                'the TCP session (from TCP_ESTABLISHED/TCP_SYN_* until TCP_CLOSE)'),
         )
         return True, self.items
+
+    def perf_buffer_lost_cb(self, lost_cnt):
+        """ Callback for lost perf buffer events """
+        self.err('lost %d events; buffer_page_count should be increased' % lost_cnt)
 
     def compile(self):
         """ Compile BPF """
@@ -208,8 +248,12 @@ class PCPBCCModule(PCPBCCBase):
                 self.log("\n" + bpf_text)
 
             self.bpf = BPF(text=bpf_text)
-            self.bpf["ipv4_events"].open_perf_buffer(self.handle_ipv4_event, page_cnt=64)
-            self.bpf["ipv6_events"].open_perf_buffer(self.handle_ipv6_event, page_cnt=64)
+            self.bpf["ipv4_events"].open_perf_buffer(self.handle_ipv4_event,
+                                                     page_cnt=self.buffer_page_count,
+                                                     lost_cb=self.perf_buffer_lost_cb)
+            self.bpf["ipv6_events"].open_perf_buffer(self.handle_ipv6_event,
+                                                     page_cnt=self.buffer_page_count,
+                                                     lost_cb=self.perf_buffer_lost_cb)
             self.thread.start()
             self.log("Compiled.")
         except Exception as error: # pylint: disable=broad-except
@@ -226,16 +270,8 @@ class PCPBCCModule(PCPBCCBase):
         self.insts = {}
 
         self.lock.acquire()
-        for pid in list(self.ipv4_stats):
-            if not self.pid_alive(pid):
-                del self.ipv4_stats[pid]
-            else:
-                self.insts[pid] = ct.c_int(1)
-        for pid in list(self.ipv6_stats):
-            if not self.pid_alive(pid):
-                del self.ipv6_stats[pid]
-            else:
-                self.insts[pid] = ct.c_int(1)
+        for inst in self.cache:
+            self.insts[inst] = ct.c_int(1)
         self.lock.release()
 
         return self.insts
@@ -245,11 +281,7 @@ class PCPBCCModule(PCPBCCBase):
         try:
             self.lock.acquire()
             key = self.pmdaIndom.inst_name_lookup(inst)
-            value = 0
-            if key in self.ipv4_stats:
-                value += self.ipv4_stats[key][item]
-            if key in self.ipv6_stats:
-                value += self.ipv6_stats[key][item]
+            value = self.cache[key][item]
             self.lock.release()
             return [value, 1]
         except Exception: # pylint: disable=broad-except

--- a/src/pmdas/bcc/modules/tcplife_old_kb.bpf
+++ b/src/pmdas/bcc/modules/tcplife_old_kb.bpf
@@ -53,7 +53,7 @@ int kprobe__tcp_set_state(struct pt_regs *ctx, struct sock *sk, int state)
 
     // dport is either used in a filter here, or later
     u16 dport = sk->__sk_common.skc_dport;
-    dport = ntohs(dport);
+    //dport = ntohs(dport);
     //FILTER_DPORT
 
     /*


### PR DESCRIPTION
Updated tcplife to track each TCP session independently of the process and export all metrics visible in the BCC tcplife tool. The session_count configuration option controls how many TCP sessions should be stored in the cache.

@natoscott all instance values will never change, as they show information from already closed TCP sessions, therefore PM_SEM_DISCRETE is the correct semantic for all metric values I assume?


Screenshot of the corresponding vector widget:
![vector_tcplife](https://user-images.githubusercontent.com/538011/41207752-4e216ca2-6d1b-11e8-89c6-c34a42c62351.png)
(I'll rename RADDR/RPORT to DADDR/DPORT in the vector widget to keep it consistent with the BPF code and manpage of tcplife)