### PR TITLE
Add missing includes in Qt 5.15 beta2

### DIFF
--- a/src/libpcp_qwt/src/qwt_compass_rose.cpp
+++ b/src/libpcp_qwt/src/qwt_compass_rose.cpp
@@ -11,6 +11,7 @@
 #include "qwt_point_polar.h"
 #include "qwt_painter.h"
 #include <qpainter.h>
+#include <qpainterpath.h>
 
 static QPointF qwtIntersection( 
     QPointF p11, QPointF p12, QPointF p21, QPointF p22 )

--- a/src/libpcp_qwt/src/qwt_dial_needle.cpp
+++ b/src/libpcp_qwt/src/qwt_dial_needle.cpp
@@ -13,6 +13,7 @@
 #include "qwt_painter.h"
 #include <qapplication.h>
 #include <qpainter.h>
+#include <qpainterpath.h>
 
 #if QT_VERSION < 0x040601
 #define qFastSin(x) qSin(x)

--- a/src/libpcp_qwt/src/qwt_null_paintdevice.cpp
+++ b/src/libpcp_qwt/src/qwt_null_paintdevice.cpp
@@ -9,6 +9,7 @@
 
 #include "qwt_null_paintdevice.h"
 #include <qpaintengine.h>
+#include <qpainterpath.h>
 #include <qpixmap.h>
 
 class QwtNullPaintDevice::PrivateData

--- a/src/libpcp_qwt/src/qwt_painter.cpp
+++ b/src/libpcp_qwt/src/qwt_painter.cpp
@@ -17,6 +17,7 @@
 #include <qframe.h>
 #include <qrect.h>
 #include <qpainter.h>
+#include <qpainterpath.h>
 #include <qpalette.h>
 #include <qpaintdevice.h>
 #include <qpixmap.h>

--- a/src/libpcp_qwt/src/qwt_painter_command.h
+++ b/src/libpcp_qwt/src/qwt_painter_command.h
@@ -15,8 +15,7 @@
 #include <qpixmap.h>
 #include <qimage.h>
 #include <qpolygon.h>
-
-class QPainterPath;
+#include <qpainterpath.h>
 
 /*!
   QwtPainterCommand represents the attributes of a paint operation

--- a/src/libpcp_qwt/src/qwt_plot_panner.cpp
+++ b/src/libpcp_qwt/src/qwt_plot_panner.cpp
@@ -14,6 +14,7 @@
 #include <qbitmap.h>
 #include <qstyle.h>
 #include <qstyleoption.h>
+#include <qpainterpath.h>
 
 static QBitmap qwtBorderMask( const QWidget *canvas, const QSize &size )
 {

--- a/src/libpcp_qwt/src/qwt_plot_renderer.cpp
+++ b/src/libpcp_qwt/src/qwt_plot_renderer.cpp
@@ -18,6 +18,7 @@
 #include "qwt_text_label.h"
 #include "qwt_math.h"
 #include <qpainter.h>
+#include <qpainterpath.h>
 #include <qpaintengine.h>
 #include <qtransform.h>
 #include <qprinter.h>

--- a/src/libpcp_qwt/src/qwt_widget_overlay.cpp
+++ b/src/libpcp_qwt/src/qwt_widget_overlay.cpp
@@ -10,6 +10,7 @@
 #include "qwt_widget_overlay.h"
 #include "qwt_painter.h"
 #include <qpainter.h>
+#include <qpainterpath.h>
 #include <qpaintengine.h>
 #include <qimage.h>
 #include <qevent.h>


### PR DESCRIPTION
The definition of QPainterPath is not pulled in anymore from Qt headers that included it indirectly in previous releases so it has to be included explicitly.