### PR TITLE
offer systemd timers as an alternative to crontab

### DIFF
--- a/qa/255
+++ b/qa/255
@@ -15,7 +15,7 @@ echo "QA output created by $seq"
 . ./common.filter
 . ./common.check
 
-_check_cron
+_check_job_scheduler
 [ -d $PCP_PMDAS_DIR/simple ] || _notrun "simple PMDA directory is not installed"
 
 rm -f $seq.out
@@ -138,11 +138,8 @@ _cleanup()
 	echo '=== pmcd log' >>$seq.full
 	cat $tmp.log >>$seq.full
     fi
-    if [ -f $tmp.cron ]
-    then
-	echo "=== Restoring crontab ==="
-    	_restore_cron $tmp.cron $sudo
-    fi
+    echo "=== Restoring crontab ==="
+    _restore_job_scheduler $tmp.cron $tmp.systemd $sudo
     [ -f $PCP_PMDAS_DIR/simple/simple.conf.$seq ] && $sudo mv $PCP_PMDAS_DIR/simple/simple.conf.$seq $PCP_PMDAS_DIR/simple/simple.conf
 
     echo "=== /tmp files" >>$seq.full
@@ -154,10 +151,10 @@ _cleanup()
     _wait_for_pmlogger
 }
 
-# Removing cron entries that may collide
+# Removing systemd timers or cron entries that may collide
 #
 echo "=== Removing potential cron conflicts ==="
-_remove_cron $tmp.cron $sudo
+_remove_job_scheduler $tmp.cron $tmp.systemd $sudo
 
 # Install broken pmda namespace
 #

--- a/qa/common.check
+++ b/qa/common.check
@@ -1617,8 +1617,8 @@ _remove_cron()
     then
 	:
     else
-	# error, make sure the backup is empty so no changes are made
-	echo >$rc_backup
+	# error, remove the backup file so no changes are made
+	rm -f $rc_backup
     fi
 
     if [ -s $rc_backup ]

--- a/qa/common.check
+++ b/qa/common.check
@@ -1600,30 +1600,46 @@ EOF
   fi
 }
 
-# comment pmlogger_check and pmsnap entries in the crontab file
-# (also cron.pmcheck and cron.pmsnap entries for backwards compatibility)
-# Usage: _remove_cron backup sudo
+# disable systemd timers and / or comment pmlogger_check and pmsnap entries in
+# the crontab file (also cron.pmcheck and cron.pmsnap entries for backwards
+# compatibility)
+# Usage: _remove_job_scheduler cron_backup systemd_state sudo
 #
-# backup - where to keep the old crontab file
+# cron_backup - where to keep the old crontab file
+# systemd_state - where to keep systemd timer state
 # sudo - location of sudo
 #
-_remove_cron()
+_remove_job_scheduler()
 {
-    rc_backup=${1:-crontab}
-    rc_sudo=${2:-sudo}
+    rc_cron_backup=${1:-crontab}
+    rc_systemd_state=${2:-systemd.state}
+    rc_sudo=${3:-sudo}
 
-    $rc_sudo rm -f $rc_backup
-    if $rc_sudo crontab -l 2>/dev/null >$rc_backup
+    $rc_sudo rm -f $rc_cron_backup $rc_systemd_state
+
+    if systemctl cat pmie_daily.timer >/dev/null 2>&1; then
+	for i in pmie_daily.timer pmie_check.timer pmlogger_daily.timer \
+		pmlogger_daily_poll.timer pmlogger_daily_check.timer \
+		pmlogger_daily_report.timer pmlogger_daily_report_poll.timer; do
+	    $rc_sudo systemctl is-active "$i" > /dev/null || continue
+	    $rc_sudo systemctl stop $i >/dev/null
+	    echo "$i" >> $rc_systemd_state
+	done
+    fi
+
+    which crontab >/dev/null 2>&1 || return	# systemd timers only
+
+    if $rc_sudo crontab -l 2>/dev/null >$rc_cron_backup
     then
 	:
     else
 	# error, remove the backup file so no changes are made
-	rm -f $rc_backup
+	rm -f $rc_cron_backup
     fi
 
-    if [ -s $rc_backup ]
+    if [ -s $rc_cron_backup ]
     then
-	$rc_sudo cat $rc_backup \
+	$rc_sudo cat $rc_cron_backup \
 	| sed \
 	    -e 's/^[^#].*pmlogger_check/#&/' \
 	    -e 's/^[^#].*pmsnap/#&/' \
@@ -1633,34 +1649,43 @@ _remove_cron()
     fi
 }
 
