### PR TITLE
pmdabcc: renamed old biotop to bioperpid, add new biotop tool

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -132,7 +132,8 @@ disable=print-statement,
         import-error,
         attribute-defined-outside-init,
         unused-argument,
-        no-self-use
+        no-self-use,
+        too-many-instance-attributes
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/qa/1116
+++ b/qa/1116
@@ -55,7 +55,7 @@ _pmdabcc_wait_for_metric
 dd if=/dev/zero of=${out_file} bs=${write_size} count=1 oflag=direct 2>/dev/null
 
 echo "=== report metric values ==="
-pminfo -dfmtT bcc.proc.io.perdev 2>&1 | tee -a $here/$seq.full \
+pminfo -dfmtT bcc.proc.io.perpid 2>&1 | tee -a $here/$seq.full \
 | _value_filter
 
 _pmdabcc_remove

--- a/qa/1116
+++ b/qa/1116
@@ -55,7 +55,7 @@ _pmdabcc_wait_for_metric
 dd if=/dev/zero of=${out_file} bs=${write_size} count=1 oflag=direct 2>/dev/null
 
 echo "=== report metric values ==="
-pminfo -dfmtT bcc.proc.io.perpid 2>&1 | tee -a $here/$seq.full \
+pminfo -dfmtT bcc.proc.io.total 2>&1 | tee -a $here/$seq.full \
 | _value_filter
 
 _pmdabcc_remove

--- a/qa/1116
+++ b/qa/1116
@@ -1,6 +1,6 @@
 #!/bin/sh
 # PCP QA Test No. 1116
-# Exercise the BCC PMDA biotop module - install, remove and values.
+# Exercise the BCC PMDA bioperpid module - install, remove and values.
 #
 # Copyright (c) 2018 Andreas Gerstmayr.
 #
@@ -42,15 +42,15 @@ _stop_auto_restart pmcd
 # real QA test starts here
 cat <<EOF | _pmdabcc_install
 [pmda]
-modules = biotop
+modules = bioperpid
 prefix = bcc.
-[biotop]
-module = biotop
+[bioperpid]
+module = bioperpid
 cluster = 1
 EOF
 _pmdabcc_wait_for_metric
 
-# Generate system activity for the BCC biotop module
+# Generate system activity for the BCC bioperpid module
 # block device required here, no tmpfs (e.g. /tmp)
 dd if=/dev/zero of=${out_file} bs=${write_size} count=1 oflag=direct 2>/dev/null
 

--- a/qa/1116.out
+++ b/qa/1116.out
@@ -3,36 +3,36 @@ QA output created by 1116
 === bcc agent installation ===
 Info: Initializing, currently in 'notready' state.
 Info: Enabled modules:
-Info: ['biotop']
+Info: ['bioperpid']
 Info: Configuring modules:
-Info: biotop
+Info: bioperpid
 Info: Modules configured.
 Info: Initializing modules:
-Info: biotop
-Info: biotop: Initialized.
+Info: bioperpid
+Info: bioperpid: Initialized.
 Info: Modules initialized.
 Info: Registering metrics:
-Info: biotop
+Info: bioperpid
 Info: Metrics registered.
 Info: Registering helpers:
-Info: biotop
+Info: bioperpid
 Info: Helpers registered.
 Info: Ready to process requests.
 Info: Initializing, currently in 'notready' state.
 Info: Enabled modules:
-Info: ['biotop']
+Info: ['bioperpid']
 Info: Configuring modules:
-Info: biotop
+Info: bioperpid
 Info: Modules configured.
 Info: Initializing modules:
-Info: biotop
-Info: biotop: Initialized.
+Info: bioperpid
+Info: bioperpid: Initialized.
 Info: Modules initialized.
 Info: Registering metrics:
-Info: biotop
+Info: bioperpid
 Info: Metrics registered.
 Info: Registering helpers:
-Info: biotop
+Info: bioperpid
 Info: Helpers registered.
 Info: Ready to process requests.
 Updating the Performance Metrics Name Space (PMNS) ...

