### PR TITLE
pmproxy -F, rc and systemd service changes + QA

### DIFF
--- a/man/man1/pmproxy.1
+++ b/man/man1/pmproxy.1
@@ -19,7 +19,7 @@
 \f3pmproxy\f1 \- proxy for performance metrics collector and querying
 .SH SYNOPSIS
 \f3pmproxy\f1
-[\f3\-Aft?\f1]
+[\f3\-AFft?\f1]
 [\f3\-C\f1 \f2dirname\f1]
 [\f3\-i\f1 \f2ipaddress\f1]
 [\f3\-l\f1 \f2logfile\f1]
@@ -147,6 +147,36 @@ option indicates that it should run in the foreground.
 This is most useful when trying to diagnose problems with establishing
 connections.
 .TP
+\f3\-F\f1, \f3\-\-systemd\f1
+Like
+.BR \-f ,
+the
+.B \-F
+option runs
+.B pmproxy
+in the foreground, but also does some housekeeping (like create a
+``pid'' file and change user id).  This is intended for use when
+.B pmproxy
+is launched from
+.BR systemd (1)
+and the daemonizing has already been done by
+.BR systemd (1)
+and does not need to be done again by
+.BR pmproxy ,
+which is the case when neither
+.B \-f
+nor
+.B \-F
+is specified.
+.RS +5n
+.PP
+At most one of
+.B \-f
+and
+.B \-F
+may be specified.
+.RE
+.TP
 \f3\-h\f1 \f2host\f1, \f3\-\-redishost\f1=\f2host\f1
 Specify an alternate Redis
 .I host
@@ -212,7 +242,7 @@ will try to use a certificate called
 in its server role.
 The
 .B \-M
-option allows this certficate
+option allows this certificate
 .I name
 to be changed.
 This option implies \f3pmproxy\f1 is running in \f3deprecated\f1 mode.

--- a/qa/1190
+++ b/qa/1190
@@ -127,7 +127,7 @@ _check_file()
 
 # real QA test starts here
 
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mcd ' >$tmp.out
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mcd |[p]mcd$' >$tmp.out
 n=`grep -v PID <$tmp.out | wc -l | sed -e 's/ //g'`
 if [ "$n" -eq 1 ]
 then

--- a/qa/1190
+++ b/qa/1190
@@ -79,6 +79,11 @@ _check_file()
 	    #
 	    rm -f $tmp.out
 	    ;;
