### PR TITLE
shell completion changes for pmlogextract -x and qa notes Changes committed to git@github.com:kmcdonell/pcp.git 20190730

### DIFF
--- a/qa/README
+++ b/qa/README
@@ -63,21 +63,33 @@ Basic getting started
     set up:
 
     (a) PCP installed from packages,
+
     (b) pmcd(1) running,
+
     (c) a login for the user "pcpqa" needs to be created, and then set
         up in such a way that ssh/scp will work without the need for any
         password, i.e. these sorts of commands
 	    $ ssh pcpqa@pcp-qa-host some-command
 	    $ scp some-file pcpqa@pcp-qa-host:some-dir
-        must work correctly when run from the local host.  The "pcpqa"
-        user's environment must also be initialized so that their shell's
-        path includes all of the PCP binary directories (identify these
-        with $ grep BIN /etc/pcp.conf), so that all PCP commands are
-        executable without full pathnames.  Of most concern would be
-        auxilliary directory (usually /usr/pcp/bin, /usr/share/pcp/bin or
-        /usr/libexec/pcp/bin) where commands like pmlogger(1), pmhostname(1),
-        mkaf(1), etc.) are installed. And finally, the "pcpqa" user needs
-	to be included in the group "pcp".
+	must work correctly when run from the local host with no
+	interactive input and no Password: prompt
+
+	On systems enforcing selinux it may be necessary to execute
+	the following command to make this work:
+	    $ sudo chcon -R unconfined_u:object_r:ssh_home_t:s0 ~pcpqa/.ssh
+	so that the ssh_home_t attribute is set on ~pcpqa/.ssh and
+	all the files below there.
+
+	The "pcpqa" user's environment must also be initialized so that
+	their shell's path includes all of the PCP binary directories
+	(identify these with $ grep BIN /etc/pcp.conf), so that all
+	PCP commands are executable without full pathnames.  Of most
+	concern would be auxilliary directory (usually /usr/pcp/bin,
+	/usr/share/pcp/bin or /usr/libexec/pcp/bin) where commands like
+	pmlogger(1), pmhostname(1), mkaf(1), etc.) are installed.
+	
+	And finally, the "pcpqa" user needs to be included in the group
+	"pcp".
 
     Once you've modified common.config and qa_hosts.master, then run
     "chk.setup" to validate the settings.

--- a/src/bashrc/pcp_completion.sh
+++ b/src/bashrc/pcp_completion.sh
@@ -65,7 +65,7 @@ _pcp_complete()
         arg_regex="-[nSTZ]"
     ;;
     pmlogextract)
-        all_args="cdfmSsTvwZz"
+        all_args="cdfmSsTvwxZz"
         arg_regex="-[cSsTvZ]"
     ;;
     pmlogsummary)

--- a/src/zshrc/_pcp
+++ b/src/zshrc/_pcp
@@ -534,6 +534,7 @@ _pcp () {
       "(-T --finish $exargs)"{-T+,--finish=}'[set end of time window]:timespec:' \
       "(-v $exargs)"-v+'[switch log volumes after this many samples]' \
       "(-w $exargs)"-w'[ignore day/month/year]' \
+      "(-x $exargs)"-x'[skip metrics with mismatched metadata]' \
       "(-Z --timezone -z --hostzone $exargs)"{-Z+,--timezone=}'[set reporting timezone]:timezone:_time_zone' \
       "(-z --hostzone -Z --timezone $exargs)"{-z,--hostzone}'[use metrics source timezone]' \
       '*:archive:->archives' \


### PR DESCRIPTION
Ken McDonell (1):
      qa/README: add notes for ssh access to pcpqa login with selinux

 qa/README |   30 +++++++++++++++++++++---------
 1 file changed, 21 insertions(+), 9 deletions(-)

Details ...

commit a995f2f27c2f318eca4328a400baf8c6c9895021
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Jul 31 06:20:08 2019 +1000

    qa/README: add notes for ssh access to pcpqa login with selinux
    
    Thanks to Mark for diagnosing this issue that surfaced recently
    when vm03 moved to Fedora 30.