### PR TITLE
qa (small), pmproxy compilation warning fix

### DIFF
--- a/build/tar/postinstall.tail
+++ b/build/tar/postinstall.tail
@@ -330,7 +330,9 @@ done
 _do_dir "pcpqa:pcpqa" 775 "$PCP_VAR_DIR"/testsuite
 chown -R pcpqa:pcpqa "$PCP_VAR_DIR"/testsuite
 
-# Note: do not start daemons other than: pmcd, pmlogger, pmie and pmproxy
+# Note:
+#   Do not start daemons other than: pmcd, pmlogger, pmie,
+#   pmproxy and pmmgr
 #
 if which svcs >/dev/null 2>&1
 then

--- a/qa/1190
+++ b/qa/1190
@@ -66,7 +66,7 @@ _check_file()
 	    mv $tmp.tmp $tmp.out
 	    ;;
 	"$PCP_PMCDOPTIONS_PATH")
-	    # Need to cocommodate old-style and new-style here
+	    # Need to accommodate old-style and new-style here
 	    #
 	    sed <$tmp.out >$tmp.tmp \
 		-e '/^# added by PCP QA/d' \
@@ -86,7 +86,8 @@ _check_file()
 	then
 	    echo "$1 ... BAD (QA text found)"
 	else
-	    orig=`echo "$1" | sed -e "s@^$2@"'$2@'`
+	    prefix=`eval echo "$2"`
+	    orig=`echo "$1" | sed -e "s@^$prefix@$2@"`
 	    echo "$orig ... BAD (QA text found)"
 	fi
 	cat $tmp.out | sed -e 's/^/  /'
@@ -96,7 +97,8 @@ _check_file()
 	then
 	    :
 	else
-	    orig=`echo "$1" | sed -e "s@^$2@"'$2@'`
+	    prefix=`eval echo "$2"`
+	    orig=`echo "$1" | sed -e "s@^$prefix@$2@"`
 	    echo "$orig ... OK"
 	fi
     fi
@@ -231,22 +233,31 @@ for arg in \
     '$PCP_PMDAS_DIR/linux/bandwidth.conf' \
 
 do
-    conf="$arg"
+    conf=`eval echo "$arg"`
     if [ -z "$conf" ]
     then
 	echo "empty var!"
     elif [ -f "$conf" ]
     then
-	_check_file "$conf" '$arg'
+	_check_file "$conf" "$arg"
     elif [ -d "$conf" ]
     then
+	rm -f $tmp.tmp
 	find "$conf" -type f \
 	| while read file
 	do
-	    _check_file "$file" '$arg'
+	    _check_file "$file" "$arg" >>$tmp.tmp
 	done
+	if [ -s $tmp.tmp ] && grep BAD $tmp.tmp
+	then
+	    # at least one BAD file below this dir, already reported from grep
+	    #
+	    :
+	else
+	    $check || echo "$arg ... OK"
+	fi
     else
-	$check || echo "$conf ... OK"
+	$check || echo "$arg ... OK"
     fi
 done
 

--- a/qa/1190
+++ b/qa/1190
@@ -33,7 +33,8 @@ _cleanup()
 }
 
 status=0	# success is the default!
-$sudo rm -rf $tmp $tmp.* $seq.full
+$sudo rm -rf $tmp $tmp.*
+$check || $sudo rm -f $seq.full
 trap "_cleanup; exit \$status" 0 1 2 3 15
 
 # Usage: _check_file <realpath> <unexpanded_path_or_prefix>

--- a/qa/294
+++ b/qa/294
@@ -144,6 +144,7 @@ mkdir -p $tmp.rundir
 export PCP_RUN_DIR=$tmp.rundir
 proxyargs="-Dcontext -U $username"
 $PCP_BINADM_DIR/pmproxy $proxyargs -l $tmp.log 2>&1 | _filter_pmproxy
+_wait_for_pmproxy
 $PCP_BINADM_DIR/pmcd_wait -t 5sec -h localhost@localhost
 
 # real QA test starts here
