### PR TITLE
pmns: don't install .NeedRebuild on Linux

### DIFF
--- a/src/pmns/GNUmakefile
+++ b/src/pmns/GNUmakefile
@@ -60,7 +60,7 @@ install:	default
 	$(INSTALL) -m 755 Rebuild $(PMNS_VAR_DIR)/Rebuild
 	$(INSTALL) -m 755 Make.stdpmid $(PMNS_VAR_DIR)/Make.stdpmid
 	$(INSTALL) -m 644 $(STDPMID) $(PMNS_VAR_DIR)
-ifeq (, $(filter redhat debian suse, $(PACKAGE_DISTRIBUTION)))
+ifneq "$(TARGET_OS)" "linux"
 	$(INSTALL) -m 644 .NeedRebuild $(PMNS_VAR_DIR)/.NeedRebuild
 endif
 


### PR DESCRIPTION
The existing filter already covers RedHat, Debian and SUSE distros, but
depends on os-release file based distro detection.
Change the .NeedRebuild install check to cover all Linux build targets,
so that os-release distro detection isn't necessary.

Signed-off-by: David Disseldorp <ddiss@suse.de>