### PR TITLE
Add perl-Data-Dumper dependency for pcp-pmda-redis

### DIFF
--- a/build/rpm/fedora.spec
+++ b/build/rpm/fedora.spec
@@ -985,6 +985,7 @@ URL: https://pcp.io
 Requires: perl-PCP-PMDA = %{version}-%{release}
 Requires: perl-autodie
 Requires: perl-Time-HiRes
+Requires: perl-Data-Dumper
 
 %description pmda-redis
 This package contains the PCP Performance Metrics Domain Agent (PMDA) for


### PR DESCRIPTION
The `pcp-pmda-redis` package is not depending on `perl-Data-Dumper` as it should.

Data-Dumper is being using by pmdaredis.pl https://github.com/performancecopilot/pcp/blob/0ab16a9017a1a0b56fbb969bec659be258234dc5/src/pmdas/redis/pmdaredis.pl#L72

This PR adds it to the specfile as requested [here](https://bugzilla.redhat.com/show_bug.cgi?id=1788519#c3).