### PR TITLE
qa and small coverity-driven fixes Changes committed to git@github.com:kmcdonell/pcp.git 20190910

### DIFF
--- a/qa/1146
+++ b/qa/1146
@@ -50,7 +50,7 @@ do
     _filter_pcp_start <$tmp.$i
 done
 
-./870 --check
+./870 --check $seq
 
 echo "+++ at the end primary pmlogger pid = `_get_primary_logger_pid`" >>$here/$seq.full
 

--- a/qa/660
+++ b/qa/660
@@ -62,7 +62,6 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 # *   Trying LOCALADDR...
 # * Connection refused
 # * connect to ::1 port 44323 failed: Connection refused
-# * Mark bundle as not supporting multiuse
 # WARNING: gnome-keyring:: couldn't connect to: ...
 # * TCP_NODELAY set
 # * Curl_http_done: called premature == 0
@@ -75,12 +74,12 @@ _filter()
 	-e '/Hostname was NOT found in DNS cache/d' \
 	-e '/About to connect() to LOCALHOST port 44323 (####)/d' \
 	-e '/^\* Connected to LOCALHOST (LOCALADDR) port 44323/d' \
+	-e '/^\* Mark bundle as not supporting multiuse/d' \
 	-e '/^\* HTTP 1.1 or later with persistent connection/d' \
 	-e '/^\* additional stuff not fine/d' \
 	-e '/^\*  *Trying LOCALADDR/d' \
 	-e '/^\* Connection refused/d' \
 	-e '/^\* connect to .*: Connection refused/d' \
-	-e '/^\* Mark bundle as not supporting multiuse/d' \
 	-e '/WARNING: gnome-keyring::/d' \
 	-e '/^\* TCP_NODELAY set/d' \
 	-e '/^\* Curl_http_done: called premature == 0/d' \

--- a/qa/660
+++ b/qa/660
@@ -62,6 +62,7 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 # *   Trying LOCALADDR...
 # * Connection refused
 # * connect to ::1 port 44323 failed: Connection refused
+# * Mark bundle as not supporting multiuse
 # WARNING: gnome-keyring:: couldn't connect to: ...
 # * TCP_NODELAY set
 # * Curl_http_done: called premature == 0
@@ -74,12 +75,12 @@ _filter()
 	-e '/Hostname was NOT found in DNS cache/d' \
 	-e '/About to connect() to LOCALHOST port 44323 (####)/d' \
 	-e '/^\* Connected to LOCALHOST (LOCALADDR) port 44323/d' \
-	-e '/^\* Mark bundle as not supporting multiuse/d' \
 	-e '/^\* HTTP 1.1 or later with persistent connection/d' \
 	-e '/^\* additional stuff not fine/d' \
 	-e '/^\*  *Trying LOCALADDR/d' \
 	-e '/^\* Connection refused/d' \
 	-e '/^\* connect to .*: Connection refused/d' \
+	-e '/^\* Mark bundle as not supporting multiuse/d' \
 	-e '/WARNING: gnome-keyring::/d' \
 	-e '/^\* TCP_NODELAY set/d' \
 	-e '/^\* Curl_http_done: called premature == 0/d' \

--- a/qa/870
+++ b/qa/870
@@ -193,13 +193,12 @@ $2 == '"$pid"'	{ print }'
 		    # OK
 		    :
 		else
-		    echo "Error: no matching pmlogger process for ..."
-		    ls -l $PCP_TMP_DIR/pmlogger/$file
+		    echo "Warning: no matching pmlogger process for ..." >>$here/$seq.full
+		    ls -l $PCP_TMP_DIR/pmlogger/$file >>$here/$seq.full
 		    if $check
 		    then
 			$sudo rm -f $PCP_TMP_DIR/pmlogger/$file
-			echo "File removed."
-			touch $tmp.err
+			echo "File removed." >>$here/$seq.full
 		    fi
 		fi
 	    fi
@@ -248,19 +247,18 @@ $2 == '"$pid"'	{ print }'
 		    # OK
 		    :
 		else
-		    echo "Error: no matching pmlogger process for ..."
-		    ls -l $PCP_RUN_DIR/$file
+		    echo "Warning: no matching pmlogger process for ..." >>$here/$seq.full
+		    ls -l $PCP_RUN_DIR/$file >>$here/$seq.full
 		    if $check
 		    then
 			$sudo rm -f $PCP_RUN_DIR/$file
 			case "$file"
 			in
-			    *.socket)	echo "Socket removed."
+			    *.socket)	echo "Socket removed." >>$here/$seq.full
 					;;
-			    *)		echo "File removed."
+			    *)		echo "File removed." >>$here/$seq.full
 					;;
 			esac
-			touch $tmp.err
 		    fi
 		fi
 	    fi