--- a/qa/1117
+++ b/qa/1117
@@ -46,7 +46,7 @@ _pmdabcc_wait_for_metric
 
 # Generate system activity for the BCC biolatency module
 # block device required here, no tmpfs (e.g. /tmp)
-dd if=/dev/zero of=${out_file} bs=${write_size} count=1 oflag=direct 2>/dev/null
+dd if=/dev/zero of=${out_file} bs=${write_size} count=1 oflag=direct 2>$here/$seq.full
 
 echo "=== report metric values ==="
 pminfo -dfmtT bcc.disk.all.latency 2>&1 | tee -a $here/$seq.full \

--- a/qa/1158
+++ b/qa/1158
@@ -1,0 +1,100 @@
+#!/bin/sh
+# PCP QA Test No. 1158
+# Exercise the BCC PMDA biotop module - install, remove and values.
+#
+# Copyright (c) 2018 Andreas Gerstmayr.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+. ./common.bcc
+
+_pmdabcc_check
+
+status=1       # failure is the default!
+signal=$PCP_BINADM_DIR/pmsignal
+$sudo rm -rf $tmp.* $seq.full
+
+write_size=`expr 20 \* 1024 \* 1024` # number of bytes to write into testfile
+out_file="$PCP_TMPFILE_DIR/pcp-qa-$seq"
+
+_value_filter_bytes()
+{
+    cat > $tmp.value
+    echo === input to _value_filter >>$here/$seq.full
+    cat $tmp.value >> $here/$seq.full
+
+    _values=`awk '/inst.*value/ {print $NF}' $tmp.value`
+    for value in $_values
+    do
+        if _within_tolerance "Expecting ${write_size} +- 10%" $value ${write_size} 10%; then
+            echo "found value ${write_size} +- 10%"
+            break
+        fi
+    done
+}
+
+_prepare_pmda bcc
+trap "_pmdabcc_cleanup; exit \$status" 0 1 2 3 15
+_stop_auto_restart pmcd
+
+# real QA test starts here
+cat <<EOF | _pmdabcc_install
+[pmda]
+modules = biotop
+prefix = bcc.
+[biotop]
+module = biotop
+cluster = 10
+interval = 5
+EOF
+_pmdabcc_wait_for_metric
+
+# Generate system activity for the BCC biotop module
+# block device required here, no tmpfs (e.g. /tmp)
+dd if=/dev/zero of=${out_file} bs=${write_size} count=1 oflag=direct 2>$here/$seq.full
+
+# wait until PMDA refreshes BPF table containing dd
+_pmdabcc_wait_for_value bcc.proc.io.perdev.comm '"dd"'
+
+echo "=== report metric values for pid ==="
+pminfo -dfmtT bcc.proc.io.perdev.pid 2>&1 | tee -a $here/$seq.full \
+| _value_filter_nonzero
+
+echo "=== report metric values for comm ==="
+pminfo -dfmtT bcc.proc.io.perdev.comm 2>&1 | tee -a $here/$seq.full \
+| _value_filter_exact '"dd"'
+
+echo "=== report metric values for direction ==="
+pminfo -dfmtT bcc.proc.io.perdev.direction 2>&1 | tee -a $here/$seq.full \
+| _value_filter_exact '"W"'
+
+echo "=== report metric values for major ==="
+pminfo -dfmtT bcc.proc.io.perdev.major 2>&1 | tee -a $here/$seq.full \
+| _value_filter_nonzero
+
+echo "=== report metric values for minor ==="
+pminfo -dfmtT bcc.proc.io.perdev.minor 2>&1 | tee -a $here/$seq.full \
+| _value_filter_any
+
+echo "=== report metric values for disk ==="
+pminfo -dfmtT bcc.proc.io.perdev.disk 2>&1 | tee -a $here/$seq.full \
+| _value_filter_any
+
+echo "=== report metric values for io ==="
+pminfo -dfmtT bcc.proc.io.perdev.io 2>&1 | tee -a $here/$seq.full \
+| _value_filter_nonzero
+
+echo "=== report metric values for bytes ==="
+pminfo -dfmtT bcc.proc.io.perdev.bytes 2>&1 | tee -a $here/$seq.full \
+| _value_filter_bytes
+
+echo "=== report metric values for duration ==="
+pminfo -dfmtT bcc.proc.io.perdev.duration 2>&1 | tee -a $here/$seq.full \
+| _value_filter_nonzero
+
+_pmdabcc_remove
+
+status=0
+exit

