### PR TITLE
misc qa Changes committed to git@github.com:kmcdonell/pcp.git 20191121

### DIFF
--- a/qa/756
+++ b/qa/756
@@ -19,6 +19,36 @@ echo "QA output created by $seq"
 [ -f $PCP_INC_DIR/builddefs ] || _notrun "No $PCP_INC_DIR/builddefs"
 grep 'PMDA_PERFEVENT[ 	]*=[ 	]*true' $PCP_INC_DIR/builddefs >/dev/null 2>&1 || _notrun "PMDA_PERFEVENT is not true in builddefs"
 
+# some output is dependent on directory order in the filesystem, e.g.
+# PMU name : pmu1
+#	event name : bar
+#	event name : foo
+# need to divert this and sort it before output.
+#
+_filter()
+{
+    ( sed -e 's/^ ===/===/' ; echo "===== END ====") \
+    | $PCP_AWK_PROG '
+BEGIN		{ divert = 0; ndiv = 0 }
+/^===== END ====/	{ next }
+divert == 0	{ print }
+divert > 0 && /^[ 	]/	{ # line beginning with whitespace continues
+				  # the diversion
+				  print $0 >"'$tmp.sort'." ndiv
+				  divert++
+				  next
+				}
+divert > 0	{ # end of diversion
+		  if (divert > 1) {
+		      # at least one line diverted
+		      system("LC_COLLATE=POSIX sort '$tmp.sort'." ndiv)
+		  }
+		  divert = 0
+		  print
+		}
+/^PMU name/	{ divert = 1; ndiv++; next }'
+}
+
 status=1	# failure is the default
 rm -f $seq.full
 cd perfevent
@@ -37,10 +67,11 @@ then
     fi
 fi
 
-if ./perfevent_test all 2>/dev/null;
+./perfevent_test all 2>/dev/null | _filter
+status=$?
+if [ "$status" -eq 0 ]
 then
-	echo "Unit tests Passed"
-	status=0
+    echo "Unit tests Passed"
 fi
 
 cd - > /dev/null

--- a/qa/756.out
+++ b/qa/756.out
@@ -1,7 +1,7 @@
 QA output created by 756
- ===== test_init ==== 
- ===== test_fail_init ==== 
- ===== test_lots_of_counters ==== 
+===== test_init ==== 
+===== test_fail_init ==== 
+===== test_lots_of_counters ==== 
 data[0].name = DTLB_MISSES data[0].instances = 1
 	value[0] = 0
 data[1].name = SEGMENT_REG_LOADS data[1].instances = 1
@@ -30,18 +30,18 @@ data[12].name = UNHALTED_REFERENCE_CYCLES data[12].instances = 1
 	value[0] = 0
 data[13].name = INSTRUCTIONS_RETIRED data[13].instances = 1
 	value[0] = 0
- ===== test_config ==== 
- ===== test_config_filenotfound ==== 
- ===== test_config_syntax_error ==== 
- ===== test_config_empty ==== 
- ===== test_pfm_fail_init ==== 
- ===== test_perf_strerror ==== 
- ===== test_missing_pmu_config ==== 
- ===== test_api_safety ==== 
- ===== test_malloc_checking ==== 
- ===== test_node_rr ==== 
- ===== test_event_programming_fail ==== 
- ===== test_rapl ==== 
+===== test_config ==== 
+===== test_config_filenotfound ==== 
+===== test_config_syntax_error ==== 
+===== test_config_empty ==== 
+===== test_pfm_fail_init ==== 
+===== test_perf_strerror ==== 
+===== test_missing_pmu_config ==== 
+===== test_api_safety ==== 
+===== test_malloc_checking ==== 
+===== test_node_rr ==== 
+===== test_event_programming_fail ==== 
+===== test_rapl ==== 
 data[0].name = DTLB_MISSES data[0].instances = 1
 	value[0] = 0
 data[1].name = SEGMENT_REG_LOADS data[1].instances = 1
@@ -72,7 +72,7 @@ data[12].name = UNHALTED_REFERENCE_CYCLES data[12].instances = 1
 	value[0] = 0
 data[13].name = INSTRUCTIONS_RETIRED data[13].instances = 1
 	value[0] = 0
- ===== test_derived_counters ==== 
+===== test_derived_counters ==== 
 pddata[0].name = derived_event1 pddata[0].instances = 1
 clist->name : BRANCH_INSTRUCTIONS_RETIRED
 clist->name : MISPREDICTED_BRANCH_RETIRED
