### PR TITLE
Fedora rawhide fix pmdastatsd

### DIFF
--- a/src/pmdas/statsd/src/GNUmakefile
+++ b/src/pmdas/statsd/src/GNUmakefile
@@ -81,7 +81,7 @@ install_pcp : install
 $(OBJECTS): domain.h $(RFILES)
 
 $(RFILES): $(RAGELTARGET).rl
-	$(RAGEL) -C $<
+	$(RAGEL) $<
 
 $(VERSION_SCRIPT):
 	$(VERSION_SCRIPT_MAKERULE)

--- a/src/pmdas/statsd/src/parser-ragel.rl
+++ b/src/pmdas/statsd/src/parser-ragel.rl
@@ -194,10 +194,6 @@ ragel_parser_parse(char* str, struct statsd_datagram** datagram) {
 		write exec;
 
 	}%%
-	(void)statsd_en_main;
-	(void)statsd_error;
-	(void)statsd_first_final;
-	(void)_statsd_eof_actions;
 
 	if (any_tags) {
 		char* json = tag_collection_to_json(tags);


### PR DESCRIPTION
Should address issues regarding building pmdastatsd on Fedora Rawhide caused by new Ragel version.