-# restore crontab back to original state
-# Usage: _restore_cron backup sudo
+# restore systemd timers and / or crontab back to original state
+# Usage: _restore_job_scheduler cron_backup systemd_state sudo
 #
-# backup - where to keep the old crontab file
+# cron_backup - where to keep the old crontab file
+# systemd_state - where to keep systemd timer state
 # sudo - location of sudo
 #
-_restore_cron()
+_restore_job_scheduler()
 {
-    rc_backup=${1:-crontab}
-    rc_sudo=${2:-sudo}
+    rc_cron_backup=${1:-crontab}
+    rc_systemd_state=${2:-systemd.state}
+    rc_sudo=${3:-sudo}
 
-    if [ -s $rc_backup ]
+    if [ -s $rc_systemd_state ]; then
+	for i in $(cat $rc_systemd_state); do
+	    $rc_sudo systemctl start $i >/dev/null
+	done
+	rm -f $rc_systemd_state
+    fi
+
+    if [ -s $rc_cron_backup ]
     then
 	$rc_sudo rm -f rc_cron_out rc_cron_check rc_cron_diff
-	if $rc_sudo crontab $rc_backup >rc_cron_out 2>&1
+	if $rc_sudo crontab $rc_cron_backup >rc_cron_out 2>&1
 	then
 	    # check everything is OK
 	    #
 	    $rc_sudo crontab -l >rc_cron_check
-	    sed -e '/^#/d' $rc_backup >$rc_backup.clean
+	    sed -e '/^#/d' $rc_cron_backup >$rc_cron_backup.clean
 	    sed -e '/^#/d' rc_cron_check >rc_cron_check.clean
-	    if diff -u $rc_backup.clean rc_cron_check.clean >rc_cron_diff 2>&1
+	    if diff -u $rc_cron_backup.clean rc_cron_check.clean >rc_cron_diff 2>&1
 	    then
 		:
 	    else
 		echo "_restore_cron: Warning: could not restore crontab to original state"
 		echo "               Unexpected differences ..."
-		diff -u $rc_backup rc_cron_check
+		diff -u $rc_cron_backup rc_cron_check
 	    fi
 	    $rc_sudo rm -f rc_cron_check rc_cron_check.clean rc_cron_diff
 	else
@@ -1673,11 +1698,12 @@ _restore_cron()
 }
 
 # running QA within a container can mean no crontab setup;
-# _check_cron is a convenience routine checking the external
-# dependencies of _remove_cron() and _restore_cron()
+# _check_job_scheduler() is a convenience routine checking the external
+# dependencies of _remove_job_scheduler() and _restore_job_scheduler()
 #
-_check_cron()
+_check_job_scheduler()
 {
+    systemctl cat pmie_daily.timer >/dev/null 2>&1 && return
     which crontab >/dev/null 2>&1 || _notrun "No crontab binary found"
 }
 

--- a/src/pmie/.gitignore
+++ b/src/pmie/.gitignore
@@ -1,3 +1,5 @@
 crontab
 crontab.docker
 pmie.service
+pmie_check.service
+pmie_daily.service

--- a/src/pmie/GNUmakefile
+++ b/src/pmie/GNUmakefile
@@ -18,7 +18,7 @@ include $(TOPDIR)/src/include/builddefs
 
 SUBDIRS	= src examples
 OTHERS  = control stomp rc_pmie pmie2col.sh pmie_check.sh pmie_daily.sh
-LDIRT	= crontab crontab.docker pmie.service
+LDIRT	= crontab crontab.docker pmie.service pmie_daily.service pmie_check.service
 
 ifeq ($(TARGET_OS),linux)
 CRONTAB_USER = $(PCP_USER)
@@ -28,7 +28,7 @@ CRONTAB_USER =
 CRONTAB_PATH = $(PCP_SYSCONF_DIR)/pmie/crontab
 endif
 
-default:: crontab crontab.docker pmie.service
+default:: crontab crontab.docker pmie.service pmie_daily.service pmie_check.service
 
 default:: $(SUBDIRS)
 	$(SUBDIRS_MAKERULE)
@@ -50,6 +50,13 @@ endif
 	$(INSTALL) -m 755 rc_pmie $(PCP_RC_DIR)/pmie
 ifeq ($(ENABLE_SYSTEMD),true)
 	$(INSTALL) -m 644 pmie.service $(PCP_SYSTEMDUNIT_DIR)/pmie.service
