### PR TITLE
Handle incomplete container setup

### DIFF
--- a/src/pmdas/root/root.h
+++ b/src/pmdas/root/root.h
@@ -39,6 +39,11 @@ enum {
     NUM_UPTODATE
 };
 
+enum {
+    CGROUP_VERIFIED	= 0,
+    CGROUP_NOT_VERIFIED	= 1,
+};
+
 /*
  * General container services, abstracting individual implementations into
  * "engines" which are then instantiated one-per-container-technology.
@@ -76,6 +81,7 @@ typedef struct container {
     char		cgroup[128];
     struct stat		stat;
     container_engine_t	*engine;
+    int			cgroup_verified;
 } container_t;
 
 enum {


### PR DESCRIPTION
If a non-default cgroup fs path is used, and the container is not quite
set up before polling begins, an invalid entry could be cached. This
prevents the container from being properly discovered once the container
becomes available.

So, when executing the fallback default path, check that the file exists
before accepting it as a correct fallback.

Fixes #770