### PR TITLE
qa and misc Changes committed to git@github.com:kmcdonell/pcp.git 20191002a

### DIFF
--- a/qa/GNUmakefile
+++ b/qa/GNUmakefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/src/include/builddefs
 -include ./GNUlocaldefs
 
 TESTDIR = $(PCP_VAR_DIR)/testsuite
-TESTS	= $(shell sed -n -e '/^[0-9]/s/:retired//' -e '/^[0-9][0-9]*:reserved/d' -e '/^[0-9]/s/[        ].*//' -e '/^[0-9]/p' <group)
+TESTS	= $(shell sed -n -e '/^[0-9][0-9]*:reserved/d' -e '/^[0-9]/s/[        ].*//' -e '/^[0-9]/p' <group)
 
 SUBDIRS = src pmdas cisco gluster pconf sadist collectl nfsclient named \
 	  archives badarchives views qt linux unbound cifs gpfs lustre ganglia \

--- a/qa/GNUmakefile
+++ b/qa/GNUmakefile
@@ -12,7 +12,7 @@ include $(TOPDIR)/src/include/builddefs
 -include ./GNUlocaldefs
 
 TESTDIR = $(PCP_VAR_DIR)/testsuite
-TESTS	= $(shell sed -n -e '/^[0-9][0-9]*:reserved/d' -e '/^[0-9]/s/[        ].*//' -e '/^[0-9]/p' <group)
+TESTS	= $(shell sed -n -e '/^[0-9][0-9]*:retired/d' -e '/^[0-9][0-9]*:reserved/d' -e '/^[0-9]/s/[        ].*//' -e '/^[0-9]/p' <group)
 
 SUBDIRS = src pmdas cisco gluster pconf sadist collectl nfsclient named \
 	  archives badarchives views qt linux unbound cifs gpfs lustre ganglia \

--- a/qa/group
+++ b/qa/group
@@ -52,6 +52,7 @@ kernel
 pmcd
 pmproxy
 pmcpp
+pmwebd		# note this group has been retired
 # strip chart app
 pmchart
 # 3D scene app
@@ -1060,7 +1061,10 @@ BAD
 657 pmda.dm local
 658 logutil local pmlogrewrite
 659 pmlogreduce local
+660:retired pmwebd local
+661:retired pmwebd local python kernel
 662 pmproxy pmda.sample local python pmda.sample
+663:retired pmwebd local python
 664 logutil local pmlogrewrite
 665 pmda.linux local
 666 pmmgr local slow valgrind pmrep python pmlogrewrite
@@ -1124,6 +1128,7 @@ BAD
 724 pmfind local
 725 pmda.jbd2 local
 726 pmlogger pmdumplog local
+727:retired avahi local
 728 libpcp getopt local timezone
 729 python local
 730 pmda.proc local cgroups
@@ -1178,6 +1183,7 @@ BAD
 779 pmda local
 780 pmproxy local
 781 logutil local
+782:retired pmwebd local
 783 pmda.rpm local valgrind
 784 pmda.mic python local
 785 pcp atop local
@@ -1595,6 +1601,7 @@ BAD
 1221 labels pmda.prometheus local python
 1222 pmda.linux pmda.proc local valgrind
 1224 pcp dstat python local
+1225:retired pmwebd local pmrep python pcp kernel
 1227 derive local
 1229 pmlogextract pmdumplog labels help local sanity
 1231 pmlogrewrite labels help pmdumplog local
@@ -1652,6 +1659,7 @@ BAD
 1383 pmlogrewrite labels pmdumplog local
 1385 pmda.prometheus local python
 1388 pmproxy local
+1389:retired pmwebd local
 1390 atop local
 1393 pmda.linux local
 1395 pmda.prometheus local python

--- a/scripts/new-branch
+++ b/scripts/new-branch
@@ -15,7 +15,7 @@ trap "rm -f $tmp.*; exit \$sts" 0 1 2 3 15
 
 _usage()
 {
-    echo >&2 "Usage: new-branch [options]"
+    echo >&2 "Usage: new-branch [options] [suffix]"
     echo >&2
     echo >&2 "options:"
     echo >&2 "  -n                  dryrun"
@@ -39,6 +39,14 @@ do
 done
 shift `expr $OPTIND - 1`
 
+if [ $# -eq 1 ]
+then
+    suff="$1"
+    shift
+else
+    suff=''
+fi
+
 [ $# -eq 0 ] || _usage
 
 # expect to be on master branch at this point
@@ -49,7 +57,7 @@ then
     echo "Error: should be on master branch (not $branch)"
     exit
 fi
-branch=`date '+%Y%m%d'`
+branch=`date '+%Y%m%d'`$suff
 if git branch --list | sed -e 's/\*//' -e 's/ //g' | grep "^$branch\$" >/dev/null
 then
     echo "Error: branch $branch already exists"


### PR DESCRIPTION
Ken McDonell (4):
      scripts/new-branch: add optional branch "suffix" argument
      qa/group: put back the deleted pmwebd tests, but mark as retired
      qa/GNUmakefile: don't package retired: tests
      qa/GNUmakefile: don't package retired: tests (do it properly this time)

Nathan Scott (1):
      selinux: build fix for platforms without map for class file

 qa/GNUmakefile                |    4 ++--
 qa/group                      |    8 ++++++++
 scripts/new-branch            |   12 ++++++++++--
 src/selinux/pcpupstream.te.in |    2 +-
 4 files changed, 21 insertions(+), 5 deletions(-)

Details ...

commit c88247a65c3d96a2b0cd2af26ddc50d7a81495b3
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Oct 3 06:16:42 2019 +1000

    qa/GNUmakefile: don't package retired: tests (do it properly this time)

commit 05e22d9c6619889596e73b34ef3a8eb851bb436d
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Oct 2 17:15:14 2019 +1000

    qa/GNUmakefile: don't package retired: tests

commit cd9a1d4db1f8fb74b3fff09c9e1a68cbb2e83a59
Author: Nathan Scott <nathans@redhat.com>
Date:   Wed Oct 2 17:09:00 2019 +1000

    selinux: build fix for platforms without map for class file

commit 23f184969bd69ff43a7b8a5f8f05bf04781bfad3
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Oct 2 14:59:27 2019 +1000

    qa/group: put back the deleted pmwebd tests, but mark as retired
    
    To avoid confusion and possible re-use of test script numbers I've
    re-inserted the recently removed pmwebd qa tests and marked them
    ":retired".
    
    This is just in the group file ... the tests themselves remain deleted.

commit db48c79b05610c62024cf583a1e668eb61b87a29
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Oct 2 14:58:09 2019 +1000

    scripts/new-branch: add optional branch "suffix" argument
    
    If two different pull requests are to be made in the same day,
    this allows the branch names to be unique.