### PR TITLE
Allow --with-qt=DIR to specify QT installation dir

### DIFF
--- a/configure
+++ b/configure
@@ -8086,6 +8086,11 @@ if test "x$do_qt" != "xno"; then :
 
     enable_qt=true
 
+    # Allow specifying the QT directory using --with-qt=/the/qt/dir
+    case "$do_qt" in
+    /*) export QTDIR="$do_qt" ; do_qt="check" ;;
+    esac
+
     if test -z "$QMAKE"
     then
 					for ac_prog in qtchooser

--- a/configure.ac
+++ b/configure.ac
@@ -1203,6 +1203,11 @@ qt_version=0
 AS_IF([test "x$do_qt" != "xno"], [
     enable_qt=true
 
+    # Allow specifying the QT directory using --with-qt=/the/qt/dir
+    case "$do_qt" in
+    /*) export QTDIR="$do_qt" ; do_qt="check" ;;
+    esac
+
     if test -z "$QMAKE"
     then
 	dnl default to qmake from qtchooser whenever it is available


### PR DESCRIPTION
The configure script cannot be given a value for the QT installation
directory except by setting the environment variable QTDIR.  There is a
--with-qt option but you cannot pass it a directory, the only valid
values are "yes" "no" and "check".

Regrettably Homebrew makes it super hard to set an environment variable
during build, and really wants you to do everything with commandline
options to configure.

This change extends the syntax of the --with-qt option by allowing its
value to be the absolute path of the QT installation directory.  This is
consistent with many open source users of autoconf.