### PR TITLE
pcp-atop: fix STDATE/STTIME in -v output

### DIFF
--- a/src/pcp/atop/atop.c
+++ b/src/pcp/atop/atop.c
@@ -164,6 +164,7 @@ char		**argvp;
 int		fetchmode;
 int		fetchstep;
 
+long long	system_boottime;
 
 struct visualize vis = {generic_samp, generic_error,
 			generic_end,  generic_usage,
@@ -587,7 +588,8 @@ engine(void)
 			if ((*vis.next)() < 0)
 				cleanstop(1);
 			goto reset;
-               }
+		}
+		system_boottime = cursstat->cpu.btime;
 
 		/*
 		** take a snapshot of the current task-level statistics 

--- a/src/pcp/atop/atop.h
+++ b/src/pcp/atop/atop.h
@@ -119,6 +119,8 @@ extern int		netbadness;
 extern int		pagbadness;
 extern int		almostcrit;
 
+extern long long	system_boottime;
+
 /*
 ** bit-values for supportflags
 */

--- a/src/pcp/atop/photosyst.c
+++ b/src/pcp/atop/photosyst.c
@@ -296,6 +296,7 @@ photosyst(struct sstat *si)
 	si->cpu.csw = extract_count_t(result, descs, CPU_CSW);
 	si->cpu.devint = extract_count_t(result, descs, CPU_DEVINT);
 	si->cpu.nprocs = extract_count_t(result, descs, CPU_NPROCS);
+	si->cpu.btime  = extract_count_t(result, descs, CPU_BTIME);
 	si->cpu.all.utime = extract_count_t(result, descs, CPU_UTIME);
 	si->cpu.all.ntime = extract_count_t(result, descs, CPU_NTIME);
 	si->cpu.all.stime = extract_count_t(result, descs, CPU_STIME);

--- a/src/pcp/atop/photosyst.h
+++ b/src/pcp/atop/photosyst.h
@@ -107,6 +107,7 @@ struct	cpustat {
 	count_t	devint;	/* number of device interrupts 		*/
 	count_t	csw;	/* number of context switches		*/
 	count_t	nprocs;	/* number of processes started          */
+	count_t	btime;	/* boot time                            */
 	float	lavg1;	/* load average last    minute          */
 	float	lavg5;	/* load average last  5 minutes         */
 	float	lavg15;	/* load average last 15 minutes         */

--- a/src/pcp/atop/showprocs.c
+++ b/src/pcp/atop/showprocs.c
@@ -999,7 +999,11 @@ procprt_STDATE_ae(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[11];
 
-        convdate(curstat->gen.btime, buf, sizeof buf);
+        if (system_boottime)
+                convdate(system_boottime + curstat->gen.btime / 1000, buf, sizeof buf);
+        else
+                strcpy(buf, "----/--/--");
+
         return buf;
 }
 
@@ -1011,7 +1015,11 @@ procprt_STTIME_ae(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[9];
 
-        convtime(curstat->gen.btime, buf, sizeof buf);
+        if (system_boottime)
+                convtime(system_boottime + curstat->gen.btime / 1000, buf, sizeof buf);
+        else
+                strcpy(buf, "--:--:--");
+
         return buf;
 }
 
@@ -1033,7 +1041,10 @@ procprt_ENDATE_e(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[11];
 
-        convdate(curstat->gen.btime + curstat->gen.elaps, buf, sizeof buf);
+        if (system_boottime)
+                convdate(system_boottime + curstat->gen.btime / 1000 + curstat->gen.elaps, buf, sizeof buf);
+        else
+                strcpy(buf, "----/--/--");
 
         return buf;
 }
@@ -1056,7 +1067,10 @@ procprt_ENTIME_e(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[9];
 
-        convtime(curstat->gen.btime + curstat->gen.elaps, buf, sizeof buf);
+        if (system_boottime)
+                convtime(system_boottime + curstat->gen.btime / 1000 + curstat->gen.elaps, buf, sizeof buf);
+        else
+                strcpy(buf, "--:--:--");
 
         return buf;
 }

--- a/src/pcp/atop/systmetrics.map
+++ b/src/pcp/atop/systmetrics.map
@@ -10,6 +10,7 @@ systmetrics {
 	kernel.all.pswitch			CPU_CSW
 	kernel.all.intr				CPU_DEVINT
 	kernel.all.sysfork			CPU_NPROCS
+	kernel.all.boottime			CPU_BTIME
 	kernel.all.cpu.user			CPU_UTIME
 	kernel.all.cpu.nice			CPU_NTIME
 	kernel.all.cpu.sys			CPU_STIME

--- a/src/pmdas/linux/help
+++ b/src/pmdas/linux/help
@@ -775,6 +775,7 @@ e.g. mirroring the results from existing performance tools:
 @ kernel.all.sysfork fork rate metric from /proc/stat
 @ kernel.all.running number of currently running processes from /proc/stat
 @ kernel.all.blocked number of currently blocked processes from /proc/stat
+@ kernel.all.boottime boot time from /proc/stat
 @ kernel.all.intr interrupt count metric from /proc/stat
 The value is the first value from the intr field in /proc/stat,
 which is a counter of the total number of interrupts processed.

--- a/src/pmdas/linux/pmda.c
+++ b/src/pmdas/linux/pmda.c
@@ -688,6 +688,11 @@ static pmdaMetric metrictab[] = {
       { PMDA_PMID(CLUSTER_STAT,16), KERNEL_ULONG, PM_INDOM_NULL, PM_SEM_INSTANT, 
       PMDA_PMUNITS(0,0,0,0,0,0) }, },
 
+/* kernel.all.boottime */
+    { NULL,
+      { PMDA_PMID(CLUSTER_STAT,17), PM_TYPE_64, PM_INDOM_NULL, PM_SEM_DISCRETE,
+      PMDA_PMUNITS(0,0,0,0,0,0) }, },
+
 /* kernel.all.cpu.user */
     { NULL, 
       { PMDA_PMID(CLUSTER_STAT,20), KERNEL_UTYPE, PM_INDOM_NULL, PM_SEM_COUNTER,
@@ -6576,6 +6581,9 @@ linux_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
 	    break;
 	case 16: /* kernel.all.blocked */
 	    _pm_assign_ulong(atom, proc_stat.procs_blocked);
+	    break;
+	case 17: /* kernel.all.boottime */
+	    atom->ll = proc_stat.btime;
 	    break;
 
 	case 20: /* kernel.all.cpu.user */

--- a/src/pmdas/linux/root_linux
+++ b/src/pmdas/linux/root_linux
@@ -93,6 +93,7 @@ kernel.all {
     sysfork		60:0:14
     running		60:0:15
     blocked		60:0:16
+    boottime		60:0:17
     hz			60:0:48
     uptime		60:26:0
     idletime		60:26:1

--- a/src/pmlogconf/platform/linux
+++ b/src/pmlogconf/platform/linux
@@ -8,4 +8,5 @@ delta	once
 	network.interface.speed
 	network.interface.duplex
 	network.interface.inet_addr
+	kernel.all.boottime
 


### PR DESCRIPTION
STDATE/STTIME of pcp atop -v was wrong (e.g. STDATE=1970/01/01).
A new metric kernel.all.btime is added and used to fix the issue.

Note:
- This may not be best but I defined a new global function set_system_btime to pass btime to showprocs.c.
- ENDATE/ENTIME are also modified but not be tested because curstat->gen.elaps seems not to be implemented yet.