### PR TITLE
pmdabcc: move module options description to bcc.conf, add short description of each module

### DIFF
--- a/src/pmdas/bcc/bcc.conf
+++ b/src/pmdas/bcc/bcc.conf
@@ -12,79 +12,163 @@
 # 200-299 are reserved for possible site-local modules.
 
 [pmda]
+# list of enabled modules
 modules = biolatency,sysfork,tcpperpid,runqlat
-#modules = bioperpid,exectop
-#modules = ext4dist,xfsdist,zfsdist
-#modules = biotop,tcptop
-#modules = tcplife,tcpretrans,execsnoop
-#modules = tracepoint_hits,usdt_hits,uprobe_hits
-#modules = usdt_jvm_threads,usdt_jvm_alloc
+
+# prefix of the metric name
 prefix = bcc.
+
+# specifies whether the PMDA should exit when a module fails
 module_failure_fatal = True
 
 
-[biolatency]
-module = biolatency
-cluster = 0
-queued = False
+#
+# Process related modules
+#
 
-[bioperpid]
-module = bioperpid
-cluster = 1
-
+# This module counts the number of new processes
 [sysfork]
 module = sysfork
 cluster = 2
 
+# This module shows the scheduler run queue latency as a histogram
+[runqlat]
+module = runqlat
+cluster = 4
+
+# This module traces new processes
+#
+# Configuration options:
+# Name              - type    - default
+#
+# include_failed    - boolean - false : include failed exec()s
+# command           - string  - unset : include only commands matching this regex
+# args              - string  - unset : include only arguments matching this regex
+# max_args          - int     - 20    : maximum number of arguments to capture
+# session_count     - int     - 20    : number of closed TCP sessions to keep in the cache
+# buffer_page_count - int     - 64    : number of pages for the perf ring buffer, power of two
+[execsnoop]
+module = execsnoop
+cluster = 8
+#command = sh
+#args = --verbose
+
+# This module counts how often a specific program was executed
+[exectop]
+module = exectop
+cluster = 13
+
+# This module records stack traces at a specific interval
+# It should be used in combination with Vector, which will display them as flame graphs.
+#
+# Configuration options:
+# Name               - type    - default
+#
+# pid                - int     - unset : capture this PID only
+# user_stacks_only   - boolean - false : capture only user stacks
+# kernel_stacks_only - boolean - false : capture only kernel stacks
+# stack_storage_size - int     - 16384 : the number of unique stack traces that can be stored and displayed
+# sample_frequency   - int     - 47    : sample frequency, Hertz
+# sample_period      - int     - unset : sample period, number of events
+[profile]
+module = profile
+cluster = 14
+
+
+#
+# Block device I/O modules
+#
+
+# This module traces block device I/O (disk I/O) and shows the I/O latency as a histogram
+#
+# Configuration options:
+# Name   - type    - default
+#
+# queued - boolean - False : include OS queued time in I/O time
+[biolatency]
+module = biolatency
+cluster = 0
+
+# This module counts block device I/O per process
+[bioperpid]
+module = bioperpid
+cluster = 1
+
+# This module summarizes which processes are performing disk I/O
+#
+# Configuration options:
+# Name          - type   - default
+#
+# interval      - int    - 1      : interval for calculating summaries
+# process_count - int    - 20     : number of processes to show
+# sort          - string - -bytes : sort key: bytes/io/duration/rw
+#                                   sort order can be reversed by prepending '-'
+[biotop]
+module = biotop
+cluster = 10
+
+
+#
+# Filesystem modules
+#
+
+# This module traces ext4 reads, writes, opens, and fsyncs, and shows their latency as a histogram
+[ext4dist]
+module = fs.ext4dist
+cluster = 5
+
+# This module traces xfs reads, writes, opens, and fsyncs, and shows their latency as a histogram
+[xfsdist]
+module = fs.xfsdist
+cluster = 6
+
+# This module traces zfs reads, writes, opens, and fsyncs, and shows their latency as a histogram
+[zfsdist]
+module = fs.zfsdist
+cluster = 7
+
+
+#
+# TCP related modules
+#
+
+# This module summarizes TCP sessions
+#
+# Configuration options:
+# Name              - type   - default
+#
+# process           - string - unset : list of names/pids or regex of processes to monitor
+# dport             - int    - unset : list of remote ports to monitor
+# lport             - int    - unset : list of local ports to monitor
+# session_count     - int    - 20    : number of closed TCP sessions to keep in the cache
+# buffer_page_count - int    - 64    : number of pages for the perf ring buffer, power of two
 [tcplife]
 module = tcplife
 cluster = 3
 #process = java
 #lport = 8443
 #dport = 80,443
