### PR TITLE
pmwebd: stop leaking open-fd for 304 (not modified) file service case

### DIFF
--- a/src/pmwebd/pmresapi.cxx
+++ b/src/pmwebd/pmresapi.cxx
@@ -141,6 +141,7 @@ pmwebres_respond (struct MHD_Connection *connection, const http_params& params, 
         if (! resp)
             return MHD_NO;
 
+        close (fd); // don't leak file fd
         resp_code = 304;
         goto out_304;
     }


### PR DESCRIPTION
In the case where pmwebd is serving a file, and it turns out eligible
for HTTP-304 optimization, the file descriptor was left open.  We now
close 'er up to avoid this leak.