### PR TITLE
qa, rc scripts (cosmetic), pmproxy

### DIFF
--- a/build/tar/postinstall.tail
+++ b/build/tar/postinstall.tail
@@ -330,7 +330,9 @@ done
 _do_dir "pcpqa:pcpqa" 775 "$PCP_VAR_DIR"/testsuite
 chown -R pcpqa:pcpqa "$PCP_VAR_DIR"/testsuite
 
-# Note: do not start daemons other than: pmcd, pmlogger, pmie and pmproxy
+# Note:
+#   Do not start daemons other than: pmcd, pmlogger, pmie,
+#   pmproxy and pmmgr
 #
 if which svcs >/dev/null 2>&1
 then

--- a/qa/1190
+++ b/qa/1190
@@ -66,7 +66,7 @@ _check_file()
 	    mv $tmp.tmp $tmp.out
 	    ;;
 	"$PCP_PMCDOPTIONS_PATH")
-	    # Need to cocommodate old-style and new-style here
+	    # Need to accommodate old-style and new-style here
 	    #
 	    sed <$tmp.out >$tmp.tmp \
 		-e '/^# added by PCP QA/d' \
@@ -86,7 +86,8 @@ _check_file()
 	then
 	    echo "$1 ... BAD (QA text found)"
 	else
-	    orig=`echo "$1" | sed -e "s@^$2@"'$2@'`
+	    prefix=`eval echo "$2"`
+	    orig=`echo "$1" | sed -e "s@^$prefix@$2@"`
 	    echo "$orig ... BAD (QA text found)"
 	fi
 	cat $tmp.out | sed -e 's/^/  /'
@@ -96,7 +97,8 @@ _check_file()
 	then
 	    :
 	else
-	    orig=`echo "$1" | sed -e "s@^$2@"'$2@'`
+	    prefix=`eval echo "$2"`
+	    orig=`echo "$1" | sed -e "s@^$prefix@$2@"`
 	    echo "$orig ... OK"
 	fi
     fi
@@ -231,22 +233,31 @@ for arg in \
     '$PCP_PMDAS_DIR/linux/bandwidth.conf' \
 
 do
-    conf="$arg"
+    conf=`eval echo "$arg"`
     if [ -z "$conf" ]
     then
 	echo "empty var!"
     elif [ -f "$conf" ]
     then
-	_check_file "$conf" '$arg'
+	_check_file "$conf" "$arg"
     elif [ -d "$conf" ]
     then
+	rm -f $tmp.tmp
 	find "$conf" -type f \
 	| while read file
 	do
-	    _check_file "$file" '$arg'
+	    _check_file "$file" "$arg" >>$tmp.tmp
 	done
+	if [ -s $tmp.tmp ] && grep BAD $tmp.tmp
+	then
+	    # at least one BAD file below this dir, already reported from grep
+	    #
+	    :
+	else
+	    $check || echo "$arg ... OK"
+	fi
     else
-	$check || echo "$conf ... OK"
+	$check || echo "$arg ... OK"
     fi
 done
 

--- a/qa/1190
+++ b/qa/1190
@@ -33,7 +33,8 @@ _cleanup()
 }
 
 status=0	# success is the default!
-$sudo rm -rf $tmp $tmp.* $seq.full
+$sudo rm -rf $tmp $tmp.*
+$check || $sudo rm -f $seq.full
 trap "_cleanup; exit \$status" 0 1 2 3 15
 
 # Usage: _check_file <realpath> <unexpanded_path_or_prefix>

--- a/qa/294
+++ b/qa/294
@@ -144,6 +144,7 @@ mkdir -p $tmp.rundir
 export PCP_RUN_DIR=$tmp.rundir
 proxyargs="-Dcontext -U $username"
 $PCP_BINADM_DIR/pmproxy $proxyargs -l $tmp.log 2>&1 | _filter_pmproxy
+_wait_for_pmproxy
 $PCP_BINADM_DIR/pmcd_wait -t 5sec -h localhost@localhost
 
 # real QA test starts here
@@ -169,6 +170,9 @@ _do pmstat -h $PMPROXY_HOST -t 0.5 -s 2
 _do_config 
 _do pmlogger -h localhost -c $tmp.config -t 0.5sec -s 3 -l $tmp.logger.log $tmp.arch
 _do pmstat -S +0.25sec -t 0.5sec -a $tmp.arch -z
+
+( echo ""; echo "=== pmproxy.log ===" ) >>$seq.full
+cat $tmp.log >>$seq.full
 
 # success, all done
 status=0

--- a/qa/915
+++ b/qa/915
@@ -39,7 +39,9 @@ _cleanup()
     # ensure we do not leave local-only settings enabled
     _restore_config $PCP_SYSCONFIG_DIR/pmcd
     _restore_config $PCP_SYSCONFIG_DIR/pmproxy
+    _restore_config $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
     _restore_config $PCP_SYSCONFIG_DIR/pmlogger
+    _restore_config $PCP_PMPROXYOPTIONS_PATH
 
     if $pmproxy_was_running
     then
