### PR TITLE
qa + trace PMDA for *BSD Changes committed to git@github.com:kmcdonell/pcp.git 20190903

### DIFF
--- a/qa/1100.out
+++ b/qa/1100.out
@@ -1,5 +1,2 @@
 QA output created by 1100
-== only V+u for pmlogger should be missing
-V missing for pmlogger zsh completions
-u missing for pmlogger zsh completions
 == done

--- a/qa/1671
+++ b/qa/1671
@@ -30,7 +30,8 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 for t in 1s 5s 30s 1m 5m 10m; do
     echo;echo == testing replay of corrupted archive with interval $t for max 10000 samples | tee -a $seq.full
     pmrep -Dinterp,log -s 10000 -z -a archives/multi-corrupted -t$t -pf%c kernel.percpu.cpu.user >>$seq.full 2>&1
-    pmrep -s 10000 -z -a archives/multi-corrupted -t$t -pf%c kernel.percpu.cpu.user
+    pmrep -s 10000 -z -a archives/multi-corrupted -t$t -pf%c kernel.percpu.cpu.user 2>$tmp.err
+    cat $tmp.err
 done
 
 echo if unexpected output, see $seq.full

--- a/qa/1671.out
+++ b/qa/1671.out
@@ -679,7 +679,6 @@ Fri May  8 11:55:15 2015     950.000     952.000     989.000     213.000
 Fri May  8 11:55:16 2015     950.000     951.000     989.000     213.000
 Fri May  8 11:55:17 2015     950.000     951.000     989.000     213.000
 Fri May  8 11:55:18 2015     950.000     952.000     989.000     213.000
-pmrep: Corrupted record in a PCP archive log
 Fri May  8 11:55:19 2015     950.000     951.000     988.000     212.000
 Fri May  8 11:55:20 2015     950.000     951.000     989.000     213.000
 Fri May  8 11:55:21 2015     950.000     952.000     989.000     213.000
@@ -749,6 +748,7 @@ Fri May  8 11:56:24 2015     965.000     364.000     998.000     780.000
 Fri May  8 11:56:25 2015     965.000     363.000     997.000     781.000
 Fri May  8 11:56:26 2015     965.000     364.000     998.000     780.000
 Fri May  8 11:56:27 2015     965.000     363.000     998.000     781.000
+pmrep: Corrupted record in a PCP archive log
 
 == testing replay of corrupted archive with interval 5s for max 10000 samples
                           k.p.c.user  k.p.c.user  k.p.c.user  k.p.c.user
@@ -864,7 +864,6 @@ Fri May  8 11:52:54 2015     547.600     670.200     979.000     273.600
 Fri May  8 11:52:59 2015     547.400     670.400     979.000     273.600
 Fri May  8 11:53:04 2015     547.600     670.400     979.000     273.800
 Fri May  8 11:53:09 2015     547.400     670.400     979.000     273.600
-pmrep: Corrupted record in a PCP archive log
 Fri May  8 11:53:14 2015     547.600     670.400     979.000     273.800
 Fri May  8 11:53:19 2015     547.600     670.200     979.200     273.600
 Fri May  8 11:53:24 2015     547.400     670.400     979.000     273.600
@@ -904,9 +903,9 @@ Fri May  8 11:56:09 2015     965.000     363.400     997.800     780.600
 Fri May  8 11:56:14 2015     965.200     363.400     997.600     780.600
 Fri May  8 11:56:19 2015     965.000     363.600     997.600     780.400
 Fri May  8 11:56:24 2015     965.200     363.400     997.600     780.600
+pmrep: Corrupted record in a PCP archive log
 
 == testing replay of corrupted archive with interval 30s for max 10000 samples
-pmrep: Corrupted record in a PCP archive log
                           k.p.c.user  k.p.c.user  k.p.c.user  k.p.c.user
                                 cpu0        cpu1        cpu2        cpu3
                                 ms/s        ms/s        ms/s        ms/s
@@ -935,9 +934,9 @@ Fri May  8 11:54:34 2015     961.600     589.233     972.633     593.800
 Fri May  8 11:55:04 2015     950.033     951.367     988.867     212.800
 Fri May  8 11:55:34 2015     953.433     817.133     990.833     342.433
 Fri May  8 11:56:04 2015     965.133     363.433     997.600     780.533
