### PR TITLE
pmdabcc: profile module and store callback, python: release GIL

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -136,7 +136,11 @@ disable=print-statement,
         no-else-return,
         too-many-instance-attributes,
         too-many-locals,
-        too-many-public-methods
+        too-many-public-methods,
+        too-many-branches,
+        invalid-name,
+        too-many-statements,
+        abstract-method
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/qa/1171
+++ b/qa/1171
@@ -1,0 +1,63 @@
+#!/bin/sh
+# PCP QA Test No. 1171
+# Exercise the BCC PMDA profile module - install, remove and values.
+#
+# Copyright (c) 2018 Andreas Gerstmayr.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+. ./common.bcc
+
+_pmdabcc_check
+_pmdabcc_require_kernel_version 4 9
+
+status=1       # failure is the default!
+signal=$PCP_BINADM_DIR/pmsignal
+$sudo rm -rf $tmp.* $seq.full
+
+_prepare_pmda bcc
+trap "_pmdabcc_cleanup; exit \$status" 0 1 2 3 15
+_stop_auto_restart pmcd
+
+# real QA test starts here
+cat <<EOF | _pmdabcc_install
+[pmda]
+modules = profile
+prefix = bcc.
+[profile]
+module = profile
+cluster = 14
+EOF
+_pmdabcc_wait_for_metric
+
+echo "=== start profiling ==="
+pmstore bcc.proc.profile start
+for i in `seq 1 10`; do pminfo -f bcc.proc.profile | grep started > /dev/null && break; sleep 1; done
+if [ $i -ge 10 ]; then
+    echo Could not start profiling, test failed
+    exit
+fi
+
+echo
+echo "=== start test program ==="
+src/bcc_profile 5
+
+echo
+echo "=== stop profiling ==="
+pmstore bcc.proc.profile stop
+for i in `seq 1 10`; do pminfo -f bcc.proc.profile | grep stopped > /dev/null && break; sleep 1; done
+if [ $i -ge 10 ]; then
+    echo Could not stop profiling, test failed
+    exit
+fi
+
+echo
+echo "=== verify captured stack frames ==="
+pminfo -f bcc.proc.profile | grep bcc_profile > /dev/null && echo 'OK'
+
+_pmdabcc_remove
+
+status=0
+exit

--- a/qa/1171.out
+++ b/qa/1171.out
@@ -1,0 +1,59 @@
+QA output created by 1171
+
+=== bcc agent installation ===
+Info: Initializing, currently in 'notready' state.
+Info: Enabled modules:
+Info: ['profile']
+Info: Configuring modules:
+Info: profile
+Info: Modules configured.
+Info: Initializing modules:
+Info: profile
+Info: profile: Initialized.
+Info: Modules initialized.
+Info: Registering metrics:
+Info: profile
+Info: Metrics registered.
+Info: Registering helpers:
+Info: Helpers registered.
+Info: Initializing, currently in 'notready' state.
+Info: Enabled modules:
+Info: ['profile']
+Info: Configuring modules:
+Info: profile
+Info: Modules configured.
+Info: Initializing modules:
+Info: profile
+Info: profile: Initialized.
+Info: Modules initialized.
+Info: Registering metrics:
+Info: profile
+Info: Metrics registered.
+Info: Registering helpers:
+Info: Helpers registered.
+Updating the Performance Metrics Name Space (PMNS) ...
+Terminate PMDA if already installed ...
+[...install files, make output...]
+Updating the PMCD control file, and notifying PMCD ...
+Check bcc metrics have appeared ... X metrics and X values
+
+=== start profiling ===
+bcc.proc.profile old value="{"status": "stopped", "data": null}" new value="start"
+
+=== start test program ===
+
+=== stop profiling ===
+bcc.proc.profile old value="{"status": "started", "data": null}" new value="stop"
+
+=== verify captured stack frames ===
+OK
+
+=== remove bcc agent ===
+Culling the Performance Metrics Name Space ...
+bcc ... done
+Updating the PMCD control file, and notifying PMCD ...
+[...removing files...]
+Check bcc metrics have gone away ... OK
+Waiting for pmcd to terminate ...
+Starting pmcd ... 
+Starting pmlogger ... 

--- a/qa/group
+++ b/qa/group
@@ -1511,6 +1511,7 @@ BAD
 1167 pmdumplog labels archive local pmrep python
 1169 pmrep python local
 1170 pmda.bcc local python
