### PR TITLE
[SELinux] Add generic policy rules to allow pcp_pmcd process to read system objects

### DIFF
--- a/src/selinux/pcpupstream.te.in
+++ b/src/selinux/pcpupstream.te.in
@@ -1,6 +1,8 @@
 module pcpupstream @PACKAGE_VERSION@;
 
 require {
+    attribute domain;
+    attribute file_type;
 	type pcp_pmcd_t;
 	type user_home_t;
 	type user_home_dir_t; #RHBZ1488116
@@ -462,3 +464,18 @@ allow pcp_pmcd_t self:capability sys_rawio;
 #============= pmda-redis ==============
 #type=AVC msg=audit(1533183330.416:362367): avc:  denied  { name_connect } for  pid=15299 comm="pmdaredis" dest=6379 scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:object_r:redis_port_t:s0 tclass=tcp_socket permissive=0
 allow pcp_pmcd_t redis_port_t:tcp_socket name_connect;
+
+# allow pcp_pmcd_t domain to read all dirs,files and fifo_file in attribute file_type
+files_list_non_auth_dirs(pcp_pmcd_t)
+files_read_all_files(pcp_pmcd_t)
+allow pcp_pmcd_t file_type:fifo_file read_fifo_file_perms;
+
+# allow pcp_pmcd_t domain to read shared memory and semaphores of all domain on system
+allow pcp_pmcd_t domain:shm r_sem_perms;
+allow pcp_pmcd_t domain:sem r_shm_perms;
+
+# allow pcp_pmcd_t domain stream connect to all domains
+allow pcp_pmcd_t domain:unix_stream_socket connectto;
+
+# allow pcp_pmcd_t domain to connect to all ports.
+corenet_tcp_connect_all_ports(pcp_pmcd_t)


### PR DESCRIPTION

allow pcp_pmcd_t domain to read all dirs,files and fifo_file in attribute file_type
allow pcp_pmcd_t domain to read shared memory and semaphores of all domain on system
allow pcp_pmcd_t domain stream connect to all domains
allow pcp_pmcd_t domain to connect to all ports.