### PR TITLE
pcp-atop: fix write mode (-w) handling of proc vs hotproc metrics

### DIFF
--- a/qa/1266
+++ b/qa/1266
@@ -1,0 +1,50 @@
+#!/bin/sh
+# PCP QA Test No. 1266
+# Ensure pcp-atop(1) writes correct pmlogger configurations.
+#
+# Copyright (c) 2019 Red Hat.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+[ -f $PCP_BINADM_DIR/pcp-atop ] || _notrun "system monitoring tools not installed"
+
+_cleanup()
+{
+    cd $here
+    rm -fr $here/atoplog$seq
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+# real QA test starts here
+rm -fr $here/atoplog
+pcp atop -w atoplog$seq 1 2
+pminfo -a atoplog$seq proc hotproc >$tmp.out 2>$tmp.err
+echo "== Expect no hotproc metrics logged by default"
+if test -s $tmp.err; then
+    cat $tmp.err >> $seq.full
+    echo "passed"
+else
+    echo "failed"
+fi
+echo "== Expect some proc metrics logged by default"
+if test -s $tmp.out; then
+    cat $tmp.out >> $seq.full
+    echo "passed"
+else
+    echo "failed"
+fi
+
+# success, all done
+status=0
+exit

--- a/qa/1266.out
+++ b/qa/1266.out
@@ -1,0 +1,5 @@
+QA output created by 1266
+== Expect no hotproc metrics logged by default
+passed
+== Expect some proc metrics logged by default
+passed

--- a/qa/group
+++ b/qa/group
@@ -1611,6 +1611,7 @@ BAD
 1258 pmda.linux local valgrind
 1264 archive multi-archive collectl decompress-xz local pmlogextract pcp python
 1265 pmda.linux local valgrind
+1266 atop pcp local
 1267 pmlogrewrite labels help pmdumplog local
 1269 libpcp local kernel
 1274 pmlogextract pmdumplog labels help local sanity

--- a/src/pcp/atop/various.c
+++ b/src/pcp/atop/various.c
@@ -1166,7 +1166,7 @@ static void
 rawconfig(FILE *fp, double interval)
 {
 	char		**p;
-	unsigned int	delta;
+	unsigned int	delta, offset;
 	extern char	*hostmetrics[];
 	extern char	*ifpropmetrics[];
 	extern char	*systmetrics[];
@@ -1183,8 +1183,9 @@ rawconfig(FILE *fp, double interval)
 	fprintf(fp, "log mandatory on every %u milliseconds {\n", delta);
 	for (p = systmetrics; (*p)[0] != '.'; p++)
 		fprintf(fp, "    %s\n", *p);
+	offset = hotprocflag ? 0 : 3;
 	for (p = procmetrics; (*p)[0] != '.'; p++)
-		fprintf(fp, "    %s\n", *p);
+		fprintf(fp, "    %s\n", *p + offset);
 	fputs("}\n", fp);
 }
 


### PR DESCRIPTION
This resolves Red Hat BZ #1733866.