### PR TITLE
Fixed file name for libpcp_web

### DIFF
--- a/src/libpcp_web/src/GNUmakefile
+++ b/src/libpcp_web/src/GNUmakefile
@@ -48,6 +48,11 @@ DSOVERSION = 1
 LIBTARGET = libpcp_web.$(DSOSUFFIX).$(DSOVERSION)
 SYMTARGET = libpcp_web.$(DSOSUFFIX)
 
+ifeq "$(TARGET_OS)" "darwin"
+LIBTARGET = libpcp_web.$(DSOVERSION).$(DSOSUFFIX)
+SYMTARGET = libpcp_web.$(DSOSUFFIX)
+endif
+
 VERSION_SCRIPT = exports
 LDIRT = $(XFILES) $(YFILES:%.y=%.tab.?)
 


### PR DESCRIPTION
Changed GNUmakefile for libpcp_web to fix file name.