+	"$HOME"/.pki/nssdb/*.db)
+	    # nothing to see inside these database files
+	    #
+	    rm -f $tmp.out
+	    ;;
     esac
     if [ -s $tmp.out ]
     then

--- a/qa/1379
+++ b/qa/1379
@@ -29,12 +29,25 @@ _cleanup()
 	_restore_config $PCP_SYSCONF_DIR/pmproxy
 	_sighup_pmcd
     fi
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+    fi
     $sudo rm -rf $tmp $tmp.*
 }
 
 status=1	# failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 trap "_cleanup; exit \$status" 0 1 2 3 15
+
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
 
 hostname=`hostname`
 machineid=`_machine_id`

--- a/qa/1388
+++ b/qa/1388
@@ -60,14 +60,24 @@ _cleanup()
     _service pmcd start >>$seq.full 2>&1
     _wait_for_pmcd
 
-    _service pmproxy stop >>$seq.full 2>&1
-    _service pmproxy start >>$seq.full 2>&1
-    _wait_for_pmproxy
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+    fi
 
     $sudo rm -f $tmp.*
 }
 
 trap "_cleanup; exit \$status" 0 1 2 3 15
+
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
 
 _filter_credentials()
 {

--- a/qa/1401
+++ b/qa/1401
@@ -20,12 +20,25 @@ _check_series
 _cleanup()
 {
     cd $here
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+    fi
     $sudo rm -rf $tmp $tmp.*
 }
 
 status=1	# failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 trap "_cleanup; exit \$status" 0 1 2 3 15
+
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
 
 _filter_context()
 {

--- a/qa/1433
+++ b/qa/1433
@@ -22,13 +22,25 @@ _cleanup()
 {
     cd $here
     _restore_config $PCP_PMPROXYOPTIONS_PATH
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+    fi
     $sudo rm -rf $tmp $tmp.*
-    _service pmproxy condrestart >/dev/null 2>&1
 }
 
 status=1	# failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 trap "_cleanup; exit \$status" 0 1 2 3 15
+
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
 
 # real QA test starts here
 _save_config $PCP_PMPROXYOPTIONS_PATH

--- a/qa/1543
+++ b/qa/1543
@@ -25,6 +25,15 @@ _cleanup()
         _restore_config $PCP_SYSCONF_DIR/pmproxy
 	_sighup_pmcd
     fi
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+    fi
     $sudo rm -rf $tmp $tmp.*
 }
 
@@ -32,6 +41,10 @@ status=1	# failure is the default!
 need_restore=false
 $sudo rm -rf $tmp $tmp.* $seq.full
 trap "_cleanup; exit \$status" 0 1 2 3 15
+
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
 
 hostname=`hostname`
 machineid=`_machine_id`

--- a/qa/1544
+++ b/qa/1544
@@ -31,6 +31,16 @@ _cleanup()
         $sudo rm -f domain.h.python
         cd $here
     fi
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+    fi
+    $sudo rm -rf $tmp $tmp.*
 }
 
 _filter_json()
@@ -49,6 +59,10 @@ _filter_ctx()
 status=1	# failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 trap "_cleanup; exit \$status" 0 1 2 3 15
+
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
 
 # real QA test starts here
 # start pmproxy

--- a/qa/1573
+++ b/qa/1573
@@ -28,10 +28,16 @@ _cleanup()
 	_service pcp restart 2>&1 | _filter_pcp_stop | _filter_pcp_start
 	_wait_for_pmcd
 	_wait_for_pmlogger
-	echo === restarting pmproxy
 	_restore_config $PCP_SYSCONF_DIR/pmproxy
-	_service pmproxy restart 2>&1 | _filter_pcp_start
+    fi
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
 	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
     fi
     $sudo rm -rf $tmp $tmp.*
 }
@@ -40,6 +46,10 @@ status=1	# failure is the default!
 need_restore=false
 $sudo rm -rf $tmp $tmp.* $seq.full
 trap "_cleanup; exit \$status" 0 1 2 3 15
+
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
 
 # real QA test starts here
 _save_config $PCP_SYSCONF_DIR/pmproxy

--- a/qa/1573.out
+++ b/qa/1573.out
@@ -5,4 +5,3 @@ QA output created by 1573
 === extract updated rss
 === checking rss within tolerance
 === see 1573.full for pmproxy rss and logs
-=== restarting pmproxy

--- a/qa/1661
+++ b/qa/1661
@@ -34,9 +34,15 @@ _cleanup()
     _service pcp restart 2>&1 | _filter_pcp_stop | _filter_pcp_start
     _wait_for_pmcd
     _wait_for_pmlogger
-    echo;echo === restarting pmproxy
-    _service pmproxy restart 2>&1 | _filter_pcp_start | _filter_pmproxy
-    _wait_for_pmproxy
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+    fi
     $sudo rm -rf $tmp.*
 }
 
@@ -61,6 +67,10 @@ _log_volume()
 status=1	# failure is the default!
 $sudo rm -rf $tmp $tmp.*
 trap "_cleanup; exit \$status" 0 1 2 3 15
+
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
 
 # real QA test starts here
 LOCALHOST=`hostname`

--- a/qa/1661.out
+++ b/qa/1661.out
@@ -23,5 +23,3 @@ passed
 === cleaning up
 
 === see 1661.full for logs
-
-=== restarting pmproxy

--- a/qa/1696
+++ b/qa/1696
@@ -13,6 +13,10 @@ echo "QA output created by $seq"
 . ./common.filter
 . ./common.check
 
+# needed by ./src/pmproxy_load_test.python
+#
+which python3 >/dev/null 2>&1 || _notrun "No binary named python3 found"
+
 _check_valgrind
 _check_series
 

--- a/qa/294
+++ b/qa/294
@@ -22,6 +22,10 @@ username=`id -u -n`
 $sudo rm -rf $tmp.* $seq.full
 trap "_cleanup; rm -rf $tmp.*; exit \$status" 0 1 2 3 15
 
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
+
 rm -f $seq.out
 case $PCP_PLATFORM
 in
@@ -35,8 +39,15 @@ esac
 
 _cleanup()
 {
-    $sudo $signal -a pmproxy >/dev/null 2>&1
-    _service pmproxy restart >/dev/null 2>&1
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+    fi
 }
 
 _filter()

--- a/qa/295
+++ b/qa/295
@@ -21,10 +21,21 @@ username=`id -u -n`
 $sudo rm -rf $tmp.* $seq.full
 trap "_cleanup; rm -rf $tmp.*; exit \$status" 0 1 2 3 15
 
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
+
 _cleanup()
 {
-    $sudo $signal -a pmproxy >/dev/null 2>&1
-    _service pmproxy restart >/dev/null 2>&1
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+    fi
 }
 
 _filter_pmproxy()

--- a/qa/297
+++ b/qa/297
@@ -26,14 +26,26 @@ killpid=""
 username=`id -u -n`
 $sudo rm -rf $tmp.* $seq.full
 trap "_cleanup; rm -rf $tmp.*; exit \$status" 0 1 2 3 15
+
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
+
 _stop_auto_restart pmcd
 _stop_auto_restart pmlogger
 
 _cleanup()
 {
     [ -n "$killpid" ] && $signal $killpid
-    $sudo $signal -a pmproxy >>$seq.full 2>&1
-    _service pmproxy restart >>$seq.full 2>&1
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+    fi
 }
 
 realname=`hostname`

--- a/qa/297
+++ b/qa/297
@@ -36,6 +36,7 @@ _stop_auto_restart pmlogger
 
 _cleanup()
 {
+    $sudo $signal -a pmproxy >>$seq.full 2>&1
     [ -n "$killpid" ] && $signal $killpid
     if $pmproxy_was_running
     then

--- a/qa/457
+++ b/qa/457
@@ -18,9 +18,15 @@ _cleanup()
 {
     if $_needclean
     then
-	[ -f $PCP_VAR_DIR/config/logger/logger.conf.$seq ] && \
-	_restore_config $PCP_VAR_DIR/config/logger/logger.conf
-	_restore_pmda_install logger
+	if [ -f $PCP_VAR_DIR/config/logger/logger.conf.$seq ]
+	then
+	    _restore_config $PCP_VAR_DIR/config/logger/logger.conf
+	else
+	    # don't leave our one behind here!
+	    #
+	    $sudo rm -f $PCP_VAR_DIR/config/logger/logger.conf
+	fi
+	_restore_pmda_install logger NOINSTALL
 	if $install_on_cleanup
 	then
 	    ( cd $PCP_PMDAS_DIR/logger; $sudo ./Install <$tmp.input >/dev/null 2>&1 )
@@ -49,7 +55,9 @@ _filter()
 	-e "s,$tmp,TMPFILE,g" \
 	-e "s,$here,HERE,g" \
 	-e "s,$PCP_VAR_DIR,\$PCP_VAR_DIR,g" \
-	-e 's/[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9][0-9]*[0-9]/TIMESTAMP/g'
+	-e 's/[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\.[0-9][0-9]*[0-9]/TIMESTAMP/g' \
+	-e '/^# Installed/s/ on .*/ on .../' \
+    # end
 }
 
 _filter_dir()
