### PR TITLE
pmchart.desktop: standards require a ";" at end of Categories field

### DIFF
--- a/src/pmchart/pmchart.desktop
+++ b/src/pmchart/pmchart.desktop
@@ -5,4 +5,4 @@ Exec=pmchart
 Icon=pmchart
 Terminal=false
 Type=Application
-Categories=System
+Categories=System;


### PR DESCRIPTION
Merging Frank's XDG desktop categories fix