### PR TITLE
pmproxy: return authentication errors

### DIFF
--- a/qa/1388
+++ b/qa/1388
@@ -153,39 +153,51 @@ _service pmproxy start >>$here/$seq.full 2>&1
 echo "Start test Python PMDA to check if username is in per-context state"
 cd pmdas/test_python
 $sudo ./Install </dev/null \
-    | _filter_pmda_install \
-    | sed -e '/^Waiting for pmcd/s/\.\.\.[. ]*$/DOTS/' \
-    | $PCP_AWK_PROG '
-/Check test_python metrics have appeared/ { if ($10 >= 0 && $10 <= 9) $10 = "N" }
-                                          { print }'
+| _filter_pmda_install
 cd $here
 
-echo && echo "=== pmproxy no authentication (expect errors) ==="
-curl -s -S "http://localhost:44322/pmapi/context?hostspec=localhost%3Fusername%3Dbob" | pmjson | _filter_json
-curl -s -S "http://localhost:44322/pmapi/context?hostspec=localhost%3Fpassword%3Dbib" | pmjson | _filter_json
-curl -s --user $username:bob "http://localhost:44322/pmapi/context?hostspec=localhost%3Fusername%3Dbob" | pmjson | _filter_json
+echo && echo "=== invalid username with pminfo ==="
+pminfo -f -h "pcp://127.0.0.1?username=nonexisting_user&password=bob" test_python.current_username
 
-echo && echo "=== pmproxy with authentication (expect success) ==="
-curl -s --user $username:y "http://localhost:44322/pmapi/context" | pmjson | _filter_json | _filter_credentials
-
-echo && echo "=== state without authentication ==="
-ctx_no_auth=`curl -s "http://localhost:44322/pmapi/context" | pmpython -c 'import sys,json; print(json.load(sys.stdin)["context"])'`
-curl -s "http://localhost:44322/pmapi/$ctx_no_auth/fetch?names=test_python.current_username" | pmjson | grep '"value"' | _filter_ctx
-
-echo && echo "=== state with authentication ==="
-ctx_with_auth=`curl -s --user $username:y "http://localhost:44322/pmapi/context" | pmpython -c 'import sys,json; print(json.load(sys.stdin)["context"])'`
-curl -s "http://localhost:44322/pmapi/$ctx_with_auth/fetch?names=test_python.current_username" | pmjson | grep '"value"' | _filter_ctx | _filter_username
-
-echo && echo "=== verify with pminfo (expect error) ==="
+echo && echo "=== invalid password with pminfo ==="
 pminfo -f -h "pcp://127.0.0.1?username=$username&password=bob" test_python.current_username
 
-echo && echo "=== verify with pminfo (expect success) ==="
+echo && echo "=== correct password with pminfo ==="
 pminfo -f -h "pcp://127.0.0.1?username=$username&password=y" test_python.current_username | _filter_ctx | _filter_username
+
+
+echo && echo "=== no authentication ==="
+response=$(curl -s "http://localhost:44322/pmapi/context")
+echo "${response}" | pmjson | _filter_json
+ctx_unauthenticated=$(echo "${response}" | pmpython -c 'import sys,json; print(json.load(sys.stdin)["context"])')
+
+echo && echo "=== invalid username ==="
+curl -s --user nonexisting_user:bob "http://localhost:44322/pmapi/context" | pmjson | _filter_json
+
+echo && echo "=== invalid password ==="
+curl -s --user $username:bob "http://localhost:44322/pmapi/context" | pmjson | _filter_json
+
+echo && echo "=== correct password ==="
+response=$(curl -s --user $username:y "http://localhost:44322/pmapi/context")
+echo "${response}" | pmjson | _filter_json | _filter_credentials
+ctx_authenticated=$(echo "${response}" | pmpython -c 'import sys,json; print(json.load(sys.stdin)["context"])')
+
+
+echo && echo "=== using unauthenticated context ==="
+curl -s "http://localhost:44322/pmapi/$ctx_unauthenticated/fetch?names=test_python.current_username" | pmjson | grep '"value"' | _filter_ctx
+
+echo && echo "=== using authenticated context, missing HTTP auth headers (expect failure) ==="
+curl -s "http://localhost:44322/pmapi/$ctx_authenticated/fetch?names=test_python.current_username" | pmjson | _filter_json
+
+echo && echo "=== using authenticated context, with HTTP auth headers (expect success) ==="
+curl -s --user $username:y "http://localhost:44322/pmapi/$ctx_authenticated/fetch?names=test_python.current_username" | pmjson | grep '"value"' | _filter_ctx | _filter_username
 
 
 echo >>$here/$seq.full
 echo "=== pmproxy log ===" >>$here/$seq.full
 cat $PCP_LOG_DIR/pmproxy/pmproxy.log >>$here/$seq.full
