### PR TITLE
pmdabcc: fix install (due to README rename)

### DIFF
--- a/src/pmdas/bcc/GNUmakefile
+++ b/src/pmdas/bcc/GNUmakefile
@@ -38,7 +38,7 @@ build-me:	check_domain
 install_pcp install ::	default
 	$(INSTALL) -m 755 -d $(PMDADIR)
 	$(INSTALL) -m 755 Install Remove Upgrade $(PYSCRIPT) $(PMDADIR)
-	$(INSTALL) -m 644 README $(CONFIGS) $(PMDADIR)
+	$(INSTALL) -m 644 README.md $(CONFIGS) $(PMDADIR)
 	$(INSTALL) -m 644 pmdautil.python $(PMDADIR)/pmdautil.python
 	@$(INSTALL_MAN)
 


### PR DESCRIPTION
I really should get the azure pipelines integrated soon, that would have catched this bug