--- a/qa/1158.out
+++ b/qa/1158.out
@@ -1,0 +1,71 @@
+QA output created by 1158
+
+=== bcc agent installation ===
+Info: Initializing, currently in 'notready' state.
+Info: Enabled modules:
+Info: ['biotop']
+Info: Configuring modules:
+Info: biotop
+Info: Modules configured.
+Info: Initializing modules:
+Info: biotop
+Info: biotop: Initialized.
+Info: Modules initialized.
+Info: Registering metrics:
+Info: biotop
+Info: Metrics registered.
+Info: Registering helpers:
+Info: biotop
+Info: Helpers registered.
+Info: Ready to process requests.
+Info: Initializing, currently in 'notready' state.
+Info: Enabled modules:
+Info: ['biotop']
+Info: Configuring modules:
+Info: biotop
+Info: Modules configured.
+Info: Initializing modules:
+Info: biotop
+Info: biotop: Initialized.
+Info: Modules initialized.
+Info: Registering metrics:
+Info: biotop
+Info: Metrics registered.
+Info: Registering helpers:
+Info: biotop
+Info: Helpers registered.
+Info: Ready to process requests.
+Updating the Performance Metrics Name Space (PMNS) ...
+Terminate PMDA if already installed ...
+[...install files, make output...]
+Updating the PMCD control file, and notifying PMCD ...
+Check bcc metrics have appeared ... X metrics and X values
+
+=== report metric values for pid ===
+OK
+=== report metric values for comm ===
+OK
+=== report metric values for direction ===
+OK
+=== report metric values for major ===
+OK
+=== report metric values for minor ===
+OK
+=== report metric values for disk ===
+OK
+=== report metric values for io ===
+OK
+=== report metric values for bytes ===
+found value 20971520 +- 10%
+=== report metric values for duration ===
+OK
+
+=== remove bcc agent ===
+Culling the Performance Metrics Name Space ...
+bcc ... done
+Updating the PMCD control file, and notifying PMCD ...
+[...removing files...]
+Check bcc metrics have gone away ... OK
+Waiting for pmcd to terminate ...
+Starting pmcd ... 
+Starting pmlogger ... 

--- a/qa/common.bcc
+++ b/qa/common.bcc
@@ -78,7 +78,9 @@ _pmdabcc_wait_for_metric()
 
 _pmdabcc_wait_for_value()
 {
-    for i in `seq 1 30`; do pminfo -f $1 | grep -q 'inst .* value .*' && break; sleep 1; done
+    value_regex=${2:-'.*'}
+
+    for i in `seq 1 30`; do pminfo -f $1 | grep -q 'inst .* value '$value_regex && break; sleep 1; done
     if [ $i -ge 30 ]; then
         echo Could not get a single value, test failed
         exit
@@ -172,5 +174,5 @@ _value_filter_nonzero()
 
 _value_filter_exact()
 {
-    grep "$1" > /dev/null && echo OK
+    grep "value $1" > /dev/null && echo OK
 }

--- a/qa/group
+++ b/qa/group
@@ -1498,6 +1498,7 @@ BAD
 1154 pmda.bcc local python
 1155 pmda.bcc local python
 1156 pmda.bcc local python
+1158 pmda.bcc local python
 1159 pmlogger local pmdumplog
 1163 pmlogrewrite local
 1164 pmda.linux local

--- a/src/pmdas/bcc/bcc.conf
+++ b/src/pmdas/bcc/bcc.conf
@@ -14,7 +14,7 @@
 
 [pmda]
 modules = biolatency,sysfork,tcplife,runqlat
-#modules = biotop
+#modules = bioperpid
 #modules = ext4dist,xfsdist,zfsdist
 #modules = tracepoint_hits,usdt_hits,uprobe_hits
 #modules = usdt_jvm_threads,usdt_jvm_alloc
@@ -27,8 +27,8 @@ module = biolatency
 cluster = 0
 queued = False
 
-[biotop]
-module = biotop
+[bioperpid]
+module = bioperpid
 cluster = 1
 debug = True
 

--- a/src/pmdas/bcc/bcc.conf
+++ b/src/pmdas/bcc/bcc.conf
@@ -30,7 +30,7 @@ queued = False
 [bioperpid]
 module = bioperpid
 cluster = 1
-debug = True
+#debug = False
 
 [sysfork]
 module = sysfork
@@ -70,6 +70,14 @@ cluster = 8
 #max_args = 20
 #session_count = 20
 #buffer_page_count = 64
+
+[biotop]
+module = biotop
+cluster = 10
+#interval = 1
+#process_count = 20
+#sort = -bytes
+#debug = False
 
 [tracepoint_hits]
 module = tracepoint_hits

--- a/src/pmdas/bcc/modules/bioperpid.python
+++ b/src/pmdas/bcc/modules/bioperpid.python
@@ -34,7 +34,7 @@ bpf_src = "modules/biotop.bpf"
 # PCP BCC PMDA constants
 #
 MODULE = 'bioperpid'
-METRIC = 'proc.io.perpid'
+METRIC = 'proc.io.total'
 units_bytes = pmUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0)
 
 #