+1171 pmda.bcc local python
 1174 threads valgrind local
 1177 pmns derive libpcp pmlogger local
 1180 logutil local pmrep python BAD @vm34

--- a/qa/src/.gitignore
+++ b/qa/src/.gitignore
@@ -18,6 +18,7 @@ badmmv
 badpmcdpmid
 badpmda
 batch_import.pl
+bcc_profile
 chain
 check_fault_injection
 check_import

--- a/qa/src/GNUlocaldefs
+++ b/qa/src/GNUlocaldefs
@@ -47,7 +47,7 @@ CFILES = disk_test.c exercise.c context_test.c chkoptfetch.c \
 	archctl_segfault.c debug.c int2pmid.c int2indom.c exectest.c \
 	unpickargs.c hanoi.c chain.c progname.c countmark.c spawn.c \
 	indom2int.c pmid2int.c scanmeta.c traverse_return_codes.c \
-	timeshift.c checkstructs.c
+	timeshift.c checkstructs.c bcc_profile.c
 
 #ifeq "$(HAVE_LIBUV)" "true"
 #CFILES += discover-logtail.c
@@ -302,6 +302,9 @@ stripmark: stripmark.c
 
 anon-sa: anon-sa.c
 	$(CCF) $(CDEFS) -o $@ anon-sa.c
+
+bcc_profile: bcc_profile.c
+	$(CCF) $(CDEFS) -g -fno-omit-frame-pointer -o $@ bcc_profile.c
 
 # --- need libpcp
 #

--- a/qa/src/bcc_profile.c
+++ b/qa/src/bcc_profile.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 Andreas Gerstmayr.
+ */
+
+#include <ctype.h>
+#include <pcp/pmapi.h>
+#include "libpcp.h"
+
+static time_t exit_time;
+static long counter = 0;
+
+void bcc_profile_fn2()
+{
+    counter++;
+}
+
+void bcc_profile_fn1()
+{
+    struct timeval t;
+    while(1) {
+        bcc_profile_fn2();
+
+        gettimeofday(&t, 0);
+        if (t.tv_sec >= exit_time) {
+            exit(0);
+        }
+    }
+}
+
+int
+main(int argc, char **argv)
+{
+    struct timeval t;
+    long duration;
+
+    if (argc != 2) {
+        fprintf(stderr, "Usage: %s duration\n", argv[0]);
+        exit(1);
+    }
+
+    duration = strtol(argv[1], NULL, 10);
+    gettimeofday(&t, 0);
+    exit_time = t.tv_sec + duration;
+
+    bcc_profile_fn1();
+    return 0;
+}

--- a/src/pmdas/bcc/bcc.conf
+++ b/src/pmdas/bcc/bcc.conf
@@ -17,6 +17,7 @@ modules = biolatency,sysfork,tcpperpid,runqlat
 #modules = ext4dist,xfsdist,zfsdist
 #modules = biotop,tcptop
 #modules = tcplife,tcpretrans,execsnoop
+#modules = profile
 #modules = tracepoint_hits,usdt_hits,uprobe_hits
 #modules = usdt_jvm_threads,usdt_jvm_alloc
 prefix = bcc.
@@ -102,6 +103,13 @@ cluster = 12
 module = exectop
 cluster = 13
 
+[profile]
+module = profile
+cluster = 14
+#user_stacks_only = false
+#kernel_stacks_only = false
+#stack_storage_size = 16384
+#sample_frequency = 47
 
 [tracepoint_hits]
 module = tracepoint_hits

--- a/src/pmdas/bcc/modules/pcpbcc.python
+++ b/src/pmdas/bcc/modules/pcpbcc.python
@@ -78,6 +78,10 @@ class PCPBCCBase(object):
         """ Instance labels """
         return '{}'
 
+    def store(self, item, inst, val):
+        """ Store callback """
+        raise NotImplementedError
+
     def cleanup(self):
         """ Clean up at exit """
         if self.bpf is not None:

