### PR TITLE
pmwebd issues/580: tolerate empty prometheus metrics query

### DIFF
--- a/src/pmwebd/pmwebapi.cxx
+++ b/src/pmwebd/pmwebapi.cxx
@@ -1160,6 +1160,10 @@ metric_prometheus_batch_fetch(void *closure) {
     struct metric_prometheus_traverse_closure *mptc = (struct metric_prometheus_traverse_closure *)
             closure;
     int rc;
+
+    if (mptc->pmids.size() == 0) // no metrics found?  no soup for you
+        return;
+
     struct webcontext *c = mptc->c;
     pmResult *result;
     rc = pmFetch (mptc->pmids.size(), &mptc->pmids[0], &result);


### PR DESCRIPTION
Previous code could crash on http://localhost:PORT/pmapi/1/metrics
sans the ?target=FOO querystrings.