### PR TITLE
create reproducible tarballs

### DIFF
--- a/man/html/cpuperf/GNUmakefile
+++ b/man/html/cpuperf/GNUmakefile
@@ -15,7 +15,7 @@ $(BINTAR): $(PCPLOGS) $(CONFIGS)
 	for f in `echo $^`; do \
 	    echo $(BUNDLE)/$$f >> $$CDIR/manifest; \
 	done; \
-	$(TAR) -T $$CDIR/manifest -cf - | $(ZIP) --best > $$CDIR/$(BINTAR); \
+	$(TAR) --format ustar -T $$CDIR/manifest -cf - | $(ZIP) --best --no-name > $$CDIR/$(BINTAR); \
 	echo "Created $(BINTAR)"
 
 include $(BUILDRULES)

--- a/man/html/diskmodel/GNUmakefile
+++ b/man/html/diskmodel/GNUmakefile
@@ -16,7 +16,7 @@ $(BINTAR): $(PCPLOGS) $(CONFIGS) $(MODELS)
 	for f in `echo $^`; do \
 	    echo $(BUNDLE)/$$f >> $$CDIR/manifest; \
 	done; \
-	$(TAR) -T $$CDIR/manifest -cf - | $(ZIP) --best > $$CDIR/$(BINTAR); \
+	$(TAR) --format ustar -T $$CDIR/manifest -cf - | $(ZIP) --best --no-name > $$CDIR/$(BINTAR); \
 	echo "Created $(BINTAR)"
 
 include $(BUILDRULES)

--- a/man/html/diskperf/GNUmakefile
+++ b/man/html/diskperf/GNUmakefile
@@ -15,7 +15,7 @@ $(BINTAR): $(PCPLOGS) $(CONFIGS)
 	for f in `echo $^`; do \
 	    echo $(BUNDLE)/$$f >> $$CDIR/manifest; \
 	done; \
-	$(TAR) -T $$CDIR/manifest -cf - | $(ZIP) --best > $$CDIR/$(BINTAR); \
+	$(TAR) --format ustar -T $$CDIR/manifest -cf - | $(ZIP) --best --no-name > $$CDIR/$(BINTAR); \
 	echo "Created $(BINTAR)"
 
 include $(BUILDRULES)

--- a/man/html/pmie/GNUmakefile
+++ b/man/html/pmie/GNUmakefile
@@ -15,7 +15,7 @@ $(BINTAR): $(PCPLOGS) $(CONFIGS)
 	for f in `echo $^`; do \
 	    echo $(BUNDLE)/$$f >> $$CDIR/manifest; \
 	done; \
-	$(TAR) -T $$CDIR/manifest -cf - | $(ZIP) --best > $$CDIR/$(BINTAR); \
+	$(TAR) --format ustar -T $$CDIR/manifest -cf - | $(ZIP) --best --no-name > $$CDIR/$(BINTAR); \
 	echo "Created $(BINTAR)"
 
 include $(BUILDRULES)

--- a/man/html/pmview/GNUmakefile
+++ b/man/html/pmview/GNUmakefile
@@ -15,7 +15,7 @@ $(BINTAR): $(PCPLOGS) $(CONFIGS)
 	for f in `echo $^`; do \
 	    echo $(BUNDLE)/$$f >> $$CDIR/manifest; \
 	done; \
-	$(TAR) -T $$CDIR/manifest -cf - | $(ZIP) --best > $$CDIR/$(BINTAR); \
+	$(TAR) --format ustar -T $$CDIR/manifest -cf - | $(ZIP) --best --no-name > $$CDIR/$(BINTAR); \
 	echo "Created $(BINTAR)"
 
 include $(BUILDRULES)


### PR DESCRIPTION
tar's default pax/posix format stores ctime and atime that vary across builds.
ustar format works everywhere and creates more reproducible output.
gzip --no-name causes it to not store a 4-byte UNIX timestamp in .gz header (actually it stores 0)