+	$(INSTALL) -m 644 pmie_daily.timer $(PCP_SYSTEMDUNIT_DIR)/pmie_daily.timer
+	$(INSTALL) -m 644 pmie_daily.service $(PCP_SYSTEMDUNIT_DIR)/pmie_daily.service
+	$(INSTALL) -m 644 pmie_check.timer $(PCP_SYSTEMDUNIT_DIR)/pmie_check.timer
+	$(INSTALL) -m 644 pmie_check.service $(PCP_SYSTEMDUNIT_DIR)/pmie_check.service
+else
+	$(INSTALL) -m 755 -d `dirname $(CRONTAB_PATH)`
+	$(INSTALL) -m 644 crontab $(CRONTAB_PATH)
 endif
 	$(INSTALL) -m 775 -o $(PCP_USER) -g $(PCP_GROUP) -d $(PCP_LOG_DIR)/pmie
 	$(INSTALL) -m 775 -o $(PCP_USER) -g $(PCP_GROUP) -d $(PCP_TMP_DIR)/pmie
@@ -57,9 +64,7 @@ ifeq ($(TARGET_OS),linux)
 	# In a Docker container environment, the rc_pmie script installs the
 	# Docker version of the crontab into the hosts /etc/cron.d directory.
 	$(INSTALL) -m 644 crontab.docker $(PCP_VAR_DIR)/config/pmie/crontab.docker
-	$(INSTALL) -m 755 -d `dirname $(CRONTAB_PATH)`
 endif
-	$(INSTALL) -m 644 crontab $(CRONTAB_PATH)
 
 include $(BUILDRULES)
 
@@ -71,6 +76,18 @@ pmie.service : pmie.service.in
 	$(SED) <$< >$@ \
 	    -e 's;@PCP_RC_DIR@;'$(PCP_RC_DIR)';' \
 	    -e 's;@PCP_RUN_DIR@;'$(PCP_RUN_DIR)';' \
+	# END
+
+pmie_check.service : pmie_check.service.in
+	$(SED) <$< >$@ \
+	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
+	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
+	# END
+
+pmie_daily.service : pmie_daily.service.in
+	$(SED) <$< >$@ \
+	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
+	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	# END
 
 crontab: crontab.in

--- a/src/pmie/GNUmakefile
+++ b/src/pmie/GNUmakefile
@@ -54,6 +54,7 @@ ifeq ($(ENABLE_SYSTEMD),true)
 	$(INSTALL) -m 644 pmie_daily.service $(PCP_SYSTEMDUNIT_DIR)/pmie_daily.service
 	$(INSTALL) -m 644 pmie_check.timer $(PCP_SYSTEMDUNIT_DIR)/pmie_check.timer
 	$(INSTALL) -m 644 pmie_check.service $(PCP_SYSTEMDUNIT_DIR)/pmie_check.service
+	$(INSTALL) -m 644 pmie_timers.sysconfig $(PCP_SYSCONFIG_DIR)/pmie_timers
 else
 	$(INSTALL) -m 755 -d `dirname $(CRONTAB_PATH)`
 	$(INSTALL) -m 644 crontab $(CRONTAB_PATH)
@@ -81,6 +82,7 @@ pmie.service : pmie.service.in
 pmie_check.service : pmie_check.service.in
 	$(SED) <$< >$@ \
 	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
+	    -e 's;@PCP_SYSCONFIG_DIR@;'$(PCP_SYSCONFIG_DIR)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	# END
@@ -88,6 +90,7 @@ pmie_check.service : pmie_check.service.in
 pmie_daily.service : pmie_daily.service.in
 	$(SED) <$< >$@ \
 	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
+	    -e 's;@PCP_SYSCONFIG_DIR@;'$(PCP_SYSCONFIG_DIR)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	# END

--- a/src/pmie/GNUmakefile
+++ b/src/pmie/GNUmakefile
@@ -80,12 +80,14 @@ pmie.service : pmie.service.in
 
 pmie_check.service : pmie_check.service.in
 	$(SED) <$< >$@ \
+	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	# END
 
 pmie_daily.service : pmie_daily.service.in
 	$(SED) <$< >$@ \
+	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	# END

--- a/src/pmie/pmie_check.service.in
+++ b/src/pmie/pmie_check.service.in
@@ -5,5 +5,7 @@ ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=oneshot
-ExecStart=@PCP_BINADM_DIR@/pmie_check -C
+Environment=PMIE_CHECK_PARAMS="-C"
+EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmie_timers
+ExecStart=@PCP_BINADM_DIR@/pmie_check ${PMIE_CHECK_PARAMS}
 User=@PCP_USER@

