### PR TITLE
Fix Python install flags for DIST_ROOT=

### DIFF
--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -705,7 +705,7 @@ PYTHON_PREFIX=@python_prefix@
 SETUP_PY_BUILD_OPTIONS = --include-dirs=$(TOPDIR)/src/include:$(TOPDIR)/src/include/pcp$(EXTRA_PY_INCLUDES)
 SETUP_PY_BUILD_OPTIONS += --library-dirs=$(TOPDIR)/src/libpcp/src:$(TOPDIR)/src/libpcp_pmda/src:$(TOPDIR)/src/libpcp_gui/src:$(TOPDIR)/src/libpcp_import/src:$(TOPDIR)/src/libpcp_mmv/src
 SETUP_PY_INSTALL_OPTIONS = --skip-build
-SETUP_PY_INSTALL_OPTIONS += --root="$${DIST_ROOT-/}"
+SETUP_PY_INSTALL_OPTIONS += --root="$${DIST_ROOT:-/}"
 ifeq "$(PYTHON_PREFIX)" "/usr"
 ifeq "$(PACKAGE_DISTRIBUTION)" "debian"
 SETUP_PY_INSTALL_OPTIONS += --install-layout=deb


### PR DESCRIPTION
Fix an invalid shell variable reference in builddefs.in which
accidentally works when the DIST_ROOT variable is not empty, but causes
installation of Python modules to fail when DIST_ROOT is empty.  The
Homebrew packaging system for MacOS uses an empty DIST_ROOT to build and
install directly into a user-writable directory under /usr/local/Cellar.