### PR TITLE
fix rhel6 build breakage Changes committed to git@github.com:kmcdonell/pcp.git 20191229

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -60,7 +60,7 @@ BuildRequires: qt4-devel >= 4.4
 %endif
 %endif
 %if "%{_vendor}" == "redhat"
-BuildRequires: man hostname
+BuildRequires: man /bin/hostname
 %if "@enable_systemd@" == "false"
 BuildRequires: initscripts
 %endif
@@ -99,7 +99,7 @@ Provides: pcp-webapi
 # Utilities used indirectly e.g. by scripts we install
 Requires: bash xz gawk sed grep coreutils findutils
 %if "%{_vendor}" == "redhat"
-Requires: hostname
+Requires: /bin/hostname
 %endif
 # which(1) comes from different places
 %if 0%{?suse_version} >= 1100


### PR DESCRIPTION
Ken McDonell (1):
      build/rpm/pcp.spec.in: hostname change

 build/rpm/pcp.spec.in |    4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

Details ...

commit c0c0c6e0968ce760093fc00c92ada3223f582984
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Dec 29 07:01:37 2019 +1100

    build/rpm/pcp.spec.in: hostname change
    
    Requires: and BuildRequires: clauses need /bin/hostname not hostname
    (need the executable and the associated package is not hostname).
    
    Tracks changes in fedora.spec.
    
    Without this change the build is broken on RHEL6 and CentOS 6.