--- a/src/pmie/pmie_check.service.in
+++ b/src/pmie/pmie_check.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Check PMIE instances are running
 Documentation=man:pmie(1)
+ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=oneshot

--- a/src/pmie/pmie_check.service.in
+++ b/src/pmie/pmie_check.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Check PMIE instances are running
+Documentation=man:pmie(1)
+
+[Service]
+Type=oneshot
+ExecStart=@PCP_BINADM_DIR@/pmie_check -C
+User=@PCP_USER@

--- a/src/pmie/pmie_check.timer
+++ b/src/pmie/pmie_check.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Half-hourly check of PMIE instances
+
+[Timer]
+OnCalendar=*-*-* *:28:00
+OnCalendar=*-*-* *:58:00
+
+[Install]
+WantedBy=timers.target
+

--- a/src/pmie/pmie_daily.service.in
+++ b/src/pmie/pmie_daily.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Process PMIE logs
+Documentation=man:pmie(1)
+
+[Service]
+Type=oneshot
+ExecStart=@PCP_BINADM_DIR@/pmie_daily -X xz -x 3
+User=@PCP_USER@

--- a/src/pmie/pmie_daily.service.in
+++ b/src/pmie/pmie_daily.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Process PMIE logs
 Documentation=man:pmie(1)
+ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=oneshot

--- a/src/pmie/pmie_daily.service.in
+++ b/src/pmie/pmie_daily.service.in
@@ -5,5 +5,7 @@ ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=oneshot
-ExecStart=@PCP_BINADM_DIR@/pmie_daily -X xz -x 3
+Environment=PMIE_DAILY_PARAMS="-X xz -x 3"
+EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmie_timers
+ExecStart=@PCP_BINADM_DIR@/pmie_daily ${PMIE_DAILY_PARAMS}
 User=@PCP_USER@

--- a/src/pmie/pmie_daily.timer
+++ b/src/pmie/pmie_daily.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Daily processing of PMIE logs
+
+[Timer]
+OnCalendar=*-*-* 00:08:00
+
+[Install]
+WantedBy=timers.target

--- a/src/pmie/pmie_timers.sysconfig
+++ b/src/pmie/pmie_timers.sysconfig
@@ -1,0 +1,15 @@
+## Type:        string
+## Default:	"-C"
+#
+# Run the pmie_check binary, via pmie_check.service, with the following
+# parameters.
+#
+#PMIE_CHECK_PARAMS=""
+
+## Type:        string
+## Default:	"-X xz -x 3"
+#
+# Run the pmie_daily binary, via pmie_daily.service, with the following
+# parameters.
+#
+#PMIE_DAILY_PARAMS=""

--- a/src/pmlogger/.gitignore
+++ b/src/pmlogger/.gitignore
@@ -4,3 +4,8 @@ crontab.daily_report
 gram.tab.h
 pmlogger
 pmlogger.service
+pmlogger_daily.service
+pmlogger_daily_check.service
+pmlogger_daily_poll.service
+pmlogger_daily_report.service
+pmlogger_daily_report_poll.service

--- a/src/pmlogger/GNUmakefile
+++ b/src/pmlogger/GNUmakefile
@@ -70,6 +70,7 @@ ifeq ($(ENABLE_SYSTEMD),true)
 	$(INSTALL) -m 644 pmlogger_daily_report.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily_report.service
 	$(INSTALL) -m 644 pmlogger_daily_report_poll.timer $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily_report_poll.timer
 	$(INSTALL) -m 644 pmlogger_daily_report_poll.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily_report_poll.service
+	$(INSTALL) -m 644 pmlogger_timers.sysconfig $(PCP_SYSCONFIG_DIR)/pmlogger_timers
 else
 	$(INSTALL) -m 755 -d `dirname $(CRONTAB_PATH)`
 	$(INSTALL) -m 644 crontab $(CRONTAB_PATH)
@@ -101,6 +102,7 @@ pmlogger.service : pmlogger.service.in
 pmlogger_daily.service : pmlogger_daily.service.in
 	$(SED) <$< >$@ \
 	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
+	    -e 's;@PCP_SYSCONFIG_DIR@;'$(PCP_SYSCONFIG_DIR)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	# END
@@ -108,6 +110,7 @@ pmlogger_daily.service : pmlogger_daily.service.in
 pmlogger_daily_poll.service : pmlogger_daily_poll.service.in
 	$(SED) <$< >$@ \
 	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
