### PR TITLE
build: update do-maybe-requires script to check provides metadata

### DIFF
--- a/build/rpm/do-maybe-requires
+++ b/build/rpm/do-maybe-requires
@@ -21,7 +21,7 @@ grep '^Maybe-Requires:' pcp.spec \
 | uniq \
 | while read pkg
 do
-    if rpm -q "$pkg" >/dev/null
+    if rpm -q --whatprovides "$pkg" >/dev/null
     then
 	$verbose && echo "Requires: $pkg"
 	echo "/^Maybe-Requires: $pkg\$/s/Maybe-Requires:/Requires:/" >>$tmp.sed


### PR DESCRIPTION
If we have a

    Maybe-Requires: perl(Net::SNMP)

line in pcp.spec.in, the do-maybe-requires script calls

    rpm -q "perl(Net::SNMP)"

which exits with status 1, because no package with this name is
installed (however, perl-Net-SNMP is installed!).

Therefore rpm needs to check the Provides: metadata of installed
packages as well, which is accomplished with the --whatprovides argument.