### PR TITLE
qa: increase min kernel version for ucalls qa test 1173

### DIFF
--- a/qa/1173
+++ b/qa/1173
@@ -11,7 +11,7 @@ echo "QA output created by $seq"
 . ./common.bcc
 
 _pmdabcc_check
-_pmdabcc_require_kernel_version 4 7
+_pmdabcc_require_kernel_version 4 18
 _python_probe_check
 
 status=1       # failure is the default!


### PR DESCRIPTION
test fails with kernel `4.15 `, but works with `4.18+`