+	    -e 's;@PCP_SYSCONFIG_DIR@;'$(PCP_SYSCONFIG_DIR)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	# END
@@ -115,6 +118,7 @@ pmlogger_daily_poll.service : pmlogger_daily_poll.service.in
 pmlogger_daily_check.service : pmlogger_daily_check.service.in
 	$(SED) <$< >$@ \
 	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
+	    -e 's;@PCP_SYSCONFIG_DIR@;'$(PCP_SYSCONFIG_DIR)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	# END
@@ -122,6 +126,7 @@ pmlogger_daily_check.service : pmlogger_daily_check.service.in
 pmlogger_daily_report.service : pmlogger_daily_report.service.in
 	$(SED) <$< >$@ \
 	    -e 's;@CRONTAB_DAILY_REPORT_PATH@;'$(CRONTAB_DAILY_REPORT_PATH)';' \
+	    -e 's;@PCP_SYSCONFIG_DIR@;'$(PCP_SYSCONFIG_DIR)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	    -e 's;@PCP_SA_DIR@;'$(PCP_SA_DIR)';' \
@@ -130,6 +135,7 @@ pmlogger_daily_report.service : pmlogger_daily_report.service.in
 pmlogger_daily_report_poll.service : pmlogger_daily_report_poll.service.in
 	$(SED) <$< >$@ \
 	    -e 's;@CRONTAB_DAILY_REPORT_PATH@;'$(CRONTAB_DAILY_REPORT_PATH)';' \
+	    -e 's;@PCP_SYSCONFIG_DIR@;'$(PCP_SYSCONFIG_DIR)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	    -e 's;@PCP_SA_DIR@;'$(PCP_SA_DIR)';' \

--- a/src/pmlogger/GNUmakefile
+++ b/src/pmlogger/GNUmakefile
@@ -20,7 +20,10 @@ SUBDIRS = src
 OTHERS	= pmnewlog.sh control rc_pmlogger \
 	  pmlogger_daily.sh pmlogger_check.sh pmlogger_merge.sh pmlogmv.sh \
 	  pmlogger_daily_report.sh pmlogger_rewrite.sh
-LDIRT	= crontab crontab.docker crontab.daily_report pmlogger.service
+LDIRT	= crontab crontab.docker crontab.daily_report pmlogger.service \
+	  pmlogger_daily.service pmlogger_daily_poll.service \
+	  pmlogger_daily_check.service pmlogger_daily_report.service \
+	  pmlogger_daily_report_poll.service
 
 ifeq ($(TARGET_OS),linux)
 CRONTAB_USER = $(PCP_USER)
@@ -31,7 +34,7 @@ CRONTAB_PATH = $(PCP_SYSCONF_DIR)/pmlogger/crontab
 endif
 CRONTAB_DAILY_REPORT_PATH = $(CRONTAB_PATH)-daily-report
 
-default:: crontab crontab.docker pmlogger.service crontab.daily_report
+default:: $(LDIRT)
 
 default:: $(SUBDIRS)
 	$(SUBDIRS_MAKERULE)
@@ -57,6 +60,20 @@ endif
 	$(INSTALL) -m 755 rc_pmlogger $(PCP_RC_DIR)/pmlogger
 ifeq ($(ENABLE_SYSTEMD),true)
 	$(INSTALL) -m 644 pmlogger.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger.service
+	$(INSTALL) -m 644 pmlogger_daily.timer $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily.timer
+	$(INSTALL) -m 644 pmlogger_daily.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily.service
+	$(INSTALL) -m 644 pmlogger_daily_poll.timer $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily_poll.timer
+	$(INSTALL) -m 644 pmlogger_daily_poll.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily_poll.service
+	$(INSTALL) -m 644 pmlogger_daily_check.timer $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily_check.timer
+	$(INSTALL) -m 644 pmlogger_daily_check.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily_check.service
+	$(INSTALL) -m 644 pmlogger_daily_report.timer $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily_report.timer
+	$(INSTALL) -m 644 pmlogger_daily_report.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily_report.service
+	$(INSTALL) -m 644 pmlogger_daily_report_poll.timer $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily_report_poll.timer
+	$(INSTALL) -m 644 pmlogger_daily_report_poll.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily_report_poll.service
+else
+	$(INSTALL) -m 755 -d `dirname $(CRONTAB_PATH)`
+	$(INSTALL) -m 644 crontab $(CRONTAB_PATH)
+	$(INSTALL) -m 644 crontab.daily_report $(CRONTAB_DAILY_REPORT_PATH)
 endif
 	$(INSTALL) -m 775 -o $(PCP_USER) -g $(PCP_GROUP) -d $(PCP_LOG_DIR)/pmlogger
 	$(INSTALL) -m 775 -o $(PCP_USER) -g $(PCP_GROUP) -d $(PCP_TMP_DIR)/pmlogger
