### PR TITLE
Fix for new version of ActiveMQ broker

### DIFF
--- a/src/pmdas/activemq/RESTClient.pm
+++ b/src/pmdas/activemq/RESTClient.pm
@@ -41,7 +41,8 @@ sub get {
 	$json = $cached_json;
     }
     else {
-	my $response = $self->{_http_client}->get("http://" . $self->{_host} . ":" . $self->{_port} . $url);
+        my $header = ('Origin' => 'http://localhost',);
+	my $response = $self->{_http_client}->get("http://" . $self->{_host} . ":" . $self->{_port} . $url, $header);
 	return undef unless defined($response);
 	return undef unless $response->is_success;
 	$json = decode_json($response->decoded_content);


### PR DESCRIPTION
In the new version of AcrtiveMQ (5.12+), when sending REST request through Jolokia API, it requires an 'Origin' value in HTTP request header(https://activemq.apache.org/rest) otherwise it will fail.
$ curl -u admin:admin http://localhost:8161/api/jolokia/read/org.apache.activemq:brokerName=localhost,destinationName=NOTIFICATIONS,destinationType=Queue,type=Broker
{"error_type":"java.lang.Exception","error":"java.lang.Exception : Origin null is not allowed to call this agent","status":403}