+echo "=== test_python PMDA log ===" >>$here/$seq.full
+cat $PCP_LOG_DIR/pmcd/test_python.log >>$here/$seq.full
 
 status=0
 exit

--- a/qa/1388.out
+++ b/qa/1388.out
@@ -10,23 +10,44 @@ Updating the Performance Metrics Name Space (PMNS) ...
 Terminate PMDA if already installed ...
 [...install files, make output...]
 Updating the PMCD control file, and notifying PMCD ...
-Check test_python metrics have appeared ... 6 metrics and N values
+Check test_python metrics have appeared ... 6 metrics and 7 values
 
-=== pmproxy no authentication (expect errors) ===
+=== invalid username with pminfo ===
+Error: test_python.current_username: Authentication - user not found
+
+=== invalid password with pminfo ===
+Error: test_python.current_username: Authentication - authentication failure
+
+=== correct password with pminfo ===
+
+test_python.current_username
+    value "ctx ? user USER"
+
+=== no authentication ===
 {
-    "message": "authentication required",
-    "success": false
+    "context": "CONTEXT"
+    "source": "SOURCE"
+    "hostspec": "HOSTSPEC"
+    "labels": {
+        "domainname": "DOMAINNAME"
+        "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
+    }
 }
+
+=== invalid username ===
 {
-    "message": "cannot connect to PMCD on host \u0022localhost?password=bib\u0022: Authentication - invalid parameter supplied",
-    "success": false
-}
-{
-    "message": "authentication failed",
+    "message": "failed to get context labels: Authentication - user not found",
     "success": false
 }
 
-=== pmproxy with authentication (expect success) ===
+=== invalid password ===
+{
+    "message": "failed to get context labels: Authentication - authentication failure",
+    "success": false
+}
+
+=== correct password ===
 {
     "context": "CONTEXT"
     "source": "SOURCE"
@@ -40,16 +61,15 @@ Check test_python metrics have appeared ... 6 metrics and N values
     }
 }
 
-=== state without authentication ===
+=== using unauthenticated context ===
                     "value": "ctx ? user None"
 
-=== state with authentication ===
+=== using authenticated context, missing HTTP auth headers (expect failure) ===
+{
+    "context": "CONTEXT"
+    "message": "authentication required",
+    "success": false
+}
+
+=== using authenticated context, with HTTP auth headers (expect success) ===
                     "value": "ctx ? user USER"
-
-=== verify with pminfo (expect error) ===
-Error: test_python.current_username: Authentication - authentication failure
-
-=== verify with pminfo (expect success) ===
-
-test_python.current_username
-    value "ctx ? user USER"

--- a/qa/pmdas/test_python/pmdatest_python.python
+++ b/qa/pmdas/test_python/pmdatest_python.python
@@ -79,6 +79,7 @@ class TestPMDA(PMDA):
         self.set_fetch_callback(self.test_fetch_callback)
         self.set_store_callback(self.test_store_callback)
         self.set_attribute_callback(self.test_attribute_callback)
+        self.set_endcontext_callback(self.test_endcontext_callback)
         self.set_user(PCP.pmGetConfig('PCP_USER'))
         self.set_comm_flags(cpmda.PMDA_FLAG_AUTHORIZE)
 