@@ -64,12 +81,9 @@ ifeq ($(TARGET_OS),linux)
 	# In a container environment, the rc_pmlogger script installs the
 	# Docker version of the crontab into the hosts cron.d directory.
 	$(INSTALL) -m 644 crontab.docker $(PCP_VAR_DIR)/config/pmlogger/crontab.docker
-	$(INSTALL) -m 755 -d `dirname $(CRONTAB_PATH)`
 endif
-	$(INSTALL) -m 644 crontab $(CRONTAB_PATH)
 	$(INSTALL) -m 644 utilproc.sh $(PCP_SHARE_DIR)/lib/utilproc.sh
 	$(INSTALL) -m 755 pmlogger_daily_report.sh $(PCP_BINADM_DIR)/pmlogger_daily_report$(SHELLSUFFIX)
-	$(INSTALL) -m 644 crontab.daily_report $(CRONTAB_DAILY_REPORT_PATH)
 	$(INSTALL) -m 775 -o $(PCP_USER) -g $(PCP_GROUP) -d $(PCP_SA_DIR)
 
 include $(BUILDRULES)
@@ -82,6 +96,38 @@ pmlogger.service : pmlogger.service.in
 	$(SED) <$< >$@ \
 	    -e 's;@PCP_RC_DIR@;'$(PCP_RC_DIR)';' \
 	    -e 's;@PCP_RUN_DIR@;'$(PCP_RUN_DIR)';' \
+	# END
+
+pmlogger_daily.service : pmlogger_daily.service.in
+	$(SED) <$< >$@ \
+	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
+	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
+	# END
+
+pmlogger_daily_poll.service : pmlogger_daily_poll.service.in
+	$(SED) <$< >$@ \
+	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
+	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
+	# END
+
+pmlogger_daily_check.service : pmlogger_daily_check.service.in
+	$(SED) <$< >$@ \
+	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
+	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
+	# END
+
+pmlogger_daily_report.service : pmlogger_daily_report.service.in
+	$(SED) <$< >$@ \
+	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
+	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
+	    -e 's;@PCP_SA_DIR@;'$(PCP_SA_DIR)';' \
+	# END
+
+pmlogger_daily_report_poll.service : pmlogger_daily_report_poll.service.in
+	$(SED) <$< >$@ \
+	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
+	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
+	    -e 's;@PCP_SA_DIR@;'$(PCP_SA_DIR)';' \
 	# END
 
 crontab : crontab.in

--- a/src/pmlogger/GNUmakefile
+++ b/src/pmlogger/GNUmakefile
@@ -100,24 +100,28 @@ pmlogger.service : pmlogger.service.in
 
 pmlogger_daily.service : pmlogger_daily.service.in
 	$(SED) <$< >$@ \
+	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	# END
 
 pmlogger_daily_poll.service : pmlogger_daily_poll.service.in
 	$(SED) <$< >$@ \
+	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	# END
 
 pmlogger_daily_check.service : pmlogger_daily_check.service.in
 	$(SED) <$< >$@ \
+	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	# END
 
 pmlogger_daily_report.service : pmlogger_daily_report.service.in
 	$(SED) <$< >$@ \
+	    -e 's;@CRONTAB_DAILY_REPORT_PATH@;'$(CRONTAB_DAILY_REPORT_PATH)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	    -e 's;@PCP_SA_DIR@;'$(PCP_SA_DIR)';' \
@@ -125,6 +129,7 @@ pmlogger_daily_report.service : pmlogger_daily_report.service.in
 
 pmlogger_daily_report_poll.service : pmlogger_daily_report_poll.service.in
 	$(SED) <$< >$@ \
+	    -e 's;@CRONTAB_DAILY_REPORT_PATH@;'$(CRONTAB_DAILY_REPORT_PATH)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_USER@;'$(PCP_USER)';' \
 	    -e 's;@PCP_SA_DIR@;'$(PCP_SA_DIR)';' \

--- a/src/pmlogger/pmlogger_daily.service.in
+++ b/src/pmlogger/pmlogger_daily.service.in
@@ -5,5 +5,6 @@ ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=oneshot
-ExecStart=@PCP_BINADM_DIR@/pmlogger_daily
+EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
+ExecStart=@PCP_BINADM_DIR@/pmlogger_daily ${PMLOGGER_DAILY_PARAMS}
 User=@PCP_USER@

