### PR TITLE
refactor pmlogrewrite rules for linux pmda, qa, compilation warnings

### DIFF
--- a/qa/1198
+++ b/qa/1198
@@ -30,7 +30,7 @@ pmprobe -i disk.all | grep -v PM_IN_NULL
 
 echo
 echo "Check rewrite rules ..."
-pmlogrewrite -c $PCP_VAR_DIR/config/pmlogrewrite/disk_all_fixups.conf \
+pmlogrewrite -c $PCP_VAR_DIR/config/pmlogrewrite/linux_disk_all_fixups.conf \
     badarchives/bozo-vm-disk $tmp
 
 pmdumplog -z -a badarchives/bozo-vm-disk >$tmp.bad

--- a/qa/check.callback.sample
+++ b/qa/check.callback.sample
@@ -37,7 +37,7 @@ fi
 audit=/var/log/audit/audit.log
 sudo=`which sudo`
 
-# Did pmlogger.daily get run as expected?
+# Did pmlogger_daily get run as expected?
 # But don't bother if it is just after midnight!
 #
 case `pmdate %H:%M`
@@ -55,7 +55,7 @@ in
 	    bozo|bozo-vm|vm01|vm03|vm36)
 		    if [ ! -f $PCP_LOG_DIR/pmlogger/$host/$yesterday.meta.xz -a ! -f $PCP_LOG_DIR/pmlogger/$host/$yesterday.meta ]
 		    then
-			echo "check.callback: fail: pmlogger.daily not well!"
+			echo "check.callback: fail: pmlogger_daily not well!"
 			echo "Missing $yesterday archive ..."
 			ls -l $PCP_LOG_DIR/pmlogger/$host/$yesterday.*
 		    fi

--- a/qa/src/pmcdgone.c
+++ b/qa/src/pmcdgone.c
@@ -33,6 +33,7 @@ _ConnectLogger(void)
     int		n;
     int		pid = PM_LOG_PRIMARY_PID;
     int		port = PM_LOG_NO_PORT;
+    int		sts;
 
     if ((n = __pmConnectLogger("localhost", &pid, &port)) < 0) {
 	printf("Cannot connect to primary pmlogger on \"localhost\": %s\n", pmErrStr(n));
@@ -43,7 +44,9 @@ _ConnectLogger(void)
 	 * Lines starting "+ " are debug from pmcdgone, and get syphoned
 	 * off to the .full file in qa/025
 	 */
-	system(". $PCP_DIR/etc/pcp.env; ( ls -l $PCP_TMP_DIR/pmlogger/primary; cat $PCP_TMP_DIR/pmlogger/primary ) | sed -e 's/^/+ /' >&2");
+	sts = system(". $PCP_DIR/etc/pcp.env; ( ls -l $PCP_TMP_DIR/pmlogger/primary; cat $PCP_TMP_DIR/pmlogger/primary ) | sed -e 's/^/+ /' >&2");
+	if (sts != 0)
+	    fprintf(stderr, "Warning: ls returns %d\n", sts);
 	fprintf(stderr, "+ __pmConnectLogger: returns pid=%d port=%d\n", pid, port);
     }
 

--- a/src/pmdas/linux/.gitignore
+++ b/src/pmdas/linux/.gitignore
@@ -4,7 +4,4 @@ help.pag
 pmda_linux.so
 pmdalinux
 exports
-linux_kernel_ulong.conf
-linux_kernel_fixups.conf
-proc_fs_nfsd_fixups.conf
-proc_net_sockstat_deprecate.conf
+kernel_ulong.conf

--- a/src/pmdas/linux/GNUmakefile
+++ b/src/pmdas/linux/GNUmakefile
@@ -58,11 +58,7 @@ HFILES		= linux.h linux_table.h convert.h namespaces.h \
 
 VERSION_SCRIPT	= exports
 HELPTARGETS	= help.dir help.pag
-CONFTARGETS	= linux_kernel_ulong.conf \
-		  linux_kernel_fixups.conf \
-		  proc_net_sockstat_deprecate.conf \
-		  proc_fs_nfsd_fixups.conf \
-		  disk_all_fixups.conf \
+CONFTARGETS	= kernel_ulong.conf
 
 LDIRT		= $(HELPTARGETS) domain.h $(VERSION_SCRIPT) $(CONFTARGETS)
 
@@ -85,6 +81,8 @@ build-me: $(LIBTARGET) $(CMDTARGET) $(HELPTARGETS) $(CONFTARGETS)
 	    fi; \
 	fi
 
+# Note: pmlogrewrite configs are installed with linux_ prefix
+#
 install: default
 	$(INSTALL) -m 755 -d $(PMDADIR)
 	$(INSTALL) -m 644 domain.h help $(HELPTARGETS) $(PMDADIR)
