### PR TITLE
revert python2 build change Changes committed to git@github.com:kmcdonell/pcp.git 20191005

### DIFF
--- a/build/rpm/fedora.spec
+++ b/build/rpm/fedora.spec
@@ -3159,7 +3159,7 @@ cd
 %files -n perl-PCP-LogSummary -f perl-pcp-logsummary.list
 
 %if !%{disable_python2}
-%files -n %{__python2}-pcp -f python2-pcp.list.rpm
+%files -n %{__python2}-pcp -f python-pcp.list.rpm
 %endif
 
 %if !%{disable_python3}

--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -3353,7 +3353,7 @@ cd
 %files -n perl-PCP-LogSummary -f perl-pcp-logsummary.list
 
 %if "@enable_python2@" == "true"
-%files -n %{__python2}-pcp -f python2-pcp.list.rpm
+%files -n %{__python2}-pcp -f python-pcp.list.rpm
 %endif
 
 %if "@enable_python3@" == "true"

--- a/configure
+++ b/configure
@@ -846,7 +846,7 @@ have_python
 enable_python3
 enable_python2
 PYTHON3
-PYTHON2
+PYTHON
 PYLINT
 CPPCHECK_POSIX_OPT
 CPPCHECK
@@ -990,7 +990,7 @@ with_systemd
 with_qt
 with_qt3d
 with_perl
-with_python2
+with_python
 with_python3
 with_dstat_symlink
 with_books
@@ -1707,7 +1707,7 @@ Optional Packages:
                           on)
   --with-perl             enable support for tools requiring Perl (default is
                           on)
-  --with-python2          enable support for tools requiring Python (default
+  --with-python           enable support for tools requiring Python (default
                           is on)
   --with-python3          enable support for tools requiring Python3 (default
                           is on)
@@ -2800,11 +2800,11 @@ fi
 
 
 
-# Check whether --with-python2 was given.
-if test "${with_python2+set}" = set; then :
-  withval=$with_python2; do_python2=$withval; PACKAGE_CONFIGURE="$PACKAGE_CONFIGURE --with-python=$withval"
+# Check whether --with-python was given.
+if test "${with_python+set}" = set; then :
+  withval=$with_python; do_python=$withval; PACKAGE_CONFIGURE="$PACKAGE_CONFIGURE --with-python=$withval"
 else
-  do_python2=check
+  do_python=check
 fi
 
 
@@ -7250,17 +7250,17 @@ test -n "$PYLINT" || PYLINT="/bin/true"
 
 
 
-for ac_prog in python2 python2.7 python2.6 python
+for ac_prog in python python2.7
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_PYTHON2+:} false; then :
+if ${ac_cv_prog_PYTHON+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  if test -n "$PYTHON2"; then
-  ac_cv_prog_PYTHON2="$PYTHON2" # Let the user override the test.
+  if test -n "$PYTHON"; then
+  ac_cv_prog_PYTHON="$PYTHON" # Let the user override the test.
 else
 as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
@@ -7269,7 +7269,7 @@ do
   test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
   if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_PYTHON2="$ac_prog"
+    ac_cv_prog_PYTHON="$ac_prog"
     $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
@@ -7279,17 +7279,17 @@ IFS=$as_save_IFS
 
 fi
 fi
-PYTHON2=$ac_cv_prog_PYTHON2
-if test -n "$PYTHON2"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON2" >&5
-$as_echo "$PYTHON2" >&6; }
+PYTHON=$ac_cv_prog_PYTHON
+if test -n "$PYTHON"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON" >&5
+$as_echo "$PYTHON" >&6; }
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 fi
 
 
-  test -n "$PYTHON2" && break
+  test -n "$PYTHON" && break
 done
 
 
@@ -7339,16 +7339,16 @@ done
 
 
 enable_python2=false
-if test "x$do_python2" != "xno"; then :
+if test "x$do_python" != "xno"; then :
 
     enable_python2=true
-    if test -z "$PYTHON2"
+    if test -z "$PYTHON"
     then
 	enable_python2=false
     else
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking Python version" >&5
 $as_echo_n "checking Python version... " >&6; }
