### PR TITLE
pmda: perfevent: Add support for raw perf events

### DIFF
--- a/qa/756.out
+++ b/qa/756.out
@@ -129,4 +129,7 @@ PMU : software
  ===== test_parse_hv_24x7_dynamic_events ==== 
 event = pmu1.bar chip value = 0
 event = pmu1.foo chip value = -1
+ ===== test_parse_raw_events ==== 
+event = RAW:bar raw code = 0x1
+event = RAW:foo raw code = 0x0
 Unit tests Passed

--- a/qa/perfevent/config/test_raw_events.txt
+++ b/qa/perfevent/config/test_raw_events.txt
@@ -1,0 +1,3 @@
+[raw]
+RAW:foo
+RAW:bar rawcode=0x0001

--- a/qa/perfevent/perf_event_test.c
+++ b/qa/perfevent/perf_event_test.c
@@ -1071,6 +1071,26 @@ void test_parse_hv_24x7_dynamic_events(void)
     }
 }
 
+void test_parse_raw_events(void)
+{
+    struct pmcsetting *pmctmp;
+    configuration_t *config;
+    const char *configfile = "config/test_raw_events.txt";
+
+    config = parse_configfile(configfile);
+    assert(config != NULL);
+    printf(" ===== %s ==== \n", __FUNCTION__);
+    assert(config->configArr != NULL);
+    assert((pmctmp = config->configArr->pmcSettingList) != NULL);
+    assert(!strcmp(pmctmp->name, "RAW:bar"));
+    assert(pmctmp->rawcode == 0x1);
+    printf("event = %s raw code = 0x%lx\n", pmctmp->name, pmctmp->rawcode);
+    assert((pmctmp = pmctmp->next) != NULL);
+    assert(!strcmp(pmctmp->name, "RAW:foo"));
+    assert(pmctmp->rawcode == 0x0);
+    printf("event = %s raw code = 0x%lx\n", pmctmp->name, pmctmp->rawcode);
+}
+
 int runtest(int n)
 {
     init_mock();
@@ -1176,6 +1196,10 @@ int runtest(int n)
 	    break;
 	case 32:
 	    test_parse_hv_24x7_dynamic_events();
+	    break;
+        case 33:
+            test_parse_raw_events();
+            break;
         default:
             ret = -1;
     }

--- a/src/pmdas/perfevent/configparser.h
+++ b/src/pmdas/perfevent/configparser.h
@@ -37,6 +37,7 @@ typedef struct pmcsetting {
     double scale;    /* Currently, only used by derived events */
     int need_perf_scale;  /* Currently, only used by derived events */
     int chip;	/* Currently, only used by hv_24x7 dynamic events */
+    unsigned long rawcode;  /* Currently, only used by raw events */
     struct pmcsetting *next;
 } pmcsetting_t; 
 

--- a/src/pmdas/perfevent/configparser.l
+++ b/src/pmdas/perfevent/configparser.l
@@ -272,7 +272,7 @@ static void add_pmcsetting_name(configuration_t *config, char *name)
 
     entry = &config->configArr[config->nConfigEntries-1];
 
-    newpmcsetting = malloc(sizeof *newpmcsetting);
+    newpmcsetting = calloc(1, sizeof *newpmcsetting);
     newpmcsetting->name = strdup(name);
     newpmcsetting->cpuConfig = CPUCONFIG_EACH_CPU;
     newpmcsetting->next = entry->pmcSettingList;
@@ -382,6 +382,21 @@ static void set_pmcsetting_chip(configuration_t *config, char *chip)
 
 	pmcsetting->chip = atoi(chip);
     }
+}
+
+static void set_pmcsetting_rawcode(configuration_t *config,
+                                   unsigned long rawcode)
+{
+    pmcsetting_t *pmcsetting;
+
+    if (!config || !config->nConfigEntries || context_derived || context_dynamic)
+        return;
+
+    pmcsetting = config->configArr[config->nConfigEntries-1].pmcSettingList;
+    if (!pmcsetting)
+        return;
+
+    pmcsetting->rawcode = rawcode;
 }
 
 #ifdef DEBUG_PRINT_CONFIG