--- a/src/pmlogger/pmlogger_daily.service.in
+++ b/src/pmlogger/pmlogger_daily.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Process archive logs
 Documentation=man:pmlogger(1)
+ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=oneshot

--- a/src/pmlogger/pmlogger_daily.service.in
+++ b/src/pmlogger/pmlogger_daily.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Process archive logs
+Documentation=man:pmlogger(1)
+
+[Service]
+Type=oneshot
+ExecStart=@PCP_BINADM_DIR@/pmlogger_daily
+User=@PCP_USER@

--- a/src/pmlogger/pmlogger_daily.timer
+++ b/src/pmlogger/pmlogger_daily.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Daily processing of archive logs
+
+[Timer]
+OnCalendar=*-*-* 00:10:00
+
+[Install]
+WantedBy=timers.target

--- a/src/pmlogger/pmlogger_daily_check.service.in
+++ b/src/pmlogger/pmlogger_daily_check.service.in
@@ -5,5 +5,7 @@ ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=oneshot
-ExecStart=@PCP_BINADM_DIR@/pmlogger_daily -C
+Environment=PMLOGGER_DAILY_CHECK_PARAMS="-C"
+EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
+ExecStart=@PCP_BINADM_DIR@/pmlogger_daily ${PMLOGGER_DAILY_CHECK_PARAMS}
 User=@PCP_USER@

--- a/src/pmlogger/pmlogger_daily_check.service.in
+++ b/src/pmlogger/pmlogger_daily_check.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Check pmlogger instances are running
 Documentation=man:pmlogger(1)
+ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=oneshot

--- a/src/pmlogger/pmlogger_daily_check.service.in
+++ b/src/pmlogger/pmlogger_daily_check.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Check pmlogger instances are running
+Documentation=man:pmlogger(1)
+
+[Service]
+Type=oneshot
+ExecStart=@PCP_BINADM_DIR@/pmlogger_daily -C
+User=@PCP_USER@

--- a/src/pmlogger/pmlogger_daily_check.timer
+++ b/src/pmlogger/pmlogger_daily_check.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Half-hourly check of pmlogger instances
+
+[Timer]
+OnCalendar=*-*-* *:25:00
+OnCalendar=*-*-* *:55:00
+
+[Install]
+WantedBy=timers.target

--- a/src/pmlogger/pmlogger_daily_poll.service.in
+++ b/src/pmlogger/pmlogger_daily_poll.service.in
@@ -5,5 +5,7 @@ ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=oneshot
-ExecStart=@PCP_BINADM_DIR@/pmlogger_daily -p
+Environment=PMLOGGER_DAILY_POLL_PARAMS="-p"
+EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
+ExecStart=@PCP_BINADM_DIR@/pmlogger_daily ${PMLOGGER_DAILY_POLL_PARAMS}
 User=@PCP_USER@

--- a/src/pmlogger/pmlogger_daily_poll.service.in
+++ b/src/pmlogger/pmlogger_daily_poll.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Poll log processing
 Documentation=man:pmlogger(1)
+ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=oneshot

--- a/src/pmlogger/pmlogger_daily_poll.service.in
+++ b/src/pmlogger/pmlogger_daily_poll.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Poll log processing
+Documentation=man:pmlogger(1)
+
+[Service]
+Type=oneshot
+ExecStart=@PCP_BINADM_DIR@/pmlogger_daily -p
+User=@PCP_USER@

--- a/src/pmlogger/pmlogger_daily_poll.timer
+++ b/src/pmlogger/pmlogger_daily_poll.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Hourly polling of log processing
+
+[Timer]
+OnCalendar=*-*-* *:30:00
+
+[Install]
+WantedBy=timers.target

--- a/src/pmlogger/pmlogger_daily_report.service.in
+++ b/src/pmlogger/pmlogger_daily_report.service.in
@@ -5,5 +5,7 @@ ConditionPathExists=!@CRONTAB_DAILY_REPORT_PATH@
 
 [Service]
 Type=oneshot
-ExecStart=@PCP_BINADM_DIR@/pmlogger_daily_report -o @PCP_SA_DIR@
+Environment=PMLOGGER_DAILY_REPORT_PARAMS="-o @PCP_SA_DIR@"
+EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
+ExecStart=@PCP_BINADM_DIR@/pmlogger_daily_report ${PMLOGGER_DAILY_REPORT_PARAMS}
 User=@PCP_USER@