@@ -175,6 +176,13 @@ class TestPMDA(PMDA):
         self.log("attribute callback for ctx %d attr %d value %s" % (ctx, attr, repr(value)))
         if attr == cpmda.PMDA_ATTR_USERNAME:
             self.ctxtabuser[ctx] = value
+
+    def test_endcontext_callback(self, ctx):
+        self.log("endcontext callback for ctx %d " % (ctx,))
+        if ctx in self.ctxtabval:
+            del self.ctxtabval[ctx]
+        if ctx in self.ctxtabuser:
+            del self.ctxtabuser[ctx]
 
 
 if __name__ == '__main__':

--- a/src/include/pcp/pmapi.h
+++ b/src/include/pcp/pmapi.h
@@ -326,6 +326,7 @@ PCP_CALL extern int pmGetInDomArchive(pmInDom, int **, char ***);
  */
 PCP_CALL extern const char *pmGetContextHostName(int);
 PCP_CALL extern char *pmGetContextHostName_r(int, char *, int);
+PCP_CALL extern int pmGetContextHostName_rr(int, char *, int);
 
 /*
  * Return the handle of the current context

--- a/src/libpcp/src/context.c
+++ b/src/libpcp/src/context.c
@@ -229,8 +229,8 @@ __pmPtrToHandle(__pmContext *ctxp)
 /*
  * Determine the hostname associated with the given context.
  */
-char *
-pmGetContextHostName_r(int handle, char *buf, int buflen)
+int
+pmGetContextHostName_rr(int handle, char *buf, int buflen)
 {
     __pmContext *ctxp;
     char	*name;
@@ -238,7 +238,7 @@ pmGetContextHostName_r(int handle, char *buf, int buflen)
     pmResult	*resp;
     int		save_handle;
     __pmContext	*save_ctxp;
-    int		sts;
+    int		sts = 0;
 
     PM_INIT_LOCKS();
 
@@ -257,7 +257,7 @@ pmGetContextHostName_r(int handle, char *buf, int buflen)
 	     * context switch, then switch back.
 	     */
 	    if (pmDebugOptions.context)
-		fprintf(stderr, "pmGetContextHostName_r context(%d) -> 0\n", handle);
+		fprintf(stderr, "pmGetContextHostName_rr context(%d) -> 0\n", handle);
 	    save_handle = PM_TPD(curr_handle);
 	    save_ctxp = PM_TPD(curr_ctxp);
 	    PM_TPD(curr_handle) = handle;
@@ -268,7 +268,7 @@ pmGetContextHostName_r(int handle, char *buf, int buflen)
 	    if (sts >= 0)
 		sts = pmFetch_ctx(ctxp, 1, &pmid, &resp);
 	    if (pmDebugOptions.context)
-		fprintf(stderr, "pmGetContextHostName_r reset(%d) -> 0\n", save_handle);
+		fprintf(stderr, "pmGetContextHostName_rr reset(%d) -> 0\n", save_handle);
 
 	    PM_TPD(curr_handle) = save_handle;
 	    PM_TPD(curr_ctxp) = save_ctxp;
@@ -311,6 +311,16 @@ pmGetContextHostName_r(int handle, char *buf, int buflen)
 	PM_UNLOCK(ctxp->c_lock);
     }
 
+    return sts;
+}
+
+/*
+ * Backward-compatibility interface, does not return status code.
+ */
+char *
+pmGetContextHostName_r(int handle, char *buf, int buflen)
+{
+    pmGetContextHostName_rr(handle, buf, buflen);
     return buf;
 }
 

--- a/src/libpcp/src/exports.master
+++ b/src/libpcp/src/exports.master
@@ -700,4 +700,5 @@ PCP_3.28 {
   global:
     __pmServerNotifyServiceManagerReady;
     __pmServerNotifyServiceManagerStopping;
+    pmGetContextHostName_rr;
 } PCP_3.27;

--- a/src/libpcp_web/src/util.c
+++ b/src/libpcp_web/src/util.c
@@ -321,9 +321,9 @@ pmwebapi_source_meta(context_t *c, char *buffer, int length)
     char	host[MAXHOSTNAMELEN];
     int		sts;
 
