### PR TITLE
pmdaproc: fix memory leak in pidlist refresh

### DIFF
--- a/src/pcp/atop/ifprop.c
+++ b/src/pcp/atop/ifprop.c
@@ -71,6 +71,7 @@ initifprop(void)
 	char		**insts;
 	int		sts, i;
 	int		*ids, count;
+	struct ifprop	*new_ifprops;
 
 	if (!setup)
 	{
@@ -84,13 +85,17 @@ initifprop(void)
 	count = get_instances("ifprop", IF_SPEED, descs, &ids, &insts);
 
 	propsize = (count + 1) * sizeof(ifprops[0]);
-	if ((ifprops = realloc(ifprops, propsize)) == NULL)
+	if ((new_ifprops = realloc(ifprops, propsize)) == NULL)
 	{
 		fprintf(stderr,
 			"%s: allocating interface table: %s [%ld bytes]\n",
 			pmGetProgname(), strerror(errno), (long)propsize);
+		if (ifprops)
+		    free(ifprops);
 		cleanstop(1);
+		/* NOTREACHED */
 	}
+	ifprops = new_ifprops;
 
 	for (i=0; i < count; i++)
 	{

--- a/src/pcp2elasticsearch/pcp2elasticsearch.py
+++ b/src/pcp2elasticsearch/pcp2elasticsearch.py
@@ -372,7 +372,7 @@ class pcp2elasticsearch(object):
             sys.stdout.write("Sending %d archived metrics to Elasticsearch at %s...\n(Ctrl-C to stop)\n" % (len(self.metrics), self.es_server))
             return
 
-        sys.stdout.write("Sending %d metrics to Elasticsearch at %s every %d sec" % (len(self.metrics), self.es_server, self.interval))
+        sys.stdout.write("Sending %d metrics to Elasticsearch at %s every %.1f sec" % (len(self.metrics), self.es_server, float(self.interval)))
         if self.runtime != -1:
             sys.stdout.write(":\n%s samples(s) with %.1f sec interval ~ %d sec runtime.\n" % (self.samples, float(self.interval), self.runtime))
         elif self.samples:

--- a/src/pcp2graphite/pcp2graphite.py
+++ b/src/pcp2graphite/pcp2graphite.py
@@ -385,7 +385,7 @@ class PCP2Graphite(object):
             sys.stdout.write("Sending %d archived metrics to Graphite host %s...\n(Ctrl-C to stop)\n" % (len(self.metrics), self.graphite_host))
             return
 
-        sys.stdout.write("Sending %d metrics to Graphite host %s every %d sec" % (len(self.metrics), self.graphite_host, self.interval))
+        sys.stdout.write("Sending %d metrics to Graphite host %s every %.1f sec" % (len(self.metrics), self.graphite_host, float(self.interval)))
         if self.runtime != -1:
             sys.stdout.write(":\n%s samples(s) with %.1f sec interval ~ %d sec runtime.\n" % (self.samples, float(self.interval), self.runtime))
         elif self.samples:

--- a/src/pcp2influxdb/pcp2influxdb.py
+++ b/src/pcp2influxdb/pcp2influxdb.py
@@ -477,7 +477,7 @@ class PCP2InfluxDB(object):
             sys.stdout.write("Sending %d archived metrics to InfluxDB at %s...\n(Ctrl-C to stop)\n" % (len(self.metrics), self.influx_server))
             return
 
-        sys.stdout.write("Sending %d metrics to InfluxDB at %s every %d sec" % (len(self.metrics), self.influx_server, self.interval))
+        sys.stdout.write("Sending %d metrics to InfluxDB at %s every %.1f sec" % (len(self.metrics), self.influx_server, float(self.interval)))
         if self.runtime != -1:
             sys.stdout.write(":\n%s samples(s) with %.1f sec interval ~ %d sec runtime.\n" % (self.samples, float(self.interval), self.runtime))
         elif self.samples:

--- a/src/pcp2spark/pcp2spark.py
+++ b/src/pcp2spark/pcp2spark.py
@@ -375,7 +375,7 @@ class PCP2Spark(object):
             sys.stdout.write("Sending %d archived metrics to Spark %s:%d...\n(Ctrl-C to stop)\n" % (len(self.metrics), self.spark_server, self.spark_port))
             return
 
-        sys.stdout.write("Sending %d metrics to Spark %s:%d every %d sec" % (len(self.metrics), self.spark_server, self.spark_port, self.interval))
+        sys.stdout.write("Sending %d metrics to Spark %s:%d every %.1f sec" % (len(self.metrics), self.spark_server, self.spark_port, float(self.interval)))
         if self.runtime != -1:
             sys.stdout.write(":\n%s samples(s) with %.1f sec interval ~ %d sec runtime.\n" % (self.samples, float(self.interval), self.runtime))
         elif self.samples:

--- a/src/pmdas/linux_proc/proc_pid.h
+++ b/src/pmdas/linux_proc/proc_pid.h
@@ -20,6 +20,10 @@
 #include "proc_runq.h"
 #include "hotproc.h"
 
+/*
+ * Maximim length of psargs and proc instance name.
+ */
+#define PROC_PID_STAT_CMD_MAXLEN	4096
 
 /*
  * /proc/<pid>/stat metrics
@@ -252,7 +256,8 @@ enum {
 typedef struct {
     int			id;	/* pid, hash key and internal instance id */
     int			flags;	/* combinations of PROC_PID_FLAG_* values */
-    char		*name;	/* external instance name (<pid> cmdline) */
+    char		*name;	/* full command line and args */
+    char		*instname; /* external instance name (truncated <pid> cmdline) */
 
     /* /proc/<pid>/stat cluster */
     int			stat_buflen;

--- a/src/pmdas/mmv/src/mmv.c
+++ b/src/pmdas/mmv/src/mmv.c
@@ -556,7 +556,7 @@ map_stats(pmdaExt *pmda)
 	ap->scnt = 0;
     }
 
-    num = scandir(ap->statsdir, &files, NULL, NULL);
+    num = scandir(ap->statsdir, &files, NULL, alphasort);
     for (i = 0; i < num; i++) {
 	if (files[i]->d_name[0] == '.')
 	    continue;


### PR DESCRIPTION
RHBZ #1721107

The pidlist refresh function was leaking instance name buffers for
processes that had exited between refreshes. Fix this by storing the
instance name (truncated psargs) in a new field of the hash table
entry, and harvest them correctly if they've exited after each refresh.
The indom table instance names now share a pointer to the new field
in the hash table entry so they dont need to be separately free'd.
This similifies the code and memory management.

Also put a 4K cap on the maximum length of a psargs string for the
unlikely scenario of a psargs string that is not NULL terminated,
i.e. use strndup() rather than strdup(). This may be possible if
a rogue process modified it's argv[0] at run-time.

For testing, the recipe in RHBZ#1721107 was repro'd using valgind
and a workload with lots of process churn (i.e. a couple of large
builds running). Before the fix, valgrind reported numerous similar
leaks as reported in the bug. With the fix applied, those leaks
are gone. The refresh is more efficient now too because we only
have one copy of the psargs strings (in the hash table entry).

Also thoroughly exercised all tests in the QA pmda.proc and
pmda.hotproc groups. A new test might be possible, but the nature
of the required workload would make it difficult (and expensive)
to run.