### PR TITLE
pcp-dstat: fix misaligned headers in CSV output

### DIFF
--- a/qa/1187.out
+++ b/qa/1187.out
@@ -256,8 +256,8 @@ CSV instances contents
 "Author:","PCP team <pcp@groups.io> and Dag Wieers <dag@wieers.com>",,,,"URL:","https://pcp.io/ and http://dag.wieers.com/home-made/dstat/"
 "Host:","shard",,,,"User:","USER"
 "Cmdline:","pcp-dstat --time --cpu -C 1,2,total --cpu-use -o TMP.csv2 1 3",,,,"Date:","DATE"
-"system","cpu1 usage",,,,,"cpu2 usage",,,,,"total usage",,,,,,,,,"per cpu usage"
-"time","cpu1 usage:usr","cpu1 usage:sys","cpu1 usage:idl","cpu1 usage:wai","cpu1 usage:stl",,"cpu2 usage:usr","cpu2 usage:sys","cpu2 usage:idl","cpu2 usage:wai","cpu2 usage:stl",,"total usage:usr","total usage:sys","total usage:idl","total usage:wai","total usage:stl","0","1","2","3","4","5","6","7"
+"system","cpu1 usage",,,,,"cpu2 usage",,,,,"total usage",,,,,"per cpu usage",,,,,,,
+"time","cpu1 usage:usr","cpu1 usage:sys","cpu1 usage:idl","cpu1 usage:wai","cpu1 usage:stl","cpu2 usage:usr","cpu2 usage:sys","cpu2 usage:idl","cpu2 usage:wai","cpu2 usage:stl","total usage:usr","total usage:sys","total usage:idl","total usage:wai","total usage:stl","0","1","2","3","4","5","6","7"
 25-07 16:08:19,,,,,,,,,,,,,,,,
 25-07 16:08:20,3.100,2.100,95.800,0,0,3.300,1,95.800,0,0,5.525,1.362,93.100,0,0,5.200,4.200,4.200,14.200,19.900,1.100,5.200,1.200
 25-07 16:08:21,17,2.900,79.400,0,0,6.600,1.900,91.500,0,0,10.888,1.387,87.713,0,0,8.500,20.600,8.500,5,5.800,6.400,37.800,5.700

--- a/src/pcp/dstat/pcp-dstat.py
+++ b/src/pcp/dstat/pcp-dstat.py
@@ -349,7 +349,7 @@ class DstatPlugin(object):
 
     def csvtitle(self):
         if self.grouptype is None:
-            label = '"' + self.label + '"'
+            label = '"' + self.label + '"' + CHAR['sep'] * (len(self.names) - 1)
             return label
         ret = ''
         ilist = self.instlist()
@@ -373,8 +373,6 @@ class DstatPlugin(object):
             return ret
         ilist = self.instlist()
         for i, name in enumerate(ilist):
-            if i > 0:
-                ret = ret + CHAR['sep']
             name = self.label.replace('%I', name)
             for j, nick in enumerate(self.names):
                 if j > 0 or i > 0:
@@ -1404,7 +1402,7 @@ class DstatTool(object):
         for o in visible:
             line += o.csvtitle()
             if o is not visible[-1]:
-                line += CHAR['sep'] * len(o.names)
+                line += CHAR['sep']
             elif self.totlist != visible:
                 pass #line += THEME['title'] + CHAR['gt']
         line += '\n'


### PR DESCRIPTION
The number of commas in title and sub-title headers were more than expected.

Resolves github issue #639.