--- a/src/pmdas/bcc/modules/profile.bpf
+++ b/src/pmdas/bcc/modules/profile.bpf
@@ -1,0 +1,56 @@
+// Copyright 2016 Netflix, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License")
+
+#include <uapi/linux/ptrace.h>
+#include <uapi/linux/bpf_perf_event.h>
+#include <linux/sched.h>
+struct key_t {
+    u32 pid;
+    u64 kernel_ip;
+    u64 kernel_ret_ip;
+    int user_stack_id;
+    int kernel_stack_id;
+    char name[TASK_COMM_LEN];
+};
+BPF_HASH(counts, struct key_t);
+BPF_STACK_TRACE(stack_traces, STACK_STORAGE_SIZE);
+// This code gets a bit complex. Probably not suitable for casual hacking.
+int do_perf_event(struct bpf_perf_event_data *ctx) {
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+    if (!(THREAD_FILTER))
+        return 0;
+    // create map key
+    u64 zero = 0, *val;
+    struct key_t key = {.pid = pid};
+    bpf_get_current_comm(&key.name, sizeof(key.name));
+    // get stacks
+    key.user_stack_id = USER_STACK_GET;
+    key.kernel_stack_id = KERNEL_STACK_GET;
+    if (key.kernel_stack_id >= 0) {
+        // populate extras to fix the kernel stack
+        u64 ip = PT_REGS_IP(&ctx->regs);
+        u64 page_offset;
+        // if ip isn't sane, leave key ips as zero for later checking
+#if defined(CONFIG_X86_64) && defined(__PAGE_OFFSET_BASE)
+        // x64, 4.16, ..., 4.11, etc., but some earlier kernel didn't have it
+        page_offset = __PAGE_OFFSET_BASE;
+#elif defined(CONFIG_X86_64) && defined(__PAGE_OFFSET_BASE_L4)
+        // x64, 4.17, and later
+#if defined(CONFIG_DYNAMIC_MEMORY_LAYOUT) && defined(CONFIG_X86_5LEVEL)
+        page_offset = __PAGE_OFFSET_BASE_L5;
+#else
+        page_offset = __PAGE_OFFSET_BASE_L4;
+#endif
+#else
+        // earlier x86_64 kernels, e.g., 4.6, comes here
+        // arm64, s390, powerpc, x86_32
+        page_offset = PAGE_OFFSET;
+#endif
+        if (ip > page_offset) {
+            key.kernel_ip = ip;
+        }
+    }
+    val = counts.lookup_or_init(&key, &zero);
+    (*val)++;
+    return 0;
+}