--- a/src/pmdas/bcc/modules/bioperpid.python
+++ b/src/pmdas/bcc/modules/bioperpid.python
@@ -34,7 +34,7 @@ bpf_src = "modules/biotop.bpf"
 # PCP BCC PMDA constants
 #
 MODULE = 'bioperpid'
-METRIC = 'proc.io.perdev'
+METRIC = 'proc.io.perpid'
 units_bytes = pmUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0)
 
 #

--- a/src/pmdas/bcc/modules/bioperpid.python
+++ b/src/pmdas/bcc/modules/bioperpid.python
@@ -11,7 +11,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 #
-""" PCP BCC PMDA biotop module """
+""" PCP BCC PMDA bioperpid module """
 
 # pylint: disable=invalid-name, line-too-long
 
@@ -33,7 +33,7 @@ bpf_src = "modules/biotop.bpf"
 #
 # PCP BCC PMDA constants
 #
-MODULE = 'biotop'
+MODULE = 'bioperpid'
 METRIC = 'proc.io.perdev'
 units_bytes = pmUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0)
 
@@ -41,7 +41,7 @@ units_bytes = pmUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0)
 # PCP BCC Module
 #
 class PCPBCCModule(PCPBCCBase):
-    """ PCP BCC biotop module """
+    """ PCP BCC bioperpid module """
     def __init__(self, config, log, err):
         """ Constructor """
         PCPBCCBase.__init__(self, MODULE, config, log, err)