@@ -94,8 +92,9 @@ install: default
 	$(INSTALL) -m 644 proc_fs_nfsd_fixups.conf $(LOGREWRITEDIR)/linux_proc_fs_nfsd_fixups.conf
 	$(INSTALL) -m 644 proc_net_snmp_migrate.conf $(LOGREWRITEDIR)/linux_proc_net_snmp_migrate.conf
 	$(INSTALL) -m 644 proc_net_tcp_migrate.conf $(LOGREWRITEDIR)/linux_proc_net_tcp_migrate.conf
-	$(INSTALL) -m 644 linux_kernel_ulong.conf linux_kernel_fixups.conf $(LOGREWRITEDIR)
-	$(INSTALL) -m 644 disk_all_fixups.conf $(LOGREWRITEDIR)/disk_all_fixups.conf
+	$(INSTALL) -m 644 disk_all_fixups.conf $(LOGREWRITEDIR)/linux_disk_all_fixups.conf
+	$(INSTALL) -m 644 kernel_fixups.conf $(LOGREWRITEDIR)/linux_kernel_fixups.conf
+	$(INSTALL) -m 644 kernel_ulong.conf $(LOGREWRITEDIR)/linux_kernel_ulong.conf
 else
 build-me:
 install:

--- a/src/pmdas/linux/kernel_fixups.conf
+++ b/src/pmdas/linux/kernel_fixups.conf
@@ -1,0 +1,45 @@
+# These metrics are all exported from the linux PMDA and
+# parts of their metadata have changed over time to fix
+# previous errors.
+#
+# The rules here allow rewriting of old archives to produce
+# archives with metadata that matches the current PMDA
+# implementation.
+
+# swapdev.priority had the wrong Units:
+#
+metric swapdev.priority { units -> 0,0,0,0,0,0 }
+
+# network.interface.baudrate changed to 64 bits:
+#
+metric network.interface.baudrate { type -> U64 }
+
+# hinv.cpu.cache had incorrect units:
+#
+metric hinv.cpu.cache { units -> 1,0,0,KBYTE,0,0 }
+
+# hinv.cpu.clock is frequency in MHz which had incorrect units:
+#
+metric hinv.cpu.clock { units -> 0,-1,0,0,USEC,0 }
+
+# several string typed metrics should be discrete; their string value
+# prevails over time and changes very infrequently, if at all.
+#
+metric kernel.uname.release { sem -> discrete }
+metric kernel.uname.version { sem -> discrete }
+metric kernel.uname.sysname { sem -> discrete }
+metric kernel.uname.machine { sem -> discrete }
+metric kernel.uname.nodename { sem -> discrete }
+metric kernel.uname.distro { sem -> discrete }
+metric pmda.uname { sem -> discrete }
+metric pmda.version { sem -> discrete }
+metric disk.dev.scheduler { sem -> discrete }
+metric network.interface.inet_addr { sem -> discrete }
+metric network.interface.ipv6_addr { sem -> discrete }
+metric network.interface.ipv6_scope { sem -> discrete }
+metric network.interface.hw_addr { sem -> discrete }
+
+# kernel.all.uptime and kernel.all.idletime changed to double:
+#
+metric kernel.all.uptime { type -> DOUBLE }
+metric kernel.all.idletime { type -> DOUBLE }

--- a/src/pmdas/linux/mk.rewrite
+++ b/src/pmdas/linux/mk.rewrite
@@ -1,11 +1,9 @@
 #!/bin/sh
 #
 # Construct pmlogrewrite rules ...
-# linux_kernel_ulong.conf
+# kernel_ulong.conf
 #	Needs to be done dynamically because the type of KERNEL_ULONG is
 #	platform dependent.
-# linux_kernel_fixups.conf
-#	Miscellaneous corrections to metadata for the linux PMDA.
 #
 
 tmp=/var/tmp/$$
@@ -25,7 +23,7 @@ End-of-File
 eval `${CPP-cpp} -I${INCDIR-.} $tmp.c \
       | sed -n -e '/KERNEL_ULONG/s/PM_TYPE_//p'`
 
-cat <<End-of-File >linux_kernel_ulong.conf
+cat <<End-of-File >kernel_ulong.conf
 # These metrics are all exported from the linux PMDA
 # using the KERNEL_ULONG type which might be U32
 # or could be U64.
@@ -96,84 +94,6 @@ metric disk.dev.blktotal { type -> U64 }
 # and this one was KERNEL_ULONG in this file, but that was incorrect
 #
 metric disk.dm.total { type -> U64 }