+pmrep: Corrupted record in a PCP archive log
 
 == testing replay of corrupted archive with interval 1m for max 10000 samples
-pmrep: Corrupted record in a PCP archive log
                           k.p.c.user  k.p.c.user  k.p.c.user  k.p.c.user
                                 cpu0        cpu1        cpu2        cpu3
                                 ms/s        ms/s        ms/s        ms/s
@@ -954,21 +953,22 @@ Fri May  8 11:53:04 2015     708.567     518.800     977.150     530.800
 Fri May  8 11:54:04 2015     804.050     554.583     972.183     539.767
 Fri May  8 11:55:04 2015     955.817     770.300     980.750     403.300
 Fri May  8 11:56:04 2015     959.283     590.283     994.217     561.483
+pmrep: Corrupted record in a PCP archive log
 
 == testing replay of corrupted archive with interval 5m for max 10000 samples
-pmrep: Corrupted record in a PCP archive log
                           k.p.c.user  k.p.c.user  k.p.c.user  k.p.c.user
                                 cpu0        cpu1        cpu2        cpu3
                                 ms/s        ms/s        ms/s        ms/s
 Fri May  8 11:44:04 2015         N/A         N/A         N/A         N/A
 Fri May  8 11:49:04 2015         N/A         N/A         N/A         N/A
 Fri May  8 11:54:04 2015         N/A         N/A         N/A         N/A
+pmrep: Corrupted record in a PCP archive log
 
 == testing replay of corrupted archive with interval 10m for max 10000 samples
-pmrep: Corrupted record in a PCP archive log
                           k.p.c.user  k.p.c.user  k.p.c.user  k.p.c.user
                                 cpu0        cpu1        cpu2        cpu3
                                 ms/s        ms/s        ms/s        ms/s
 Fri May  8 11:44:04 2015         N/A         N/A         N/A         N/A
 Fri May  8 11:54:04 2015         N/A         N/A         N/A         N/A
+pmrep: Corrupted record in a PCP archive log
 if unexpected output, see 1671.full

--- a/qa/915
+++ b/qa/915
@@ -13,6 +13,14 @@ echo "QA output created by $seq"
 . ./common.filter
 . ./common.check
 
+if which systemctl >/dev/null 2>&1
+then
+    :
+else
+    _notrun "No systemctl executable"
+    # NOTREACHED
+fi
+
 host=`hostname`
 [ -z "$host" ] && _notrun "Cannot discover local host name"
 interface=`_host_to_ipaddr $host`

--- a/qa/953
+++ b/qa/953
@@ -47,6 +47,8 @@ _filter_ncpu()
 # 192.0.2.22 -51 (Network is unreachable, Mac OS X)
 # and
 # 192.0.2.22 -65 (No route to host, Mac OS X)
+# and
+# 192.0.2.22 -61 (Connection refused. *BSD)
 # so treat 'em as equivalent here ...
 #
 _filter_connect_fail()
@@ -59,6 +61,7 @@ _filter_connect_fail()
 	-e '/^192\..*-60$/s/-60/NETERROR/' \
 	-e '/^192\..*-51$/s/-51/NETERROR/' \
 	-e '/^192\..*-65$/s/-65/NETERROR/' \
+	-e '/^192\..*-61$/s/-65/NETERROR/' \
     # end
 }
 

--- a/qa/967
+++ b/qa/967
@@ -1,6 +1,6 @@
 #!/bin/sh
-# PCP QA Test No. 1100
-# bash shell completion check (see 967 for zsh version)
+# PCP QA Test No. 967
+# zsh shell completion check (see 1100 for bash version)
 #
 # Copyright (c) 2017 Red Hat.
 #
@@ -12,6 +12,14 @@ echo "QA output created by $seq"
 . ./common.python
 . ./common.config
 echo "PCPQA_CLOSE_X_SERVER=$PCPQA_CLOSE_X_SERVER" >>$here/$seq.full
+
+if which zsh >/dev/null 2>&1
+then
+    :
+else
+    _notrun "No zsh executable"
+    # NOTREACHED
+fi
 
 status=1       # failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
@@ -81,14 +89,12 @@ fi
 
 # sources
 share_dir=`dirname $PCP_SHARE_DIR`
-bash_comp=${share_dir}/bash-completion/completions/pcp
+zsh_comp=${share_dir}/zsh/site-functions/_pcp
 
 # functions