--- a/src/external/dict.c
+++ b/src/external/dict.c
@@ -1066,7 +1066,8 @@ size_t _dictGetStatsHt(char *buf, size_t bufsize, dictht *ht, int tableid) {
         " Chain length distribution:\n",
         tableid, (tableid == 0) ? "main hash table" : "rehashing target",
         ht->size, ht->used, slots, maxchainlen,
-        (float)totchainlen/slots, (float)ht->used/slots);
+        slots > 0 ? (float)totchainlen/slots : 0.0,
+	slots > 0 ? (float)ht->used/slots : 0.0);
 
     for (i = 0; i <= DICT_STATS_VECTLEN-1; i++) {
         if (clvector[i] == 0) continue;

--- a/src/libpcp/src/events.c
+++ b/src/libpcp/src/events.c
@@ -525,8 +525,10 @@ UnpackEventRecords(__pmContext *ctxp, pmValueSet *vsp, int idx, pmResult ***rap)
      */
 PM_FAULT_POINT("libpcp/" __FILE__ ":1", PM_FAULT_ALLOC);
     need = (eap->ea_nrecords + 1) * sizeof(pmResult *);
-    if ((rpp = (pmResult **)malloc(need)) == NULL)
+    if ((rpp = (pmResult **)malloc(need)) == NULL) {
+	*rap = NULL;
 	return -oserror();
+    }
     *rap = rpp;
 
     base = (char *)&eap->ea_record[0];
@@ -626,8 +628,10 @@ pmUnpackHighResEventRecords(pmValueSet *vsp, int idx, pmHighResResult ***rap)
      */
 PM_FAULT_POINT("libpcp/" __FILE__ ":7", PM_FAULT_ALLOC);
     need = (hreap->ea_nrecords + 1) * sizeof(pmHighResResult *);
-    if ((rpp = (pmHighResResult **)malloc(need)) == NULL)
+    if ((rpp = (pmHighResResult **)malloc(need)) == NULL) {
+	*rap = NULL;
 	return -oserror();
+    }
     *rap = rpp;
 
     base = (char *)&hreap->ea_record[0];

--- a/src/libpcp_gui/src/timestate.c
+++ b/src/libpcp_gui/src/timestate.c
@@ -120,6 +120,7 @@ pmTimeStateSetup(
     pmTime	*pmtime = malloc(sizeof(pmTime));
     pmTime	*pmtime_tmp;
     int		fd, sts, tzlen;
+    char	tzbuf[PM_TZ_MAXLEN];
 
     if (pmtime == NULL) {
 	fprintf(stderr, "%s: pmTimeConnect: malloc: %s\n", pmGetProgname(), osstrerror());
@@ -141,7 +142,6 @@ pmTimeStateSetup(
 	pmtimevalNow(&pmtime->position);
     }
     if (tz == NULL) {
-	char	tzbuf[PM_TZ_MAXLEN];
 	tz = __pmTimezone_r(tzbuf, sizeof(tzbuf));
 	if (ctxt == PM_CONTEXT_ARCHIVE) {
 	    if ((sts = pmNewZone(tz)) < 0) {

--- a/src/libpcp_mmv/src/mmv_stats.c
+++ b/src/libpcp_mmv/src/mmv_stats.c
@@ -988,8 +988,15 @@ get_label(const char *name, const char *value, mmv_value_type_t type,
 	    }
 	    break;
 	case MMV_NUMBER_TYPE:
-	    if (value)
-		(void)strtod(value, &endnum);
+	    if (value) {
+		/*
+		 * Don't even ask ... we want to scan the input buffer
+		 * and are only interested in a possible error ... the
+		 * (void)(...+1) babble is the only way to silence new
+		 * "smart" C compilers!
+		 */
+		(void)(strtod(value, &endnum)+1);
+	    }
 	    if (len < 1 || *endnum != '\0') {
 		setoserror(EINVAL);
 		return -1;

--- a/src/libpcp_qmc/src/qmc_metric.cpp
+++ b/src/libpcp_qmc/src/qmc_metric.cpp
@@ -116,6 +116,7 @@ QmcMetric::setupDesc(QmcGroup* group, pmMetricSpec *metricSpec)
     int descType;
     char *src = NULL;
     char *name = NULL;
+    char *host = NULL;
 
     if (metricSpec->isarch == 1)
 	contextType = PM_CONTEXT_ARCHIVE;
@@ -153,10 +154,12 @@ QmcMetric::setupDesc(QmcGroup* group, pmMetricSpec *metricSpec)
 	    my.status = PM_ERR_CONV;
 	    name = strdup(nameAscii());
 	    src = strdup(context()->source().sourceAscii());
+	    /* hostAscii() is already a strdup'd result */
+	    host = context()->source().hostAscii();
 	    pmprintf("%s: Error: %s%c%s is not supported on %s\n",
 		     pmGetProgname(), contextType == PM_CONTEXT_LOCAL ? "@" : src,
 		     (contextType == PM_CONTEXT_ARCHIVE ? '/' : ':'),
-		     name, context()->source().hostAscii());
+		     name, host);
 	}
 	else if (descType == PM_TYPE_AGGREGATE ||
 		 descType == PM_TYPE_AGGREGATE_STATIC ||
@@ -176,6 +179,8 @@ QmcMetric::setupDesc(QmcGroup* group, pmMetricSpec *metricSpec)
 	free(name);
     if (src)
 	free(src);
+    if (host)
+	free(host);
 }
 
 void

--- a/src/pcp/atop/atopsar.c
+++ b/src/pcp/atop/atopsar.c
@@ -1539,6 +1539,9 @@ gendskline(struct sstat *ss, char *tstamp, char selector)
 		if (nlines++)
 			printf("%s  ", tstamp);
 
+		if (mstot == 0)
+			mstot = 1;	/* avoid divide-by-zero */
+
 		if (dskbadness)
 			badness = (dp->io_ms * 100.0 / mstot) * 100/dskbadness;
                 else

--- a/src/pcp/atop/showgeneric.c
+++ b/src/pcp/atop/showgeneric.c
@@ -1421,7 +1421,15 @@ generic_samp(double curtime, double nsecs,
 					break;
 
 				   case 12:	// container id
-					(void)strtol(procsel.container, &p, 16);
+					/*
+					 * Don't even ask ... we want to
+					 * scan the input buffer and are only
+					 * interested in a possible error ...
+					 * the (void)(...+1) babble is the
+					 * only way to silence new "smart" C
+					 * compilers!
+					 */
+					(void)(strtol(procsel.container, &p, 16)+1);
 
 					if (*p)
 					{

--- a/src/pmdas/weblog/check_match.c
+++ b/src/pmdas/weblog/check_match.c
@@ -387,26 +387,29 @@ main(int argc, char *argv[])
 
 	fprintf(stderr,
 	    "Client Cache %% hit rate: %.2f\n", 
-	    100.0*(float)client_cache_hits/(float)(client_cache_hits + proxy_cache_hits + remote_fetches));
+	    client_cache_hits + proxy_cache_hits + remote_fetches> 0 ?
+		100.0*(float)client_cache_hits/(float)(client_cache_hits + proxy_cache_hits + remote_fetches) : 0.0);
 	fprintf(stderr,
 	    "Proxy  Cache %% hit rate: %.2f\n", 
-	    100.0*(float)proxy_cache_hits/(float)(client_cache_hits + proxy_cache_hits + remote_fetches));
+	    client_cache_hits + proxy_cache_hits + remote_fetches > 0 ?
+		100.0*(float)proxy_cache_hits/(float)(client_cache_hits + proxy_cache_hits + remote_fetches) : 0.0);
 	fprintf(stderr,
 	    "Local  Cache %% hit rate: %.2f\n", 
-	    100.0*(float)(client_cache_hits + proxy_cache_hits)/
-		(float)(client_cache_hits + proxy_cache_hits + remote_fetches));
+	    client_cache_hits + proxy_cache_hits + remote_fetches > 0 ?
+		100.0*(float)(client_cache_hits + proxy_cache_hits)/
+		    (float)(client_cache_hits + proxy_cache_hits + remote_fetches) : 0.0);
 
 	fprintf(stderr,
 	    "\nAverage fetch size: Proxy  -> Client: %.2f  Kb\n",
-	    proxy_bytes/proxy_cache_hits/1000.0);
+	    proxy_cache_hits > 0 ? proxy_bytes/proxy_cache_hits/1000.0 : 0.0);
 	fprintf(stderr,
 	    "Average fetch size: Remote -> Client : %.2f  Kb\n",
-	    remote_bytes/remote_fetches/1000.0);
+	    remote_fetches > 0 ? remote_bytes/remote_fetches/1000.0 : 0.0);
 
 	fprintf(stderr,"\nClient Cache bandwidth reduction effectiveness: UNKNOWN\n");
 	fprintf(stderr,
 	    "Proxy  Cache bandwidth reduction effectiveness: %f%%\n", 
-	    100.0*proxy_bytes/(proxy_bytes +  remote_bytes));
+	    proxy_bytes +  remote_bytes > 0 ? 100.0*proxy_bytes/(proxy_bytes +  remote_bytes) : 0.0);
 
     }
 


