### PR TITLE
rc scripts rework (freebsd) and qa changes

### DIFF
--- a/src/pmcd/rc_pcp
+++ b/src/pmcd/rc_pcp
@@ -43,6 +43,10 @@
 
 . $PCP_DIR/etc/pcp.env
 
+# for chasing arguments we're passed from init/systemd/...
+#
+#debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pcp.log
+
 tmp=`mktemp -d $PCP_DIR/var/tmp/pcp.XXXXXXXXX` || exit 1
 status=0
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15

--- a/src/pmcd/rc_pmcd
+++ b/src/pmcd/rc_pmcd
@@ -44,7 +44,9 @@
 . $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/rc-proc.sh
 
-echo "$1: `date`" >>$PCP_LOG_DIR/pmcd/rc.log
+# for chasing arguments we're passed from init/systemd/...
+#
+#debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmcd.log
 
 PMCD=$PCP_BINADM_DIR/pmcd
 PMCDOPTS=$PCP_PMCDOPTIONS_PATH

--- a/src/pmcd/rc_pmcd
+++ b/src/pmcd/rc_pmcd
@@ -32,9 +32,19 @@
 # Short-Description: Control pmcd (the collection daemon for PCP)
 # Description:       Configure and control pmcd (the collection daemon for the Performance Co-Pilot)
 ### END INIT INFO
+#
+# For FreeBSD
+# PROVIDE: pmcd
+# REQUIRE: NETWORKING FILESYSTEMS syslogd
+# KEYWORD: shutdown
+# And add the following lines to /etc/rc.conf to run pmcd:
+# pmcd_enable="YES"
+#
 
 . $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/rc-proc.sh
+
+echo "$1: `date`" >>$PCP_LOG_DIR/pmcd/rc.log
 
 PMCD=$PCP_BINADM_DIR/pmcd
 PMCDOPTS=$PCP_PMCDOPTIONS_PATH
@@ -421,7 +431,7 @@ Warning: process ID in $PCP_RUN_DIR/pmcd.pid ($runpid) is different.
 
 _usage()
 {
-    echo "Usage: $prog [-v] {start|restart|condrestart|stop|status|reload|force-reload}"
+    echo "Usage: $prog [-v] {start|faststart|restart|condrestart|stop|status|reload|force-reload}"
 }
 
 VERBOSE_CTL=on
@@ -482,7 +492,7 @@ $RC_RESET
 # considered a success.
 case "$1" in
 
-  'start'|'restart'|'condrestart'|'reload'|'force-reload')
+  start|faststart|restart|condrestart|reload|force-reload)
 	if [ "$1" = "condrestart" ] && ! is_chkconfig_on pmcd
 	then
 	    status=0
@@ -593,7 +603,7 @@ Error: pmcd control file '"$PCP_PMCDCONF_PATH"' is missing, cannot start pmcd.'
 	status=0
         ;;
 
-  'stop')
+  stop)
 	# site-local customisations before pmcd shutdown
 	#
 	[ -x $PCPLOCAL ] && $PCPLOCAL $VFLAG stop
@@ -601,7 +611,7 @@ Error: pmcd control file '"$PCP_PMCDCONF_PATH"' is missing, cannot start pmcd.'
 	status=0
         ;;
 
-  'status')
+  status)
 	# NOTE: $RC_CHECKPROC returns LSB compliant status values.
 	$ECHO $PCP_ECHO_N "Checking for pmcd:" "$PCP_ECHO_C"
         if [ -r /etc/rc.status ]

--- a/src/pmie/rc_pmie
+++ b/src/pmie/rc_pmie
@@ -42,6 +42,10 @@
 . $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/rc-proc.sh
 
+# for chasing arguments we're passed from init/systemd/...
+#
+#debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmie.log
+
 PMIECTRL=$PCP_PMIECONTROL_PATH
 rcprog=$PCP_DIR/etc/init.d/pmie
 pmprog=$PCP_RC_DIR/pmie

--- a/src/pmie/rc_pmie
+++ b/src/pmie/rc_pmie
@@ -30,6 +30,14 @@
 # Short-Description: Control pmie (performance inference engine for PCP)
 # Description:       Configure and control pmie (the performance inference engine for the Performance Co-Pilot)
 ### END INIT INFO
+#
+# For FreeBSD
+# PROVIDE: pmie
+# REQUIRE: NETWORKING FILESYSTEMS pmcd
+# KEYWORD: shutdown
+# And add the following lines to /etc/rc.conf to run pmcd:
+# pmie_enable="YES"
+#
 
 . $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/rc-proc.sh
@@ -244,7 +252,7 @@ else                            # For a quiet startup and shutdown
 fi
 
 case "$1" in
-  'start'|'restart'|'condrestart'|'reload'|'force-reload')
+  start|faststart|restart|condrestart|reload|force-reload)
 	if [ "$1" = "condrestart" ] && ! is_chkconfig_on pmie
 	then
 	    status=0
