### PR TITLE
Fix for broken link to installation guide

### DIFF
--- a/man/html/guide.html
+++ b/man/html/guide.html
@@ -58,7 +58,7 @@
 <a name="install"></a>
 <H1>Installation</H1>
 
-<P>PCP is available on all recent Linux distribution releases, including Debian/Fedora/RHEL/SUSE/Ubuntu. For other operating systems and distributions you might want to consider installation <A HREF="https://pcp.io/source.html">from sources</A>.
+<P>PCP is available on all recent Linux distribution releases, including Debian/Fedora/RHEL/SUSE/Ubuntu. For other operating systems and distributions you might want to consider installation <A HREF="https://github.com/performancecopilot/pcp/blob/master/INSTALL.md">from sources</A>.
 
 <a name="collectors"></a>
 <H3>Installing Collector Hosts</H3>


### PR DESCRIPTION
Fixes: [performancecopilot/pcp#916](https://github.com/performancecopilot/pcp/issues/916)