-#session_count = 20
-#buffer_page_count = 64
 
-[runqlat]
-module = runqlat
-cluster = 4
-
-[ext4dist]
-module = fs.ext4dist
-cluster = 5
-
-[xfsdist]
-module = fs.xfsdist
-cluster = 6
-
-[zfsdist]
-module = fs.zfsdist
-cluster = 7
-
-[execsnoop]
-module = execsnoop
-cluster = 8
-#include_failed = true
-#command = sh
-#args = --verbose
-#max_args = 20
-#session_count = 20
-#buffer_page_count = 64
-
+# This module traces TCP retransmits
+#
+# Configuration options:
+# Name              - type    - default
+#
+# include_tlp       - boolean - false : include tail loss probe attempts
+# flow_count        - int     - 20    : number of closed TCP sessions to keep in the cache
+# buffer_page_count - int     - 64    : number of pages for the perf ring buffer, power of two
 [tcpretrans]
 module = tcpretrans
 cluster = 9
-#include_tlp = false
-#flow_count = 20
-#buffer_page_count = 64
 
-[biotop]
-module = biotop
-cluster = 10
-#interval = 1
-#process_count = 20
-#sort = -bytes
-
+# This module counts the amount of sent and received data per process
+#
+# Configuration options:
+# Name    - type   - default
+#
+# process - string - unset : list of names/pids or regex of processes to monitor
+# dport   - int    - unset : list of remote ports to monitor
+# lport   - int    - unset : list of local ports to monitor
 [tcpperpid]
 module = tcpperpid
 cluster = 11
@@ -92,17 +176,29 @@ cluster = 11
 #lport = 8443
 #dport = 80,443
 
+# This module summarizes TCP throughput by host and port
+#
+# Configuration options:
+# Name       - type   - default
+#
+# interval   - int    - 1      : interval for calculating summaries
+# conn_count - int    - 20     : number of processes to show
 [tcptop]
 module = tcptop
 cluster = 12
-#interval = 1
-#conn_count = 20
 
-[exectop]
-module = exectop
-cluster = 13
+#
+# Probe hits modules
+#
 
-
+# This module counts the number of tracepoint hits
+#
+# Configuration options:
+# Name         - type    - default
+#
+# compile_test - boolean - False : disable failing tracepoints on-the-fly
+# process      - string  - unset : list of names/pids or regex of processes to monitor
+# tracepoints  - string  - unset : file or comma-separated list of tracepoints
 [tracepoint_hits]
 module = tracepoint_hits
 cluster = 100
@@ -115,6 +211,13 @@ tracepoints = random:urandom_read
 #tracepoints = xfs:.*
 #tracepoints = bcc-tracepoint.conf
 
+# This module counts the number of user-level statically defined tracing (USDT) probe hits
+#
+# Configuration options:
+# Name    - type   - default
+#
+# process - string - unset : list of names/pids or regex of processes to monitor
+# usdts   - string - unset : file or comma-separated list of usdts
 [usdt_hits]
 module = usdt_hits
 cluster = 101
@@ -123,6 +226,13 @@ process = java
 usdts = /etc/alternatives/jre/lib/server/libjvm.so:gc__begin
 #usdts = bcc-usdt.conf
 
+# This module counts the number of user-level probe (uprobes) hits
+#
+# Configuration options:
+# Name    - type   - default
+#
+# process - string - unset : list of names/pids or regex of processes to monitor
+# uprobes - string - unset : file or comma-separated list of uprobes
 [uprobe_hits]
 module = uprobe_hits
 cluster = 102
@@ -130,19 +240,36 @@ cluster = 102
 uprobes = c:malloc,c:strlen
 #uprobes = bcc-uprobe.conf
 
+
+#
+# Java related modules
+#
+
+# This module counts the number of started and stopped JVM threads
+#
+# Configuration options:
+# Name     - type   - default
+#
+# jvm_path - string - /etc/alternatives/jre/lib/server/libjvm.so : path to libjvm.so
+# process  - string - unset                                      : list of names/pids or regex of processes to monitor
 [usdt_jvm_threads]
 module = usdt_jvm_threads
 cluster = 110