--- a/src/pmdas/bcc/modules/profile.python
+++ b/src/pmdas/bcc/modules/profile.python
@@ -1,0 +1,298 @@
+#
+# Copyright (C) 2018 Andreas Gerstmayr <andreas@gerstmayr.me>
+# Based on the profile BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/profile.py
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+""" PCP BCC PMDA profile module """
+
+from threading import Thread, Lock
+from os import path
+import json
+import errno
+
+from bcc import BPF, PerfType, PerfSWConfig
+
+from pcp.pmapi import pmUnits
+from cpmapi import PM_TYPE_STRING, PM_SEM_INSTANT
+from cpmapi import PM_ERR_AGAIN, PM_ERR_BADSTORE
+
+from modules.pcpbcc import PCPBCCBase
+
+#
+# BPF program
+#
+bpf_src = "modules/profile.bpf"
+
+#
+# PCP BCC PMDA constants
+#
+MODULE = 'profile'
+METRIC = 'proc.profile'
+units_none = pmUnits(0, 0, 0, 0, 0, 0)
+
+class StackNode(object):
+    """ Stack Node """
+    def __init__(self, name, libtype=None):
+        self.name = name
+        self.libtype = libtype
+        self.value = 0
+        self.children = {}
+        self.parents = []
+
+    def find_or_create(self, name, libtype=None):
+        """ Finds or creates a new stack node """
+        if name in self.children:
+            return self.children[name]
+
+        new_node = StackNode(name, libtype)
+        new_node.parents = self.parents + [self]
+        self.children[name] = new_node
+        return new_node
+
+    def increment(self, n):
+        """ Increment node and all parents """
+        self.value += n
+        for parent in self.parents:
+            parent.value += n
+
+class StackNodeEncoder(json.JSONEncoder):
+    """ Stack Node JSON Encoder """
+    def default(self, o): # pylint: disable=method-hidden
+        return {"name": o.name, "libtype": o.libtype, "value": o.value,
+                "children": list(o.children.values())}
+
+#
+# PCP BCC Module
+#
+class PCPBCCModule(PCPBCCBase):
+    """ PCP BCC profile module """
+    def __init__(self, config, log, err):
+        """ Constructor """
+        PCPBCCBase.__init__(self, MODULE, config, log, err)
+
+        self.pid = None
+        self.user_stacks_only = False
+        self.kernel_stacks_only = False
+        self.stack_storage_size = 16384
+        self.sample_frequency = 47
+        self.sample_period = 1000000
+
+        for opt in self.config.options(MODULE):
+            if opt == 'pid':
+                self.pid = int(self.config.get(MODULE, opt))
+            if opt == 'user_stacks_only':
+                self.user_stacks_only = self.config.getboolean(MODULE, opt)
+            if opt == 'kernel_stacks_only':
+                self.kernel_stacks_only = self.config.getboolean(MODULE, opt)
+            if opt == 'stack_storage_size':
+                self.stack_storage_size = int(self.config.get(MODULE, opt))
+            if opt == 'sample_frequency':
+                self.sample_frequency = int(self.config.get(MODULE, opt))
+            if opt == 'sample_period':
+                self.sample_period = int(self.config.get(MODULE, opt))
+
+        self.lock = Lock()
+        self.status = "stopped"
+        self.data = "null"
+
+        self.log("Initialized.")
+
+    def metrics(self):
+        """ Get metric definitions """
+        name = METRIC
+        self.items.append(
+            # Name - reserved - type - semantics - units - help
+            (name, None, PM_TYPE_STRING, PM_SEM_INSTANT, units_none, 'stack traces'),
+        )
+        return False, self.items
+
+    def compile(self):
+        """ Compile BPF """
+        # this module compiles the BPF code on-the-fly if a profiling request is received
+
+    def start_profiling(self):
+        """ Starts profiling """
+        with self.lock:
+            if self.status != "stopped":
+                self.err("Profiling must be stopped before, current status: %s" % self.status)
+                return
+            self.status = "starting"
+            self.data = "null"
+
+        self.log("Starting profiling...")
+        try:
+            with open(path.dirname(__file__) + '/../' + bpf_src) as f:
+                bpf_text = f.read()
+
+            # set thread filter
+            if self.pid is not None:
+                thread_filter = 'pid == %s' % self.pid
+            else:
+                thread_filter = '1'
+            bpf_text = bpf_text.replace('THREAD_FILTER', thread_filter)
+
+            # set stack storage size
+            bpf_text = bpf_text.replace('STACK_STORAGE_SIZE', str(self.stack_storage_size))
+
+            # handle stack args
+            kernel_stack_get = "stack_traces.get_stackid(&ctx->regs, 0)"
+            user_stack_get = "stack_traces.get_stackid(&ctx->regs, BPF_F_USER_STACK)"
+            if self.user_stacks_only:
+                kernel_stack_get = "-1"
+            elif self.kernel_stacks_only:
+                user_stack_get = "-1"
+            bpf_text = bpf_text.replace('USER_STACK_GET', user_stack_get)
+            bpf_text = bpf_text.replace('KERNEL_STACK_GET', kernel_stack_get)
+
+            sample_freq = 0
+            sample_period = 0
+            if self.sample_frequency:
+                sample_freq = self.sample_frequency
+            elif self.sample_period:
+                sample_period = self.sample_period
+
+            if self.debug:
+                self.log("BPF to be compiled:")
+                self.log("\n" + bpf_text)
+
+            self.bpf = BPF(text=bpf_text)
+            self.bpf.attach_perf_event(ev_type=PerfType.SOFTWARE, ev_config=PerfSWConfig.CPU_CLOCK,
+                                       fn_name="do_perf_event", sample_period=sample_period,
+                                       sample_freq=sample_freq)
+
+            self.log("Started profiling")
+            with self.lock:
+                self.status = "started"
+        except Exception as error: # pylint: disable=broad-except
+            self.bpf = None
+            self.err(str(error))
+            self.err("Cannot compile BPF code")
+            with self.lock:
+                self.status = "stopped"
+            raise
+
+    @staticmethod
+    def stack_id_err(stack_id):
+        """ Helper method to detect stack id errors """
+        # -EFAULT in get_stackid normally means the stack-trace is not availible,
+        # Such as getting kernel stack trace in userspace code
+        return (stack_id < 0) and (stack_id != -errno.EFAULT)
+
+    @staticmethod
+    def enforce_str(x):
+        """ Decode bytes object """
+        if isinstance(x, bytes):
+            return x.decode()
+        else:
+            return x
+
+    def stop_profiling(self):
+        """ Stops profiling and generates JSON of stacktraces """
+        with self.lock:
+            if self.status != "started":
+                self.err("Please start profiling first, current status: %s" % self.status)
+                return
+            self.status = "stopping"
+
+        self.log("Stopping profiling...")
+        missing_stacks = 0
+        has_enomem = False
+
+        counts = self.bpf["counts"]
+        stack_traces = self.bpf["stack_traces"]
+
+        root_node = StackNode('root')
+        for k, v in sorted(counts.items(), key=lambda counts: counts[1].value):
+            # handle get_stackid errors
+            if not self.user_stacks_only and self.stack_id_err(k.kernel_stack_id):
+                missing_stacks += 1
+                has_enomem = has_enomem or k.kernel_stack_id == -errno.ENOMEM
+            if not self.kernel_stacks_only and self.stack_id_err(k.user_stack_id):
+                missing_stacks += 1
+                has_enomem = has_enomem or k.user_stack_id == -errno.ENOMEM
+
+            user_stack = [] if k.user_stack_id < 0 else stack_traces.walk(k.user_stack_id)
+            kernel_tmp = [] if k.kernel_stack_id < 0 else stack_traces.walk(k.kernel_stack_id)
+
+            # fix kernel stack
+            kernel_stack = []
+            if k.kernel_stack_id >= 0:
+                for addr in kernel_tmp:
+                    kernel_stack.append(addr)
+                # the later IP checking
+                if k.kernel_ip:
+                    kernel_stack.insert(0, k.kernel_ip)
+
+            user_stack = list(user_stack)
+            kernel_stack = list(kernel_stack)
+            cur_node = root_node.find_or_create(k.name.decode(), libtype="user")
+
+            # if we failed to get the stack is, such as due to no space (-ENOMEM) or
+            # hash collision (-EEXIST), we still print a placeholder for consistency
+            if not self.kernel_stacks_only:
+                if self.stack_id_err(k.user_stack_id):
+                    cur_node = cur_node.find_or_create("[Missed User Stack]", libtype="user")
+                else:
+                    for addr in reversed(user_stack):
+                        cur_node = cur_node.find_or_create(
+                            self.enforce_str(self.bpf.sym(addr, k.pid)), libtype="user")
+            if not self.user_stacks_only:
+                if self.stack_id_err(k.kernel_stack_id):
+                    cur_node = cur_node.find_or_create("[Missed Kernel Stack]", libtype="kernel")
+                else:
+                    for addr in reversed(kernel_stack):
+                        cur_node = cur_node.find_or_create(
+                            self.enforce_str(self.bpf.ksym(addr)), libtype="kernel")
+            cur_node.increment(v.value)
+
+        # check missing
+        if missing_stacks > 0:
+            enomem_str = "" if not has_enomem else " Consider increasing --stack-storage-size."
+            self.log("WARNING: %d stack traces could not be displayed.%s" %
+                     (missing_stacks, enomem_str))
+
+        self.bpf.cleanup()
+        self.bpf = None
+        self.log("Stopped profiling")
+
+        with self.lock:
+            self.data = json.dumps(root_node, cls=StackNodeEncoder)
+            self.status = "stopped"
+
+    def refresh(self):
+        """ Refresh BPF data """
+
+    def bpfdata(self, item, inst):
+        """ Return BPF data as PCP metric value """
+        try:
+            with self.lock:
+                value = '{"status": "%s", "data": %s}' % (self.status, self.data)
+            return [value, 1]
+        except Exception: # pylint: disable=broad-except
+            return [PM_ERR_AGAIN, 0]
+
+    def store(self, _item, _inst, val):
+        """ Start/stop profiling """
+        if val == "start":
+            thread = Thread(target=self.start_profiling)
+            thread.setDaemon(True)
+            thread.start()
+        elif val == "stop":
+            thread = Thread(target=self.stop_profiling)
+            thread.setDaemon(True)
+            thread.start()
+        else:
+            self.err("Received invalid command: " + val)
+            return PM_ERR_BADSTORE
+
+        return 0

