### PR TITLE
Simple idea how to store timeseries replies from Redis

### DIFF
--- a/src/libpcp_web/src/query.h
+++ b/src/libpcp_web/src/query.h
@@ -109,6 +109,12 @@ typedef struct node {
     sds			*matches;
     regex_t		regex;	/* compiled regex */
     unsigned long long	cursor;
+
+    /* record SID for function-type node */
+    void		**SID;
+
+    /* store series values of this node */
+    pmSeriesValue	***series_values;
 } node_t;
 
 typedef struct timing {

--- a/src/libpcp_web/src/query_parser.y
+++ b/src/libpcp_web/src/query_parser.y
@@ -155,7 +155,7 @@ static const char initial_str[]  = "Unexpected initial";
 
 %type  <n>  query
 %type  <n>  expr
-//%type  <n>  func
+%type  <n>  func
 %type  <n>  exprlist
 %type  <n>  exprval
 %type  <n>  number
@@ -207,6 +207,17 @@ vector:	L_NAME L_LBRACE exprlist L_RBRACE L_EOS
 		  $$ = lp->yy_series.expr = lp->yy_np;
 		  YYACCEPT;
 		}
+	| func L_LBRACE exprlist L_RBRACE L_LSQUARE timelist L_RSQUARE L_EOS
+		{ lp->yy_np = newmetricquery($1->left->value, $3);
+		  $$ = lp->yy_series.expr = lp->yy_np;
+		  YYACCEPT;
+		}
+	| func L_LSQUARE timelist L_RSQUARE L_EOS
+		{ lp->yy_np = $1;
+		  $$ = lp->yy_series.expr = lp->yy_np;
+		  YYACCEPT;
+		}
+	;
 
 exprlist : exprlist L_COMMA expr
 		{ lp->yy_np = newnode(N_AND);
@@ -308,7 +319,13 @@ expr	: /* relational expressions */
 	;
 
 	/* TODO: functions */
-//func	: L_AVG L_LPAREN L_NAME L_RPAREN
+func	: L_RATE L_LPAREN L_NAME L_RPAREN
+		{ lp->yy_np = newnode(N_RATE);
+		  lp->yy_np->left = newmetric($3);
+		  $$ = lp->yy_np;
+		}
+	;
+//	| L_AVG L_LPAREN L_NAME L_RPAREN
 //		{ lp->yy_np = newnode(N_AVG);
 //		  lp->yy_np->left = newnode(N_NAME);
 //		  lp->yy_np->left->value = sdsnew($3);
@@ -340,12 +357,6 @@ expr	: /* relational expressions */
 //		}
 //	| L_SUM L_LPAREN L_NAME L_RPAREN
 //		{ lp->yy_np = newnode(N_SUM);
-//		  lp->yy_np->left = newnode(N_NAME);
-//		  lp->yy_np->left->value = sdsnew($3);
-//		  $$ = lp->yy_np;
-//		}
-//	| L_RATE L_LPAREN L_NAME L_RPAREN
-//		{ lp->yy_np = newnode(N_RATE);
 //		  lp->yy_np->left = newnode(N_NAME);
 //		  lp->yy_np->left->value = sdsnew($3);
 //		  $$ = lp->yy_np;


### PR DESCRIPTION
To extend time-series query language with RATE() and ADD() functions, this PR is a very first thing I think about how to deal with the replies from Redis. (NOTE: the following code still has bugs, I will continue to fix them.) The following modified code part is to store timeseries values returned from Redis into the corresponding nodes in the parser tree.

A query statement will be transformed into a parser tree consist of struct node_t, then we will take processing on it. Since all the queries to Redis are async and I think there is no simple method to ensure the order of points' queries is correct according to the parser tree. Take an example, a query statement `metric.A + (metric.B + metric.C)[count:10]`, when we have the instances' values of A and going to compute them with B&C's, how can we know the instances' values of B&C's have been obtained? And there are other issues, assume that we do not use functions implemented in Redis, we request to Redis for values of `metric.A`, then `metric.B`, but when the reply to metric.A arrive, after the callback function being called we can never access the replies' values unless we save them somewhere.

That's the reason why I add `void **SID` and `pmSeriesValue ***series_values` into `struct node_t`. For each function-type node, use its child nodes' information to request to Redis and store the corresponding instance values into child nodes. And for the further functions' implementation, it's very convenient because for a function-type node, the values required for calculation have already existed in its child nodes.