### PR DESCRIPTION
Ken McDonell (11):
      qa/1146: add $seq arg for ./870 --check call
      qa/870: relax checks for pmlogger control files
      qa/660: tweak filter
      misc: pander to gcc warning insanity
      external/dict.c: fix coverity CID 287860 Division or modulo by float zero
      src/pcp/atop/atopsar.c: fix coverity CID 288176 Division or modulo by float zero
      src/pmdas/weblog/check_match.c: fix coverity CID 341701 Division or modulo by float zero
      src/libpcp_gui/src/timestate.c: fix coverity CID 288030 Pointer to local outside scope
      src/libpcp_qmc/src/qmc_metric.cpp: coverity fix CID 288108 Resource leak
      Revert "qa/660: tweak filter"
      src/libpcp/src/events.c: fix a couple of Coverity reported issues

 qa/1146                           |    2 +-
 qa/660                            |    6 +++---
 qa/870                            |   16 +++++++---------
 src/external/dict.c               |    3 ++-
 src/libpcp/src/events.c           |    8 ++++++--
 src/libpcp_gui/src/timestate.c    |    2 +-
 src/libpcp_mmv/src/mmv_stats.c    |   11 +++++++++--
 src/libpcp_qmc/src/qmc_metric.cpp |    7 ++++++-
 src/pcp/atop/atopsar.c            |    3 +++
 src/pcp/atop/showgeneric.c        |   10 +++++++++-
 src/pmdas/weblog/check_match.c    |   17 ++++++++++-------
 11 files changed, 57 insertions(+), 28 deletions(-)