--- a/src/pmdas/bcc/pmdabcc.python
+++ b/src/pmdas/bcc/pmdabcc.python
@@ -29,7 +29,7 @@ from collections import OrderedDict
 
 from pcp.pmapi import pmContext as PCP
 from pcp.pmda import PMDA, pmdaIndom, pmdaMetric
-from cpmapi import PM_INDOM_NULL, PM_ERR_VALUE, PM_LABEL_CLUSTER
+from cpmapi import PM_INDOM_NULL, PM_ERR_VALUE, PM_ERR_PMID, PM_LABEL_CLUSTER
 
 # Module references
 CONFIG = 1
@@ -46,6 +46,7 @@ INDOM = 11
 INSTS = 12
 LABEL_CLUSTER = 13
 LABEL_INSTANCE = 14
+STORE = 15
 
 class BCCPMDA(PMDA):
     """ PCP BCC PMDA """
@@ -74,6 +75,7 @@ class BCCPMDA(PMDA):
         self.set_fetch_callback(self.bcc_fetch_callback)
         self.set_label(self.bcc_label)
         self.set_label_callback(self.bcc_label_callback)
+        self.set_store_callback(self.bcc_store_callback)
 
         self.pmda_ready()
         if not os.environ.get('PCP_PYTHON_DOMAIN') and not os.environ.get('PCP_PYTHON_PMNS'):
