### PR TITLE
debian packaging Changes committed to git@github.com:kmcdonell/pcp.git 20191003a

### DIFF
--- a/debian/control.master
+++ b/debian/control.master
@@ -45,7 +45,7 @@ Description: Performance Co-Pilot runtime configuration
 Package: libpcp3-dev
 Section: libdevel
 Depends: ${misc:Depends}, libpcp3 (= ${binary:Version}), libc6-dev | libc-dev
-Breaks: pcp (<< 4.3.4), libpcp-gui2-dev (<< 3.11.10~)
+Breaks: pcp (<< 4.3.4), libpcp-gui2-dev (<< 3.11.10~), pcp-webapi
 Replaces: libpcp-gui2-dev (<< 3.11.10~)
 Architecture: any
 Description: Performance Co-Pilot library and headers

--- a/debian/control.master
+++ b/debian/control.master
@@ -45,8 +45,8 @@ Description: Performance Co-Pilot runtime configuration
 Package: libpcp3-dev
 Section: libdevel
 Depends: ${misc:Depends}, libpcp3 (= ${binary:Version}), libc6-dev | libc-dev
-Breaks: pcp (<< 4.3.4), libpcp-gui2-dev (<< 3.11.10~), pcp-webapi
-Replaces: libpcp-gui2-dev (<< 3.11.10~)
+Breaks: pcp (<< 4.3.4), libpcp-gui2-dev (<< 3.11.10~), pcp-webapi (<< 5.0.0)
+Replaces: libpcp-gui2-dev (<< 3.11.10~), pcp-webapi (<< 5.0.0)
 Architecture: any
 Description: Performance Co-Pilot library and headers
  The libpcp-dev package contains the base Performance Co-Pilot (PCP)

--- a/qa/.gitignore
+++ b/qa/.gitignore
@@ -82,7 +82,6 @@ sudo
 605.out
 660.out
 661.png
-662.out
 740.out
 769.out
 798.out


### PR DESCRIPTION
Ken McDonell (3):
      qa/.gitignore: remove 662.out (now checked in)
      debian/control.master: add Breaks pcp-webapi for libpcp3-dev
      debian/control.master: changes for libpcp3-dev

 debian/control.master |    6 +++---
 qa/.gitignore         |    1 -
 2 files changed, 3 insertions(+), 4 deletions(-)

Details ...

commit ea9890a331d82c71d96b24ee26638102cd76cd0a
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Oct 3 13:23:32 2019 +1000

    debian/control.master: changes for libpcp3-dev
    
    Need to tweak the transition with the demise of pcp-webapi.

commit eb836213a322faf0f6faf77f9ec9fa30aa4840aa
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Oct 3 10:27:15 2019 +1000

    debian/control.master: add Breaks pcp-webapi for libpcp3-dev

commit f6d29f7f6a0209c325225ecd8efb2b3ebe84023d
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Oct 3 10:26:50 2019 +1000

    qa/.gitignore: remove 662.out (now checked in)