--- a/src/pmdas/bcc/modules/biotop.python
+++ b/src/pmdas/bcc/modules/biotop.python
@@ -1,0 +1,214 @@
+#
+# Copyright (C) 2017-2018 Marko Myllynen <myllynen@redhat.com>
+# Copyright (C) 2018 Andreas Gerstmayr <andreas@gerstmayr.me>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+""" PCP BCC PMDA biotop module """
+
+# Configuration options
+# Name - type - default
+#
+# interval      - int    - 1      : interval
+# process_count - int    - 20     : number of processes to show
+# sort          - string - -bytes : sort key: bytes/io/duration/rw
+#                                   sort order can be reversed by prepending '-'
+
+# pylint: disable=invalid-name, line-too-long
+
+import ctypes as ct
+from threading import Lock, Thread
+from os import path
+from time import sleep
+
+from bcc import BPF
+
+from pcp.pmapi import pmUnits
+from cpmapi import PM_TYPE_U32, PM_TYPE_U64, PM_TYPE_STRING, PM_TIME_USEC, PM_SEM_INSTANT, PM_SPACE_BYTE
+from cpmapi import PM_ERR_AGAIN
+
+from modules.pcpbcc import PCPBCCBase
+
+#
+# BPF program
+#
+bpf_src = "modules/biotop.bpf"
+
+#
+# PCP BCC PMDA constants
+#
+MODULE = 'biotop'
+METRIC = 'proc.io.perdev.'
+units_bytes = pmUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0)
+units_usecs = pmUnits(0, 1, 0, 0, PM_TIME_USEC, 0)
+units_none = pmUnits(0, 0, 0, 0, 0, 0)
+
+#
+# PCP BCC Module
+#
+class PCPBCCModule(PCPBCCBase):
+    """ PCP BCC biotop module """
+    def __init__(self, config, log, err):
+        """ Constructor """
+        PCPBCCBase.__init__(self, MODULE, config, log, err)
+
+        self.sort_fns = {
+            'bytes': lambda counts: counts[1].bytes,
+            'io': lambda counts: counts[1].io,
+            'duration': lambda counts: float(counts[1].us) / counts[1].io,
+            'rw': lambda counts: counts[1].rwflag,
+        }
+
+        self.interval = 1
+        self.process_count = 20
+        sort_key = '-bytes'
+
+        for opt in self.config.options(MODULE):
+            if opt == 'interval':
+                self.interval = int(self.config.get(MODULE, opt))
+            if opt == 'process_count':
+                self.process_count = int(self.config.get(MODULE, opt))
+            if opt == 'sort':
+                sort_key = self.config.get(MODULE, opt)
+
+        self.sort_reversed = False
+        if sort_key[0] == "-":
+            sort_key = sort_key[1:]
+            self.sort_reversed = True
+        if sort_key not in self.sort_fns.keys():
+            raise RuntimeError("Sort key must be one of %s." % ", ".join(self.sort_fns.keys()))
+        self.sort_fn = self.sort_fns[sort_key]
+
+        self.cache = {}
+        self.insts = {str(i) : ct.c_int(1) for i in range(0, self.process_count)}
+        self.disklookup = {}
+
+        self.lock = Lock()
+        self.thread = Thread(name="biotop_refresh", target=self.refresh_stats_loop)
+        self.thread.setDaemon(True)
+
+        self.log("Initialized.")
+
+    def update_disk_info(self):
+        """ Update disk info cache """
+        # Cache disk major,minor -> diskname
+        self.disklookup = {}
+        if self.debug:
+            self.log("Updating disk cache...")
+        with open("/proc/diskstats") as stats:
+            for line in stats:
+                a = line.split()
+                self.disklookup[a[0] + "," + a[1]] = a[2]
+
+    def metrics(self):
+        """ Get metric definitions """
+        name = METRIC
+        self.items = (
+            # Name - reserved - type - semantics - units - help
+            (name + 'pid', None, PM_TYPE_U32, PM_SEM_INSTANT, units_none, 'PID'),
+            (name + 'comm', None, PM_TYPE_STRING, PM_SEM_INSTANT, units_none, 'command'),
+            (name + 'direction', None, PM_TYPE_STRING, PM_SEM_INSTANT, units_none, 'IO direction'),
+            (name + 'major', None, PM_TYPE_U32, PM_SEM_INSTANT, units_none, 'disk major'),
+            (name + 'minor', None, PM_TYPE_U32, PM_SEM_INSTANT, units_none, 'disk minor'),
+            (name + 'disk', None, PM_TYPE_STRING, PM_SEM_INSTANT, units_none, 'disk name'),
+            (name + 'io', None, PM_TYPE_U32, PM_SEM_INSTANT, units_none, 'IO count'),
+            (name + 'bytes', None, PM_TYPE_U64, PM_SEM_INSTANT, units_bytes, 'number of bytes'),
+            (name + 'duration', None, PM_TYPE_U32, PM_SEM_INSTANT, units_usecs, 'avg duration'),
+        )
+        return True, self.items
+
+    def compile(self):
+        """ Compile BPF """
+        try:
+            with open(path.dirname(__file__) + '/../' + bpf_src) as f:
+                bpf_text = f.read()
+
+            if self.debug:
+                self.log("BPF to be compiled:")
+                self.log("\n" + bpf_text)
+
+            self.bpf = BPF(text=bpf_text)
+            self.bpf.attach_kprobe(event="blk_account_io_start", fn_name="trace_pid_start")
+            self.bpf.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
+            self.bpf.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
+            self.bpf.attach_kprobe(event="blk_account_io_completion", fn_name="trace_req_completion")
+            self.thread.start()
+            self.log("Compiled.")
+        except Exception as error: # pylint: disable=broad-except
+            self.bpf = None
+            self.err(str(error))
+            self.err("Module NOT active!")
+            raise
+
+    def refresh_stats(self):
+        """ Refresh statistics from BPF table """
+        self.lock.acquire()
+        self.cache.clear()
+        self.lock.release()
+
+        counts = self.bpf.get_table("counts")
+        sorted_counts = sorted(counts.items(), key=self.sort_fn, reverse=self.sort_reversed)
+
+        idx = 0
+        for k, v in sorted_counts:
+            disk = str(k.major) + "," + str(k.minor)
+
+            if disk in self.disklookup:
+                diskname = self.disklookup[disk]
+            else:
+                # Check for hot swapped devices
+                self.update_disk_info()
+                diskname = self.disklookup.get(disk, "?")
+
+            self.lock.acquire()
+            self.cache[idx] = [
+                k.pid,
+                k.name.decode(),
+                "W" if k.rwflag else "R",
+                k.major,
+                k.minor,
+                diskname,
+                v.io,
+                v.bytes,
+                int(float(v.us) / v.io)
+            ]
+            self.lock.release()
+
+            idx += 1
+            if idx >= self.process_count:
+                break
+
+        counts.clear()
+
+    def refresh_stats_loop(self):
+        """ Refresh statistics thread loop """
+        while True:
+            self.refresh_stats()
+            sleep(self.interval)
+
+    def refresh(self):
+        """ Refresh BPF data """
+        if self.bpf is None:
+            return None
+
+        return self.insts
+
+    def bpfdata(self, item, inst):
+        """ Return BPF data as PCP metric value """
+        try:
+            key = int(self.pmdaIndom.inst_name_lookup(inst))
+            self.lock.acquire()
+            value = self.cache[key][item]
+            self.lock.release()
+            return [value, 1]
+        except Exception: # pylint: disable=broad-except
+            self.lock.release()
+            return [PM_ERR_AGAIN, 0]