-    if ((pmGetContextHostName_r(c->context, host, sizeof(host))) == NULL) {
+    if ((sts = pmGetContextHostName_rr(c->context, host, sizeof(host))) < 0) {
 	c->setup = 0;
-	return PM_ERR_GENERIC;
+	return sts;
     }
     c->host = sdsnew(host);
     sts = pmGetContextLabels(set);

--- a/src/pmproxy/src/webapi.c
+++ b/src/pmproxy/src/webapi.c
@@ -562,18 +562,17 @@ on_pmwebapi_check(sds context, pmWebAccess *access,
     /* Does this context require username/password authentication? */
     if (access->username != NULL ||
 		__pmServerHasFeature(PM_SERVER_FEATURE_CREDS_REQD)) {
-	if (access->username == NULL || access->password == NULL) {
+	if (access->username == NULL || access->password == NULL ||
+		client->u.http.username == NULL || client->u.http.password == NULL) {
 	    *message = sdsnew("authentication required");
 	    *status = -EAGAIN;
-	    return 1;
+	    return -1;
 	}
-	if ((access->username != NULL &&
-		sdscmp(access->username, client->u.http.username) != 0) ||
-	    (access->password != NULL &&
-		(sdscmp(access->password, client->u.http.password) != 0))) {
+	if (sdscmp(access->username, client->u.http.username) != 0 ||
+		sdscmp(access->password, client->u.http.password) != 0) {
 	    *message = sdsnew("authentication failed");
 	    *status = -EPERM;
-	    return 1;
+	    return -1;
 	}
     }
 


### PR DESCRIPTION
somehow I messed up the last PR (#879) and set the base branch of that PR to the master branch of my fork, instead of the `auth-changes` feature branch of my fork... here is it again:

Looks like after creating a new context (`pmwebapi_new_context`) the first PDU pmproxy sends to the PMCD with authentication credentials comes from the `pmGetContextHostName_r` function (`pmLookupName_ctx` inside this function), which gets called from `pmwebapi_new_context` -> `pmwebapi_source_meta`.

Unfortunately this function doesn't return the `sts`, so pmproxy doesn't know about any authentication errors. This PR introduces `pmGetContextHostName_rr` which returns the `sts`, and fixes QA 1388.

Another issue remains however, valgrind reports the following when the authentication is unsuccessful:
```
==459557== Invalid write of size 8
==459557==    at 0x4C51FA3: uv_run (in /usr/lib64/libuv.so.1.0.0)
==459557==    by 0x112411: main_loop (server.c:856)
==459557==    by 0x11194E: main (pmproxy.c:427)
==459557==  Address 0x57f13f0 is 176 bytes inside a block of size 360 free'd
==459557==    at 0x483AA0C: free (vg_replace_malloc.c:540)
==459557==    by 0x48AB593: webgroup_new_context (webgroup.c:207)
==459557==    by 0x48AB593: webgroup_lookup_context (webgroup.c:260)
==459557==    by 0x48ACA4E: pmWebGroupContext (webgroup.c:299)
==459557==    by 0x4C4DBCD: ??? (in /usr/lib64/libuv.so.1.0.0)
==459557==    by 0x4C7D4E1: start_thread (in /usr/lib64/libpthread-2.30.so)
==459557==    by 0x4E406A2: clone (in /usr/lib64/libc-2.30.so)
==459557==  Block was alloc'd at
==459557==    at 0x483BB1A: calloc (vg_replace_malloc.c:762)
==459557==    by 0x48AB2CE: webgroup_new_context (webgroup.c:162)
==459557==    by 0x48AB2CE: webgroup_lookup_context (webgroup.c:260)
==459557==    by 0x48ACA4E: pmWebGroupContext (webgroup.c:299)
==459557==    by 0x4C4DBCD: ??? (in /usr/lib64/libuv.so.1.0.0)
==459557==    by 0x4C7D4E1: start_thread (in /usr/lib64/libpthread-2.30.so)
==459557==    by 0x4E406A2: clone (in /usr/lib64/libc-2.30.so)
==459557== 
```