@@ -169,6 +170,9 @@ _do pmstat -h $PMPROXY_HOST -t 0.5 -s 2
 _do_config 
 _do pmlogger -h localhost -c $tmp.config -t 0.5sec -s 3 -l $tmp.logger.log $tmp.arch
 _do pmstat -S +0.25sec -t 0.5sec -a $tmp.arch -z
+
+( echo ""; echo "=== pmproxy.log ===" ) >>$seq.full
+cat $tmp.log >>$seq.full
 
 # success, all done
 status=0

--- a/qa/915
+++ b/qa/915
@@ -39,7 +39,9 @@ _cleanup()
     # ensure we do not leave local-only settings enabled
     _restore_config $PCP_SYSCONFIG_DIR/pmcd
     _restore_config $PCP_SYSCONFIG_DIR/pmproxy
+    _restore_config $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
     _restore_config $PCP_SYSCONFIG_DIR/pmlogger
+    _restore_config $PCP_PMPROXYOPTIONS_PATH
 
     if $pmproxy_was_running
     then
@@ -68,20 +70,41 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 # real QA test starts here
 _save_config $PCP_SYSCONFIG_DIR/pmcd
 _save_config $PCP_SYSCONFIG_DIR/pmproxy
+_save_config $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 _save_config $PCP_SYSCONFIG_DIR/pmlogger
+_save_config $PCP_PMPROXYOPTIONS_PATH
 
 _stop_auto_restart pmproxy
 _service pmproxy stop >>$here/$seq.full 2>&1
 
-echo "# Dummy entry added by PCP QA test $seq" > $tmp.local
+echo "# Installed by PCP QA test $seq on `date`" > $tmp.local
 echo PMCD_LOCAL=1 >> $tmp.local
 $sudo cp $tmp.local $PCP_SYSCONFIG_DIR/pmcd
-echo "# Dummy entry added by PCP QA test $seq" > $tmp.local
+
+echo "# Installed by PCP QA test $seq on `date`" > $tmp.local
 echo PMPROXY_LOCAL=1 >> $tmp.local
 $sudo cp $tmp.local $PCP_SYSCONFIG_DIR/pmproxy
-echo "# Dummy entry added by PCP QA test $seq" > $tmp.local
+
+cat >$tmp.local << End-Of-File
+# Installed by PCP QA test $seq on `date`
+# ... aiming for a minimal and fast startup
+[pmproxy]
+pcp.enabled = true
+[discover]
+enabled = true
+[pmseries]
+enabled = false
+End-Of-File
+$sudo cp $tmp.local $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
+
+echo "# Installed by PCP QA test $seq on `date`" > $tmp.local
 echo PMLOGGER_LOCAL=1 >> $tmp.local
 $sudo cp $tmp.local $PCP_SYSCONFIG_DIR/pmlogger
+
+echo "# Installed by PCP QA test $seq on `date`" > $tmp.local
+# uncomment the next line to make the logfile names unique
+#echo "-Dappl1" >> $tmp.local
+$sudo cp $tmp.local $PCP_PMPROXYOPTIONS_PATH
 
 _service pmproxy start 2>&1 | _filter_pmproxy_start
 _wait_for_pmproxy

--- a/qa/915
+++ b/qa/915
@@ -48,6 +48,9 @@ _cleanup()
 	echo "Restart pmproxy ..." >>$here/$seq.full
 	_service pmproxy restart >>$here/$seq.full 2>&1
 	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
     fi
     _restore_auto_restart pmproxy
     _service pcp restart 2>&1 | _filter_pcp_stop | _filter_pcp_start

--- a/qa/check.callback.sample
+++ b/qa/check.callback.sample
@@ -196,12 +196,15 @@ fi
 # the PMDA not in pmcd.conf, but with bogus entries in the PMNS
 #
 # CONFIGURE-ME
-# - may need to add metrics (in the grep -v part) that are OK to return
+# - may need to add metrics (in the sed part) that are OK to return
 #   'Unknown or illegal metric', but this is most unlikely
 #
 pminfo -v 2>&1 \
 | grep 'Unknown or illegal metric' \
