### PR TITLE
pmns: don't package .NeedRebuild for SUSE distros

### DIFF
--- a/configure
+++ b/configure
@@ -3324,6 +3324,7 @@ then
 $as_echo "#define IS_LINUX 1" >>confdefs.h
 
     test -f /etc/SuSE-release && target_distro=suse
+    grep -q 'ID_LIKE="suse"' /etc/os-release 2> /dev/null && target_distro=suse
     test -f /etc/fedora-release && target_distro=fedora
     test -f /etc/redhat-release && target_distro=redhat
     test -f /etc/debian_version && target_distro=debian

--- a/configure.ac
+++ b/configure.ac
@@ -281,6 +281,7 @@ if test $target_os = linux
 then
     AC_DEFINE(IS_LINUX, [1], [Platform is Linux])
     test -f /etc/SuSE-release && target_distro=suse
+    grep -q 'ID_LIKE="suse"' /etc/os-release 2> /dev/null && target_distro=suse
     test -f /etc/fedora-release && target_distro=fedora
     test -f /etc/redhat-release && target_distro=redhat
     test -f /etc/debian_version && target_distro=debian

--- a/src/pmns/GNUmakefile
+++ b/src/pmns/GNUmakefile
@@ -60,7 +60,7 @@ install:	default
 	$(INSTALL) -m 755 Rebuild $(PMNS_VAR_DIR)/Rebuild
 	$(INSTALL) -m 755 Make.stdpmid $(PMNS_VAR_DIR)/Make.stdpmid
 	$(INSTALL) -m 644 $(STDPMID) $(PMNS_VAR_DIR)
-ifeq (, $(filter redhat debian, $(PACKAGE_DISTRIBUTION)))
+ifeq (, $(filter redhat debian suse, $(PACKAGE_DISTRIBUTION)))
 	$(INSTALL) -m 644 .NeedRebuild $(PMNS_VAR_DIR)/.NeedRebuild
 endif
 


### PR DESCRIPTION
.NeedRebuild creation is handled by rpm scripts.
This change also fixes the target_distro configure check for modern
[open]SUSE distros, which only include /etc/os-release.

Signed-off-by: David Disseldorp <ddiss@suse.de>