-	eval `$PYTHON2 -V 2>&1 | awk '/^Python/ { ver=2; print $ver }' | awk -F. '{ major=1; minor=2; point=3; printf "export PY_MAJOR=%d PY_MINOR=%d PY_POINT=%d\n",$major,$minor,$point }'`
+	eval `$PYTHON -V 2>&1 | awk '/^Python/ { ver=2; print $ver }' | awk -F. '{ major=1; minor=2; point=3; printf "export PY_MAJOR=%d PY_MINOR=%d PY_POINT=%d\n",$major,$minor,$point }'`
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $PY_MAJOR.$PY_MINOR.$PY_POINT" >&5
 $as_echo "$PY_MAJOR.$PY_MINOR.$PY_POINT" >&6; }
 	if test "$PY_MAJOR" -lt 2; then
@@ -7382,9 +7382,9 @@ done
 	fi
     fi
 
-    if test "$do_python2" != "check" -a "$enable_python2" != "true"
+    if test "$do_python" != "check" -a "$enable_python2" != "true"
     then
-	as_fn_error $? "cannot enable Python2 - no supported version found" "$LINENO" 5
+	as_fn_error $? "cannot enable Python - no supported version found" "$LINENO" 5
     fi
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -102,11 +102,11 @@ AC_ARG_WITH([perl],
     [do_perl=$withval; PACKAGE_CONFIGURE="$PACKAGE_CONFIGURE --with-perl=$withval"],
     [do_perl=check])
 
