### PR TITLE
pmwebd: add -r NUM option to retain open archive contexts

### DIFF
--- a/src/pmwebd/main.cxx
+++ b/src/pmwebd/main.cxx
@@ -1,7 +1,7 @@
 /*
  * JSON web bridge for PMAPI.
  *
- * Copyright (c) 2011-2017 Red Hat.
+ * Copyright (c) 2011-2018 Red Hat.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -487,6 +487,7 @@ longopts[] = {
     {"graphite", 0, 'G', 0, "enable graphite 0.9 API/backend emulation"},
     {"graphite-noencode", 0, 'X', 0, "don't encode special characters that are now allowed by graphite"},
     {"graphite-timestamp", 1, 'i', "SEC", "minimum graphite timestep (s) [default 60]"},
+    {"graphite-retain", 1, 'r', "NUM", "number of graphite archives to keep open [default 1]"},
     {"graphite-archivedir", 0, 'I', 0, "prefer archive directories [default OFF]"},
     {"graphite-host", 0, 'J', 0, "prefer hostname as metric component [default OFF]"},
     PMAPI_OPTIONS_HEADER ("Context options"),
@@ -543,7 +544,7 @@ main (int argc, char *argv[])
     pmGetUsername (&username_str);
     __pmServerSetFeature (PM_SERVER_FEATURE_DISCOVERY);
 
-    opts.short_options = "A:a:c:CD:h:Ll:NM:Pp:R:GJi:It:U:vx:d:SX46?";
+    opts.short_options = "A:a:c:CD:h:Ll:NM:Pp:R:r:GJi:It:U:vx:d:SX46?";
     opts.long_options = longopts;
     opts.override = option_overrides;
 
@@ -571,6 +572,10 @@ main (int argc, char *argv[])
 
         case 'R':
             resourcedir = opts.optarg;
+            break;
+
+        case 'r':
+            max_retained_archive_contexts = (unsigned) atoi(opts.optarg);
             break;
 
         case 'G':

--- a/src/pmwebd/pmwebapi.h
+++ b/src/pmwebd/pmwebapi.h
@@ -72,6 +72,7 @@ extern unsigned multithread;			/* set by -M option */
 extern unsigned graphite_timestep;              /* set by -i option */
 extern unsigned graphite_hostcache;             /* set by -J option */
 extern unsigned graphite_encode;                /* set by -X option */
+extern unsigned max_retained_archive_contexts;  /* set by -r option */
 
 struct http_params: public std::multimap <std::string, std::string> {
     std::string operator [] (const std::string &) const;

--- a/src/pmwebd/pmwebd.1
+++ b/src/pmwebd/pmwebd.1
@@ -35,6 +35,7 @@
 [\f3\-J\f1
 [\f3\-K\f1 \f2spec\f1]
 [\f3\-A\f1 \f2archivesdir\f1]
+[\f3\-r\f1 \f2number\f1]
 [\f3\-S\f1]
 [\f3\-l\f1 \f2logfile\f1]
 [\f3\-U\f1 \f2username\f1]
@@ -128,6 +129,14 @@ The default is 60.  Smaller values give higher precision (but not
 necessarily accuracy) data, but may cost extra processing time at
 .B pmwebd
 or the web browser; and vice versa.
+.TP
+\f3\-r\f1 \f2number\f1
+When serving graphite time series queries, pmwebd must frequently
+reopen archive files.  For some times of files (e.g., huge .meta),
+this can reopening can take many seconds.  pmwebd can optionally
+retain \f2number\f1 open archives for quick reopening.  This trades
+memory for time and I/O, so no single setting is ideal.  The default
+is 1.
 .TP
 \f3\-J\f1
 When constructing graphite metric names, use the stored \f2hostname\f1

--- a/src/pmwebd/pmwebd.options
+++ b/src/pmwebd/pmwebd.options
@@ -15,6 +15,9 @@ OPTIONS="$OPTIONS -R $PCP_SHARE_DIR/webapps -A $PCP_LOG_DIR -G -X"
 # Use _-canonicalized hostnames as the first component of graphite metrics.
 OPTIONS="$OPTIONS -J"
 
+# Retain a cache of open archive contexts
+# OPTIONS="$OPTIONS -r 10"
+
 # Assume identity of some user other than "pcp"
 # OPTIONS="$OPTIONS -U nobody"
 


### PR DESCRIPTION
This option permits pmwebd to avoid incurring potentially long libpcp
delays when opening archive contexts, by keeping some number of them
open.  This is done on an LRU basis, and governed by a new "-r NUM"
option.  This makes a huge difference on archives with O(4GB) .meta
files, such as reported on RHBZ1619708.