### PR TITLE
freebsd PMDA (take 2)

### DIFF
--- a/src/pmdas/freebsd/freebsd.c
+++ b/src/pmdas/freebsd/freebsd.c
@@ -485,7 +485,7 @@ freebsd_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
 	    case 22:		/* kernel.all.pswitch */
 	    case 23:		/* kernel.all.syscall */
 	    case 24:		/* kernel.all.intr */
-		sts = do_sysctl(mp, sizeof(atom->ull));
+		sts = do_sysctl(mp, 0);
 		if (sts > 0) {
 		    switch (sts) {
 			case 4:


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200125

Ken McDonell (1):
      src/pmdas/freebsd/freebsd.c: rework last 32->64 bit change

 src/pmdas/freebsd/freebsd.c |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Details ...

commit ef11d7d50b1d576e2250d6cc8f4bde66e730000e
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Jan 25 20:23:53 2020 +1100

    src/pmdas/freebsd/freebsd.c: rework last 32->64 bit change
    
    Botched the second argument to do_sysctl(), so it worked on newer
    platforms where the metrics are 64-bit in the kernel, but was failing
    on the older platforms where the metrics are 32-bit in the kernel.
    
    Fixed now.