### PR TITLE
configure: make build reproducible

### DIFF
--- a/configure
+++ b/configure
@@ -5819,7 +5819,7 @@ PACKAGE_VERSION=${PACKAGE_MAJOR}.${PACKAGE_MINOR}.${PACKAGE_REVISION}
 
 
 if test -z "$PACKAGE_BUILD_DATE" ; then
-    PACKAGE_BUILD_DATE=`date +%Y-%m-%d`
+    PACKAGE_BUILD_DATE=`date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y-%m-%d`
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -786,7 +786,7 @@ AC_SUBST(PACKAGE_REVISION)
 AC_SUBST(PACKAGE_BUILD)
 
 if test -z "$PACKAGE_BUILD_DATE" ; then
-    PACKAGE_BUILD_DATE=`date +%Y-%m-%d`
+    PACKAGE_BUILD_DATE=`date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y-%m-%d`
 fi
 AC_SUBST(PACKAGE_BUILD_DATE)
 


### PR DESCRIPTION
pcp.lsm embeds the build date which makes the package un reproducible,
use SOURCE_DATE_EPOCH to always generate a deterministic builddate when
reproducing pcp.

Motiviation: https://reproducible-builds.org/

Signed-off-by: Jelle van der Waa <jelle@archlinux.org>