@@ -276,12 +284,12 @@ case "$1" in
 	status=0
         ;;
 
-  'stop')
+  stop)
 	_shutdown verbose
 	status=0
         ;;
 
-  'status')
+  status)
         # NOTE: $RC_CHECKPROC returns LSB compliant status values.
 	$ECHO $PCP_ECHO_N "Checking for pmie:" "$PCP_ECHO_C"
         if [ -r /etc/rc.status ]

--- a/src/pmlogger/rc_pmlogger
+++ b/src/pmlogger/rc_pmlogger
@@ -44,7 +44,9 @@
 . $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/rc-proc.sh
 
-echo "$1: `date`" >>$PCP_LOG_DIR/pmlogger/rc.log
+# for chasing arguments we're passed from init/systemd/...
+#
+#debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmlogger.log
 
 PMLOGCTRL=$PCP_PMLOGGERCONTROL_PATH
 PMLOGGER=$PCP_BINADM_DIR/pmlogger

--- a/src/pmlogger/rc_pmlogger
+++ b/src/pmlogger/rc_pmlogger
@@ -32,9 +32,19 @@
 # Short-Description: Control pmlogger (the performance metrics logger for PCP)
 # Description:       Configure and control pmlogger (the performance metrics logger for the Performance Co-Pilot)
 ### END INIT INFO
+#
+# For FreeBSD
+# PROVIDE: pmlogger
+# REQUIRE: NETWORKING FILESYSTEMS pmcd
+# KEYWORD: shutdown
+# And add the following lines to /etc/rc.conf to run pmcd:
+# pmlogger_enable="YES"
+#
 
 . $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/rc-proc.sh
+
+echo "$1: `date`" >>$PCP_LOG_DIR/pmlogger/rc.log
 
 PMLOGCTRL=$PCP_PMLOGGERCONTROL_PATH
 PMLOGGER=$PCP_BINADM_DIR/pmlogger
@@ -203,7 +213,7 @@ _shutdown()
 
 _usage()
 {
-    echo "Usage: $prog [-v] {start|restart|condrestart|stop|status|reload|force-reload}"
+    echo "Usage: $prog [-v] {start|faststart|restart|condrestart|stop|status|reload|force-reload}"
 }
 
 while getopts v c
@@ -263,7 +273,7 @@ $RC_RESET
 # considered a success.
 case "$1" in
 
-  'start'|'restart'|'condrestart'|'reload'|'force-reload')
+  start|faststart|restart|condrestart|reload|force-reload)
 	if [ "$1" = "condrestart" ] && ! is_chkconfig_on pmlogger
 	then
 	    status=0
@@ -292,12 +302,12 @@ case "$1" in
 	status=0
         ;;
 
-  'stop')
+  stop)
 	_shutdown verbose
 	status=0
         ;;
 
-  'status')
+  status)
 	# NOTE: $RC_CHECKPROC returns LSB compliant status values.
 	$ECHO $PCP_ECHO_N "Checking for pmlogger:" "$PCP_ECHO_C"
         if [ -r /etc/rc.status ]

--- a/src/pmmgr/rc_pmmgr
+++ b/src/pmmgr/rc_pmmgr
@@ -44,6 +44,10 @@
 . $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/rc-proc.sh
 
+# for chasing arguments we're passed from init/systemd/...
+#
+#debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmmgr.log
+
 PMMGR=$PCP_BINADM_DIR/pmmgr
 PMMGROPTS=$PCP_PMMGROPTIONS_PATH
 RUNDIR=$PCP_LOG_DIR/pmmgr

--- a/src/pmmgr/rc_pmmgr
+++ b/src/pmmgr/rc_pmmgr
@@ -32,6 +32,14 @@
 # Short-Description: Control pmmgr (daemon manager for PCP)
 # Description:       Configure and control pmmgr (a daemon manager for the Performance Co-Pilot)
 ### END INIT INFO
+#
+# For FreeBSD
+# PROVIDE: pmmgr
+# REQUIRE: NETWORKING FILESYSTEMS pmcd
+# KEYWORD: shutdown
+# And add the following lines to /etc/rc.conf to run pmcd:
+# pmmgr_enable="YES"
+#
 
 . $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/rc-proc.sh
@@ -194,7 +202,7 @@ $RC_RESET
 # considered a success.
 case "$1" in
 
-  'start'|'restart'|'condrestart'|'reload'|'force-reload')
+  start|faststart|restart|condrestart|reload|force-reload)
 	if [ "$1" = "condrestart" ] && ! is_chkconfig_on pmmgr
 	then
 	    status=0
@@ -272,12 +280,12 @@ END			{ if (exports != "") print "export", exports }'`
 	status=0
         ;;
 
