### PR TITLE
pmwebd: drop /dev/tty diagnostics copying from pmwebd

### DIFF
--- a/src/pmwebd/main.cxx
+++ b/src/pmwebd/main.cxx
@@ -42,7 +42,6 @@ unsigned multithread = 0;       /* set by -M option */
 unsigned graphite_timestep = 60;  /* set by -i option */
 unsigned graphite_hostcache = 0; /* set by -J option */
 string logfile = "";		/* set by -l option */
-string fatalfile = "/dev/tty";	/* fatal messages at startup go here */
 
 
 
@@ -311,22 +310,6 @@ static void
 pmweb_dont_start (void)
 {
     timestamp (cerr) << "pmwebd not started due to errors!" << endl;
-
-    ofstream tty (fatalfile.c_str ());
-    if (tty.good ()) {
-        timestamp (tty) << "NOTE: pmwebd not started due to errors!" << endl;
-
-        // copy logfile to tty, if it was specified
-        if (logfile != "") {
-            tty << "Log file \"" << logfile << "\" contains ..." << endl;
-            ifstream log (logfile.c_str ());
-            if (log.good ()) {
-                tty << log.rdbuf ();
-            } else {
-                tty << "Log file \"" << logfile << "\" has vanished ..." << endl;
-            }
-        }
-    }
     exit (1);
 }
 
@@ -510,7 +493,6 @@ longopts[] = {
 #endif
     {"dumpstats", 1, 'd', 0, "dump client stats roughly every N seconds [default 300]"},
     {"username", 1, 'U', "USER", "decrease privilege from root to user [default pcp]"},
-    {"", 1, 'x', "PATH", "fatal messages at startup sent to file [default /dev/tty]"},
     PMOPT_HELP,
     PMAPI_OPTIONS_END
 };
@@ -700,7 +682,7 @@ main (int argc, char *argv[])
             break;
 
         case 'x':
-            fatalfile = opts.optarg;
+            /* ignore obsolete option */
             break;
         }
     }

--- a/src/pmwebd/main.cxx
+++ b/src/pmwebd/main.cxx
@@ -1,7 +1,7 @@
 /*
  * JSON web bridge for PMAPI.
  *
- * Copyright (c) 2011-2017 Red Hat.
+ * Copyright (c) 2011-2018 Red Hat.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the

--- a/src/pmwebd/pmwebd.1
+++ b/src/pmwebd/pmwebd.1
@@ -38,7 +38,6 @@
 [\f3\-S\f1]
 [\f3\-l\f1 \f2logfile\f1]
 [\f3\-U\f1 \f2username\f1]
-[\f3\-x\f1 \f2file\f1]
 [\f3\-v\f1]
 [\f3\-?\f1]
 .SH DESCRIPTION
@@ -220,18 +219,6 @@ will advertise its presence on the network using any available
 mechanisms (such as Avahi/DNS-SD), assisting remote monitoring
 tools with finding it.
 These mechanisms are disabled with this option.
-.TP
-\f3\-x\f1 \f2file\f1
-Before the
-.B pmwebd
-.I logfile
-can be opened,
-.B pmwebd
-may encounter a fatal error which prevents it from starting.  By default, the
-output describing this error is sent to
-.B /dev/tty
-but it may redirected to
-.IR file .
 .TP
 \f3\-v\f1
 Increase the verbosity of


### PR DESCRIPTION
Disable pmwebd -x option.

issue #412 