@@ -66,7 +74,7 @@ $sudo rm -f $tmp.* $seq.full
 
 # setup pmdalogger configuration file
 echo "
-# from PCP QA $seq
+# Installed by PCP QA test $seq on `date`
 reg	n	$tmp.reg
 fifo	n	$here/$seq.fifo
 none	n	$tmp.none
@@ -75,13 +83,14 @@ dir	n	$tmp.dir
 pipe	n	$here/$seq.pipe|
 " >$tmp.conf
 
-# and PMDA Install script
+# and reinstall PMDA Install script (if needed)
 cat >$tmp.input <<End-of-File
 1
 End-of-File
 
 install_on_cleanup=false
 pminfo logger >/dev/null 2>&1 && install_on_cleanup=true
+echo "install_on_cleanup=$install_on_cleanup=false" >>$here/$seq.full
 
 status=1	# failure is the default!
 _needclean=true

--- a/qa/457
+++ b/qa/457
@@ -89,8 +89,8 @@ cat >$tmp.input <<End-of-File
 End-of-File
 
 install_on_cleanup=false
-pminfo logger >/dev/null 2>&1 && install_on_cleanup=true
-echo "install_on_cleanup=$install_on_cleanup=false" >>$here/$seq.full
+pminfo -v logger >>$here/$seq.full 2>&1 && install_on_cleanup=true
+echo "install_on_cleanup=$install_on_cleanup" >>$here/$seq.full
 
 status=1	# failure is the default!
 _needclean=true

--- a/qa/457.out
+++ b/qa/457.out
@@ -6,7 +6,7 @@ Possible configuration files to choose from:
 Which configuration file do you want to use ? [1] 
 Contents of the selected configuration file:
 --------------- start $PCP_VAR_DIR/config/logger/logger.conf ---------------
-# from PCP QA 457
+# Installed by PCP QA test 457 on ...
 reg	n	TMPFILE.reg
 fifo	n	HERE/457.fifo
 none	n	TMPFILE.none

--- a/qa/651
+++ b/qa/651
@@ -126,7 +126,7 @@ _wait_for_stop()
     else
 	echo "Failed to stop pmproxy"
 	$PCP_PS_PROG $PCP_PS_ALL_FLAGS \
-	| egrep 'PID|pmproxy|pmcd'
+	| egrep '[P]ID|[p]mproxy|[p]mcd'
     fi
 }
 

--- a/qa/651
+++ b/qa/651
@@ -52,14 +52,22 @@ status=0	# success is the default!
 $sudo rm -rf $tmp.*
 trap "_cleanup; exit \$status" 0 1 2 3 15
 
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
+
 _cleanup()
 {
     $sudo $signal -a pmproxy
     _wait_for_stop
     echo "final pmproxy log ..." >>$here/$seq.full
     cat $tmp.log >>$here/$seq.full
-    _service pmproxy start 2>&1 | _filter_pmproxy_start
-    _restore_auto_restart pmproxy
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    fi
     $sudo rm -f $tmp.*
 }
 
@@ -127,9 +135,7 @@ export PMCD_HOST=localhost
 export PMPROXY_HOST=$hostname
 export PMPROXY_PORT=44322
 
-_stop_auto_restart pmproxy
 _service pmproxy stop 2>&1 | _filter_pmproxy_stop
-# $sudo $signal -a pmproxy
 _wait_for_stop
 
 proxyargs="-l $tmp.log"