-| grep -v 'sample.*\.bad\.unknown' >$tmp.out
+| sed >$tmp.out \
+    -e '/^sample.*\.bad\.unknown:/d' \
+    -e '/^pmproxy\.pid:/d' \
+    # end
 if [ -s $tmp.out ]
 then
     echo "check.callback: fail: PMNS not well!"

--- a/src/pmcd/rc_pcp
+++ b/src/pmcd/rc_pcp
@@ -46,6 +46,7 @@
 # for chasing arguments we're passed from init/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pcp.log
+#debug# env >>$PCP_LOG_DIR/rc_pcp.log
 
 tmp=`mktemp -d $PCP_DIR/var/tmp/pcp.XXXXXXXXX` || exit 1
 status=0

--- a/src/pmcd/rc_pmcd
+++ b/src/pmcd/rc_pmcd
@@ -47,6 +47,7 @@
 # for chasing arguments we're passed from init/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmcd.log
+#debug# env >>$PCP_LOG_DIR/rc_pmcd.log
 
 PMCD=$PCP_BINADM_DIR/pmcd
 PMCDOPTS=$PCP_PMCDOPTIONS_PATH

--- a/src/pmie/rc_pmie
+++ b/src/pmie/rc_pmie
@@ -45,6 +45,7 @@
 # for chasing arguments we're passed from init/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmie.log
+#debug# env >>$PCP_LOG_DIR/rc_pmie.log
 
 PMIECTRL=$PCP_PMIECONTROL_PATH
 rcprog=$PCP_DIR/etc/init.d/pmie

--- a/src/pmlogger/rc_pmlogger
+++ b/src/pmlogger/rc_pmlogger
@@ -47,6 +47,7 @@
 # for chasing arguments we're passed from init/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmlogger.log
+#debug# env >>$PCP_LOG_DIR/rc_pmlogger.log
 
 PMLOGCTRL=$PCP_PMLOGGERCONTROL_PATH
 PMLOGGER=$PCP_BINADM_DIR/pmlogger

--- a/src/pmmgr/rc_pmmgr
+++ b/src/pmmgr/rc_pmmgr
@@ -47,6 +47,7 @@
 # for chasing arguments we're passed from init/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmmgr.log
+#debug# env >>$PCP_LOG_DIR/rc_pmlogger.log
 
 PMMGR=$PCP_BINADM_DIR/pmmgr
 PMMGROPTS=$PCP_PMMGROPTIONS_PATH

--- a/src/pmproxy/rc_pmproxy
+++ b/src/pmproxy/rc_pmproxy
@@ -47,6 +47,7 @@
 # for chasing arguments we're passed from init/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmproxy.log
+#debug# env >>$PCP_LOG_DIR/rc_pmproxy.log
 
 PMPROXY=$PCP_BINADM_DIR/pmproxy
 PMPROXYOPTS=$PCP_PMPROXYOPTIONS_PATH

--- a/src/pmproxy/src/pmproxy.c
+++ b/src/pmproxy/src/pmproxy.c
@@ -345,7 +345,7 @@ main(int argc, char *argv[])
 	pend = rindex(logfile, '.');
 	if (pend == NULL) {
 	    /* no '.', so append .<pid> */
-	    strncpy(newlogfile, logfile, MAXPATHLEN);
+	    strncpy(newlogfile, logfile, MAXPATHLEN-1);
 	    strcat(newlogfile, pbuf);
 	}
 	else {


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200409

Ken McDonell (2):
      src/pmproxy/src/pmproxy.c: fix strncpy() compilation warning
      qa/915: stop pmproxy if it was not running when the test started

 qa/915                    |    3 +++
 src/pmproxy/src/pmproxy.c |    2 +-
 2 files changed, 4 insertions(+), 1 deletion(-)

Details ...

commit 39aa1ad1cffd6abb9a9cc4ad4fa1d0ecb1a2c702
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Apr 9 07:35:06 2020 +1000

    qa/915: stop pmproxy if it was not running when the test started

commit aa01bb9e992532715c3e015bb174030cd618df45
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Apr 9 07:25:31 2020 +1000

    src/pmproxy/src/pmproxy.c: fix strncpy() compilation warning
    
    gcc 9.2.1 seems more pedantic.