### PR TITLE
libpcp: open NSSDB readonly for clients

### DIFF
--- a/man/html/lab.secureclient.html
+++ b/man/html/lab.secureclient.html
@@ -121,7 +121,7 @@ Once this certificate has been received, it will be installed on the client.</P>
 	<TR><TD BGCOLOR="#e2e2e2" WIDTH="70%"><BR><IMG SRC="images/stepfwd_on.png" ALT="" WIDTH=16 HEIGHT=16 BORDER=0>&nbsp;&nbsp;&nbsp;Create the local CA:<BR>
 <PRE><B>
 $ openssl genrsa -out rootCA.key 2048
-$ openssl req -new -x509 -extensions v3_ca -key ca.key -out rootCA.crt -days 3650
+$ openssl req -new -x509 -extensions v3_ca -key rootCA.key -out rootCA.crt -days 3650
 .....
 Common Name (eg, your name or your server's hostname) []:myCA
 .....

--- a/src/libpcp/src/secureconnect.c
+++ b/src/libpcp/src/secureconnect.c
@@ -244,12 +244,12 @@ __pmInitCertificates(void)
      */
     if (__pmMakePath(dbpath(nssdb, sizeof(nssdb), "sql:"), 0700) < 0)
 	return 0;
-    secsts = NSS_InitReadWrite(nssdb);
+    secsts = NSS_Init(nssdb);
 
     if (secsts != SECSuccess) {
 	/* fallback, older versions of NSS do not support sql: */
 	dbpath(nssdb, sizeof(nssdb), "");
-	secsts = NSS_InitReadWrite(nssdb);
+	secsts = NSS_Init(nssdb);
     }
 
     if (secsts != SECSuccess)


### PR DESCRIPTION
I ran the secure tests, they all pass.
The code doesn't change the pmproxy part (with the comment regarding read/write), which is in `secureserver.c`.