### PR TITLE
qa: check-vm: update file name of python3 bcc RPM package

### DIFF
--- a/qa/admin/check-vm
+++ b/qa/admin/check-vm
@@ -562,7 +562,7 @@ pacman?	/usr/lib/python2.*/site-packages/openpyxl	[python2-openpyxl? (build opti
 pacman?	/usr/lib/python3.*/site-packages/openpyxl	[python-openpyxl? (build optional)]
 # -- python bcc
 dpkg?	/usr/lib/python3/*-packages/bcc/__init__.py	[python3-bpfcc (build optional)]
-rpm?	/usr/lib*/python3.*/*-packages/bcc.py	[python3-bcc or python3-bpfcc (build optional)]
+rpm?	/usr/lib/python3.*/*-packages/bcc/__init__.py	[python3-bcc (build optional)]
 urpmi?	/usr/lib*/python*/*-packages/bcc.py	[python-bcc or python-bpfcc (build optional)]
 emerge?	/usr/lib/python*/*-packages/bcc.py	[dev-python/bcc (build optional)]
 pkgin?	/usr/pkg/lib/python3.*/*-packages/bcc.py	[py36-bcc (build optional)]


### PR DESCRIPTION
qa/admin/check-vm assumes python3-bcc is not installed, even though it is installed.

$ qa/admin/check-vm
Missing: /usr/lib*/python3.*/*-packages/bcc.py [python3-bcc or python3-bpfcc (build optional)]

$ rpm -ql python3-bcc
/usr/lib/python3.6/site-packages/bcc
/usr/lib/python3.6/site-packages/bcc-0.6.0-py3.6.egg-info
/usr/lib/python3.6/site-packages/bcc/__init__.py
/usr/lib/python3.6/site-packages/bcc/__pycache__
/usr/lib/python3.6/site-packages/bcc/__pycache__/__init__.cpython-36.opt-1.pyc
/usr/lib/python3.6/site-packages/bcc/__pycache__/__init__.cpython-36.pyc

Updated the previous file name to existing one, and deleted python3-bpfcc
because there seems to be no such RPM package.