@@ -81,20 +81,20 @@ pddata[1].name = derived_event2 pddata[1].instances = 1
 clist->name : RS_UOPS_DISPATCHED_CYCLES
 clist->name : RS_UOPS_DISPATCHED
 	value[0] = 0
- ===== test_derived_counters_fail_mismatch ==== 
- ===== test_derived_counters_fail_missing ==== 
- ===== test_derived_alternate_group ==== 
+===== test_derived_counters_fail_mismatch ==== 
+===== test_derived_counters_fail_missing ==== 
+===== test_derived_alternate_group ==== 
 derived size : 1
 pddata[0].name = derived_event1 pddata[0].instances = 1
 clist->name : BRANCH_INSTRUCTIONS_RETIRED
 clist->name : MISPREDICTED_BRANCH_RETIRED
 	value[0] = 0
- ===== test_derived_events_scale ==== 
+===== test_derived_events_scale ==== 
 derived size : 1
 pddata[0].name = derived_event1 pddata[0].instances = 1
 clist->name : BRANCH_INSTRUCTIONS_RETIRED, scale : 0.100000
 clist->name : MISPREDICTED_BRANCH_RETIRED, scale : 1.000000
- ===== test_init_dynamic_events ==== 
+===== test_init_dynamic_events ==== 
 PMU name : pmu1
 	event name : bar
 	event name : foo
@@ -112,32 +112,32 @@ PMU name : software
 	event name : minor-faults
 	event name : page-faults
 	event name : task-clock
- ===== test_minimum_dynamic_events ==== 
+===== test_minimum_dynamic_events ==== 
 9 software events found
- ===== test_dynamic_events_fail_event ==== 
+===== test_dynamic_events_fail_event ==== 
 PMU : pmu2
 PMU : software
- ===== test_dynamic_events_fail_format ==== 
+===== test_dynamic_events_fail_format ==== 
 PMU : pmu1
 PMU : software
- ===== test_dynamic_events_config ==== 
- ===== test_dynamic_events_cpumask_handling ==== 
- ===== test_only_dynamic_events ==== 
+===== test_dynamic_events_config ==== 
+===== test_dynamic_events_cpumask_handling ==== 
+===== test_only_dynamic_events ==== 
 3 allowed events
- ===== test_cpu_max_smt ==== 
- ===== test_cpu_smt ==== 
- ===== test_parse_hv_24x7_dynamic_events ==== 
+===== test_cpu_max_smt ==== 
+===== test_cpu_smt ==== 
+===== test_parse_hv_24x7_dynamic_events ==== 
 event = pmu1.bar chip value = 0
 event = pmu1.foo chip value = -1
- ===== test_parse_raw_events ==== 
+===== test_parse_raw_events ==== 
 event = RAW:bar raw code = 0x1
 event = RAW:foo raw code = 0x0
- ===== test_hv_24x7_events_on_multinode_system ==== 
+===== test_hv_24x7_events_on_multinode_system ==== 
 PMU name: pmu1 
- event name: foo_chip_0
- event name: foo_chip_1
  event name: bar_chip_0
  event name: bar_chip_1
+ event name: foo_chip_0
+ event name: foo_chip_1
 PMU name: software 
  event name: alignment-faults
  event name: context-switches

--- a/qa/886
+++ b/qa/886
@@ -40,10 +40,10 @@ _unpack()
     target=$2
     suffix=`echo "$file" | sed 's/.*\.//'`
 
-    if [ "$suffix" == "bz2" ]
+    if [ "$suffix" = "bz2" ]
     then
 	bunzip2 < "$qafile" > "$target"
-    elif [ "$suffix" == "gz" ]
+    elif [ "$suffix" = "gz" ]
     then
 	gunzip < "$qafile" > "$target"
     else


### PR DESCRIPTION
Ken McDonell (2):
      qa/756: add filter to handle filesystem directory order non-determinism
      qa/886: repeat slowly after me ... do NOT use == with test(1)

 qa/756     |   37 ++++++++++++++++++++++++++++++---
 qa/756.out |   68 ++++++++++++++++++++++++++++++-------------------------------
 qa/886     |    4 +--
 3 files changed, 70 insertions(+), 39 deletions(-)

Details ...

commit 9bb95b6ffe645b290b79e951d7295c572c3d4b70
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Nov 21 10:51:42 2019 +1100

    qa/886: repeat slowly after me ... do NOT use == with test(1)

commit 9caf4ac481f345c03abadd2bc36456d5610ae685
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Nov 21 10:43:57 2019 +1100

    qa/756: add filter to handle filesystem directory order non-determinism
    
    Was failing on more than half my QA machines.