--- a/qa/713
+++ b/qa/713
@@ -15,12 +15,20 @@ _cleanup()
 {
     nss_cleanup
 
-    $sudo $signal -a pmproxy >/dev/null 2>&1
     _service pcp restart 2>&1 | _filter_pcp_stop | _filter_pcp_start
-    _restore_auto_restart pmproxy
     _restore_auto_restart pmcd
     _wait_for_pmcd
     _wait_for_pmlogger
+    $sudo $signal -a pmproxy >/dev/null 2>&1
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+    fi
 
     $sudo rm -fr $tmp.*
     $sudo rm -fr $tmp
@@ -31,6 +39,11 @@ username=`id -u -n`
 signal=$PCP_BINADM_DIR/pmsignal
 $sudo rm -rf $tmp.* $seq.full
 trap "_cleanup; exit \$status" 0 1 2 3 15
+
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
+
 _stop_auto_restart pmcd
 _service pcp stop | _filter_pcp_stop
 

--- a/qa/780
+++ b/qa/780
@@ -21,8 +21,21 @@ status=1	# failure is the default!
 $sudo rm -rf $tmp.* $seq.full
 trap "cd $here; _cleanup; exit \$status" 0 1 2 3 15
 
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
+
 _cleanup()
 {
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+    fi
     $sudo rm -f $tmp.*
 }
 

--- a/qa/915
+++ b/qa/915
@@ -94,7 +94,7 @@ cat >$tmp.local << End-Of-File
 [pmproxy]
 pcp.enabled = true
 [discover]
-enabled = true
+enabled = false
 [pmseries]
 enabled = false
 End-Of-File

--- a/qa/admin/other-packages/manifest
+++ b/qa/admin/other-packages/manifest
@@ -1574,6 +1574,20 @@ rpm?	statsd				[statsd (QA optional)]
 rpm?	/usr/include/chan/chan.h	[chan-devel (build optional)]
 rpm?	/usr/include/hdr/hdr_thread.h	[HdrHistogram_c-devel (build optional)]
 
+# -- pstree and fuser (for QA)
+#
+dpkg?		pstree		[psmisc (QA optional)]
+rpm?		pstree		[psmisc (QA optional)]
+urpmi?		pstree		[psmisc (QA optional)]
+emerge?		pstree		[?]
+pkgin?		pstree		[?]
+pkg_add?	pstree		[?]
+F_pkg?		pstree		[?]
+S_pkg?		pstree		[?]
+slackpkg?	pstree		[?]
+pacman?		pstree		[?]
+brew?		pstree		[?]
+
 # misc
 #
 redhat?		/usr/sbin/qshape	[postfix-perl-scripts]

--- a/qa/check-flakey
+++ b/qa/check-flakey
@@ -79,7 +79,7 @@ do
     then
 	xpect=`sed -n <check.time -e "/^$seq /s/.* //p"`
     fi
-    if [ -n "$xpect" ]
+    if [ -n "$xpect" -a "$xpect" != 0 ]
     then
 	echo "$seq: checking (duration approx $xpect secs) ..."
     else

--- a/qa/check-flakey
+++ b/qa/check-flakey
@@ -26,7 +26,10 @@ _output_for_kenj()
 {
     if [ "$USER" = "kenj" ]
     then
-	printf "%4d %s%s %s %s\n" $seq $s1 $s2 `hostname -s` `date '+%Y-%m-%d'` >>$tmp.kenj
+	# dodge numbers that look like octal!
+	#
+	_seq=`echo "$seq" | sed -e 's/^0*//'`
+	printf "%4d %s%s %s %s\n" $_seq $s1 $s2 `hostname -s` `date '+%Y-%m-%d'` >>$tmp.kenj
     fi
 }
 

--- a/qa/check.callback.sample
+++ b/qa/check.callback.sample
@@ -227,14 +227,17 @@ fi
 # related to PCP ...
 #
 $sudo egrep '^type=(AVC|SELINUX).*pcp' $audit 2>/dev/null >$1.post-avc
-diff $1.pre-avc $1.post-avc \
-| sed -n -e '/> /s///p' >$tmp.out
-if [ -s $tmp.out ]
+if [ -f $1.pre-avc ]
 then
-    echo "check.callback: fail: new SELinux/AVC denials"
-    cat $tmp.out
-    echo "after `wc -l <$1.post-avc` AVC errors"
-    $abort && status=1
+    diff $1.pre-avc $1.post-avc \
+    | sed -n -e '/> /s///p' >$tmp.out
+    if [ -s $tmp.out ]
+    then
+	echo "check.callback: fail: new SELinux/AVC denials"
+	cat $tmp.out
+	echo "after `wc -l <$1.post-avc` AVC errors"
+	$abort && status=1
+    fi
 fi
 rm -f $1.pre-avc $1.post-avc
 

--- a/qa/common.avahi
+++ b/qa/common.avahi
@@ -23,12 +23,38 @@ avahi_notrun_checks()
 avahi_cleanup()
 {
     cd $here
-    $sudo $signal -a "$service" >/dev/null 2>&1
+    echo "avahi_cleanup: before pmsignal" >>$seq.full
+    grep_service=`echo "$service" | sed -e 's/./[&]/'`
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|$grep_service |$grep_service$' >>$seq.full
+    $sudo $PCP_BINADM_DIR/pmsignal -a "$service" >>$here/$seq.full 2>&1
+    pmsleep 0.5
+    echo "avahi_cleanup: after pmsignal" >>$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|$grep_service |$grep_service$' >>$seq.full
+    if $service_was_running
+    then
+	echo "Restart $service ..." >>$here/$seq.full
+	_service $service restart >>$here/$seq.full 2>&1
+	case "$service"
+	in
+	pmcd)
+	    _wait_for_pmcd
+	    ;;
+	pmproxy)
+	    _wait_for_pmproxy
+	    ;;
+	esac
+    else
+	echo "Stopping $service ..." >>$here/$seq.full
+	_service $service stop >>$here/$seq.full 2>&1
+    fi
     rm -f $tmp.*
 }
 
 avahi_service()
 {
+    service_was_running=false
+    [ -f $PCP_RUN_DIR/$service.pid ] && service_was_running=true
+    echo "service_was_running=$service_was_running" >>$here/$seq.full
     _stop_auto_restart $service
     $sudo "$PCP_RC_DIR/$service" restart >>$here/$seq.full 2>&1
     _restore_auto_restart $service

--- a/qa/common.check
+++ b/qa/common.check
@@ -2523,6 +2523,10 @@ _prepare_pmda_install()
 }
 
 # restore a saved pmcd configuration and ensure pmda back in place.
