### PR TITLE
pmdabcc: fix tcplife dport, styling, recycle old instances

### DIFF
--- a/src/pmdas/bcc/modules/tcplife.python
+++ b/src/pmdas/bcc/modules/tcplife.python
@@ -35,7 +35,7 @@ from os import path
 from bcc import BPF
 
 from pcp.pmapi import pmUnits
-from cpmapi import PM_TYPE_U32, PM_TYPE_U64, PM_TYPE_STRING, PM_SEM_DISCRETE
+from cpmapi import PM_TYPE_U32, PM_TYPE_U64, PM_TYPE_STRING, PM_SEM_INSTANT
 from cpmapi import PM_SPACE_BYTE, PM_TIME_USEC, PM_ERR_AGAIN
 
 from modules.pcpbcc import PCPBCCBase
@@ -131,8 +131,8 @@ class PCPBCCModule(PCPBCCBase):
                    self.buffer_page_count & (self.buffer_page_count - 1):
                     raise RuntimeError("Buffer page count is not power of two.")
 
-        self.cache = {}
-        self.cache_instances = deque(maxlen=self.session_count)
+        self.cache = deque(maxlen=self.session_count)
+        self.insts = {str(i) : ct.c_int(1) for i in range(0, self.session_count)}
 
         self.lock = Lock()
         self.thread = Thread(name="bpfpoller", target=self.poller)
@@ -170,9 +170,8 @@ class PCPBCCModule(PCPBCCBase):
             laddr = inet_ntop(AF_INET6, event.saddr)
             raddr = inet_ntop(AF_INET6, event.daddr)
 
-        instance = "%s::%s" % (str(event.pid).zfill(6), str(event.ts_us))
         self.lock.acquire()
-        self.cache[instance] = [
+        self.cache.appendleft([
             event.pid,
             event.task.decode(),
             laddr,
@@ -182,10 +181,7 @@ class PCPBCCModule(PCPBCCBase):
             event.tx_b,
             event.rx_b,
             event.span_us
-        ]
-        if len(self.cache_instances) == self.session_count:
-            del self.cache[self.cache_instances[0]]
-        self.cache_instances.append(instance)
+        ])
         self.lock.release()
 
     def handle_ipv4_event(self, _cpu, data, _size):