@@ -188,6 +190,7 @@ class BCCPMDA(PMDA):
             self.modules[module][CLEANUP] = obj.cleanup
             self.modules[module][LABEL_CLUSTER] = obj.label_cluster
             self.modules[module][LABEL_INSTANCE] = obj.label_instance
+            self.modules[module][STORE] = obj.store
         self.log("Modules initialized.")
 
     def register_metrics(self):
@@ -269,6 +272,16 @@ class BCCPMDA(PMDA):
         """ Instance labels """
         module = self.indoms[indom]
         return self.modules[module][LABEL_INSTANCE](inst)
+
+    def bcc_store_callback(self, cluster, item, inst, val):
+        """ Store callback """
+        module = self.clusters[cluster]
+        try:
+            return self.modules[module][STORE](item, inst, val)
+        except Exception as error: # pylint: disable=broad-except
+            self.err(str(error))
+            self.err(traceback.format_exc())
+            return PM_ERR_PMID
 
 if __name__ == '__main__':
     BCCPMDA('bcc', 149).run()

--- a/src/python/pmda.c
+++ b/src/python/pmda.c
@@ -63,6 +63,8 @@ static PyObject *label_cb_func;
 static PyObject *refresh_all_func;
 static PyObject *refresh_metrics_func;
 
+static PyThreadState *thread_state;
+
 static Py_ssize_t nindoms;
 static pmdaIndom *indom_buffer;
 static Py_ssize_t nmetrics;
@@ -1081,6 +1083,27 @@ pmda_refresh_metrics(void)
     }
 }
 
+/*
+ * Acquire the global interpreter lock before calling Python callbacks
+ */
+static int
+check_callback(void)
+{
+    PyEval_RestoreThread(thread_state);
+    return 1;
+}
+
+/*
+ * Release the global interpreter lock after calling Python callbacks
+ * This ensures that Python threads can execute while the PMDA is waiting
+ * for new PDUs
+ */
+static void
+done_callback(void)
+{
+    thread_state = PyEval_SaveThread();
+}
+
 static PyObject *
 pmda_dispatch(PyObject *self, PyObject *args, PyObject *keywords)
 {
@@ -1145,7 +1168,16 @@ pmda_dispatch(PyObject *self, PyObject *args, PyObject *keywords)
 
 	if (pmDebugOptions.libpmda)
 	    fprintf(stderr, "pmda_dispatch entering PDU loop\n");
-	pmdaMain(&dispatch);
+
+        dispatch.version.any.ext->e_checkCallBack = check_callback;
+        dispatch.version.any.ext->e_doneCallBack = done_callback;
+
+        /*
+         * done_callback() releases the GIL
+         * it will be reacquired in check_callback() once a PDU arrives
+         */
+        done_callback();
+        pmdaMain(&dispatch);
     }
     Py_INCREF(Py_None);
     return Py_None;


### PR DESCRIPTION
The profile module records stack traces at a specific interval. It should be used in combination with Vector, which will display them as flame graphs:
![profile](https://user-images.githubusercontent.com/538011/42831897-de7c8fca-89ef-11e8-9d35-59a89248d83c.png)

This PR also includes a commit which releases the GIL while the PMDA is waiting for new PDUs, otherwise the GIL would lock out background threads.