### PR TITLE
pcp-dstat: prevent comma-only lines from being added to csv output

### DIFF
--- a/src/pcp/dstat/pcp-dstat.py
+++ b/src/pcp/dstat/pcp-dstat.py
@@ -1593,7 +1593,10 @@ class DstatTool(object):
             line = newline
         else:
             line = newline + line
-        oline = newoline + oline
+        if self.novalues:
+            oline = newoline
+        else:
+            oline = newoline + oline
 
         # Print stats
         sys.stdout.write(line + THEME['input'])
@@ -1615,7 +1618,7 @@ class DstatTool(object):
         # Finish the line
         if not op.update and self.novalues is False:
             sys.stdout.write('\n')
-        if self.output and step == self.delay:
+        if self.output and step == self.delay and self.novalues is False:
             outputfile.write('\n')
 
     def execute(self):


### PR DESCRIPTION
The first sample for counter metrics returns value None. When all
metrics we are displaying are counter metrics, a comma-only line
appears in csv output. This commit prevents such comma-only lines
from being displayed to csv output.