### PR TITLE
qa - BCC PMDA Changes committed to git@github.com:kmcdonell/pcp.git 20191107

### DIFF
--- a/qa/1155
+++ b/qa/1155
@@ -14,6 +14,12 @@ _pmdabcc_check
 which curl >/dev/null 2>&1 || _notrun "No curl binary installed"
 [ "$(pmpython src/bcc_version_check.python)" = "0.6.1" ] \
   && _notrun "Broken BCC version detected"
+case "`uname -srm`"
+in
+    Linux\ 5.2.*)
+    		_notrun "Bad Linux 5.2 kernel headers will cause BPF to fail"
+		;;
+esac
 
 target_ip=1.1.1.1
 

--- a/qa/1157
+++ b/qa/1157
@@ -12,6 +12,12 @@ echo "QA output created by $seq"
 
 _pmdabcc_check
 _bcc_check_ArgString || _notrun "bcc is broken (ArgString bug) on this platform"
+case "`uname -srm`"
+in
+    Linux\ 5.2.*)
+    		_notrun "Bad Linux 5.2 kernel headers will cause BPF to fail"
+		;;
+esac
 
 # sch_netem is part of optional kernel-modules-extra on Fedora
 $sudo modprobe sch_netem

--- a/qa/1170
+++ b/qa/1170
@@ -14,6 +14,12 @@ _pmdabcc_check
 which curl >/dev/null 2>&1 || _notrun "No curl binary installed"
 [ "$(pmpython src/bcc_version_check.python)" = "0.6.1" ] \
   && _notrun "Broken BCC version detected"
+case "`uname -srm`"
+in
+    Linux\ 5.2.*)
+    		_notrun "Bad Linux 5.2 kernel headers will cause BPF to fail"
+		;;
+esac
 
 target_ip=1.1.1.1
 

--- a/qa/1178
+++ b/qa/1178
@@ -14,6 +14,12 @@ _pmdabcc_check
 which curl >/dev/null 2>&1 || _notrun "No curl binary installed"
 [ "$(pmpython src/bcc_version_check.python)" = "0.6.1" ] \
   && _notrun "Broken BCC version detected"
+case "`uname -srm`"
+in
+    Linux\ 5.2.*)
+    		_notrun "Bad Linux 5.2 kernel headers will cause BPF to fail"
+		;;
+esac
 
 target_ip=1.1.1.1
 


### PR DESCRIPTION
Ken McDonell (1):
      qa/1155,1157,1170,1178: notrun on Linux 5.2 kernels

 qa/1155 |    6 ++++++
 qa/1157 |    6 ++++++
 qa/1170 |    6 ++++++
 qa/1178 |    6 ++++++
 4 files changed, 24 insertions(+)

Details ...

commit 1f21bedebbb44bf61abcd8a1ea3b92e144fa85db
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Nov 7 06:50:43 2019 +1100

    qa/1155,1157,1170,1178: notrun on Linux 5.2 kernels
    
    The Linux 5.2 kernel headers, BPF and some of the PCP BCC modules are
    not good friends, so don't run these tests on just this kernel version.
    
    Thanks Marko.