### PR TITLE
linux pmda + logrewrite, qa

### DIFF
--- a/qa/1359.out
+++ b/qa/1359.out
@@ -59,14 +59,14 @@ Warning: deprecated __pmSetDebugBits() called
 arg: all
 pmSetDebug("all") ...
 pmDebug:	pdu,fetch,profile,value,context,indom,pdubuf,log,logmeta,optfetch,af,appl0,appl1,appl2,pmns,libpmda,timecontrol,pmc,derive,lock,interp,config,pmapi,fault,auth,discovery,attr,http,desperate
-pmDebugOptions:	pdu,fetch,profile,value,context,indom,pdubuf,log,logmeta,optfetch,af,appl0,appl1,appl2,pmns,libpmda,timecontrol,pmc,derive,lock,interp,config,pmapi,fault,auth,discovery,attr,http,desperate,deprecated,exec,labels,series,libweb,appl3,appl4,appl5
+pmDebugOptions:	pdu,fetch,profile,value,context,indom,pdubuf,log,logmeta,optfetch,af,appl0,appl1,appl2,pmns,libpmda,timecontrol,pmc,derive,lock,interp,config,pmapi,fault,auth,discovery,attr,http,desperate,deprecated,exec,labels,series,libweb,alloc,appl3,appl4,appl5
 pmClearDebug("all") ...
 pmDebug:	Nothing set
 pmDebugOptions:	Nothing set
 __pmParseDebug("all") ...
 __pmParseDebug -> 2147483647
 pmDebug:	pdu,fetch,profile,value,context,indom,pdubuf,log,logmeta,optfetch,af,appl0,appl1,appl2,pmns,libpmda,timecontrol,pmc,derive,lock,interp,config,pmapi,fault,auth,discovery,attr,http,desperate
-pmDebugOptions:	pdu,fetch,profile,value,context,indom,pdubuf,log,logmeta,optfetch,af,appl0,appl1,appl2,pmns,libpmda,timecontrol,pmc,derive,lock,interp,config,pmapi,fault,auth,discovery,attr,http,desperate,deprecated,exec,labels,series,libweb,appl3,appl4,appl5
+pmDebugOptions:	pdu,fetch,profile,value,context,indom,pdubuf,log,logmeta,optfetch,af,appl0,appl1,appl2,pmns,libpmda,timecontrol,pmc,derive,lock,interp,config,pmapi,fault,auth,discovery,attr,http,desperate,deprecated,exec,labels,series,libweb,alloc,appl3,appl4,appl5
 pmClearDebug("all") ...
 pmDebug:	Nothing set
 pmDebugOptions:	Nothing set

--- a/qa/1457
+++ b/qa/1457
@@ -17,6 +17,24 @@ _check_series
 _check_valgrind
 openssl help 2>/dev/null || _notrun "No openssl binary found"
 