-_check_completion_bash()
+_check_completion_zsh()
 {
-  cmds="$(grep '  pcp2.*)' $bash_comp | tr -d ')')"
-  cmds="$cmds $(grep '  pm.*)' $bash_comp | tr -d ')')"
-  for cmd in $cmds; do
+  for cmd in $(grep '#compdef' $zsh_comp | sed -e 's,#compdef ,,'); do
     $skip_pcp2elasticsearch && [ "$cmd" = pcp2elasticsearch ] && continue
     $skip_pcp2graphite && [ "$cmd" = pcp2graphite ] && continue
     $skip_pcp2influxdb && [ "$cmd" = pcp2influxdb ] && continue
@@ -101,32 +107,65 @@ _check_completion_bash()
     $skip_pmdumptext && [ "$cmd" = pmdumptext ] && continue
     $skip_pmrep && [ "$cmd" = pmrep ] && continue
     $skip_pmseries && [ "$cmd" = pmseries ] && continue
-    comps=$(grep -A 1 "  $cmd)" $bash_comp | tail -n 1 | sed -e 's,all_args=",,' -e 's,",,')
+    echo $cmd | grep = > /dev/null 2>&1 && continue
+    common=$(awk "/common_most=/,/  \)/" $zsh_comp)
+    pytool=$(awk "/common_python=/,/  \)/" $zsh_comp)
+    pmda=$(awk "/common_pmda=/,/  \)/" $zsh_comp)
+    version=V
+    comps=$(awk "/  $cmd\)/,/\;\;/" $zsh_comp | sed -e 's,equivalent to .*,,')
     # Need $tmp.err and PCP_STDERR for pmchart ...
     #
     rm -f $tmp.err
     touch $tmp.err
-    echo "=== bash $cmd ===" >>$here/$seq.full
+    echo "=== zsh $cmd ===" >>$here/$seq.full
     echo "comps=$comps" >>$here/$seq.full
     $cmd --help >$tmp.out 2>&1
     echo "--- stdout ---" >>$here/$seq.full
     cat $tmp.out >>$here/$seq.full
     echo "--- stderr ---" >>$here/$seq.full
     cat $tmp.err >>$here/$seq.full
-    opts=$(cat $tmp.out $tmp.err | grep -Eo -- ' -.' | tr -d '-' | tr -d '?' | sort | uniq)
+    opts=$(cat $tmp.out $tmp.err | sed -e 's,equivalent to .*,,' | grep -Eo -- ' -[^-].' | tr -d - | tr -d '?' | tr -d , | sort | uniq)
     echo "opts=$opts" >>$here/$seq.full
 
     for opt in $opts; do
-      echo $comps | grep $opt > /dev/null 2>&1
-      if [ $? -ne 0 ]; then
-        echo "$opt missing for $cmd bash completions"
+      echo $comps | grep -E -- '({-'$opt'|"-'$opt')' > /dev/null 2>&1
+      not_found=$?
+      if [ $not_found -ne 0 ]; then
+        if [ "$opt" = "V" ]; then
+          echo $comps | grep common_help > /dev/null 2>&1
+          not_found=$?
+        fi
+      fi
+      if [ $not_found -ne 0 ]; then
+        echo $comps | grep common_most > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+          echo $common | grep -E -- '({-'$opt'|"-'$opt')' > /dev/null 2>&1
+          not_found=$?
+        fi
+      fi
+      if [ $not_found -ne 0 ]; then
+        echo $comps | grep common_pmda > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+          echo $pmda | grep -E -- '({-'$opt'|"-'$opt')' > /dev/null 2>&1
+          not_found=$?
+        fi
+      fi
+      if [ $not_found -ne 0 ]; then
+        echo $comps | grep common_python > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+          echo $pytool | grep -E -- '({-'$opt'|"-'$opt')' > /dev/null 2>&1
+          not_found=$?
+        fi
+      fi
+      if [ $not_found -ne 0 ]; then
+        echo "$opt missing for $cmd zsh completions"
       fi
     done
 
-    for comp in $(echo $comps | grep -o .); do
+    for comp in $(echo $comps | grep -o \"\(-. | tr -d '"' | tr -d '(' | tr -d '-'); do
       echo $opts | grep $comp > /dev/null 2>&1
       if [ $? -ne 0 ]; then
-        echo "$comp looks extraneous for $cmd bash completions"
+        echo "$comp looks extraneous for $cmd zsh completions"
       fi
     done
 
@@ -134,7 +173,8 @@ _check_completion_bash()
 }
 
 # real QA test starts here
-_check_completion_bash
+echo "== only V+u for pmlogger should be missing"
+_check_completion_zsh
 
 # success, all done
 echo "== done"

--- a/qa/967.out
+++ b/qa/967.out
@@ -1,0 +1,5 @@
+QA output created by 1100
+== only V+u for pmlogger should be missing
+V missing for pmlogger zsh completions
+u missing for pmlogger zsh completions
+== done

--- a/qa/group
+++ b/qa/group
@@ -1367,6 +1367,7 @@ BAD
 964 pmcd local pmda.xfs pmda.dm
 965 derive local kernel
 966 secure local kernel
+967 zsh local pcp2xxx pcp2elasticsearch pcp2xlsx pcp2influxdb pcp2graphite pmrep python pcp2zabbix pcp2xml pcp2json
 968 python local derive kernel
 969 derive local kernel
 970 pmclient archive multi-archive local sanity pmlogextract python
@@ -1499,7 +1500,7 @@ BAD
 1097 pmlogconf local
 1098 python local pmstore
 1099 archive pmiostat local pmie pcp python
-1100 bash zsh local pcp2xxx pcp2elasticsearch pcp2xlsx pcp2influxdb pcp2graphite pmrep python pcp2zabbix pcp2xml pcp2json
+1100 bash local pcp2xxx pcp2elasticsearch pcp2xlsx pcp2influxdb pcp2graphite pmrep python pcp2zabbix pcp2xml pcp2json
 1101 libpcp_web local valgrind
 1102 pmda.prometheus local python
 1103 derive local

--- a/src/pmdas/trace/GNUmakefile
+++ b/src/pmdas/trace/GNUmakefile
@@ -93,6 +93,27 @@ default_pcp:	default
 
 install_pcp:	install
 
+ifneq "$(PCP_INC_DIR)" "/usr/include/pcp"
+# for cc add -I<run-time-include-dir> (need /.. at the end so
+# #include <pcp/foo.h> works) when $(PCP_INC_DIR) may not be on
+# the default cpp include search path.
+MY_INC_DIR	= -I$(PCP_INC_DIR)/..
+else
+MY_INC_DIR	=
+endif
+ifneq "$(PCP_LIB_DIR)" "/usr/lib"
+# for ld add -L<run-time-lib-dir> and include -rpath when
+# $(PCP_LIB_DIR) may not be on the default ld search path.
+#
+ifeq "$(PCP_PLATFORM)" "darwin"
+MY_LIBS		= -L$(PCP_LIB_DIR) -Wl,-rpath $(PCP_LIB_DIR)
+else
+MY_LIBS		= -L$(PCP_LIB_DIR) -Wl,-rpath=$(PCP_LIB_DIR)
+endif
+else
+MY_LIBS		=
+endif
+
 .NOTPARALLEL:
 Makefile.demos:	Makefile.proto
 	rm -f $@
@@ -100,6 +121,8 @@ Makefile.demos:	Makefile.proto
 		-e 's@PTHREAD_LIB@$(LIB_FOR_PTHREADS)@' \
 		-e 's@DLOPEN_LIB@$(LIB_FOR_DLOPEN)@' \
 		-e 's@MATH_LIB@$(LIB_FOR_MATH)@' \
+		-e 's@MY_INC_DIR@$(MY_INC_DIR)@' \
+		-e 's@MY_LIBS@$(MY_LIBS)@' \
 		<$^ >$@
 
 Makefile.stub:	GNUmakefile.stub
@@ -115,3 +138,6 @@ else
 		-e 's@$$(PCP_ETC_DIR)@$(PCP_ETC_DIR)@' \
 		<$^ >$@
 endif
+
+eek:
+	echo $(TARGET_OS)

--- a/src/pmdas/trace/Makefile.proto
+++ b/src/pmdas/trace/Makefile.proto
@@ -37,27 +37,27 @@ java:		$(JDEMO)
 
 pmtrace:	pmtrace.c
 	rm -f $@
-	$(CC) $(CFLAGS) -o $@ pmtrace.c $(LDFLAGS) -lpcp -lpcp_trace 
+	$(CC) $(CFLAGS) MY_INC_DIR -o $@ pmtrace.c $(LDFLAGS) MY_LIBS -lpcp -lpcp_trace 
 
 app1:	app1.c
 	rm -f $@
-	$(CC) $(CFLAGS) -o $@ app1.c $(LDFLAGS) -lpcp -lpcp_trace
+	$(CC) $(CFLAGS) MY_INC_DIR -o $@ app1.c $(LDFLAGS) MY_LIBS -lpcp -lpcp_trace
 
 app2:	app2.c
 	rm -f $@
-	$(CC) $(CFLAGS) -o $@ app2.c $(LDFLAGS) -lpcp -lpcp_trace
+	$(CC) $(CFLAGS) MY_INC_DIR -o $@ app2.c $(LDFLAGS) MY_LIBS -lpcp -lpcp_trace
 
 app3:	app3.c
 	rm -f $@
-	$(CC) $(CFLAGS) -o $@ app3.c $(LDFLAGS) -lpcp -lpcp_trace PTHREAD_LIB DLOPEN_LIB MATH_LIB
+	$(CC) $(CFLAGS) MY_INC_DIR -o $@ app3.c $(LDFLAGS) MY_LIBS -lpcp -lpcp_trace PTHREAD_LIB DLOPEN_LIB MATH_LIB
 
 fapp1.77:	fapp1.f
 	rm -f $@
-	$(F77C) $(FFLAGS) -o $@ fapp1.f $(LDFLAGS) -lpcp -lpcp_trace
+	$(F77C) $(FFLAGS) -o $@ fapp1.f $(LDFLAGS) MY_LIBS -lpcp -lpcp_trace
 
 fapp1.90:	fapp1.f
 	rm -f $@
-	$(F90C) $(FFLAGS) -o $@ fapp1.f $(LDFLAGS) -lpcp -lpcp_trace
+	$(F90C) $(FFLAGS) -o $@ fapp1.f $(LDFLAGS) MY_LIBS -lpcp -lpcp_trace
 
 japp1.class:	japp1.java
 	rm -f $@


### PR DESCRIPTION
Ken McDonell (5):
      qa/1671: separate stderr and stdio from pmrep
      src/pmdas/trace: makefile fixes for netbsd
      qa/953: map errno 61 (Connection refused) -> NETERROR (for *BSD systems)
      qa/915: really only makes sense to run this if systemctl is present
      qa/1100: split into 1100 (bash) and 967 (new, zsh)

 qa/1100                        |   86 -------------------
 qa/1100.out                    |    3 
 qa/1671                        |    3 
 qa/1671.out                    |   12 +-
 qa/915                         |    8 +
 qa/953                         |    3 
 qa/967                         |  182 +++++++++++++++++++++++++++++++++++++++++
 qa/967.out                     |    5 +
 qa/group                       |    3 
 src/pmdas/trace/GNUmakefile    |   26 +++++
 src/pmdas/trace/Makefile.proto |   12 +-
 11 files changed, 242 insertions(+), 101 deletions(-)

Details ...

commit 27aeb9b53494c8b86cdc82960186f65817a3796f
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Sep 4 09:00:39 2019 +1000

    qa/1100: split into 1100 (bash) and 967 (new, zsh)
    
    For systems where there is bash but no zsh (like *BSD) this will
    allow 1100 to pass and not run 967, rather than the old 1100 always
    failing.

commit 5d3289343d5259e7f0dfb382f9ea2fdbbcf6c701
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Sep 4 08:59:52 2019 +1000

    qa/915: really only makes sense to run this if systemctl is present

commit 6a319d8fbc862dbf10e2dca5454d6bacff4493be
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Sep 3 09:48:58 2019 +1000

    qa/953: map errno 61 (Connection refused) -> NETERROR (for *BSD systems)

commit 0b842ca416dbd8e5c02c9369b4031b12639501ea
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Sep 3 08:22:25 2019 +1000

    src/pmdas/trace: makefile fixes for netbsd
    
    If we install PCP headers and libraries in places where cc(1) and
    ld(1) don't look by default, we need -I and -L options in the
    Makefile to rebuild the demo apps.

commit db9759a6a537b8ea7e2745a93011a78376c74fde
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Sep 3 07:08:27 2019 +1000

    qa/1671: separate stderr and stdio from pmrep
    
    Stops buffer flushing that is not consistent across all platforms.