### PR TITLE
Fix segfault in pmdaFetch().

### DIFF
--- a/src/libpcp/src/fetchlocal.c
+++ b/src/libpcp/src/fetchlocal.c
@@ -95,25 +95,23 @@ __pmFetchLocal(__pmContext *ctxp, int numpmid, pmID pmidlist[], pmResult **resul
 	    /* based on domain, unknown PMDA */
 	    sts = PM_ERR_NOAGENT;
 	else {
-	    if (ctxp->c_sent != dp->domain) {
-		/*
-		 * current profile is _not_ already cached at other end of
-		 * IPC, so send get current profile ...
-		 * Note: trickier than the non-local case, as no per-PMDA
-		 *	 caching at the PMCD end, so need to remember the
-		 *	 last domain to receive a profile
-		 */
-		if (pmDebugOptions.fetch)
-		    fprintf(stderr, 
-			    "__pmFetchLocal: calling ???_profile(domain: %d), "
-			    "context: %d\n", dp->domain, ctx);
-		if (dp->dispatch.comm.pmda_interface >= PMDA_INTERFACE_5)
-		    dp->dispatch.version.four.ext->e_context = ctx;
-		sts = dp->dispatch.version.any.profile(ctxp->c_instprof,
-						dp->dispatch.version.any.ext);
-		if (sts >= 0)
-		    ctxp->c_sent = dp->domain;
-	    }
+	    /*
+	     * current profile is _not_ already cached at other end of
+	     * IPC, so send get current profile ...
+	     * Note: trickier than the non-local case, as no per-PMDA
+	     *       caching at the PMCD end, so need to remember the
+	     *       last domain to receive a profile
+	     */
+	    if (pmDebugOptions.fetch)
+	        fprintf(stderr, 
+	                "__pmFetchLocal: calling ???_profile(domain: %d), "
+	                "context: %d\n", dp->domain, ctx);
+	    if (dp->dispatch.comm.pmda_interface >= PMDA_INTERFACE_5)
+	        dp->dispatch.version.four.ext->e_context = ctx;
+	    sts = dp->dispatch.version.any.profile(ctxp->c_instprof,
+	                                    dp->dispatch.version.any.ext);
+	    if (sts >= 0)
+	        ctxp->c_sent = dp->domain;
 	}
 
 	/* Copy all pmID for the current domain into the temp. list */


### PR DESCRIPTION
I try to fix the following issue.
https://github.com/cockpit-project/cockpit/issues/6108

Sometimes cockpit-pcp crashes due to segfault in __pmFindProfile().
I think the cause is in __pmFetchLocal() of src/libpcp/src/fetchlocal.c.

Cockpit calls pmdaFetch() periodically. pmdaFetch() refers to pmda->e_prof
via __pmdaCountInst() to calculate the number of instances. 
Just before calling pmdaFetch() pmda->e_prof has a chance to be updated in
__pmFetchLocal() but it should satisfy a condition "ctxp->c_sent != dp->domain".

This condition is not appropriate I think because there is a following case:

 1. pmDestroyContext() frees pmda->e_prof
 2. pmda->e_prof area is reallocated and used for other purpose
 3. __pmFetchLocal() is called
 4. __pmFetchLocal() does not update pmda->e_prof due to the condition
 5. __pmFetchLocal() calls pmdaFetch()
 6. pmdaFetch() accesses corrupted area by referring to pmda->e_prof

I'm not sure it is best answer but I suggest a fix by removing the condition
in order to replace pmda->e_prof with a new profile at any time before using it.