### PR TITLE
Fix compilation with -fno-common (new GCC 10 default)

### DIFF
--- a/src/external/sds.h
+++ b/src/external/sds.h
@@ -34,7 +34,7 @@
 #define __SDS_H
 
 #define SDS_MAX_PREALLOC (1024*1024)
-const char *SDS_NOINIT;
+extern const char *SDS_NOINIT;
 
 #include <sys/types.h>
 #include <stdarg.h>

--- a/src/pmdas/cifs/pmda.c
+++ b/src/pmdas/cifs/pmda.c
@@ -25,8 +25,6 @@ static int _isDSO = 1; /* for local contexts */
 
 static char *cifs_procfsdir = "/proc/fs/cifs";
 static char *cifs_statspath = "";
-unsigned int global_version_major;
-unsigned int global_version_minor;
 
 pmdaIndom indomtable[] = {
     { .it_indom = CIFS_FS_INDOM },


### PR DESCRIPTION
As described in https://bugzilla.opensuse.org/show_bug.cgi?id=1160244

---
Starting from the upcoming GCC release 10, the default of -fcommon option will change to -fno-common:

In C, global variables with multiple tentative definitions will result in linker errors. Global variable accesses are also more efficient on various targets.

Porting advice:

A common mistake in C is omitting <code>extern</code> when declaring a global variable in a header file.  If the header is included by several files it 
results in multiple definitions of the same variable.  In previous GCC versions this error is ignored.  GCC 10 defaults to <code>-fno-common</code>, 
which means a linker error will now be reported. To fix this, use <code>extern</code> in header files when declaring global variables, and ensure each global is defined in exactly one C file. As a workaround, legacy C code can be compiled with -fcommon.

      int x;  // tentative definition - avoid in header files 
      extern int y;  // correct declaration in a header file 

Recommendations for package maintainers:
- report the violation to upstream
- cherry pick a fix from upsteam
---