@@ -201,16 +197,16 @@ class PCPBCCModule(PCPBCCBase):
         name = BASENS
         self.items = (
             # Name - reserved - type - semantics - units - help
-            (name + 'pid', None, PM_TYPE_U32, PM_SEM_DISCRETE, units_none, 'PID'),
-            (name + 'comm', None, PM_TYPE_STRING, PM_SEM_DISCRETE, units_none, 'command'),
-            (name + 'laddr', None, PM_TYPE_STRING, PM_SEM_DISCRETE, units_none, 'local address'),
-            (name + 'lport', None, PM_TYPE_U32, PM_SEM_DISCRETE, units_none, 'local port'),
-            (name + 'daddr', None, PM_TYPE_STRING, PM_SEM_DISCRETE, units_none, 'destination ' \
+            (name + 'pid', None, PM_TYPE_U32, PM_SEM_INSTANT, units_none, 'PID'),
+            (name + 'comm', None, PM_TYPE_STRING, PM_SEM_INSTANT, units_none, 'command'),
+            (name + 'laddr', None, PM_TYPE_STRING, PM_SEM_INSTANT, units_none, 'local address'),
+            (name + 'lport', None, PM_TYPE_U32, PM_SEM_INSTANT, units_none, 'local port'),
+            (name + 'daddr', None, PM_TYPE_STRING, PM_SEM_INSTANT, units_none, 'destination ' \
                 'address'),
-            (name + 'dport', None, PM_TYPE_U32, PM_SEM_DISCRETE, units_none, 'destination port'),
-            (name + 'tx', None, PM_TYPE_U64, PM_SEM_DISCRETE, units_bytes, 'transmitted data'),
-            (name + 'rx', None, PM_TYPE_U64, PM_SEM_DISCRETE, units_bytes, 'received data'),
-            (name + 'duration', None, PM_TYPE_U32, PM_SEM_DISCRETE, units_usecs, 'duration of ' \
+            (name + 'dport', None, PM_TYPE_U32, PM_SEM_INSTANT, units_none, 'destination port'),
+            (name + 'tx', None, PM_TYPE_U64, PM_SEM_INSTANT, units_bytes, 'transmitted data'),
+            (name + 'rx', None, PM_TYPE_U64, PM_SEM_INSTANT, units_bytes, 'received data'),
+            (name + 'duration', None, PM_TYPE_U32, PM_SEM_INSTANT, units_usecs, 'duration of ' \
                 'the TCP session (from TCP_ESTABLISHED/TCP_SYN_* until TCP_CLOSE)'),
         )
         return True, self.items
@@ -270,20 +266,13 @@ class PCPBCCModule(PCPBCCBase):
         if self.bpf is None:
             return None
 
-        self.insts = {}
-
-        self.lock.acquire()
-        for inst in self.cache:
-            self.insts[inst] = ct.c_int(1)
-        self.lock.release()
-
         return self.insts
 
     def bpfdata(self, item, inst):
         """ Return BPF data as PCP metric value """
         try:
             self.lock.acquire()
-            key = self.pmdaIndom.inst_name_lookup(inst)
+            key = int(self.pmdaIndom.inst_name_lookup(inst))
             value = self.cache[key][item]
             self.lock.release()
             return [value, 1]

--- a/src/pmdas/bcc/modules/tcplife.python
+++ b/src/pmdas/bcc/modules/tcplife.python
@@ -21,8 +21,7 @@
 # dport             - int    - unset : list of remote ports to monitor
 # lport             - int    - unset : list of local ports to monitor
 # session_count     - int    - 20    : number of closed TCP sessions to keep in the cache
-# buffer_page_count - int    - 64    : number of pages for the perf ring buffer (must be a
-#                                      power of two)
+# buffer_page_count - int    - 64    : number of pages for the perf ring buffer, power of two
 
 # pylint: disable=invalid-name,too-few-public-methods,too-many-instance-attributes
 
@@ -32,6 +31,7 @@ from threading import Lock, Thread
 from socket import inet_ntop, AF_INET, AF_INET6
 from struct import pack
 from os import path
+
 from bcc import BPF
 
 from pcp.pmapi import pmUnits
@@ -127,6 +127,9 @@ class PCPBCCModule(PCPBCCBase):
                 self.session_count = int(self.config.get(MODULE, opt))
             if opt == 'buffer_page_count':
                 self.buffer_page_count = int(self.config.get(MODULE, opt))
+                if not self.buffer_page_count or \
+                   self.buffer_page_count & (self.buffer_page_count - 1):
+                    raise RuntimeError("Buffer page count is not power of two.")
 
         self.cache = {}
         self.cache_instances = deque(maxlen=self.session_count)
@@ -205,8 +208,8 @@ class PCPBCCModule(PCPBCCBase):
             (name + 'daddr', None, PM_TYPE_STRING, PM_SEM_DISCRETE, units_none, 'destination ' \
                 'address'),
             (name + 'dport', None, PM_TYPE_U32, PM_SEM_DISCRETE, units_none, 'destination port'),
-            (name + 'tx', None, PM_TYPE_U64, PM_SEM_DISCRETE, units_bytes, 'tcp tx per pid'),
-            (name + 'rx', None, PM_TYPE_U64, PM_SEM_DISCRETE, units_bytes, 'tcp rx per pid'),
+            (name + 'tx', None, PM_TYPE_U64, PM_SEM_DISCRETE, units_bytes, 'transmitted data'),
+            (name + 'rx', None, PM_TYPE_U64, PM_SEM_DISCRETE, units_bytes, 'received data'),
             (name + 'duration', None, PM_TYPE_U32, PM_SEM_DISCRETE, units_usecs, 'duration of ' \
                 'the TCP session (from TCP_ESTABLISHED/TCP_SYN_* until TCP_CLOSE)'),
         )
@@ -214,7 +217,7 @@ class PCPBCCModule(PCPBCCBase):
 
     def perf_buffer_lost_cb(self, lost_cnt):
         """ Callback for lost perf buffer events """
-        self.err('lost %d events; buffer_page_count should be increased' % lost_cnt)
+        self.err("Lost %d events; buffer_page_count should be increased." % lost_cnt)
 
     def compile(self):
         """ Compile BPF """

--- a/src/pmdas/bcc/modules/tcplife_old_kb.bpf
+++ b/src/pmdas/bcc/modules/tcplife_old_kb.bpf
@@ -53,7 +53,7 @@ int kprobe__tcp_set_state(struct pt_regs *ctx, struct sock *sk, int state)
 
     // dport is either used in a filter here, or later
     u16 dport = sk->__sk_common.skc_dport;
-    //dport = ntohs(dport);
+    dport = ntohs(dport);
     //FILTER_DPORT
 
     /*
@@ -124,7 +124,7 @@ int kprobe__tcp_set_state(struct pt_regs *ctx, struct sock *sk, int state)
         data4.daddr = sk->__sk_common.skc_daddr;
         // a workaround until data4 compiles with separate lport/dport
         data4.pid = pid;
-        data4.ports = ntohs(dport) + ((0ULL + lport) << 32);
+        data4.ports = dport + ((0ULL + lport) << 32);
         if (mep == 0) {
             bpf_get_current_comm(&data4.task, sizeof(data4.task));
         } else {
@@ -141,7 +141,7 @@ int kprobe__tcp_set_state(struct pt_regs *ctx, struct sock *sk, int state)
         bpf_probe_read(&data6.daddr, sizeof(data6.daddr),
             sk->__sk_common.skc_v6_daddr.in6_u.u6_addr32);
         // a workaround until data6 compiles with separate lport/dport
-        data6.ports = ntohs(dport) + ((0ULL + lport) << 32);
+        data6.ports = dport + ((0ULL + lport) << 32);
         data6.pid = pid;
         if (mep == 0) {
             bpf_get_current_comm(&data6.task, sizeof(data6.task));

--- a/src/pmdas/bcc/modules/usdt_jvm_alloc.python
+++ b/src/pmdas/bcc/modules/usdt_jvm_alloc.python
@@ -16,7 +16,7 @@
 # Configuration options
 # Name - type - default
 #
-# frequency - int    - unset : sample every Nth allocation, power of 2
+# frequency - int    - unset : sample every Nth allocation, power of two
 # jvm_path  - string -  [1]  : path to libjvm.so
 # process   - string - unset : list of names/pids or regex of processes to monitor
 #


### PR DESCRIPTION
correct fix for the destination port (see https://github.com/iovisor/bcc/pull/1813), buffer_page_count power of 2 check and styling updates

recycle old instances by using the row number as instance key (0 = most recent TCP session)

example:
```
bcc.proc.io.net.tcp.comm PMID: 149.3.1 [command]
    Data Type: string  InDom: 149.3 0x25400003
    Semantics: instant  Units: none
Help:
command
    inst [0 or "0"] value "code"
    inst [1 or "1"] value "code"
    inst [2 or "2"] value "NetworkManager"
    inst [3 or "3"] value "curl"
    inst [4 or "4"] value "curl"

bcc.proc.io.net.tcp.pid PMID: 149.3.0 [PID]
    Data Type: 32-bit unsigned int  InDom: 149.3 0x25400003
    Semantics: instant  Units: none
Help:
PID
    inst [0 or "0"] value 8621
    inst [1 or "1"] value 8621
    inst [2 or "2"] value 1247
    inst [3 or "3"] value 3850
    inst [4 or "4"] value 3810
```