### PR TITLE
Added support for scientific notation for metric values in StatsD payloads

### DIFF
--- a/src/pmdas/statsd/README.md
+++ b/src/pmdas/statsd/README.md
@@ -356,7 +356,6 @@ These names are blacklisted for user usage. No messages with these names will pr
 
 # Roadmap
 - Make sure code is optimized
-- Allow _value_ to be expressed in _e_ notation
 
 # FAQ
 

--- a/src/pmdas/statsd/src/parser-ragel.rl
+++ b/src/pmdas/statsd/src/parser-ragel.rl
@@ -182,7 +182,7 @@ ragel_parser_parse(char* str, struct statsd_datagram** datagram) {
 		str_value = [a-z][a-zA-Z0-9_.]*;
 		tag_string = [a-zA-Z0-9_.]{1,};
 		name = str_value[:,]{1};
-		value = ('+'|'-')?[0-9]{1,310}([.][0-9]{1,310})?('|');
+		value = ('+'|'-')?[0-9]+(('.')[0-9]+)?(('e'|'E')('+'|'-')?[0-9]+)?('|');
 		type = ('c'|'g'|'ms')('@'|'\0'|'\n\0'|("|#"));
 		tags = ((tag_string'=')@tag_key_parsed(tag_string(':'|',')@tag_value_parsed))+;
 		tags_end = ((tag_string':')@tag_key_parsed(tag_string(','|'\0'|'\n\0')@tag_value_parsed))+;

--- a/src/pmdas/statsd/src/pmda-callbacks.c
+++ b/src/pmdas/statsd/src/pmda-callbacks.c
@@ -116,7 +116,17 @@ create_pcp_metric(char* key, struct metric* item, pmdaExt* pmda) {
     } else {
         new_metric->m_desc.sem = PM_SEM_INSTANT;
     }
-    memset(&new_metric->m_desc.units, 0, sizeof(pmUnits));
+    if (item->type == METRIC_TYPE_DURATION) {
+        new_metric->m_desc.units.dimSpace = 0;
+        new_metric->m_desc.units.dimCount = 0;
+        new_metric->m_desc.units.pad = 0;
+        new_metric->m_desc.units.scaleSpace = 0;
+        new_metric->m_desc.units.dimTime = 1;
+        new_metric->m_desc.units.scaleTime = PM_TIME_MSEC;
+        new_metric->m_desc.units.scaleCount = 1;
+    } else {
+        memset(&new_metric->m_desc.units, 0, sizeof(pmUnits));
+    }
     item->meta->pmid = newpmid;
     VERBOSE_LOG(
         1,

--- a/src/pmdas/statsd/src/pmdastatsd.c
+++ b/src/pmdas/statsd/src/pmdastatsd.c
@@ -136,10 +136,10 @@ create_statsd_hardcoded_metrics(struct pmda_data_extension* data) {
         if (i == 5 || i == 6) {
             // time_spent_parsing / time_spent_aggregating
             data->pcp_metrics[i].m_desc.units.dimSpace = 0;
-            data->pcp_metrics[i].m_desc.units.dimTime = 0;
             data->pcp_metrics[i].m_desc.units.dimCount = 0;
             data->pcp_metrics[i].m_desc.units.pad = 0;
             data->pcp_metrics[i].m_desc.units.scaleSpace = 0;
+            data->pcp_metrics[i].m_desc.units.dimTime = 1;
             data->pcp_metrics[i].m_desc.units.scaleTime = PM_TIME_NSEC;
             data->pcp_metrics[i].m_desc.units.scaleCount = 1;
         } else {


### PR DESCRIPTION
+ ...and small fix for underflow detection

Payloads with values such as these are valid:
:+1:
```
test:1e1|g
test:+1e+1|g
test:-1e-1|g
test:1.1e1|g
```
These are not:
:-1:
```
test:-.2e2|g
test:.2e2|g
test:e2|g
test:2e2.2|g
```