@@ -68,20 +70,41 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 # real QA test starts here
 _save_config $PCP_SYSCONFIG_DIR/pmcd
 _save_config $PCP_SYSCONFIG_DIR/pmproxy
+_save_config $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 _save_config $PCP_SYSCONFIG_DIR/pmlogger
+_save_config $PCP_PMPROXYOPTIONS_PATH
 
 _stop_auto_restart pmproxy
 _service pmproxy stop >>$here/$seq.full 2>&1
 
-echo "# Dummy entry added by PCP QA test $seq" > $tmp.local
+echo "# Installed by PCP QA test $seq on `date`" > $tmp.local
 echo PMCD_LOCAL=1 >> $tmp.local
 $sudo cp $tmp.local $PCP_SYSCONFIG_DIR/pmcd
-echo "# Dummy entry added by PCP QA test $seq" > $tmp.local
+
+echo "# Installed by PCP QA test $seq on `date`" > $tmp.local
 echo PMPROXY_LOCAL=1 >> $tmp.local
 $sudo cp $tmp.local $PCP_SYSCONFIG_DIR/pmproxy
-echo "# Dummy entry added by PCP QA test $seq" > $tmp.local
+
+cat >$tmp.local << End-Of-File
+# Installed by PCP QA test $seq on `date`
+# ... aiming for a minimal and fast startup
+[pmproxy]
+pcp.enabled = true
+[discover]
+enabled = true
+[pmseries]
+enabled = false
+End-Of-File
+$sudo cp $tmp.local $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
+
+echo "# Installed by PCP QA test $seq on `date`" > $tmp.local
 echo PMLOGGER_LOCAL=1 >> $tmp.local
 $sudo cp $tmp.local $PCP_SYSCONFIG_DIR/pmlogger
+
+echo "# Installed by PCP QA test $seq on `date`" > $tmp.local
+# uncomment the next line to make the logfile names unique
+#echo "-Dappl1" >> $tmp.local
+$sudo cp $tmp.local $PCP_PMPROXYOPTIONS_PATH
 
 _service pmproxy start 2>&1 | _filter_pmproxy_start
 _wait_for_pmproxy

--- a/qa/check.callback.sample
+++ b/qa/check.callback.sample
@@ -196,12 +196,15 @@ fi
 # the PMDA not in pmcd.conf, but with bogus entries in the PMNS
 #
 # CONFIGURE-ME
-# - may need to add metrics (in the grep -v part) that are OK to return
+# - may need to add metrics (in the sed part) that are OK to return
 #   'Unknown or illegal metric', but this is most unlikely
 #
 pminfo -v 2>&1 \
 | grep 'Unknown or illegal metric' \
-| grep -v 'sample.*\.bad\.unknown' >$tmp.out
+| sed >$tmp.out \
+    -e '/^sample.*\.bad\.unknown:/d' \
+    -e '/^pmproxy\.pid:/d' \
+    # end
 if [ -s $tmp.out ]
 then
     echo "check.callback: fail: PMNS not well!"

--- a/src/pmcd/rc_pcp
+++ b/src/pmcd/rc_pcp
@@ -46,6 +46,7 @@
 # for chasing arguments we're passed from init/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pcp.log
+#debug# env >>$PCP_LOG_DIR/rc_pcp.log
 
 tmp=`mktemp -d $PCP_DIR/var/tmp/pcp.XXXXXXXXX` || exit 1
 status=0

--- a/src/pmcd/rc_pmcd
+++ b/src/pmcd/rc_pmcd
@@ -47,6 +47,7 @@
 # for chasing arguments we're passed from init/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmcd.log
+#debug# env >>$PCP_LOG_DIR/rc_pmcd.log
 
 PMCD=$PCP_BINADM_DIR/pmcd
 PMCDOPTS=$PCP_PMCDOPTIONS_PATH

--- a/src/pmie/rc_pmie
+++ b/src/pmie/rc_pmie
@@ -45,6 +45,7 @@
 # for chasing arguments we're passed from init/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmie.log
+#debug# env >>$PCP_LOG_DIR/rc_pmie.log
 
 PMIECTRL=$PCP_PMIECONTROL_PATH
 rcprog=$PCP_DIR/etc/init.d/pmie

--- a/src/pmlogger/rc_pmlogger
+++ b/src/pmlogger/rc_pmlogger
@@ -47,6 +47,7 @@
 # for chasing arguments we're passed from init/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmlogger.log
+#debug# env >>$PCP_LOG_DIR/rc_pmlogger.log
 
 PMLOGCTRL=$PCP_PMLOGGERCONTROL_PATH
 PMLOGGER=$PCP_BINADM_DIR/pmlogger

--- a/src/pmmgr/rc_pmmgr
+++ b/src/pmmgr/rc_pmmgr
@@ -47,6 +47,7 @@
 # for chasing arguments we're passed from init/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmmgr.log
+#debug# env >>$PCP_LOG_DIR/rc_pmlogger.log
 
 PMMGR=$PCP_BINADM_DIR/pmmgr
 PMMGROPTS=$PCP_PMMGROPTIONS_PATH