-  'stop')
+  stop)
 	_shutdown
 	status=0
         ;;
 
-  'status')
+  status)
 	# NOTE: $RC_CHECKPROC returns LSB compliant status values.
 	$ECHO $PCP_ECHO_N "Checking for pmmgr:" "$PCP_ECHO_C"
         if [ -r /etc/rc.status ]

--- a/src/pmproxy/rc_pmproxy
+++ b/src/pmproxy/rc_pmproxy
@@ -32,6 +32,14 @@
 # Short-Description: Control pmproxy (the pmcd proxy daemon for PCP)
 # Description:       Configure and control pmproxy (the pmcd proxy daemon for the Performance Co-Pilot)
 ### END INIT INFO
+#
+# For FreeBSD
+# PROVIDE: pmproxy
+# REQUIRE: NETWORKING FILESYSTEMS pmcd
+# KEYWORD: shutdown
+# And add the following lines to /etc/rc.conf to run pmcd:
+# pmproxy_enable="YES"
+#
 
 . $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/rc-proc.sh
@@ -149,7 +157,7 @@ _shutdown()
 
 _usage()
 {
-    echo "Usage: $pmprog [-v] {start|restart|condrestart|stop|status|reload|force-reload}"
+    echo "Usage: $pmprog [-v] {start|faststart|restart|condrestart|stop|status|reload|force-reload}"
 }
 
 while getopts v c
@@ -205,7 +213,7 @@ $RC_RESET
 # considered a success.
 case "$1" in
 
-  'start'|'restart'|'condrestart'|'reload'|'force-reload')
+  start|faststart|restart|condrestart|reload|force-reload)
 	if [ "$1" = "condrestart" ] && ! is_chkconfig_on pmproxy
 	then
 	    status=0
@@ -280,12 +288,12 @@ Error: pmproxy options file "$PMPROXYOPTS" is missing, cannot start pmproxy.'
 	status=0
         ;;
 
-  'stop')
+  stop)
 	_shutdown
 	status=0
         ;;
 
-  'status')
+  status)
 	# NOTE: $RC_CHECKPROC returns LSB compliant status values.
 	$ECHO $PCP_ECHO_N "Checking for pmproxy:" "$PCP_ECHO_C"
         if [ -r /etc/rc.status ]

--- a/src/pmproxy/rc_pmproxy
+++ b/src/pmproxy/rc_pmproxy
@@ -44,6 +44,10 @@
 . $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/rc-proc.sh
 
+# for chasing arguments we're passed from init/systemd/...
+#
+#debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmproxy.log
+
 PMPROXY=$PCP_BINADM_DIR/pmproxy
 PMPROXYOPTS=$PCP_PMPROXYOPTIONS_PATH
 PMPROXYENVS=$PCP_SYSCONFIG_DIR/pmproxy


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200220

Ken McDonell (5):
      qa: add _notrun checks for pmda.bcc tests that need __version__
      Revert "qa: add _notrun checks for pmda.bcc tests that need __version__"
      qa: redo the __version__ test for pmda.bcc tests
      rc scripts: small changes to make things work better for FreeBSD
      */rc_*: rework the arg logging


Details ...

commit c1aafead6f3cad97b873f699fc0df41437013255
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Feb 26 17:08:47 2020 +1100

    */rc_*: rework the arg logging
    
    1. comment it out by default (to avoid AVC warnings/errors)
    2. add for all rc scripts
    3. logs got to $PCP_LOG_DIR/rc_foo.log for the foo service
    4. log all args, not just $1

commit 748019dd3d7f0b1f98ca6eb72f3c750ee1f97c01
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Feb 22 20:28:36 2020 +1100

    rc scripts: small changes to make things work better for FreeBSD
    
    Our "one size fits all" rc scripts are not exactly kosher for FreeBSD,
    but with these small changes they work acceptably well.

commit f6308a5b566f70920e5a34f84af2edc10296eb12
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Feb 20 08:40:38 2020 +1100

    qa: redo the __version__ test for pmda.bcc tests
    
    Replace the old DEBUG_BPF_REGISTER_STATE test with one that
    checks for the symbol __version__ in the Python bcc module.

commit 5da4336919889c8781478e31b901d35706ad4385
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Feb 20 08:36:21 2020 +1100

    Revert "qa: add _notrun checks for pmda.bcc tests that need __version__"
    
    This reverts commit 73c4aaef59a89a330cfe6c8eacb7c2a1b2b65e86.
    
    There is a better way to do this ... I now believe EVERY pmda.bcc test needs
    this __version__ symbol, so I'll fold the test back into _pmdabcc_check(), and
    avoid the _pmdabcc_require__version__() babble.

commit 73c4aaef59a89a330cfe6c8eacb7c2a1b2b65e86
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Feb 20 08:27:14 2020 +1100

    qa: add _notrun checks for pmda.bcc tests that need __version__