### PR TITLE
python: fix uncached instances with empty list

### DIFF
--- a/qa/1098
+++ b/qa/1098
@@ -1,6 +1,6 @@
 #!/bin/sh
 # PCP QA Test No. 1098
-# Exercise a couple of python PMDA module bugs/features.
+# Exercise a couple of python PMDA module features.
 #
 # Copyright (c) 2017 Red Hat.
 #
@@ -53,7 +53,7 @@ pmstore test_python.some_value 0 \
     | sed -e 's/old value=./old value=N/g'
 
 # need a few invocations to tickle the bug
-for i in 1 2 3 4 5; do
+for i in 1 2 3 4 5 6 7 8; do
     echo "=== Round $i ===" | tee -a $here/$seq.full
     pmprobe \
         test_python.other_indom.some_value \

--- a/qa/1098.out
+++ b/qa/1098.out
@@ -12,17 +12,29 @@ test_python.some_indom.some_value 0
 === Round 2 ===
 test_python.other_indom.some_value 0
 test_python.some_value 1
-test_python.some_indom.some_value 0
+test_python.some_indom.some_value 1
 === Round 3 ===
 test_python.other_indom.some_value 2
 test_python.some_value 1
-test_python.some_indom.some_value 0
+test_python.some_indom.some_value 1
 === Round 4 ===
 test_python.other_indom.some_value 0
 test_python.some_value 1
-test_python.some_indom.some_value 0
+test_python.some_indom.some_value 2
 === Round 5 ===
 test_python.other_indom.some_value 2
+test_python.some_value 1
+test_python.some_indom.some_value 2
+=== Round 6 ===
+test_python.other_indom.some_value 0
+test_python.some_value 1
+test_python.some_indom.some_value 4
+=== Round 7 ===
+test_python.other_indom.some_value 2
+test_python.some_value 1
+test_python.some_indom.some_value 4
+=== Round 8 ===
+test_python.other_indom.some_value 0
 test_python.some_value 1
 test_python.some_indom.some_value 0
 

--- a/qa/group
+++ b/qa/group
@@ -1499,7 +1499,7 @@ BAD
 1095 derive local kernel
 1096 libpcp threads local pmmgr local
 1097 pmlogconf local
-1098 python local pmstore
+1098 python local pmstore sanity
 1099 archive pmiostat local pmie pcp python
 1100 bash local pcp2xxx pcp2elasticsearch pcp2xlsx pcp2influxdb pcp2graphite pmrep python pcp2zabbix pcp2xml pcp2json
 1101 libpcp_web local valgrind

--- a/qa/pmdas/test_python/pmdatest_python.python
+++ b/qa/pmdas/test_python/pmdatest_python.python
@@ -82,13 +82,13 @@ class TestPMDA(PMDA):
             two_instances = [pmdaInstid(0, 'instance0'), pmdaInstid(1, 'instance1')]
             never_seen_instances = [pmdaInstid(99, 'instance99'), pmdaInstid(100, 'instance100'), pmdaInstid(101, 'instance101'), pmdaInstid(102, 'instance102')]
 
-            if self.refreshes < 1:
+            if self.refreshes <= 1:
                 self.replace_indom(self.some_indom, empty_instances)
-            elif self.refreshes < 3:
+            elif self.refreshes <= 3:
                 self.replace_indom(self.some_indom, one_instances)
-            elif self.refreshes < 5:
+            elif self.refreshes <= 5:
                 self.replace_indom(self.some_indom, two_instances)
-            elif self.refreshes < 7:
+            elif self.refreshes <= 7:
                 self.replace_indom(self.some_indom, never_seen_instances)
             else:
                 self.replace_indom(self.some_indom, empty_instances)

--- a/src/python/pcp/pmda.py
+++ b/src/python/pcp/pmda.py
@@ -179,8 +179,6 @@ class pmdaIndom(Structure):
 
     def set_list_instances(self, insts):
         instance_count = len(insts)
-        if (instance_count == 0):
-            return
         instance_array = (pmdaInstid * instance_count)()
         for i in range(instance_count):
             instance_array[i].i_inst = insts[i].i_inst


### PR DESCRIPTION
- removed early return in set_list_instances: we need to set it_numinst
to 0, and should also set the it_set to an empty array - otherwise the
old instance list will persist
- updated qa/1098: updated test pmda - the first and last round should
return an indom with empty instances
- added 1098 to the sanity QA group, as it's base functionality for
Python PMDAs