### PR TITLE
IMPORTANT pmlogrewrite mem leak fix Changes committed to git@github.com:kmcdonell/pcp.git 20191010

### DIFF
--- a/qa/1149
+++ b/qa/1149
@@ -1,0 +1,64 @@
+#!/bin/sh
+# PCP QA Test No. 1149
+# PDUBuf mem leak in pmlogrewrite?
+#
+# Copyright (c) 2019 Ken McDonell.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+_filter()
+{
+    echo "Expect no buffers to be reported ..."
+    tee -a $seq.full \
+    | $PCP_AWK_PROG '
+BEGIN				{ want=0 }
+/^__pmFindPDUBuf\(DEBUG\)/	{ want=1 }
+want == 1			{ print }' \
+    | sed -e 's/)\(:*\) /)\1#/g' \
+    | tr '#' '\012'
+}
+
+status=1	# failure is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+# real QA test starts here
+
+# reuse the 1st logrewriting case from qa/490
+#
+cat <<End-of-File >$tmp.conf
+global {
+    hostname -> whizz-bang.engr.sgi.com
+    TZ -> "GMT+10"
+    Time -> +30
+}
+indom 1.5 {
+    indom -> 42.10
+    iname "15 minute" -> "forever"
+    iname "1 minute" -> "1 minute is not very long unlike this string"
+    inst 15 -> 9999
+}
+metric 1.*.* { pmid -> 42.*.* }
+metric irix.kernel.all.load { name->load type->double }
+metric hinv.ncpu { name->hinv.number_of_cpus type->U64 }
+End-of-File
+rm -f $tmp.new.*
+cat $tmp.conf >>$seq.full
+pmlogrewrite -Dpdubuf -c $tmp.conf archives/src-rattle $tmp.new 2>&1 | _filter
+
+# success, all done
+status=0
+exit

--- a/qa/1149.out
+++ b/qa/1149.out
@@ -1,0 +1,3 @@
+QA output created by 1149
+Expect no buffers to be reported ...
+__pmFindPDUBuf(DEBUG)

--- a/qa/878
+++ b/qa/878
@@ -145,6 +145,10 @@ pmdapipe_install
 # and setup states.
 if pminfo -v pipe > $tmp.info 2> $tmp.err
 then
+    echo "--- pminfo stdout ---" >>$here/$seq.full
+    cat $tmp.info >>$here/$seq.full
+    echo "--- pminfo stderr ---" >>$here/$seq.full
+    cat $tmp.err >>$here/$seq.full
     cat $tmp.info $tmp.err | _filter_pipe
     _exercise_pipe
 else

--- a/qa/group
+++ b/qa/group
@@ -1550,6 +1550,7 @@ BAD
 1146 logutil local
 1147 logutil local
 1148 logutil local
+1149 pmlogrewrite local
 1150 pmda.bcc local python
 1151 pmda.bcc local python
 1152 pmda.bcc local python

--- a/src/pmlogrewrite/pmlogrewrite.c
+++ b/src/pmlogrewrite/pmlogrewrite.c
@@ -1965,6 +1965,11 @@ main(int argc, char **argv)
 	_pmLogRemove(bak_base, -1);
     }
 
+    if (pmDebugOptions.pdubuf) {
+	/* dump PDU buffer state ... looking for mem leaks here */
+	(void)__pmFindPDUBuf(-1);
+    }
+
     exit(0);
 }
 

--- a/src/pmlogrewrite/result.c
+++ b/src/pmlogrewrite/result.c
@@ -688,7 +688,12 @@ do_result(void)
 	    abandon();
 	    /*NOTREACHED*/
 	}
-	/* do not free inarch.logrec ... this is a libpcp PDU buffer */
+	/*
+	 * do not free inarch.logrec ... this is a libpcp PDU buffer,
+	 * so Unpin it
+	 */
+	__pmUnpinPDUBuf(inarch.logrec);
+	
 	if (pmDebugOptions.appl0) {
 	    struct timeval	stamp;
 	    fprintf(stderr, "Log: write ");


### PR DESCRIPTION
Ken McDonell (2):
      pmlogrewrite: plug major memory leak
      qa/878: separate stdout and stderr in the .full file

 qa/1149                         |   64 ++++++++++++++++++++++++++++++++++++++++
 qa/1149.out                     |    3 +
 qa/878                          |    4 ++
 qa/group                        |    1 
 src/pmlogrewrite/pmlogrewrite.c |    5 +++
 src/pmlogrewrite/result.c       |    7 +++-
 6 files changed, 83 insertions(+), 1 deletion(-)

Details ...

commit 84121693f6024bf3c73a19784d67bd70bbd043a1
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Oct 10 06:39:10 2019 +1100

    qa/878: separate stdout and stderr in the .full file
    
    Debugging aid.

commit 10309b15f3520f3e6857a8a7c0dad333348b460d
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Oct 10 06:33:13 2019 +1100

    pmlogrewrite: plug major memory leak
    
    We were keeping all the PDU buffers because they were never being
    unpinned.  This may explain some folklore around long running pmlogger
    daily tasks with big archives.
    
    Simple fix.
    
    And added conditional call to __pmFindPDUBuf(-1) before exit to dump
    the state of the PDU buffer pool to debug this.
    
    And new qa/1149 to demonstrate the problem and prove the fix works.
    
    Passes all of -g pmlogrewrite QA, so I'm sure this is safe.