-jvm_path = /etc/alternatives/jre/lib/server/libjvm.so
 # Mandatory for now - https://github.com/iovisor/bcc/issues/1774
 process = java
 
+# This module counts the allocated bytes per Java class
+#
+# Configuration options:
+# Name      - type   - default
+#
+# frequency - int    - unset                                      : sample every Nth allocation, power of two
+# jvm_path  - string - /etc/alternatives/jre/lib/server/libjvm.so : path to libjvm.so
+# process   - string - unset                                      : list of names/pids or regex of processes to monitor
+#
 # java(1) must be started with -XX:+DTraceAllocProbes
 [usdt_jvm_alloc]
 module = usdt_jvm_alloc
 cluster = 120
-# Sampling frequency, must be power of 2
-#frequency = 1024
-jvm_path = /etc/alternatives/jre/lib/server/libjvm.so
 # Mandatory for now - https://github.com/iovisor/bcc/issues/1774
 process = java

--- a/src/pmdas/bcc/modules/biolatency.python
+++ b/src/pmdas/bcc/modules/biolatency.python
@@ -13,11 +13,6 @@
 #
 """ PCP BCC PMDA biolatency module """
 
-# Configuration options
-# Name - type - default
-#
-# queued - boolean - False : include OS queued time in I/O time
-
 # pylint: disable=invalid-name, line-too-long
 
 from bcc import BPF

--- a/src/pmdas/bcc/modules/biotop.python
+++ b/src/pmdas/bcc/modules/biotop.python
@@ -14,14 +14,6 @@
 #
 """ PCP BCC PMDA biotop module """
 
-# Configuration options
-# Name - type - default
-#
-# interval      - int    - 1      : interval for calculating summaries
-# process_count - int    - 20     : number of processes to show
-# sort          - string - -bytes : sort key: bytes/io/duration/rw
-#                                   sort order can be reversed by prepending '-'
-
 # pylint: disable=invalid-name, line-too-long
 
 import ctypes as ct

--- a/src/pmdas/bcc/modules/execsnoop.python
+++ b/src/pmdas/bcc/modules/execsnoop.python
@@ -14,16 +14,6 @@
 #
 """ PCP BCC PMDA execsnoop module """
 
-# Configuration options
-# Name - type - default
-#
-# include_failed    - boolean - false : include failed exec()s
-# command           - string  - unset : include only commands matching this regex
-# args              - string  - unset : include only arguments matching this regex
-# max_args          - int     - 20    : maximum number of arguments to capture
-# session_count     - int     - 20    : number of closed TCP sessions to keep in the cache
-# buffer_page_count - int     - 64    : number of pages for the perf ring buffer, power of two
-
 # pylint: disable=invalid-name,too-few-public-methods,too-many-instance-attributes
 
 import ctypes as ct

--- a/src/pmdas/bcc/modules/tcplife.python
+++ b/src/pmdas/bcc/modules/tcplife.python
@@ -14,15 +14,6 @@
 #
 """ PCP BCC PMDA tcplife module """
 
-# Configuration options
-# Name - type - default
-#
-# process           - string - unset : list of names/pids or regex of processes to monitor
-# dport             - int    - unset : list of remote ports to monitor
-# lport             - int    - unset : list of local ports to monitor
-# session_count     - int    - 20    : number of closed TCP sessions to keep in the cache
-# buffer_page_count - int    - 64    : number of pages for the perf ring buffer, power of two
-
 # pylint: disable=invalid-name,too-few-public-methods,too-many-instance-attributes
 
 import ctypes as ct

--- a/src/pmdas/bcc/modules/tcpperpid.python
+++ b/src/pmdas/bcc/modules/tcpperpid.python
@@ -13,13 +13,6 @@
 #
 """ PCP BCC PMDA tcpperpid module """
 
-# Configuration options
-# Name - type - default
-#
-# process - string - unset : list of names/pids or regex of processes to monitor
-# dport   - int    - unset : list of remote ports to monitor
-# lport   - int    - unset : list of local ports to monitor
-
 # pylint: disable=invalid-name,too-few-public-methods,too-many-instance-attributes
 
 import ctypes as ct