+# $1 is PMDA name
+# $2 is optional, and if not empty the (default) Install is not done
+# (because the Install may be interactive or may fail without some
+# user-provided information)
 #
 _restore_pmda_install()
 {
@@ -2537,10 +2541,15 @@ _restore_pmda_install()
     then
 	_restore_config $PCP_PMCDCONF_PATH
     else
-# do a default install which ensures the pmns and any views are installed
 
-	cd $PCP_PMDAS_DIR/$iam
-        $sudo ./Install < /dev/null > /dev/null 2>&1
+	if [ -z "$2" ]
+	then
+	    # do a default install which ensures the pmns and any
+	    # views are installed
+	    #
+	    cd $PCP_PMDAS_DIR/$iam
+	    $sudo ./Install < /dev/null > /dev/null 2>&1
+	fi
 
 # PMDA may have been installed differently to default. As everything is
 # installed we can use the old pmcd.conf file to restore state.

--- a/src/pmproxy/pmproxy.service.in
+++ b/src/pmproxy/pmproxy.service.in
@@ -8,8 +8,6 @@ Type=notify
 NotifyAccess=all
 Restart=always
 ExecStart=@PCP_RC_DIR@/pmproxy start
-ExecStop=@PCP_RC_DIR@/pmproxy stop
-PIDFile=@PCP_RUN_DIR@/pmproxy.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/src/pmproxy/pmproxy.service.in
+++ b/src/pmproxy/pmproxy.service.in
@@ -7,7 +7,7 @@ After=network-online.target pmcd.service
 Type=notify
 NotifyAccess=all
 Restart=always
-ExecStart=@PCP_RC_DIR@/pmproxy start
+ExecStart=@PCP_RC_DIR@/pmproxy start-systemd
 
 [Install]
 WantedBy=multi-user.target

--- a/src/pmproxy/rc_pmproxy
+++ b/src/pmproxy/rc_pmproxy
@@ -282,10 +282,24 @@ Error: pmproxy options file "$PMPROXYOPTS" is missing, cannot start pmproxy.'
 			    -e 's/ $//' \
 		    | tr '\012' ' ' `
 
+	    $PCP_BINADM_DIR/pmpost "start pmproxy from $pmprog"
+
+	    if [ -n "$NOTIFY_SOCKET" ]
+	    then
+		# Called from systemd with Type=Notify, we need to
+		# preserve the pid and systemd has already done the
+		# necessary daemonizing
+		#
+		exec $PMPROXY -f $OPTS
+		# NOTREACHED
+		#
+	    fi
+
+	    # otherwise, use the historical approach
+	    #
 	    $PMPROXY $OPTS
 	    $RC_STATUS -v
 
-	    $PCP_BINADM_DIR/pmpost "start pmproxy from $pmprog"
 
 	    # finally, stop here if running in a container
 	    [ -z "$PCP_CONTAINER_IMAGE" ] || exec $PCP_BINADM_DIR/pmpause

--- a/src/pmproxy/rc_pmproxy
+++ b/src/pmproxy/rc_pmproxy
@@ -218,7 +218,7 @@ $RC_RESET
 # considered a success.
 case "$1" in
 
-  start|faststart|restart|condrestart|reload|force-reload)
+  start|start-systemd|faststart|restart|condrestart|reload|force-reload)
 	if [ "$1" = "condrestart" ] && ! is_chkconfig_on pmproxy
 	then
 	    status=0
@@ -284,13 +284,12 @@ Error: pmproxy options file "$PMPROXYOPTS" is missing, cannot start pmproxy.'
 
 	    $PCP_BINADM_DIR/pmpost "start pmproxy from $pmprog"
 
-	    if [ -n "$NOTIFY_SOCKET" ]
+	    if [ "$1" = "start-systemd" ]
 	    then
-		# Called from systemd with Type=Notify, we need to
-		# preserve the pid and systemd has already done the
-		# necessary daemonizing
+		# Called from systemd with need to preserve the pid and
+		# systemd has already done the necessary daemonizing
 		#
-		exec $PMPROXY -f $OPTS
+		exec $PMPROXY -F $OPTS
 		# NOTREACHED
 		#
 	    fi

--- a/src/pmproxy/src/deprecated.c
+++ b/src/pmproxy/src/deprecated.c
@@ -63,7 +63,7 @@ SignalShutdown(void)
 	    killer_sig == SIGINT ? "SIGINT" : "SIGTERM", killer_pid, killer_uid);
 #if DESPERATE
 	pmNotifyErr(LOG_INFO, "Try to find process in ps output ...\n");
-	pmsprintf(buf, sizeof(buf), "sh -c \". \\$PCP_DIR/etc/pcp.env; ( \\$PCP_PS_PROG \\$PCP_PS_ALL_FLAGS | \\$PCP_AWK_PROG 'NR==1 {print} \\$2==%" FMT_PID " {print}' )\"", pid);
+	pmsprintf(buf, sizeof(buf), "sh -c \". \\$PCP_DIR/etc/pcp.env; ( \\$PCP_PS_PROG \\$PCP_PS_ALL_FLAGS | \\$PCP_AWK_PROG 'NR==1 {print} \\$2==%" FMT_PID " {print}' )\"", killer_pid);
 	system(buf);
 #endif
     }

--- a/src/pmproxy/src/pmproxy.c
+++ b/src/pmproxy/src/pmproxy.c
@@ -387,6 +387,14 @@ main(int argc, char *argv[])
 	__pmServerStart(argc, argv, 1);
     mainpid = getpid();
 
+    /*
+     * If we're started from systemd with Type=notify, then we'll be
+     * launched with -f, but we really need to behave like a daemon from
+     * here on, e.g. so the pidfile gets created
+     */
+    if ((envstr = getenv("NOTIFY_SOCKET")) != NULL)
+	run_daemon = 1;
+
     /* Open non-blocking request ports for client connections */
     if ((info = server->openports(sockpath, sizeof(sockpath), maxpending)) == NULL)
 	DontStart();

--- a/src/pmproxy/src/pmproxy.c
+++ b/src/pmproxy/src/pmproxy.c
@@ -22,12 +22,16 @@
 #define STRINGIFY(s)    #s
 #define TO_STRING(s)    STRINGIFY(s)
 
+#define RUN_DAEMON	1		/* default */
+#define RUN_FOREGROUND	2		/* -f */
+#define RUN_SYSTEMD	3		/* -F */
+
 static void	*info;			/* opaque server information */
 static pmproxy	*server;		/* proxy server implementation */
 struct dict	*config;		/* configuration file settings */
 
 static char	*logfile = "pmproxy.log";	/* log file name */
-static int	run_daemon = 1;		/* run as a daemon, see -f */
+static int	run_mode = RUN_DAEMON;	/* style of execution, see -f and -F */
 static char	*fatalfile = "/dev/tty";/* fatal messages at startup go here */
 static char	*username;
 static char	*certdb;		/* certificate DB path (NSS) */
@@ -68,6 +72,7 @@ static pmLongOptions longopts[] = {
     { "", 0, 'A', 0, "disable service advertisement" },
     { "deprecated", 0, 'd', 0, "backward-compatibility mode; no REST APIs" },
     { "foreground", 0, 'f', 0, "run in the foreground" },
+    { "systemd", 0, 'F', 0, "run in systemd mode" },
     { "timeseries", 0, 't', 0, "automatic, scalable timeseries; REST APIs" },
     { "username", 1, 'U', "USER", "in daemon mode, run as named user [default pcp]" },
     PMAPI_OPTIONS_HEADER("Configuration options"),
@@ -89,7 +94,7 @@ static pmLongOptions longopts[] = {
 };
 
 static pmOptions opts = {
-    .short_options = "Ac:C:dD:fh:i:l:L:M:p:P:r:s:tU:x:?",
+    .short_options = "Ac:C:dD:Ffh:i:l:L:M:p:P:r:s:tU:x:?",
     .long_options = longopts,
 };
 
@@ -133,8 +138,24 @@ ParseOptions(int argc, char *argv[], int *nports, int *maxpending)
 	    }
 	    break;
 
+	case 'F':	/* foreground but do pidfile and uid work */
+	    if (run_mode != RUN_DAEMON) {
+		pmprintf("%s: at most one of -f and -F allowed\n",
+			pmGetProgname());
+		opts.errors++;
+	    }
+	    else
+		run_mode = RUN_SYSTEMD;
+	    break;
+
 	case 'f':	/* foreground, i.e. do _not_ run as a daemon */
-	    run_daemon = 0;
+	    if (run_mode != RUN_DAEMON) {
+		pmprintf("%s: at most one of -f and -F allowed\n",
+			pmGetProgname());
+		opts.errors++;
+	    }
+	    else
+		run_mode = RUN_FOREGROUND;
 	    break;
 
 	case 'h':	/* Redis host name */
@@ -383,17 +404,11 @@ main(int argc, char *argv[])
     /* Advertise the service on the network if that is supported */
     __pmServerSetServiceSpec(PM_SERVER_PROXY_SPEC);
 
-    if (run_daemon)
+    if (run_mode == RUN_DAEMON) {
+	/* daemonize - fork and parent exits, setsid */
 	__pmServerStart(argc, argv, 1);
+    }
     mainpid = getpid();
-
-    /*
-     * If we're started from systemd with Type=notify, then we'll be
-     * launched with -f, but we really need to behave like a daemon from
-     * here on, e.g. so the pidfile gets created
-     */
-    if ((envstr = getenv("NOTIFY_SOCKET")) != NULL)
-	run_daemon = 1;
 
     /* Open non-blocking request ports for client connections */
     if ((info = server->openports(sockpath, sizeof(sockpath), maxpending)) == NULL)
@@ -409,7 +424,7 @@ main(int argc, char *argv[])
 	fprintf(stderr, "%s: maxpending=%d from PMPROXY_MAXPENDING=%s in environment\n",
 			"Warning", maxpending, getenv("PMPROXY_MAXPENDING"));
 
-    if (run_daemon) {
+    if (run_mode == RUN_DAEMON || run_mode == RUN_SYSTEMD) {
 	if (__pmServerCreatePIDFile(PM_SERVER_PROXY_SPEC, PM_FATAL_ERR) < 0)
 	    DontStart();
 	if (pmSetProcessIdentity(username) < 0)


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200411

Ken McDonell (18):
      qa/1190: fix ps(1) filter for pmcd ...
      qa: most of the pmproxy group of tests
      qa/1696: need python3 (for pmproxy_load_test.python)
      qa/915: turn discovery off in the minimalist pmproxy.conf
      qa/admin/other-packages/manifest: add packages for pstree (and fuser)
      qa/common.avahi: put service state back the way it was at the beginning
      src/pmproxy/src/deprecated.c: fix compilation error
      src/pmproxy: changes to work better with systemd
      qa/297: kill off my pmproxy in _cleanup()
      qa/651: tidy up ps(1) filter
      qa/common.check: make default PMDA install optional in _restore_pmda_install()
      qa/457: clean up the logger PMDA configuration
      qa/check-flakey: dodge qa sequence numbers that look like octal to printf(1)
      pmproxy: second iteration of systemd mode
      qa/check-flakey: fix small wrinkle in data from check.time
      qa/1190: don't check for "qa" or "QA" in .pki/nssdb .db files
      qa/check.callback.sample: check if pre-run AVC file exists before diff
      qa/457: cosmetic change in diags

 man/man1/pmproxy.1               |   34 +++++++++++++++++++++++++--
 qa/1190                          |    7 ++++-
 qa/1379                          |   13 ++++++++++
 qa/1388                          |   16 ++++++++++--
 qa/1401                          |   13 ++++++++++
 qa/1433                          |   14 ++++++++++-
 qa/1543                          |   13 ++++++++++
 qa/1544                          |   14 +++++++++++
 qa/1573                          |   14 +++++++++--
 qa/1573.out                      |    1 
 qa/1661                          |   16 ++++++++++--
 qa/1661.out                      |    2 -
 qa/1696                          |    4 +++
 qa/294                           |   15 ++++++++++-
 qa/295                           |   15 ++++++++++-
 qa/297                           |   17 +++++++++++--
 qa/457                           |   25 +++++++++++++------
 qa/457.out                       |    2 -
 qa/651                           |   16 ++++++++----
 qa/713                           |   17 +++++++++++--
 qa/780                           |   13 ++++++++++
 qa/915                           |    2 -
 qa/admin/other-packages/manifest |   14 +++++++++++
 qa/check-flakey                  |    7 +++--
 qa/check.callback.sample         |   17 +++++++------
 qa/common.avahi                  |   28 +++++++++++++++++++++-
 qa/common.check                  |   15 +++++++++--
 src/pmproxy/pmproxy.service.in   |    4 ---
 src/pmproxy/rc_pmproxy           |   27 +++++++++++++++------
 src/pmproxy/src/deprecated.c     |    2 -
 src/pmproxy/src/pmproxy.c        |   49 ++++++++++++++++++++++++++++-----------
 31 files changed, 371 insertions(+), 75 deletions(-)

Details ...

commit cdb5d4e1e307a076e61686186595aa897e8799e9
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Mon Apr 13 12:19:41 2020 +1000

    qa/457: cosmetic change in diags

commit 79450dbb1a4f22cd199480e2bd3bc294e90ab648
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Mon Apr 13 11:28:23 2020 +1000

    qa/check.callback.sample: check if pre-run AVC file exists before diff

commit 681c4b2451370c354092a4679a1cc5e44a88e452
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Apr 12 15:27:38 2020 +1000

    qa/1190: don't check for "qa" or "QA" in .pki/nssdb .db files

commit 8fc382718c227e9153223527b884c82e5c470e85
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Apr 12 14:46:13 2020 +1000

    qa/check-flakey: fix small wrinkle in data from check.time

commit 706b8f1d83d1a6ea1c40689389cfb5f971d1906b
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Apr 12 14:19:15 2020 +1000

    pmproxy: second iteration of systemd mode
    
    Drop the dependence on NOTIFY_SOCKET in the environment to intuit the
    correct behaviour.
    
    1. add -F command line option to pmproxy to explicity request
       half-baked foreground mode where we do not fork(), but we do manage
       the pidfile and set the uid to that of the pcp user.
    2. add "start-systemd" as an alternative to "start" in the rc script,
       and use this to trigger the alternate exec with -F to start pmproxy.
    3. use "start-systemd" in the service file

commit 0d8ea3af7de955738fd5a297b0f0032237c4a207
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Apr 12 14:04:44 2020 +1000

    qa/check-flakey: dodge qa sequence numbers that look like octal to printf(1)

commit e1915434450f1e25fcf87221046cfda8fd356fe9
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Apr 12 14:03:01 2020 +1000

    qa/457: clean up the logger PMDA configuration
    
    qa/1190 found that this test (qa/457) was leaving a configuration
    file behind in $PCP_VAR_DIR/config/logger/logger.conf

commit 55a69bf62f90b077ccf0245f1fb64ac9cab1ae2c
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Apr 12 13:59:58 2020 +1000

    qa/common.check: make default PMDA install optional in _restore_pmda_install()
    
    The default PMDA install recipe:
        $ ./Install </dev/null
    may not work if the installation is designed to be interactive, or
    requires explicit input values.
    
    To accommodate this, _restore_pmda_install() supports an optional 2nd
    parameter and if this is not empty, the default PMDA install will not
    be attempted.  It is assumed that the caller will be taking care of
    PMDA's final well-being if this is the case.

commit ec92902bd5b53d465b6f1240d6a5100434b7aaf0
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Apr 11 17:21:14 2020 +1000

    qa/651: tidy up ps(1) filter

commit 12b375fbfc0d06dac1018183b7cced8cf5f358bf
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Apr 11 17:20:49 2020 +1000

    qa/297: kill off my pmproxy in _cleanup()

commit 7b2944ba79e0d8312651a460f89c38179e2a6fca
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Apr 11 16:30:48 2020 +1000

    src/pmproxy: changes to work better with systemd
    
    1. Drop the ExecStop and PIDFile lines in the services file (neither
       is needed, and ExecStop is harmful)
    2. Change the "rc" script so that if NOTIFY_SOCKET is set in the
       environment, assume we're being launched from systemd with
       Type=notify and we do NOT want to daemonize or launch a new process,
       so exec pmproxy with -f
    3. In pmproxy, if NOTIFY_SOCKET is set in the environment then create
       the pidfile and call pmSetProcessIdentity() even if -f is used.

commit af1762d45f18b904c7875c8491a44cb3132db23a
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Apr 11 16:16:56 2020 +1000

    src/pmproxy/src/deprecated.c: fix compilation error
    
    Only exposed when DESPERATE defined, which it is not by default.

commit e4e1a6300447a5ebfaaeac535391797a0ded9451
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Apr 11 16:15:07 2020 +1000

    qa/common.avahi: put service state back the way it was at the beginning
    
    Same as for the recent pmproxy group of tests.

commit 53fa2964fd82b8508fe2f1d147758cbf92e48ba5
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Apr 11 16:13:59 2020 +1000

    qa/admin/other-packages/manifest: add packages for pstree (and fuser)

commit 2195d11d06d985f7eacbd1c3c04180c5c3964fba
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Apr 11 16:13:01 2020 +1000

    qa/915: turn discovery off in the minimalist pmproxy.conf
    
    Not needed for the purposes of this test.

commit 1230e1da2235b8c056d41c95d2876bac1bd1820e
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Apr 11 16:12:15 2020 +1000

    qa/1696: need python3 (for pmproxy_load_test.python)

commit ef71735e707e7d71fb01419b43c48630f40be289
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Apr 11 16:10:57 2020 +1000

    qa: most of the pmproxy group of tests
    
    Check to see if pmproxy is running at the beginnning and put it back
    the way it was at the end of the test.

commit 3e70f0a024acd590c81a444149b23b41054c5b4a
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Apr 11 16:06:36 2020 +1000

    qa/1190: fix ps(1) filter for pmcd ...
    
    Need to accommodate case where pmcd is launched without arguments.