@@ -529,6 +544,7 @@ node_rr       set_pmcsetting_cpuconfig(yyextra, CPUCONFIG_ROUNDROBIN_NUMANODE);
 perf_scale    set_pmcsetting_derived_scale(yyextra, strtod(yytext, NULL), 1);
 ([0-9]*\.[0-9]+([eE][-+]?[0-9]+)?)  set_pmcsetting_derived_scale(yyextra, strtod(yytext, NULL), 0);
 (chip:)[0-9]*	set_pmcsetting_chip(yyextra, &yytext[5]);
+rawcode\=0x([0-9a-fA-F]+)           set_pmcsetting_rawcode(yyextra, strtoul(yytext+10, NULL, 16));
 }
 
 <*>.|\n { fprintf(stderr, "Syntax error on line: %d \n", yylineno); return -1; }

--- a/src/pmdas/perfevent/perfevent.conf
+++ b/src/pmdas/perfevent/perfevent.conf
@@ -48,6 +48,16 @@
 # only one group will be activated ("||" is the group separator).
 # First group with all the events available will be activated.
 #
+#
+# Typically, users can specify perf events using just the event name but
+# in case the event name is not identified by libpfm, they can directly
+# specify the raw event code in the following format:
+#   RAW:EVENT_NAME rawcode=[RAW_EVENT_CODE]
+# where the RAW_EVENT_CODE is a hexadecimal event code
+# It should be noted that the raw event codes are heavily architecture
+# dependent and their meanings might also vary across revisions of the
+# same architecture.
+#
 
 [amd64_fam10h_barcelona amd64_fam10h_shanghai amd64_fam10h_istanbul]
 

--- a/src/pmdas/perfevent/perfinterface.c
+++ b/src/pmdas/perfevent/perfinterface.c
@@ -523,7 +523,8 @@ static int perf_setup_derived_event(perfdata_t *inst, pmcderived_t *derived_pmc)
 
 /* Setup an event
  */
-static int perf_setup_event(perfdata_t *inst, const char *eventname, const int cpuSetting)
+static int perf_setup_event(perfdata_t *inst, const char *eventname,
+                            unsigned long eventcode, const int cpuSetting)
 {
     int i;
     int ncpus, ret;
@@ -607,6 +608,25 @@ static int perf_setup_event(perfdata_t *inst, const char *eventname, const int c
                 continue;
             }
 
+        } else if (!strncmp(eventname, "RAW:", 4)) {
+            info->type = EVENT_TYPE_PERF;
+
+            memset(&info->hw, 0, sizeof(info->hw));
+            info->hw.type = PERF_TYPE_RAW;
+            info->hw.size = sizeof(info->hw);
+            info->hw.config = eventcode;
+            info->hw.read_format = PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING;
+            info->hw.exclude_hv = 1;
+            info->hw.exclude_guest = 1;
+            info->hw.disabled = 1;
+            info->fd = perf_event_open(&info->hw, -1, info->cpu, -1, 0);
+
+            if (info->fd == -1) {
+                fprintf(stderr, "perf_event_open failed on cpu%d for \"%s\": %s\n",
+                        info->cpu, curr->name, strerror(errno));
+                free_eventcpuinfo(info);
+                continue;
+            }
         } else {
 
             info->type = EVENT_TYPE_PERF;
@@ -1219,7 +1239,9 @@ perfhandle_t *perf_event_create(const char *config_file)
 
     while(pmcsetting)
     {
-        (void) perf_setup_event(inst, pmcsetting->name, pmcsetting->cpuConfig);
+        (void) perf_setup_event(inst, pmcsetting->name, pmcsetting->rawcode,
+                                pmcsetting->cpuConfig);
+
         pmcsetting = pmcsetting->next;
     }
 


### PR DESCRIPTION
This adds support for using perf events which might not be exposed via standard mechanisms such as `sysfs` or `libpfm`. The alternative way to access these hardware counters is by using the architecture
dependent raw event codes directly.

Raw events can be specified in the perfevent configuration using the following syntax:
```
  RAW:[EVENT_NAME] rawcode=[RAW_EVENT_CODE]
```

E.g.
```
  $ tail -n 1 /var/lib/pcp/pmdas/perfevent/perfevent.conf
  RAW:foo rawcode=0x1e

  $ pminfo | grep foo
  perfevent.hwcounters.RAW_foo.dutycycle
  perfevent.hwcounters.RAW_foo.value
```