### PR TITLE
pcp-dstat: fix typo in printtype detection

### DIFF
--- a/src/pcp/dstat/pcp-dstat.py
+++ b/src/pcp/dstat/pcp-dstat.py
@@ -1318,7 +1318,7 @@ class DstatTool(object):
         #sys.stderr.write("colorstep: %s\n" % str(colorstep))
 
         ### Convert value to string given base and field-length
-        if op.integer and printtype in ('b', 'd', 'p' 'f'):
+        if op.integer and printtype in ('b', 'd', 'p', 'f'):
             ret, c = self.dchg(value, width, base)
         elif op.float and printtype in ('b', 'd', 'p', 'f'):
             ret, c = self.fchg(value, width, base)


### PR DESCRIPTION
the two characters get implicitly concatenated if the comma is missing, but `printtype` is always a single character