--- a/src/pmdas/bcc/modules/biotop.python
+++ b/src/pmdas/bcc/modules/biotop.python
@@ -17,7 +17,7 @@
 # Configuration options
 # Name - type - default
 #
-# interval      - int    - 1      : interval
+# interval      - int    - 1      : interval for calculating summaries
 # process_count - int    - 20     : number of processes to show
 # sort          - string - -bytes : sort key: bytes/io/duration/rw
 #                                   sort order can be reversed by prepending '-'
@@ -92,8 +92,9 @@ class PCPBCCModule(PCPBCCBase):
         self.disklookup = {}
 
         self.lock = Lock()
-        self.thread = Thread(name="biotop_refresh", target=self.refresh_stats_loop)
-        self.thread.setDaemon(True)
+        if self.interval > 0:
+            self.thread = Thread(name="biotop_refresh", target=self.refresh_stats_loop)
+            self.thread.setDaemon(True)
 
         self.log("Initialized.")
 
@@ -140,7 +141,8 @@ class PCPBCCModule(PCPBCCBase):
             self.bpf.attach_kprobe(event="blk_start_request", fn_name="trace_req_start")
             self.bpf.attach_kprobe(event="blk_mq_start_request", fn_name="trace_req_start")
             self.bpf.attach_kprobe(event="blk_account_io_completion", fn_name="trace_req_completion")
-            self.thread.start()
+            if self.interval > 0:
+                self.thread.start()
             self.log("Compiled.")
         except Exception as error: # pylint: disable=broad-except
             self.bpf = None
@@ -198,6 +200,9 @@ class PCPBCCModule(PCPBCCBase):
         """ Refresh BPF data """
         if self.bpf is None:
             return None
+
+        if self.interval == 0:
+            self.refresh_stats()
 
         return self.insts
 


### PR DESCRIPTION
bioperpid: cumulates block I/O per pid
biotop: fetches block device I/O activity every X seconds and sorts it (useful for displaying in Vector)