-End-of-File
-
-cat <<End-of-File >linux_kernel_fixups.conf
-# These metrics are all exported from the linux PMDA and
-# parts of their metadata have changed over time to fix
-# previous errors.
-#
-# The rules here allow rewriting of old archives to produce
-# archives with metadata that matches the current PMDA
-# implementation.
-
-# swapdev.priority had the wrong Units:
-#
-metric swapdev.priority { units -> 0,0,0,0,0,0 }
-
-# network.interface.baudrate changed to 64 bits:
-#
-metric network.interface.baudrate { type -> U64 }
-
-# hinv.cpu.cache had incorrect units:
-#
-metric hinv.cpu.cache { units -> 1,0,0,KBYTE,0,0 }
-
-# hinv.cpu.clock is frequency in MHz which had incorrect units:
-#
-metric hinv.cpu.clock { units -> 0,-1,0,0,USEC,0 }
-
-# several string typed metrics should be discrete; their string value
-# prevails over time and changes very infrequently, if at all.
-#
-metric kernel.uname.release { sem -> discrete }
-metric kernel.uname.version { sem -> discrete }
-metric kernel.uname.sysname { sem -> discrete }
-metric kernel.uname.machine { sem -> discrete }
-metric kernel.uname.nodename { sem -> discrete }
-metric kernel.uname.distro { sem -> discrete }
-metric pmda.uname { sem -> discrete }
-metric pmda.version { sem -> discrete }
-metric disk.dev.scheduler { sem -> discrete }
-metric network.interface.inet_addr { sem -> discrete }
-metric network.interface.ipv6_addr { sem -> discrete }
-metric network.interface.ipv6_scope { sem -> discrete }
-metric network.interface.hw_addr { sem -> discrete }
-
-# kernel.all.uptime and kernel.all.idletime changed to double:
-#
-metric kernel.all.uptime { type -> DOUBLE }
-metric kernel.all.idletime { type -> DOUBLE }
-
-End-of-File
-
-cat <<End-of-File >proc_net_sockstat_deprecate.conf
-
-# Copyright 2017 Red Hat.
-#
-# pmlogrewrite configuration for deprecating network.sockstat.{tcp,udp,raw}.{highest,util}
-#
-metric network.sockstat.tcp.highest { DELETE }
-metric network.sockstat.tcp.util { DELETE }
-metric network.sockstat.udp.highest { DELETE }
-metric network.sockstat.udp.util { DELETE }
-metric network.sockstat.raw.highest { DELETE }
-metric network.sockstat.raw.util { DELETE }
-
-End-of-File
-
-cat <<End-of-File >proc_fs_nfsd_fixups.conf
-
-# Copyright 2018 Red Hat.
-#
-# pmlogrewrite configuration for migrating archives containing old
-# NFS server thread metrics with counter semantics to instantaneous
-# semantics.
-#
-
-metric nfs.server.threads.pools { sem -> INSTANT }
-metric nfs.server.threads.total { sem -> INSTANT }
-
 End-of-File
 
 exit 0

--- a/src/pmdas/linux/proc_fs_nfsd_fixups.conf
+++ b/src/pmdas/linux/proc_fs_nfsd_fixups.conf
@@ -1,0 +1,9 @@
+# Copyright 2018 Red Hat.
+#
+# pmlogrewrite configuration for migrating archives containing old
+# NFS server thread metrics with counter semantics to instantaneous
+# semantics.
+#
+
+metric nfs.server.threads.pools { sem -> INSTANT }
+metric nfs.server.threads.total { sem -> INSTANT }

--- a/src/pmdas/linux/proc_net_sockstat_deprecate.conf
+++ b/src/pmdas/linux/proc_net_sockstat_deprecate.conf
@@ -1,0 +1,12 @@
+# Copyright 2017 Red Hat.
+#
+# pmlogrewrite configuration for deprecating network.sockstat.{tcp,udp,raw}.{highest,util}
+#
+# DO NOT INSTALL this file ... the names in the PMNS have gone.
+#
+metric network.sockstat.tcp.highest { DELETE }
+metric network.sockstat.tcp.util { DELETE }
+metric network.sockstat.udp.highest { DELETE }
+metric network.sockstat.udp.util { DELETE }
+metric network.sockstat.raw.highest { DELETE }
+metric network.sockstat.raw.util { DELETE }

--- a/src/pmlogconf/pmlogconf.c
+++ b/src/pmlogconf/pmlogconf.c
@@ -1014,6 +1014,7 @@ create_tempfile(FILE *file, FILE **tempfile, struct stat *stat)
     FILE		*fp;
     char		bytes[BUFSIZ];
     mode_t		cur_umask;
+    int			sts;
 
     /* create a temporary file in the same directory as config (for rename) */
     pmsprintf(bytes, sizeof(bytes), "%s.new", config);