+if [ -f /etc/lsb-release ]
+then
+    . /etc/lsb-release
+    if [ "$DISTRIB_ID" = Ubuntu ]
+    then
+	# This test fails for Ubuntu 19.10 with a myriad of errors involving
+	# the use of uninitialized values.  The code paths very but typically
+	# involve libuv -> libssl ->  libcrypto
+	#
+	case "$DISTRIB_RELEASE"
+	in
+	    19.10)
+		_notrun "problems with libuv, libssl, libcrypto and valgrind on Ubuntu $DISTRIB_RELEASE"
+		;;
+	esac
+    fi
+fi
+
 _cleanup()
 {
     cd $here

--- a/src/pmdas/linux/mk.rewrite
+++ b/src/pmdas/linux/mk.rewrite
@@ -30,22 +30,24 @@ cat <<End-of-File >linux_kernel_ulong.conf
 # using the KERNEL_ULONG type which might be U32
 # or could be U64.
 #
-# disk.dev group
+# Order here matches metadata definition order in pmda.c to help
+# make it easier to spot differences.
 #
+
 metric disk.dev.read { type -> $KERNEL_ULONG }
 metric disk.dev.write { type -> $KERNEL_ULONG }
-metric disk.dev.total { type -> $KERNEL_ULONG }
 metric disk.dev.blkread { type -> $KERNEL_ULONG }
 metric disk.dev.blkwrite { type -> $KERNEL_ULONG }
-metric disk.dev.blktotal { type -> $KERNEL_ULONG }
-metric disk.dev.read_bytes { type -> $KERNEL_ULONG }
-metric disk.dev.write_bytes { type -> $KERNEL_ULONG }
-metric disk.dev.total_bytes { type -> $KERNEL_ULONG }
 metric disk.dev.read_merge { type -> $KERNEL_ULONG }
 metric disk.dev.write_merge { type -> $KERNEL_ULONG }
-
-# disk.partitions group
-#
+metric kernel.all.sysfork { type -> $KERNEL_ULONG }
+metric kernel.all.running { type -> $KERNEL_ULONG }
+metric kernel.all.blocked { type -> $KERNEL_ULONG }
+metric mem.buddyinfo.pages { type -> $KERNEL_ULONG }
+metric nfs.server.threads.requests { type -> $KERNEL_ULONG }
+metric nfs.server.threads.enqueued { type -> $KERNEL_ULONG }
+metric nfs.server.threads.processed { type -> $KERNEL_ULONG }
+metric nfs.server.threads.timedout { type -> $KERNEL_ULONG }
 metric disk.partitions.read { type -> $KERNEL_ULONG }
 metric disk.partitions.write { type -> $KERNEL_ULONG }
 metric disk.partitions.total { type -> $KERNEL_ULONG }
@@ -55,21 +57,43 @@ metric disk.partitions.blktotal { type -> $KERNEL_ULONG }
 metric disk.partitions.read_bytes { type -> $KERNEL_ULONG }
 metric disk.partitions.write_bytes { type -> $KERNEL_ULONG }
 metric disk.partitions.total_bytes { type -> $KERNEL_ULONG }
-
-# disk.dm group
-#
+metric disk.partitions.read_merge { type -> $KERNEL_ULONG }
+metric disk.partitions.write_merge { type -> $KERNEL_ULONG }
+metric disk.dev.read_bytes { type -> $KERNEL_ULONG }
+metric disk.dev.write_bytes { type -> $KERNEL_ULONG }
+metric disk.dev.total_bytes { type -> $KERNEL_ULONG }
+metric disk.all.read_bytes { type -> $KERNEL_ULONG }
+metric disk.all.write_bytes { type -> $KERNEL_ULONG }
+metric disk.all.total_bytes { type -> $KERNEL_ULONG }
+metric mem.ksm.full_scans { type -> $KERNEL_ULONG }
+metric mem.ksm.merge_across_nodes { type -> $KERNEL_ULONG }
+metric mem.ksm.pages_shared { type -> $KERNEL_ULONG }
+metric mem.ksm.pages_sharing { type -> $KERNEL_ULONG }
+metric mem.ksm.pages_to_scan { type -> $KERNEL_ULONG }
+metric mem.ksm.pages_unshared { type -> $KERNEL_ULONG }
+metric mem.ksm.pages_volatile { type -> $KERNEL_ULONG }
+metric mem.ksm.run_state { type -> $KERNEL_ULONG }
+metric mem.ksm.sleep_time { type -> $KERNEL_ULONG }
 metric disk.dm.read { type -> $KERNEL_ULONG }
 metric disk.dm.write { type -> $KERNEL_ULONG }
 metric disk.dm.blkread { type -> $KERNEL_ULONG }
 metric disk.dm.blkwrite { type -> $KERNEL_ULONG }
 metric disk.dm.read_merge { type -> $KERNEL_ULONG }
 metric disk.dm.write_merge { type -> $KERNEL_ULONG }
+metric disk.md.read { type -> $KERNEL_ULONG }
+metric disk.md.write { type -> $KERNEL_ULONG }
+metric disk.md.blkread { type -> $KERNEL_ULONG }
+metric disk.md.blkwrite { type -> $KERNEL_ULONG }
+metric disk.md.read_merge { type -> $KERNEL_ULONG }
+metric disk.md.write_merge { type -> $KERNEL_ULONG }
 
-# miscellaneous group
+# these ones were KERNEL_ULONG at a point of time in the past, but the
+# current PMDA exports them as U64
 #
-metric kernel.all.sysfork { type -> $KERNEL_ULONG }
+metric disk.dev.total { type -> U64 }
+metric disk.dev.blktotal { type -> U64 }
 
-# and this one was KERNEL_ULONG but that was incorrect
+# and this one was KERNEL_ULONG in this file, but that was incorrect
 #
 metric disk.dm.total { type -> U64 }
 End-of-File


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200219

Ken McDonell (3):
      qa/1359.out: remade after -Dalloc addition to debug flags
      qa/1457: don't run on Ubuntu 19.10
      src/pmdas/linux/mk.rewrite: fix a bunch of KERNEL_ULONG errors


Details ...

commit 567d089eea08cb15b9764c8f7935bdedf732ac54
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Feb 19 11:40:01 2020 +1100

    src/pmdas/linux/mk.rewrite: fix a bunch of KERNEL_ULONG errors
    
    This file had diverged from the PMDA, so the type rewriting rules
    for KERNEL_ULONG (U32 or U64) were wrong in a number of places.

commit 45d3edbe8a32fe8ada44a6bda67a5b26caa98d4a
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Feb 19 07:14:30 2020 +1100

    qa/1457: don't run on Ubuntu 19.10
    
    There is some fatal issue here with libuv, libssl, libcrypto and valgind
    that produces 400+ different faults as reported by valgrind.  For future
    reference (in case this is really a pmproxy bug, which seems unlikely)
    here is the first of the reported errors:
    
      Conditional jump or move depends on uninitialised value(s)
      at 0x4C4C30B: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
      by 0x4C4D24B: RAND_DRBG_generate (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
      by 0x4C4E764: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
      by 0x4C4CA4D: RAND_DRBG_instantiate (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
      by 0x4C4D9BA: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
      by 0x4C4DD91: RAND_DRBG_get0_public (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
      by 0x4C4DDC3: ??? (in /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1)
      by 0x4A50537: SSL_CTX_new (in /usr/lib/x86_64-linux-gnu/libssl.so.1.1)
      by 0x11C8FF: ??? (in /usr/lib/pcp/bin/pmproxy)
      by 0x11225F: ??? (in /usr/lib/pcp/bin/pmproxy)
      by 0x4D8AF65: uv__run_timers (in /usr/lib/x86_64-linux-gnu/libuv.so.1.0.0)
      by 0x4D8E3E9: uv_run (in /usr/lib/x86_64-linux-gnu/libuv.so.1.0.0)

commit d34d9a8308963f9917a246e44fb09cb01051fec6
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Feb 19 07:00:45 2020 +1100

    qa/1359.out: remade after -Dalloc addition to debug flags