### PR TITLE
docs: add interval and samples arguments to usage of pcp-atop -r

### DIFF
--- a/src/pcp/atop/atop.c
+++ b/src/pcp/atop/atop.c
@@ -733,7 +733,7 @@ prusage(char *myname, pmOptions *opts)
 	printf("\t\tor\n");
 	printf("Usage: %s -w  file  [-S] [-%c] [interval [samples]]\n",
 					myname, MALLPROC);
-	printf("       %s -r  file  [-b hh:mm] [-e hh:mm] [-flags]\n",
+	printf("       %s -r  file  [-b hh:mm] [-e hh:mm] [-flags] [interval [samples]]\n",
 					myname);
 	printf("\n");
 	printf("\tgeneric flags:\n");

--- a/src/pcp/atop/pcp-atop.1
+++ b/src/pcp/atop/pcp-atop.1
@@ -29,7 +29,7 @@ Writing and reading PCP archive folios:
 [\f3\-a\f1] [\f3\-S\f1] [\f2interval\f1 [\f2samples\f1]]
 .br
 .B pcp\ atop
-\f3\-r\f1 [\f2folio\f1] [\f3\-AcCdDfFgGmMnNopRsuvxy1\f1] [\f3\-b\f1 \f2hh:mm\f1] [\f3\-e\f1 \f2hh:mm\f1] [\f3\-L\f1 \f2linelen\f1] [\f3\-P\f1\f2label\f1[,\f2label\f1]...]
+\f3\-r\f1 \f2folio\f1 [\f3\-AcCdDfFgGmMnNopRsuvxy1\f1] [\f3\-b\f1 \f2hh:mm\f1] [\f3\-e\f1 \f2hh:mm\f1] [\f3\-L\f1 \f2linelen\f1] [\f3\-P\f1\f2label\f1[,\f2label\f1]...] [\f2interval\f1 [\f2samples\f1]]
 .SH DESCRIPTION
 The program
 .B pcp-atop


### PR DESCRIPTION
It seems from the documents that these arguments are not available for pcp-atop -r although they works.