### PR TITLE
pcp-pidstat: fix out of range error when reading metrics from an archive

### DIFF
--- a/src/pcp/pidstat/pcp-pidstat.py
+++ b/src/pcp/pidstat/pcp-pidstat.py
@@ -833,6 +833,9 @@ class PidstatReport(pmcc.MetricGroupPrinter):
             # need two fetches to report rate converted counter metrics
             return
 
+        if not group['hinv.ncpu'].netValues or not group['kernel.uname.sysname'].netValues:
+            return
+
         if not self.Machine_info_count:
             self.print_machine_info(group, manager)
             self.Machine_info_count = 1


### PR DESCRIPTION
pcp pidstat fails with IndexError when proc.psinfo.utime metric is found prior to
kernel.uname.* or hinv.ncpu metrics.
Check whether those metrics exist before starting to show process information.

Resolves: https://github.com/performancecopilot/pcp/issues/625

The error in my environment is as follows.

```
# pcp pidstat -a archive
Traceback (most recent call last):
  File "/usr/libexec/pcp/bin/pcp-pidstat", line 916, in <module>
    sts = manager.run()
  File "/usr/lib64/python3.6/site-packages/pcp/pmcc.py", line 665, in run
    self._printer.report(self)
  File "/usr/libexec/pcp/bin/pcp-pidstat", line 838, in report
    self.print_machine_info(group, manager)
  File "/usr/libexec/pcp/bin/pcp-pidstat", line 820, in print_machine_info
    header_string += group['kernel.uname.sysname'].netValues[0][2] + '  '
IndexError: list index out of range
```