--- a/src/pmproxy/rc_pmproxy
+++ b/src/pmproxy/rc_pmproxy
@@ -47,6 +47,7 @@
 # for chasing arguments we're passed from init/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmproxy.log
+#debug# env >>$PCP_LOG_DIR/rc_pmproxy.log
 
 PMPROXY=$PCP_BINADM_DIR/pmproxy
 PMPROXYOPTS=$PCP_PMPROXYOPTIONS_PATH


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200407

Ken McDonell (8):
      build/tar/postinstall.tail: fix (misleading) error in comment
      qa/1190: important --check fix
      qa/294: wait for pmproxy to start
      qa/check.callback.sample: tweak PMNS check
      rc scripts: add "env" to the #debug# lines
      src/pmproxy/src/pmproxy.c: make logfile name unique with -Dappl1
      qa/1190: fix botch in last commit
      qa/915: taking more control of the environment

 build/tar/postinstall.tail |    4 +++-
 qa/1190                    |   28 ++++++++++++++++++++--------
 qa/294                     |    4 ++++
 qa/915                     |   29 ++++++++++++++++++++++++++---
 qa/check.callback.sample   |    7 +++++--
 src/pmcd/rc_pcp            |    1 +
 src/pmcd/rc_pmcd           |    1 +
 src/pmie/rc_pmie           |    1 +
 src/pmlogger/rc_pmlogger   |    1 +
 src/pmmgr/rc_pmmgr         |    1 +
 src/pmproxy/rc_pmproxy     |    1 +
 src/pmproxy/src/pmproxy.c  |   37 ++++++++++++++++++++++++++++++++++++-
 12 files changed, 100 insertions(+), 15 deletions(-)

Details ...

commit 92fa062939b3e7e766717dfb6be0a3ccd2ecd7ac
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Apr 9 07:11:15 2020 +1000

    qa/915: taking more control of the environment
    
    1. install a minimal pmproxy.conf with few services enabled
       ... designed to ensure speedy startup of the daemon
    2. save/restore pmproxy.conf
    3. save/restore pmproxy.options (so that -Dappl1 can easily be
       enabled for desperate debugging times)

commit 185b1b0c1566a42bc4b71271e039f452a9bc8d06
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Apr 9 07:03:22 2020 +1000

    qa/1190: fix botch in last commit
    
    Changes to the quoting logic were botched in the last commit
    ... making the test effectively do nothing!
    
    The intent was that with --check, the real pathnames should appear
    to help debugging, e.g.
        /var/lib/pcp/pmns/root ... BAD
    but without --check, the pathnames should include the PCP_* variables
    so that the output is deterministic
        $PCP_VAR_DIR/pmns/root ... BAD
    
    There was a related issue with directories that are checked ...
    without --check we should emit only a line for the directory name if
    the contents are all OK, else emit a line for each failing file within
    the directory.  Again, this makes the output deterministic across
    different platforms where directory contents may not be the same,
    and certainly may not be in the same order as reported by find(1).

commit 14cb27318b9b6bca2b1c2e2f4668245da6b4c7ad
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Apr 9 06:55:27 2020 +1000

    src/pmproxy/src/pmproxy.c: make logfile name unique with -Dappl1
    
    One(more help for debugging, with -Dappl1, the process' pid is embedded
    in the string ".<pid>" and this is stitched into) the logfile name
    to help make it unique.  This helps when multiple pmproxy instances
    are involved in a QA run.
    
    Beware, in a default setup this will pollute $PCP_LOG_DIR/pmproxy
    with lots of pmproxy.NNNN.log files and these will need to be cleaned
    up manually.

commit a94c2ddb2a39817a604b4c45062ab4c57f3b4e31
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Apr 9 06:53:34 2020 +1000

    rc scripts: add "env" to the #debug# lines
    
    With systemd + notify in the mix, we need not only the args passed
    to the script but the environment.
    
    Only useful in times of desperate debugging ... there is no change
    here to the default behaviour.

commit 4f301744e814ed1edfe47114aced99e0e8b75145
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Apr 7 14:45:41 2020 +1000

    qa/check.callback.sample: tweak PMNS check
    
    For reasons that are not yet understood, the romance between the pmproxy
    daemon and the mmv PMDA wearing its pmproxy PMDA disguise can sour.
    When this happens, the pmproxy.pid metric is left in the PMNS but
    the mmv (aka pmproxy) PMDA returns PM_ERR_PMID, so teak the filter
    to not raise this as a callback detected error.

commit fc941cd410ce515041c0fe3bd8373f7ba7f4e53b
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Apr 7 14:30:42 2020 +1000

    qa/294: wait for pmproxy to start

commit aa6e054725450abb507f7906e50b08f63094128b
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Apr 7 14:28:29 2020 +1000

    qa/1190: important --check fix
    
    When using --check (as in check.callback.sample), do not remove
    the .full file for the test currently being run (which is different
    to 1190 on about 1344 or 1345 tests).

commit f08feed277ff2ff620eda018bab4cbb1eda85356
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Apr 7 14:27:40 2020 +1000

    build/tar/postinstall.tail: fix (misleading) error in comment