### PR TITLE
tweak systemd service scripts

### DIFF
--- a/src/pmlogger/pmlogger.service.in
+++ b/src/pmlogger/pmlogger.service.in
@@ -7,6 +7,7 @@ BindsTo=pmlogger_check.timer pmlogger_daily.timer pmlogger_daily-poll.timer
 
 [Service]
 Type=forking
+TimeoutSec=120
 Restart=always
 ExecStart=@PCP_RC_DIR@/pmlogger start
 ExecStop=@PCP_RC_DIR@/pmlogger stop

--- a/src/pmlogger/pmlogger_check.service.in
+++ b/src/pmlogger/pmlogger_check.service.in
@@ -9,6 +9,3 @@ Environment="PMLOGGER_CHECK_PARAMS=-C"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
 ExecStart=@PCP_BINADM_DIR@/pmlogger_check $PMLOGGER_CHECK_PARAMS
 User=@PCP_USER@
-
-[Install]
-RequiredBy=pmlogger.service

--- a/src/pmlogger/pmlogger_check.service.in
+++ b/src/pmlogger/pmlogger_check.service.in
@@ -5,6 +5,7 @@ ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=oneshot
+TimeoutSec=120
 Environment="PMLOGGER_CHECK_PARAMS=-C"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
 ExecStart=@PCP_BINADM_DIR@/pmlogger_check $PMLOGGER_CHECK_PARAMS

--- a/src/pmlogger/pmlogger_daily.service.in
+++ b/src/pmlogger/pmlogger_daily.service.in
@@ -5,6 +5,7 @@ ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=oneshot
+TimeoutSec=120
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
 ExecStart=@PCP_BINADM_DIR@/pmlogger_daily $PMLOGGER_DAILY_PARAMS
 User=@PCP_USER@

--- a/src/pmlogger/pmlogger_daily_report.service.in
+++ b/src/pmlogger/pmlogger_daily_report.service.in
@@ -5,6 +5,7 @@ ConditionPathExists=!@CRONTAB_DAILY_REPORT_PATH@
 
 [Service]
 Type=oneshot
+TimeoutSec=120
 Environment="PMLOGGER_DAILY_REPORT_PARAMS=-o @PCP_SA_DIR@"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
 ExecStart=@PCP_BINADM_DIR@/pmlogger_daily_report $PMLOGGER_DAILY_REPORT_PARAMS


### PR DESCRIPTION
The pmlogger_check service is not required by pmlogger.service. This was causing them to run in parallel. Also, add a 120s timeout in all service scripts for both start and stop to avoid timeouts in Azure CI checks.