### PR TITLE
libpcp: fix authentication for multi-step auth methods

### DIFF
--- a/qa/1672
+++ b/qa/1672
@@ -1,0 +1,96 @@
+#!/bin/sh
+# PCP QA Test No. 1672
+# Exercise different SASL auth methods using a custom sasldb.
+#
+# Copyright (c) 2020 Red Hat.
+#
+# NOTE
+#	This test is likely to fail unless hostname(1) returns
+#	some sort of FQDN.  For example, when hostname was vm23 it
+#	failed, but when hostname was set (via /etc/hostname in
+#	this case) to vm23.localdomain the test passes.
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+. ./common.secure
+
+_get_libpcp_config
+$authentication || _notrun "No authentication support available"
+
+sasl_notrun_checks saslpasswd2 sasldblistusers2
+$pluginviewer -a | grep 'Plugin "sasldb"' >/dev/null
+test $? -eq 0 || _notrun "SASL sasldb auxprop plugin unavailable"
+$pluginviewer -c | grep 'Plugin "plain"' >/dev/null 2>&1
+test $? -eq 0 || _notrun 'No client support for plain authentication'
+$pluginviewer -s | grep 'Plugin "plain"' >/dev/null 2>&1
+test $? -eq 0 || _notrun 'No server support for plain authentication'
+
+cleanup()
+{
+    # restore any modified pmcd configuration files
+    _restore_config $PCP_SASLCONF_DIR/pmcd.conf
+
+    _service pcp stop 2>&1 | _filter_pcp_stop
+    _service pcp start 2>&1 2>&1 | _filter_pcp_start
+    _wait_for_pmcd
+    _wait_for_pmlogger
+
+    $sudo rm -rf $tmp.*
+}
+
+status=1	# failure is the default!
+hostname=`hostname`
+$sudo rm -rf $tmp.* $seq.full
+trap "cleanup; exit \$status" 0 1 2 3 15
+
+_filter_listusers2()
+{
+    sed \
+        -e "s/^$username/USER/" \
+        -e "s/@$hostname:/@HOST:/"
+}
+
+# real QA test starts here
+_save_config $PCP_SASLCONF_DIR/pmcd.conf
+echo 'mech_list: plain login digest-md5' >$tmp.sasl
+echo "sasldb_path: $tmp.passwd.db" >>$tmp.sasl
+$sudo cp $tmp.sasl $PCP_SASLCONF_DIR/pmcd.conf
+$sudo chown pcp:pcp $PCP_SASLCONF_DIR/pmcd.conf
+ls -l $PCP_SASLCONF_DIR/pmcd.conf >>$seq.full
+$sudo -u pcp cat $PCP_SASLCONF_DIR/pmcd.conf >>$seq.full
+
+echo "Creating temporary sasldb, add user running QA to it" | tee -a $seq.full
+echo y | saslpasswd2 -p -a pmcd -f $tmp.passwd.db $username
+
+echo "Verify saslpasswd2 has successfully added a new user" | tee -a $seq.full
+sasldblistusers2 -f $tmp.passwd.db \
+| tee -a $seq.full \
+| _filter_listusers2
+
+echo "Ensure pmcd can read the password file" | tee -a $seq.full
+$sudo chown pcp:pcp $tmp.passwd.db
+ls -l $tmp.passwd.db >>$seq.full
+$sudo -u pcp od -c $tmp.passwd.db >>$seq.full
+
+echo "Start pmcd with this shiny new sasldb"
+_service pcp restart 2>&1 | tee -a $seq.full >$tmp.out
+_wait_for_pmcd
+_wait_for_pmlogger
+
+for method in plain login digest-md5
+do
+    echo
+    echo "=== method: ${method}, authentication with invalid password ==="
+    pminfo -f -h "pcp://localhost?method=${method}&username=${username}&password=n" pmcd.feature.authentication 2>&1 \
+    | grep -o "authentication failure"
+
+    echo
+    echo "=== method: ${method}, authentication with correct password ==="
+    pminfo -f -h "pcp://localhost?method=${method}&username=${username}&password=y" pmcd.feature.authentication
+done
+
+
+# success, all done
+status=0
+exit