--- a/src/pmdas/bcc/modules/tcpretrans.python
+++ b/src/pmdas/bcc/modules/tcpretrans.python
@@ -14,13 +14,6 @@
 #
 """ PCP BCC PMDA tcpretrans module """
 
-# Configuration options
-# Name - type - default
-#
-# include_tlp       - boolean - false : include tail loss probe attempts
-# flow_count        - int     - 20    : number of closed TCP sessions to keep in the cache
-# buffer_page_count - int     - 64    : number of pages for the perf ring buffer, power of two
-
 # pylint: disable=invalid-name,too-few-public-methods,too-many-instance-attributes
 
 import ctypes as ct

--- a/src/pmdas/bcc/modules/tcptop.python
+++ b/src/pmdas/bcc/modules/tcptop.python
@@ -14,12 +14,6 @@
 #
 """ PCP BCC PMDA tcptop module """
 
-# Configuration options
-# Name - type - default
-#
-# interval   - int    - 1      : interval for calculating summaries
-# conn_count - int    - 20     : number of processes to show
-
 # pylint: disable=invalid-name, line-too-long
 
 import ctypes as ct

--- a/src/pmdas/bcc/modules/tracepoint_hits.python
+++ b/src/pmdas/bcc/modules/tracepoint_hits.python
@@ -13,13 +13,6 @@
 #
 """ PCP BCC PMDA tracepoint hits module """
 
-# Configuration options
-# Name - type - default
-#
-# compile_test - boolean - False : disable failing tracepoints on-the-fly
-# process      - string  - unset : list of names/pids or regex of processes to monitor
-# tracepoints  - string  - unset : file or comma-separated list of tracepoints
-
 # pylint: disable=invalid-name
 
 from ctypes import c_int

--- a/src/pmdas/bcc/modules/uprobe_hits.python
+++ b/src/pmdas/bcc/modules/uprobe_hits.python
@@ -13,12 +13,6 @@
 #
 """ PCP BCC PMDA uprobe hits module """
 
-# Configuration options
-# Name - type - default
-#
-# process - string - unset : list of names/pids or regex of processes to monitor
-# uprobes - string - unset : file or comma-separated list of uprobes
-
 # pylint: disable=invalid-name
 
 from ctypes import c_int

--- a/src/pmdas/bcc/modules/usdt_hits.python
+++ b/src/pmdas/bcc/modules/usdt_hits.python
@@ -13,12 +13,6 @@
 #
 """ PCP BCC PMDA USDT hits module """
 
-# Configuration options
-# Name - type - default
-#
-# process - string - unset : list of names/pids or regex of processes to monitor
-# usdts   - string - unset : file or comma-separated list of usdts
-
 # pylint: disable=invalid-name
 
 from ctypes import c_int

--- a/src/pmdas/bcc/modules/usdt_jvm_alloc.python
+++ b/src/pmdas/bcc/modules/usdt_jvm_alloc.python
@@ -13,15 +13,6 @@
 #
 """ PCP BCC PMDA USDT JVM allocation profile module """
 
-# Configuration options
-# Name - type - default
-#
-# frequency - int    - unset : sample every Nth allocation, power of two
-# jvm_path  - string -  [1]  : path to libjvm.so
-# process   - string - unset : list of names/pids or regex of processes to monitor
-#
-# 1) Default for jvm_path: /etc/alternatives/jre/lib/server/libjvm.so
-
 # pylint: disable=invalid-name
 
 from platform import architecture

--- a/src/pmdas/bcc/modules/usdt_jvm_threads.python
+++ b/src/pmdas/bcc/modules/usdt_jvm_threads.python
@@ -13,14 +13,6 @@
 #
 """ PCP BCC PMDA USDT JVM threads module """
 
-# Configuration options
-# Name - type - default
-#
-# jvm_path - string -  [1]  : path to libjvm.so
-# process  - string - unset : list of names/pids or regex of processes to monitor
-#
-# 1) Default for jvm_path: /etc/alternatives/jre/lib/server/libjvm.so
-
 # pylint: disable=invalid-name
 
 from ctypes import c_int


### PR DESCRIPTION
Users shouldn't have to look into the source code of each module to get a description of the configuration options - therefore I moved them to `bcc.conf` (and grouped the modules + added a short description to each module as suggested by @myllynen)