### PR TITLE
pmwebd: tolerate live archives with multi-hour-old volumes

### DIFF
--- a/qa/1389
+++ b/qa/1389
@@ -1,0 +1,107 @@
+#! /bin/sh
+# PCP QA Test No. 1389
+# checks pmwebd graphite support for multi-volume archives
+#
+# Copyright (c) 2018 Red Hat.
+#
+seq=`basename $0`
+echo "QA output created by $seq"
+
+. ./common.webapi
+
+which curl >/dev/null 2>&1 || _notrun "No curl binary installed"
+
+$sudo rm -fr $tmp.dir
+$sudo rm -f $tmp.*
+rm -f $seq.full
+
+signal=$PCP_BINADM_DIR/pmsignal
+status=1	# failure is the default!
+username=`id -u -n`
+
+_cleanup()
+{
+    $sudo rm -fr $tmp.dir
+    $sudo rm -f $tmp.*
+    kill $pmlogger_pid 2>/dev/null
+    kill $pmwebd_pid 2>/dev/null
+}
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_filter_datapoints()
+{
+    sed -e 's/.datapoints.*$/DATAPOINTS]/g'
+}
+
+# real QA test starts here
+webport=44339   # not 44323, so system pmwebd is unaffected by test case
+webargs="-U $username -p $webport"
+
+echo
+echo "=== start pmlogger ===" | tee -a $seq.full
+
+mkdir -p -m 777 $tmp.dir   # 777: as pmlogger runs as uid=pcp
+cat > $tmp.dir/pmlogger.config <<EOF
+log mandatory on every 1 sec { simple.numfetch }
+EOF
+
+_start_up_pmlogger -c $tmp.dir/pmlogger.config -l $tmp.pmlogger.log $tmp.dir/archive # sets $pid
+pmlogger_pid=$pid
+pmsleep 5
+
+echo
+echo "=== create a few volumes ===" | tee -a $seq.full
+
+pmsleep 5
+$sudo $signal -s HUP $pid
+
+pmsleep 5
+$sudo $signal -s HUP $pid
+
+
+# Force super early mtimes, so as to trigger the pmwebd
+# freshness_ratio optimization.  In reality, the subject
+# phenomenon can be observed with a few hours' difference.
+
+touch -t 201801010001 $tmp.dir/archive.0
+touch -t 201801010001 $tmp.dir/archive.1
+
+ls -al $tmp.dir >> $seq.full
+
+echo
+echo "=== start pmwebd ===" | tee -a $seq.full
+
+$PCP_BINADM_DIR/pmwebd $webargs -GX -I -i 1 -A $tmp.dir -N -M8 -d1 -vvvvv -l $tmp.pmwebd.log &
+pmwebd_pid=$!
+_wait_for_pmwebd_logfile $tmp.pmwebd.log $webport
+
+echo
+echo "=== talk to pmwebd for a few minutes ===" | tee -a $seq.full
+
+url="http://localhost:$webport/graphite/render?format=json&target=*.simple.numfetch&from=-5s&until=now"
+
+curl -s -S "$url" | tee -a $seq.full | _filter_datapoints
+echo
+
+pmsleep 60   # pmgraphite.cxx ac_refresh_all() min_refresh_interval
+$sudo $signal -s HUP $pid; pmsleep 1.1
+curl -s -S "$url" | tee -a $seq.full | _filter_datapoints
+echo
+
+pmsleep 60
+$sudo $signal -s HUP $pid; pmsleep 1.1
+curl -s -S "$url" | tee -a $seq.full | _filter_datapoints
+echo
+
+echo
+echo "=== cleanup ===" | tee -a $seq.full
+
+grep . $tmp.*.log >> $seq.full
+
+$sudo $signal -s TERM $pmwebd_pid
+$sudo $signal -s TERM $pid
+_wait_pmlogger_end $pid
+_filter_pmlogger_log <$tmp.pmlogger.log
+
+status=0
+exit

--- a/qa/1389.out
+++ b/qa/1389.out
@@ -1,0 +1,26 @@
+QA output created by 1389
+
+=== start pmlogger ===
+
+=== create a few volumes ===
+
+=== start pmwebd ===
+
+=== talk to pmwebd for a few minutes ===
+[{"target":"archive.simple.numfetch", DATAPOINTS]
+[{"target":"archive.simple.numfetch", DATAPOINTS]
+[{"target":"archive.simple.numfetch", DATAPOINTS]
+
+=== cleanup ===
+Log for pmlogger on HOST started DATE
+
+Config parsed
+Starting logger for host "HOST"
+Archive basename: ARCHIVE
+New log volume 1, via SIGHUP at DATE
+New log volume 2, via SIGHUP at DATE
+New log volume 3, via SIGHUP at DATE
+New log volume 4, via SIGHUP at DATE
+pmlogger: Caught signal 15, exiting
+
+Log finished DATE

--- a/qa/group
+++ b/qa/group
@@ -1620,6 +1620,7 @@ BAD
 1383 pmlogrewrite labels pmdumplog local
 1385 pmda.prometheus local python
 1388 pmwebd local
+1389 pmwebd local
 1395 pmda.prometheus local python
 1396 pcp python pidstat local BAD @vm34
 1397 pmda.smart local valgrind


### PR DESCRIPTION
Prior to this patch, it was observed that in a live (being written-to)
multi-volume archive, pmwebd would stop looking for the last volume#
too early.  The timestamp on that wrong "last" volume is used in a
subsequent freshness heuristic.  Because the actual last volume file
may not be found during the search, pmwebd could be temporarily blind
to newer data available in newer volumes of the same archive,
returning falsely empty results.  This patch improves this volume
enumeration logic to find the last one, via an explicit loop.  This
leaves pmwebd with a max-60-second blind spot for fresh values.

qa/1389 tests with a pmlogger with HUP-triggered volume switching, and
an explicit /bin/touch to simulate longer-running previous volumes.