--- a/qa/1672.out
+++ b/qa/1672.out
@@ -1,0 +1,30 @@
+QA output created by 1672
+Creating temporary sasldb, add user running QA to it
+Verify saslpasswd2 has successfully added a new user
+USER@HOST: userPassword
+Ensure pmcd can read the password file
+Start pmcd with this shiny new sasldb
+
+=== method: plain, authentication with invalid password ===
+authentication failure
+
+=== method: plain, authentication with correct password ===
+
+pmcd.feature.authentication
+    value 1
+
+=== method: login, authentication with invalid password ===
+authentication failure
+
+=== method: login, authentication with correct password ===
+
+pmcd.feature.authentication
+    value 1
+
+=== method: digest-md5, authentication with invalid password ===
+authentication failure
+
+=== method: digest-md5, authentication with correct password ===
+
+pmcd.feature.authentication
+    value 1

--- a/qa/group
+++ b/qa/group
@@ -1672,7 +1672,7 @@ BAD
 1379 pmproxy local
 1383 pmlogrewrite labels pmdumplog local
 1385 pmda.openmetrics local python
-1388 pmproxy local
+1388 pmproxy local secure
 1389:retired pmwebd local
 1390 atop pcp local
 1393 pmda.linux local
@@ -1719,6 +1719,7 @@ BAD
 1644 pmda.perfevent local
 1661 pmproxy libpcp_web pmlogger local
 1671 multi-archive archive libpcp pmrep local python
+1672 secure pmcd local
 1690 pmseries local
 1694 pidstat local python pcp
 1695 pmproxy valgrind local

--- a/src/libpcp/src/secureconnect.c
+++ b/src/libpcp/src/secureconnect.c
@@ -1051,6 +1051,7 @@ __pmAuthClientNegotiation(int fd, int ssf, const char *hostname, __pmHashCtl *at
     int sts, zero, saslsts = SASL_FAIL;
     int pinned, length, method_length;
     char *payload, buffer[LIMIT_AUTH_PDU];
+    const char *data;
     const char *method = NULL;
     sasl_conn_t *saslconn;
     __pmHashNode *node;
@@ -1151,7 +1152,7 @@ __pmAuthClientNegotiation(int fd, int ssf, const char *hostname, __pmHashCtl *at
 	    sts = __pmDecodeAuth(pb, &zero, &payload, &length);
 	    if (sts >= 0) {
 		saslsts = sasl_client_step(saslconn, payload, length, NULL,
-						(const char **)&buffer,
+						&data,
 						(unsigned int *)&length);
 		if (saslsts != SASL_OK && saslsts != SASL_CONTINUE) {
 		    sts = __pmSecureSocketsError(saslsts);
@@ -1162,7 +1163,7 @@ __pmAuthClientNegotiation(int fd, int ssf, const char *hostname, __pmHashCtl *at
 		}
 		if (pmDebugOptions.auth) {
 		    fprintf(stderr, "%s:__pmAuthClientNegotiation"
-				    " step recv (%d bytes)", __FILE__, length);
+				    " step send (%d bytes)", __FILE__, length);
 		}
 	    }
 	}
@@ -1174,7 +1175,7 @@ __pmAuthClientNegotiation(int fd, int ssf, const char *hostname, __pmHashCtl *at
 	if (pinned > 0)
 	    __pmUnpinPDUBuf(pb);
 	if (sts >= 0)
-	    sts = __pmSendAuth(fd, FROM_ANON, 0, length ? buffer : "", length);
+	    sts = __pmSendAuth(fd, FROM_ANON, 0, length ? data : "", length);
 	if (sts < 0)
 	    break;
     }

--- a/src/pmcd/sasl2.conf
+++ b/src/pmcd/sasl2.conf
@@ -2,7 +2,8 @@
 # You can list many mechanisms at once, then the user can choose
 # by adding e.g. '?authmech=gssapi' to their host specification.
 # For other options, refer to SASL pluginviewer command output.
-mech_list: plain login digest-md5 gssapi
+#mech_list: plain login digest-md5 gssapi
+mech_list: plain login digest-md5
 
 # If deferring to the SASL auth daemon (runs as root, can do PAM
 # login using regular user accounts, unprivileged daemons cannot).


### PR DESCRIPTION
fixes auth for login & digest-md5 methods, and removes gssapi from the default auth methods