Details ...

commit 8e98f66ea5019e9ff30f1cb0095b52d23fe1bef7
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Sep 18 06:59:38 2019 +1000

    src/libpcp/src/events.c: fix a couple of Coverity reported issues
    
    I've lost the CIDs unfortunately.

commit 39ff752695a5e763acdb4accc09447e0795d304d
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Sep 18 06:56:34 2019 +1000

    Revert "qa/660: tweak filter"
    
    This reverts commit ea75b67e4153d9e0f7b07ca1488cbf0fd1159e7a.
    
    Previous commit fixed this more consistently ... somehow I committed
    two variants of the same change.

commit bea5400c15cbcb8cc57f941ecdad47ba22f5b91d
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Sep 12 10:35:34 2019 +1000

    src/libpcp_qmc/src/qmc_metric.cpp: coverity fix CID 288108 Resource leak

commit 9c44cf021c81e5c851f7964a05e0c01cb6e87700
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Sep 12 10:29:51 2019 +1000

    src/libpcp_gui/src/timestate.c: fix coverity CID 288030 Pointer to local outside scope

commit bea74219c37da87448e20d596e7c703bf75e6980
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Sep 12 09:06:38 2019 +1000

    src/pmdas/weblog/check_match.c: fix coverity CID 341701 Division or modulo by float zero

commit 75e85cfaf84fd79c60a7a39a1ddf2ff508b8ff12
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Sep 12 07:11:07 2019 +1000

    src/pcp/atop/atopsar.c: fix coverity CID 288176 Division or modulo by float zero

commit 0e75aba39f966363e32fc5aef15c8f15e652c4b4
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Sep 12 07:05:57 2019 +1000

    external/dict.c: fix coverity CID 287860 Division or modulo by float zero

commit 23d63c3fef0e9020bc3c20a149bdec740972d96e
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Sep 10 19:42:36 2019 +1000

    misc: pander to gcc warning insanity
    
    We want to use strtol() and strtod() to parse a string for errors.
    With the flags we use for gcc this is not possible without gcc
    emitting warnings.
    
    To see how to fix this, check the commit, but be warned you'll
    want to vomit.  If anyone has a less ugly hack, to achieve the
    same result, please let me know.

commit ea75b67e4153d9e0f7b07ca1488cbf0fd1159e7a
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Sep 10 19:39:27 2019 +1000

    qa/660: tweak filter
    
    More babble from the libs pmwebd uses.

commit 8d868a5cc6c5fdb3e14b210b024270424c82fad8
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Sep 10 15:41:15 2019 +1000

    qa/870: relax checks for pmlogger control files
    
    In the normal thrust and parry of QA, it is inevitable that some
    pmlogger instances will be smacked out of existance in ways that may
    prevent orderly cleanup.
    
    If we find turdlets in $PCP_TMP_DIR/pmlogger or $PCP_RUN_DIR that
    belong to a pmlogger process that is no longer running, we now treat
    these as Warnings that are sent to $seq.full, rather than Errors that
    are emitted on stdout.

commit df2daf0a8ad71399b7b86b2db36532e08b48f5a8
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Sep 10 15:39:40 2019 +1000

    qa/1146: add $seq arg for ./870 --check call
    
    So errors (from 870 --check) get logged to 1146.full, not 870.full