### PR TITLE
pmdabpftrace: don't show errors in logs which are due to normal operation

### DIFF
--- a/src/libpcp_pmda/src/callback.c
+++ b/src/libpcp_pmda/src/callback.c
@@ -632,14 +632,15 @@ pmdaFetch(int numpmid, pmID pmidlist[], pmResult **resp, pmdaExt *pmda)
 				    inst, strbuf);
 		    }
 		}
-		else if (sts == PM_ERR_APPVERSION ||
+		else if (sts == PM_ERR_VALUE ||
+			 sts == PM_ERR_APPVERSION ||
 			 sts == PM_ERR_PERMISSION ||
 			 sts == PM_ERR_AGAIN ||
 			 sts == PM_ERR_NYI) {
 		    if (pmDebugOptions.libpmda) {
 			pmNotifyErr(LOG_ERR,
-			     "pmdaFetch: Unavailable metric PMID %s[%d]\n",
-				    strbuf, inst);
+			     "pmdaFetch: Fetch callback error from metric PMID %s[%d]: %s\n",
+				strbuf, inst, pmErrStr(sts));
 		    }
 		}
 		else {

--- a/src/pmdas/bpftrace/bpftrace/cluster.py
+++ b/src/pmdas/bpftrace/bpftrace/cluster.py
@@ -174,13 +174,7 @@ class BPFtraceCluster:
                                              key_fn=self.instance_name_sorting_key(var_def))
 
     def fetch_callback(self, item: int, inst: int):
-        """
-        PMDA fetch callback for this bpftrace instance
-
-        if a client queries a bpftrace map value, but it doesn't exist yet,
-        we return PM_ERR_VALUE, which shows up in the logs as:
-        Error: pmdaFetch: Fetch callback error from metric PMID <...>: Missing metric value(s)
-        """
+        """PMDA fetch callback for this bpftrace instance"""
         if item == Consts.Script.Status:
             return [self.script.state.status, 1]
         elif item == Consts.Script.Pid:

--- a/src/pmdas/bpftrace/bpftrace/pmda.py
+++ b/src/pmdas/bpftrace/bpftrace/pmda.py
@@ -66,6 +66,7 @@ class BPFtracePMDA(PMDA):
         self.set_attribute_callback(self.attribute_callback)
         self.set_endcontext_callback(self.endcontext_callback)
         self.set_label(self.label)
+        self.set_label_callback(self.label_callback)
         self.set_store_callback(self.store_callback)
         self.set_refresh(self.refresh_callback)
         self.set_fetch_callback(self.fetch_callback)
@@ -204,6 +205,9 @@ class BPFtracePMDA(PMDA):
             cluster = self.pmid_cluster(ident)
             if cluster not in [Consts.Control.Cluster, Consts.Info.Cluster]:
                 return self.clusters[cluster].label(ident, type_)
+        return '{}'
+
+    def label_callback(self, indom: int, inst: int) -> str:
         return '{}'
 
     def refresh_script_indom(self):


### PR DESCRIPTION
* implement (empty) label callback (hides `[Mon Dec  9 11:43:43] pmdabpftrace(3898) Debug: pmdaLabel: InDom 151.104010[16]: Missing metric value(s)`)
* don't log PM_ERR_VALUE errors (log only if libpmda debug flag is set), hides `[Mon Dec  9 11:43:54] pmdabpftrace(4533) Error: pmdaFetch: Fetch callback error from metric PMID 151.102.12[-1]: Missing metric value(s)`
  * these "errors" are normal, occurs when Grafana is querying data but the bpftrace script didn't collect any data yet