-AC_ARG_WITH([python2],
-    [AC_HELP_STRING([--with-python2],
+AC_ARG_WITH([python],
+    [AC_HELP_STRING([--with-python],
                     [enable support for tools requiring Python (default is on)])],
-    [do_python2=$withval; PACKAGE_CONFIGURE="$PACKAGE_CONFIGURE --with-python=$withval"],
-    [do_python2=check])
+    [do_python=$withval; PACKAGE_CONFIGURE="$PACKAGE_CONFIGURE --with-python=$withval"],
+    [do_python=check])
 
 AC_ARG_WITH([python3],
     [AC_HELP_STRING([--with-python3],
@@ -820,8 +820,8 @@ AC_CHECK_PROGS(PYLINT, pylint, /bin/true)
 AC_SUBST(PYLINT)
 
 dnl check if python available for the build and runtime
-AC_CHECK_PROGS(PYTHON2, [python2 python2.7 python2.6 python])
-AC_SUBST(PYTHON2)
+AC_CHECK_PROGS(PYTHON, [python python2.7])
+AC_SUBST(PYTHON)
 
 dnl check if python3 available for the build and runtime
 AC_CHECK_PROGS(PYTHON3, [python3 python3.7 python3.6 python3.4])
@@ -829,14 +829,14 @@ AC_SUBST(PYTHON3)
 
 dnl check if python tools/packages wanted (need python >= 2.6)
 enable_python2=false
-AS_IF([test "x$do_python2" != "xno"], [
+AS_IF([test "x$do_python" != "xno"], [
     enable_python2=true
-    if test -z "$PYTHON2"
+    if test -z "$PYTHON"
     then
 	enable_python2=false
     else
 	AC_MSG_CHECKING([Python version])
-	eval `$PYTHON2 -V 2>&1 | awk '/^Python/ { ver=2; print $ver }' | awk -F. '{ major=1; minor=2; point=3; printf "export PY_MAJOR=%d PY_MINOR=%d PY_POINT=%d\n",$major,$minor,$point }'`
+	eval `$PYTHON -V 2>&1 | awk '/^Python/ { ver=2; print $ver }' | awk -F. '{ major=1; minor=2; point=3; printf "export PY_MAJOR=%d PY_MINOR=%d PY_POINT=%d\n",$major,$minor,$point }'`
 	AC_MSG_RESULT([$PY_MAJOR.$PY_MINOR.$PY_POINT])
 	if test "$PY_MAJOR" -lt 2; then
 	    echo WARNING: Python version 2.6 or later does not seem to be installed.
@@ -855,9 +855,9 @@ AS_IF([test "x$do_python2" != "xno"], [
 	fi
     fi
 
-    if test "$do_python2" != "check" -a "$enable_python2" != "true"
+    if test "$do_python" != "check" -a "$enable_python2" != "true"
     then
-	AC_MSG_ERROR([cannot enable Python2 - no supported version found])
+	AC_MSG_ERROR([cannot enable Python - no supported version found])
     fi
 ])
 AC_SUBST(enable_python2)

--- a/debian/rules
+++ b/debian/rules
@@ -214,11 +214,11 @@ binary-arch: checkroot build-stamp
 	# to ensure make install after the first version works
 	for V in $(shell pyversions -vr); do \
 	    $(MAKE) -C src/python clean; \
-	    $(pkgpcp_python2) $(MAKE) PYTHON2=python$$V -C src/python install_python2; \
+	    $(pkgpcp_python2) $(MAKE) PYTHON=python$$V -C src/python install_python2; \
 	done
 	for V in $(shell py3versions -vr); do \
 	    $(MAKE) -C src/python clean; \
-	    $(pkgpcp_python3) $(MAKE) PYTHON3=python$$V -C src/python install_python3; \
+	    $(pkgpcp_python3) $(MAKE) PYTHON=python$$V -C src/python install_python3; \
 	done
 
 	dh_installdocs -a

--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -176,7 +176,7 @@ GREP    = @grep@
 GIT	= @GIT@
 CLINT	= @CPPCHECK@ @CPPCHECK_POSIX_OPT@ --inline-suppr --force --quiet --error-exitcode=1 -I$(TOPDIR)/src/include/pcp -I/usr/include/bits
 PYLINT	= @PYLINT@ --rcfile=$(TOPDIR)/.pylintrc --output-format=colorized
-PYTHON2	= @PYTHON2@
+PYTHON	= @PYTHON@
 PYTHON3	= @PYTHON3@
 DTRACE  = @DTRACE@
 ifeq "$(TARGET_OS)" "freebsd"
@@ -707,13 +707,13 @@ endif
 ifeq "$(shell [ '$(TARGET_OS)' = linux -a '$(PACKAGE_DISTRIBUTION)' != gentoo \
 	      ] && echo 1)" "1"
 # Linux and not Gentoo (which needs tarball packaging)
-PYTHON2_INSTALL = \
-	cat $(TOPDIR)/python2-pcp.list | while read f; do \
+PYTHON_INSTALL = \
+	cat $(TOPDIR)/python-pcp.list | while read f; do \
 	    dirname $$f | $(SED) -e '/.*packages$$/d'; \
-	done | $(PCP_SORT_PROG) -u > $(TOPDIR)/python2-pcp.list.rpm; \
+	done | $(PCP_SORT_PROG) -u > $(TOPDIR)/python-pcp.list.rpm; \
 	$(AWK) '{print} /\.pyc$$/ {sub(/\.pyc$$/,".pyo"); print}' \
-	    < $(TOPDIR)/python2-pcp.list >> $(TOPDIR)/python2-pcp.list.rpm; \
-	cat $(TOPDIR)/python2-pcp.list.rpm | while read f; do \
+	    < $(TOPDIR)/python-pcp.list >> $(TOPDIR)/python-pcp.list.rpm; \
+	cat $(TOPDIR)/python-pcp.list.rpm | while read f; do \
 	    touch "$${DIST_ROOT-/}$$f"; \
 	done
 PYTHON3_INSTALL = \
@@ -735,7 +735,7 @@ ifeq "$(shell [ '$(PACKAGE_DISTRIBUTION)' = cocoa \
                 -o '$(PACKAGE_DISTRIBUTION)' = freebsd \
 	      ] && echo 1)" "1"
 # Gather installed Python files before packaging
-# Lines in python*-pcp.list are like this
+# Lines in python-pcp.list are like this
 # /usr/lib/python2.7/site-packages/pcp.py
 # /usr/lib/python2.7/site-packages/pcp.pyc
 # /usr/lib/python2.7/site-packages/pmapi.so
@@ -743,9 +743,9 @@ ifeq "$(shell [ '$(PACKAGE_DISTRIBUTION)' = cocoa \
 #
 # Matching build artifacts are below src/python/build
 #
-PYTHON2_INSTALL = \
+PYTHON_INSTALL = \
 	if [ -n "$(DIST_MANIFEST)" ]; then \
-	    cat $(TOPDIR)/python2-pcp.list \
+	    cat $(TOPDIR)/python-pcp.list \
 	    | while read f; do \
 		bn=`basename $$f`; \
 		dn=`dirname $$f`; \
@@ -772,9 +772,9 @@ ifeq "$(shell [ '$(PACKAGE_DISTRIBUTION)' = openbsd \
 	      ] && echo 1)" "1"
 # similar to above, but files already installed in DIST_ROOT so
 # just append to the manifest
-PYTHON2_INSTALL = \
+PYTHON_INSTALL = \
 	if [ -n "$(DIST_MANIFEST)" ]; then \
-	    cat $(TOPDIR)/python2-pcp.list \
+	    cat $(TOPDIR)/python-pcp.list \
 	    | while read f; do \
 		bn=`basename $$f`; \
 		dn=`dirname $$f`; \

--- a/src/python/GNUmakefile
+++ b/src/python/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2016,2019 Red Hat.
+# Copyright (c) 2012-2016 Red Hat.
 # 
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -45,16 +45,16 @@ endif
 default default_pcp: build_python2 build_python3
 
 ifeq "$(ENABLE_PYTHON2)" "true"
-PY2_BUILD_OPTS = $(SETUP_PY_BUILD_OPTIONS)
-PY2_INSTALL_OPTS = $(SETUP_PY_INSTALL_OPTIONS) --record=$(TOPDIR)/python2-pcp.list
+PY_BUILD_OPTS = $(SETUP_PY_BUILD_OPTIONS)
+PY_INSTALL_OPTS = $(SETUP_PY_INSTALL_OPTIONS) --record=$(TOPDIR)/python-pcp.list
 build_python2: $(SETUP_PY) $(CFILES)
-	export $(ENV); $(PYTHON2) $(SETUP_PY) build_ext $(PY2_BUILD_OPTS)
-	export $(ENV); $(PYTHON2) $(SETUP_PY) build
+	export $(ENV); $(PYTHON) $(SETUP_PY) build_ext $(PY_BUILD_OPTS)
+	export $(ENV); $(PYTHON) $(SETUP_PY) build
 	touch build_python2
 
 install_python2: build_python2
-	export $(ENV); $(PYTHON2) $(SETUP_PY) install $(PY2_INSTALL_OPTS)
-	export $(ENV); $(PYTHON2_INSTALL)
+	export $(ENV); $(PYTHON) $(SETUP_PY) install $(PY_INSTALL_OPTS)
+	export $(ENV); $(PYTHON_INSTALL)
 else
 build_python2:
 install_python2:


### PR DESCRIPTION
Ken McDonell (1):
      Revert "build: when calling 'python' prefer a 2/3-versioned binary if available"

 build/rpm/fedora.spec    |    2 +-
 build/rpm/pcp.spec.in    |    2 +-
 configure                |   44 ++++++++++++++++++++++----------------------
 configure.ac             |   22 +++++++++++-----------
 debian/rules             |    4 ++--
 src/include/builddefs.in |   22 +++++++++++-----------
 src/python/GNUmakefile   |   14 +++++++-------
 7 files changed, 55 insertions(+), 55 deletions(-)

Details ...

commit d095412fe71ccc5917448f18b194de729fd1ee4a
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Oct 5 06:41:01 2019 +1000

    Revert "build: when calling 'python' prefer a 2/3-versioned binary if available"
    
    This reverts commit 6635e2ee08e37e3e90cf9e6651e2cad3ec0b7582.
    
    This commit was addressing a build warning seen on Fedora, but seems
    to have introduced build breakage on older platforms that still have
    a dependence on Python2.
    
    We'll revisit the issue after the PCP 5.0.0 release.