@@ -1036,8 +1037,14 @@ create_tempfile(FILE *file, FILE **tempfile, struct stat *stat)
     umask(cur_umask);
 
     if (stat) {
-	fchown(fd, stat->st_uid, stat->st_gid);
-	fchmod(fd, stat->st_mode);
+	if ((sts = fchown(fd, stat->st_uid, stat->st_gid)) < 0) {
+	    fprintf(stderr, "%s: Warning: fchown() failed: %s\n",
+			pmGetProgname(), osstrerror());
+	}
+	if ((sts = fchmod(fd, stat->st_mode)) < 0) {
+	    fprintf(stderr, "%s: Warning: fchmod() failed: %s\n",
+			pmGetProgname(), osstrerror());
+	}
     }
 
     *tempfile = fp;

--- a/src/python/pmapi.c
+++ b/src/python/pmapi.c
@@ -951,7 +951,10 @@ pmnsDecodeCallback(const char *name, void *closure)
 static PyObject *
 pmUnits_int(PyObject *self, PyObject *args, PyObject *keywords)
 {
-    pmUnits units = {0};
+    union {
+	pmUnits		units;
+	unsigned int	uint;
+    } val;
     unsigned int dimSpace = 0, dimTime = 0, dimCount = 0;
     unsigned int scaleSpace = 0, scaleTime = 0, scaleCount = 0;
     char *keyword_list[] = {"dimSpace", "dimTime", "dimCount",
@@ -963,14 +966,15 @@ pmUnits_int(PyObject *self, PyObject *args, PyObject *keywords)
 		&scaleSpace, &scaleTime, &scaleCount))
 	return NULL;
 
-    units.dimSpace = dimSpace;
-    units.dimTime = dimTime;
-    units.dimCount = dimCount;
-    units.scaleSpace = scaleSpace;
-    units.scaleTime = scaleTime;
-    units.scaleCount = scaleCount;
+    val.uint = 0;
+    val.units.dimSpace = dimSpace;
+    val.units.dimTime = dimTime;
+    val.units.dimCount = dimCount;
+    val.units.scaleSpace = scaleSpace;
+    val.units.scaleTime = scaleTime;
+    val.units.scaleCount = scaleCount;
 
-    return Py_BuildValue("i", *(unsigned int *)&units);
+    return Py_BuildValue("i", val.uint);
 }
 
 /*


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200523

Ken McDonell (5):
      linux pmda: rework the pmlogrewrite conf file handling
      src/pmlogconf/pmlogconf.c: fix a couple of compilation warnings
      qa/check.callback.sample: fix misleading typo in name of pmlogger_daily
      qa/src/pmcdgone.c: remove one last system() compilation warning
      src/python/pmapi.c: remove (scary) compilation warning

 qa/1198                                          |    2 
 qa/check.callback.sample                         |    4 -
 qa/src/pmcdgone.c                                |    5 +
 src/pmdas/linux/.gitignore                       |    5 -
 src/pmdas/linux/GNUmakefile                      |   13 +--
 src/pmdas/linux/kernel_fixups.conf               |   45 ++++++++++++
 src/pmdas/linux/mk.rewrite                       |   84 -----------------------
 src/pmdas/linux/proc_fs_nfsd_fixups.conf         |    9 ++
 src/pmdas/linux/proc_net_sockstat_deprecate.conf |   12 +++
 src/pmlogconf/pmlogconf.c                        |   11 ++-
 src/python/pmapi.c                               |   20 +++--
 11 files changed, 103 insertions(+), 107 deletions(-)

Details ...

commit 5f36b15f53d2b96c04d57f87376bb45c9bc8e2f2
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat May 23 09:29:47 2020 +1000

    src/python/pmapi.c: remove (scary) compilation warning
    
    This one:
    pmapi.c:973:32: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
      973 |     return Py_BuildValue("i", *(unsigned int *)&units);
          |                                ^~~~~~~~~~~~~~~~~~~~~~
    has been there for a long time ... finally annoyed me enough to make it go away.

commit 4bf46e293d3b56e0aed9b8de13baaddb5f847acb
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat May 23 09:21:15 2020 +1000

    qa/src/pmcdgone.c: remove one last system() compilation warning

commit 157174c7a0ee03174715412cfca135155182031f
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat May 23 09:20:45 2020 +1000

    qa/check.callback.sample: fix misleading typo in name of pmlogger_daily

commit 833f05938471f9390910e5545fd8fd05bb718b62
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat May 23 09:17:13 2020 +1000

    src/pmlogconf/pmlogconf.c: fix a couple of compilation warnings
    
    Check return values from fchown() and ftruncate().

commit 846b3de5037af6f172215117d1ccf7e87ddd9156
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat May 23 07:50:47 2020 +1000

    linux pmda: rework the pmlogrewrite conf file handling
    
    My last checkin was wrong and broke the build.  Now mk.rewrite
    only generates the ones that are platform-dependent, and the
    constant ones are checked into git.
    
    When installed, disk_all... got renamed to linux_disk_all... for
    consistency.