### PR TITLE
libpcp,libpcp_pmda: fortify pmdaCache against NULL instance names

### DIFF
--- a/qa/1152
+++ b/qa/1152
@@ -59,6 +59,13 @@ echo "=== report metric values ==="
 pminfo -dfmtT bcc.usdt.jvm.alloc 2>&1 | tee -a $here/$seq.full \
 | grep TestUnit | _value_filter
 
+echo "=== check for libpcp pmdaCacheOp segfault if key field is empty ==="
+cp /var/lib/pcp/config/pmda/149.120 $tmp.149.120
+$sudo sed -i 's/ TestUnit//' /var/lib/pcp/config/pmda/149.120
+$sudo mv $tmp.149.120 /var/lib/pcp/config/pmda/149.120
+pminfo -dfmtT bcc.usdt.jvm.alloc 2>&1 | tee -a $here/$seq.full \
+| grep TestUnit | _value_filter
+
 $signal -s KILL $javapid > /dev/null 2>&1
 _pmdabcc_remove 2>&1
 

--- a/qa/1152.out
+++ b/qa/1152.out
@@ -43,6 +43,8 @@ Check bcc metrics have appeared ... X metrics and X values
 
 === report metric values ===
 OK
+=== check for libpcp pmdaCacheOp segfault if key field is empty ===
+OK
 
 === remove bcc agent ===
 Culling the Performance Metrics Name Space ...

--- a/src/libpcp_pmda/src/cache.c
+++ b/src/libpcp_pmda/src/cache.c
@@ -558,9 +558,18 @@ insert_cache(hdr_t *h, const char *name, int inst, int *sts)
     entry_t	*last_e = NULL;
     char	*dup;
     int		i;
-    int		hashlen = get_hashlen(h, name);
+    int		hashlen;
 
     *sts = 0;
+
+    if (name == NULL || strlen(name) == 0) {
+	pmNotifyErr(LOG_ERR, 
+	     "insert_cache: NULL or zero length instance name for inst %d\n", inst);
+	*sts = PM_ERR_GENERIC;
+	return NULL;
+    }
+
+    hashlen = get_hashlen(h, name);
 
     if (inst != PM_IN_NULL) {
 	/*


### PR DESCRIPTION
A while back Marko reported pminfo segfaults involving bcc metrics
when used to instrument Java12. This turned out to be NULL instance
names being stored in the pmdaCache file (which is actually a bug
in pmdabcc).

In defense of that scenario, fortify libpcp_pmda and libpcp
against NULL instance names being read in from the indom cache;
rather than segfault, return an appropriate error.

Also update qa/1152 to test and verify the fix. The pmdabcc bug
will be fixed separately now that it's easier to debug.