### PR TITLE
pmproxy: send only one fetch response

### DIFF
--- a/qa/src/pmproxy_load_test.python
+++ b/qa/src/pmproxy_load_test.python
@@ -22,8 +22,8 @@ async def get_json(url):
 async def context_and_fetch(host: str, port: int):
     ctx = await get_json(f"http://{host}:{port}/pmapi/context?hostspec=127.0.0.1&polltimeout=30")
     ctx_id = ctx["context"]
-    #metric = await get_json(f"http://{host}:{port}/pmapi/{ctx_id}/fetch?names=disk.dev.read")
-    inst_val = ctx_id#metric["values"][0]["instances"][0]["value"]
+    metric = await get_json(f"http://{host}:{port}/pmapi/{ctx_id}/fetch?names=disk.dev.read")
+    inst_val = metric["values"][0]["instances"][0]["value"]
     if not inst_val:
         raise Exception("cannot find any instance value for disk.dev.rad")
     return inst_val


### PR DESCRIPTION
pmWebGroupFetch() calls webgroup_fetch_names() which calls
webgroup_fetch() which calls on_pmwebapi_done()
However, at the end of pmWebGroupFetch(), on_pmwebapi_done() is called
also.

This results in (trying to) send the actual fetch response *and* a
generic {context:XXX, success:true} response, and for HTTP/1.0 clients to
close the connection twice, which results in a libuv assert.

This commit removes the call to on_pmwebapi_done in the webgroup_fetch()
function, and instead returns the error message and status code via
a parameter and return value (like the other webgroup_* functions).