--- a/src/pmlogger/pmlogger_daily_report.service.in
+++ b/src/pmlogger/pmlogger_daily_report.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Generate system activity reports
+Documentation=man:pmlogger(1)
+
+[Service]
+Type=oneshot
+ExecStart=@PCP_BINADM_DIR@/pmlogger_daily_report -o @PCP_SA_DIR@
+User=@PCP_USER@

--- a/src/pmlogger/pmlogger_daily_report.service.in
+++ b/src/pmlogger/pmlogger_daily_report.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Generate system activity reports
 Documentation=man:pmlogger(1)
+ConditionPathExists=!@CRONTAB_DAILY_REPORT_PATH@
 
 [Service]
 Type=oneshot

--- a/src/pmlogger/pmlogger_daily_report.timer
+++ b/src/pmlogger/pmlogger_daily_report.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Daily generation of system activity reports
+
+[Timer]
+OnCalendar=*-*-* 02:00:00
+
+[Install]
+WantedBy=timers.target

--- a/src/pmlogger/pmlogger_daily_report_poll.service.in
+++ b/src/pmlogger/pmlogger_daily_report_poll.service.in
@@ -5,5 +5,7 @@ ConditionPathExists=!@CRONTAB_DAILY_REPORT_PATH@
 
 [Service]
 Type=oneshot
-ExecStart=@PCP_BINADM_DIR@/pmlogger_daily_report -o @PCP_SA_DIR@ -p
+Environment=PMLOGGER_DAILY_REPORT_POLL_PARAMS="-o @PCP_SA_DIR@ -p"
+EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
+ExecStart=@PCP_BINADM_DIR@/pmlogger_daily_report ${PMLOGGER_DAILY_REPORT_POLL_PARAMS}
 User=@PCP_USER@

--- a/src/pmlogger/pmlogger_daily_report_poll.service.in
+++ b/src/pmlogger/pmlogger_daily_report_poll.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Poll system activity report generation
 Documentation=man:pmlogger(1)
+ConditionPathExists=!@CRONTAB_DAILY_REPORT_PATH@
 
 [Service]
 Type=oneshot

--- a/src/pmlogger/pmlogger_daily_report_poll.service.in
+++ b/src/pmlogger/pmlogger_daily_report_poll.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Poll system activity report generation
+Documentation=man:pmlogger(1)
+
+[Service]
+Type=oneshot
+ExecStart=@PCP_BINADM_DIR@/pmlogger_daily_report -o @PCP_SA_DIR@ -p
+User=@PCP_USER@

--- a/src/pmlogger/pmlogger_daily_report_poll.timer
+++ b/src/pmlogger/pmlogger_daily_report_poll.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Hourly polling of system activity report generation
+
+[Timer]
+OnCalendar=*-*-* *:30:00
+
+[Install]
+WantedBy=timers.target

--- a/src/pmlogger/pmlogger_timers.sysconfig
+++ b/src/pmlogger/pmlogger_timers.sysconfig
@@ -1,0 +1,40 @@
+## Type:        string
+## Default:	""
+#
+# Run the pmlogger_daily binary, via pmlogger_daily.service, with the
+# following parameters.
+#
+#PMLOGGER_DAILY_PARAMS=""
+
+## Type:        string
+## Default:	"-C"
+#
+# Run the pmlogger_daily binary, via pmlogger_daily_check.service, with the
+# following parameters.
+#
+#PMLOGGER_DAILY_CHECK_PARAMS=""
+
+## Type:        string
+## Default:	"-p"
+#
+# Run the pmlogger_daily binary, via pmlogger_daily_poll.service, with the
+# following parameters.
+#
+#PMLOGGER_DAILY_POLL_PARAMS=""
+
+
+## Type:        string
+## Default:	"-o /var/log/pcp/sa/"
+#
+# Run the pmlogger_daily_report binary, via pmlogger_daily_report.service, with
+# the following parameters.
+#
+#PMLOGGER_DAILY_REPORT_PARAMS=""
+
+## Type:        string
+## Default:	"-o /var/log/pcp/sa/ -p"
+#
+# Run the pmlogger_daily_report binary, via pmlogger_daily_report_poll.service,
+# with the following parameters.
+#
+#PMLOGGER_DAILY_REPORT_POLL_PARAMS=""


### PR DESCRIPTION
This patchset converts (non-docker) pmie and pmlogger crontab entries to systemd timer + service files, which are installed when ENABLE_SYSTEMD is configured.