### PR TITLE
Fix for BZ1805146 (pmlogger_daily_report)

### DIFF
--- a/src/pmlogger/pmlogger_daily_report.sh
+++ b/src/pmlogger/pmlogger_daily_report.sh
@@ -214,7 +214,8 @@ $VERBOSE && echo REPORTDIR=$REPORTDIR
 
 # Create output directory - if this fails due to permissions we exit later
 #
-[ -d "$REPORTDIR" ] || mkdir -p "$REPORTDIR" 2>/dev/null
+[ -d "$REPORTDIR" ] \
+    || { mkdir -p "$REPORTDIR" 2>/dev/null; chmod 0775 "$REPORTDIR" 2>/dev/null; }
 
 # Default output file is the day of month for yesterday in REPORTDIR
 #


### PR DESCRIPTION
Fix for BZ1805146 - pmlogger_daily_report causing PCP upstream testsuite to fail
This fix makes sure a newly created $REPORTDIR has the expected permissions.