### PR TITLE
pmdabcc: add attribution to the author of each BCC tool

### DIFF
--- a/src/pmdas/bcc/modules/biolatency.python
+++ b/src/pmdas/bcc/modules/biolatency.python
@@ -1,5 +1,7 @@
 #
 # Copyright (C) 2017-2018 Marko Myllynen <myllynen@redhat.com>
+# Based on the biolatency BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/biolatency.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pmdas/bcc/modules/bioperpid.python
+++ b/src/pmdas/bcc/modules/bioperpid.python
@@ -1,5 +1,7 @@
 #
 # Copyright (C) 2017-2018 Marko Myllynen <myllynen@redhat.com>
+# Based on the biotop BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/biotop.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pmdas/bcc/modules/biotop.python
+++ b/src/pmdas/bcc/modules/biotop.python
@@ -1,6 +1,8 @@
 #
 # Copyright (C) 2017-2018 Marko Myllynen <myllynen@redhat.com>
 # Copyright (C) 2018 Andreas Gerstmayr <andreas@gerstmayr.me>
+# Based on the biotop BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/biotop.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pmdas/bcc/modules/execsnoop.python
+++ b/src/pmdas/bcc/modules/execsnoop.python
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2018 Andreas Gerstmayr <andreas@gerstmayr.me>
-# Based on https://github.com/iovisor/bcc/blob/master/tools/execsnoop.py
+# Based on the execsnoop BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/execsnoop.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pmdas/bcc/modules/fs/ext4dist.python
+++ b/src/pmdas/bcc/modules/fs/ext4dist.python
@@ -1,5 +1,7 @@
 #
 # Copyright (C) 2018 Andreas Gerstmayr <andreas@gerstmayr.me>
+# Based on the ext4dist BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/ext4dist.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -41,7 +43,7 @@ units_count = pmUnits(0, 0, 1, 0, 0, PM_COUNT_ONE)
 # PCP BCC Module
 #
 class PCPBCCModule(PCPBCCBase):
-    """ PCP BCC runqlat module """
+    """ PCP BCC ext4dist module """
     def __init__(self, config, log, err):
         """ Constructor """
         PCPBCCBase.__init__(self, MODULE, config, log, err)

--- a/src/pmdas/bcc/modules/fs/xfsdist.python
+++ b/src/pmdas/bcc/modules/fs/xfsdist.python
@@ -1,5 +1,7 @@
 #
 # Copyright (C) 2018 Andreas Gerstmayr <andreas@gerstmayr.me>
+# Based on the xfsdist BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/xfsdist.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -41,7 +43,7 @@ units_count = pmUnits(0, 0, 1, 0, 0, PM_COUNT_ONE)
 # PCP BCC Module
 #
 class PCPBCCModule(PCPBCCBase):
-    """ PCP BCC runqlat module """
+    """ PCP BCC xfsdist module """
     def __init__(self, config, log, err):
         """ Constructor """
         PCPBCCBase.__init__(self, MODULE, config, log, err)

--- a/src/pmdas/bcc/modules/fs/zfsdist.python
+++ b/src/pmdas/bcc/modules/fs/zfsdist.python
@@ -1,5 +1,7 @@
 #
 # Copyright (C) 2018 Andreas Gerstmayr <andreas@gerstmayr.me>
+# Based on the zfsdist BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/zfsdist.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -41,7 +43,7 @@ units_count = pmUnits(0, 0, 1, 0, 0, PM_COUNT_ONE)
 # PCP BCC Module
 #
 class PCPBCCModule(PCPBCCBase):
-    """ PCP BCC runqlat module """
+    """ PCP BCC zfsdist module """
     def __init__(self, config, log, err):
         """ Constructor """
         PCPBCCBase.__init__(self, MODULE, config, log, err)

--- a/src/pmdas/bcc/modules/runqlat.python
+++ b/src/pmdas/bcc/modules/runqlat.python
@@ -1,5 +1,7 @@
 #
 # Copyright (C) 2018 Andreas Gerstmayr <andreas@gerstmayr.me>
+# Based on the runqlat BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/runqlat.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pmdas/bcc/modules/sysfork.python
+++ b/src/pmdas/bcc/modules/sysfork.python
@@ -41,7 +41,7 @@ units_count = pmUnits(0, 0, 1, 0, 0, PM_COUNT_ONE)
 # PCP BCC Module
 #
 class PCPBCCModule(PCPBCCBase):
-    """ PCP BCC biotop module """
+    """ PCP BCC sysfork module """
     def __init__(self, config, log, err):
         """ Constructor """
         PCPBCCBase.__init__(self, MODULE, config, log, err)

--- a/src/pmdas/bcc/modules/tcplife.python
+++ b/src/pmdas/bcc/modules/tcplife.python
@@ -1,6 +1,8 @@
 #
 # Copyright (C) 2017-2018 Marko Myllynen <myllynen@redhat.com>
 # Copyright (C) 2018 Andreas Gerstmayr <andreas@gerstmayr.me>
+# Based on the tcplife BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/tcplife.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -97,7 +99,7 @@ class Data_ipv6(ct.Structure):
 # PCP BCC Module
 #
 class PCPBCCModule(PCPBCCBase):
-    """ PCP BCC biotop module """
+    """ PCP BCC tcplife module """
     def __init__(self, config, log, err):
         """ Constructor """
         PCPBCCBase.__init__(self, MODULE, config, log, err)

--- a/src/pmdas/bcc/modules/tcpperpid.python
+++ b/src/pmdas/bcc/modules/tcpperpid.python
@@ -1,5 +1,7 @@
 #
 # Copyright (C) 2017-2018 Marko Myllynen <myllynen@redhat.com>
+# Based on the tcplife BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/tcplife.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -87,7 +89,7 @@ class Data_ipv6(ct.Structure):
 # PCP BCC Module
 #
 class PCPBCCModule(PCPBCCBase):
-    """ PCP BCC biotop module """
+    """ PCP BCC tcpperpid module """
     def __init__(self, config, log, err):
         """ Constructor """
         PCPBCCBase.__init__(self, MODULE, config, log, err)

--- a/src/pmdas/bcc/modules/tcpretrans.python
+++ b/src/pmdas/bcc/modules/tcpretrans.python
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2018 Andreas Gerstmayr <andreas@gerstmayr.me>
-# Based on https://github.com/iovisor/bcc/blob/master/tools/tcpretrans.py
+# Based on the tcpretrans BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/tcpretrans.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/pmdas/bcc/modules/tcptop.python
+++ b/src/pmdas/bcc/modules/tcptop.python
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2018 Andreas Gerstmayr <andreas@gerstmayr.me>
-# Based on https://github.com/iovisor/bcc/blob/master/tools/tcptop.py
+# Based on the tcptop BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/tcptop.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
imho we should also include attribution to the original author in the header of each BCC PMDA module (where appropriate), as quite a few lines of python code are copied and adapted from the original BCC tool