### PR TITLE
libpcp_trace/src/trace.c: Avoid dereferencing of possible NULL pointe…

### DIFF
--- a/src/libpcp_trace/src/trace.c
+++ b/src/libpcp_trace/src/trace.c
@@ -76,10 +76,11 @@ _pmlibdel(void *entry)
 {
     _pmTraceLibdata	*data = (_pmTraceLibdata *)entry;
 
-    if (data->tag)
-	free(data->tag);
-    if (data)
-	free(data);
+    if (data) {
+        if (data->tag)
+            free(data->tag);
+        free(data);
+    }
 }
 
 static int		__pmfd;


### PR DESCRIPTION
libpcp_trace/src/trace.c: Avoid dereferencing of possible NULL pointer 'data'

We need check the NULL pointer for 'data' to avoid dereferencing NULL pointer
in data->tag.

Signed-off-by: LiaoPingfang <liao.pingfang@zte.com.cn>