### PR TITLE
build & configure

### DIFF
--- a/Makepkgs
+++ b/Makepkgs
@@ -225,6 +225,23 @@ then
     # $(configure_tools)
     #
     configopts=''
+    if [ -f /etc/lsb-release ]
+    then
+	if grep -q 'DISTRIB_ID=Ubuntu' /etc/lsb-release
+	then
+	    eval `grep DISTRIB_RELEASE= /etc/lsb-release`
+	    XDISTRIB_RELEASE=`echo $DISTRIB_RELEASE | sed -e 's/[^0-9]//g'`
+	    [ -z "$XDISTRIB_RELEASE" ] && XDISTRIB_RELEASE=0000
+	    if [ $XDISTRIB_RELEASE -gt 2004 ]
+	    then
+		# As of Ubuntu 20.04 the Python2 dependency packages have
+		# been renamed (at least python-dev -> python-dev-is-python2)
+		# so try building without Python2
+		#
+		configopts='$configopts --without-python'
+	    fi
+	fi
+    fi
 elif $dorpm
 then
     # On RPM-based platforms, rpm macros provide an excellent set of defaults.

--- a/configure
+++ b/configure
@@ -691,7 +691,6 @@ pcp_pmloggercontrol_path
 pcp_pmsnapcontrol_path
 pcp_pmiecontrol_path
 pcp_pmproxyoptions_path
-pcp_pmmgroptions_path
 pcp_pmcdrclocal_path
 pcp_pmcdoptions_path
 pcp_pmcdconf_path
@@ -743,7 +742,6 @@ pcp_selinux_cap_userns_ptrace
 pcp_selinux_dir
 enable_selinux
 SEINFO
-enable_manager
 PMDA_POSTFIX
 QSHAPE
 PMDA_RPM
@@ -971,6 +969,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -1019,8 +1018,6 @@ with_pmdabpftrace
 with_pmdajson
 with_pmdanutcracker
 with_pmdasnmp
-with_manager
-with_webapi
 with_selinux
 with_make
 with_tar
@@ -1118,6 +1115,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -1370,6 +1368,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1507,7 +1514,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1660,6 +1667,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -1741,8 +1749,6 @@ Optional Packages:
   --with-pmdajson         enable JSON pmda (default is on)
   --with-pmdanutcracker   enable nutcracker pmda (default is on)
   --with-pmdasnmp         enable SNMP pmda (default is on)
-  --with-manager          enable daemon manager (default is on)
-  --with-webapi           enable REST API daemon (default is on)
   --with-selinux          enable building of selinux package (default is on)
   --with-make             path to GNU compatible make(1) (default is empty for
                           auto discovery)
@@ -2929,24 +2935,6 @@ if test "${with_pmdasnmp+set}" = set; then :
   withval=$with_pmdasnmp; do_pmdasnmp=$withval; PACKAGE_CONFIGURE="$PACKAGE_CONFIGURE --with-pmdasnmp=$withval"
 else
   do_pmdasnmp=check
-fi
-
-
-
-# Check whether --with-manager was given.
-if test "${with_manager+set}" = set; then :
-  withval=$with_manager; do_manager=$withval; PACKAGE_CONFIGURE="$PACKAGE_CONFIGURE --with-manager=$withval"
-else
-  do_manager=check
-fi
-
-
-
-# Check whether --with-webapi was given.
-if test "${with_webapi+set}" = set; then :
-  withval=$with_webapi; do_webapi=$withval; PACKAGE_CONFIGURE="$PACKAGE_CONFIGURE --with-webapi=$withval"
-else
-  do_webapi=check
 fi
 
 
@@ -11585,52 +11573,6 @@ if $pmda_postfix; then { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }; else { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }; fi
 
-enable_manager=false
-if test "x$do_manager" != "xno"; then :
-
-    enable_manager=true
-
-    if test "$target_os" = "mingw"
-    then
-	enable_manager=false
-	test "$do_manager" != "check" && \
-	as_fn_error $? "MinGW build, cannot enable daemon manager" "$LINENO" 5
-    elif test "x$cxx" = "x"
-    then
-	enable_manager=false
-	test "$do_manager" != "check" && \
-	as_fn_error $? "C++ compiler unavailable, cannot enable daemon manager" "$LINENO" 5
-    fi
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking compilation features for daemon manager" >&5
-$as_echo_n "checking compilation features for daemon manager... " >&6; }
-    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
- #ifndef _XOPEN_SOURCE
-	  #define _XOPEN_SOURCE 600
-	  #endif
-	  #include <stdio.h>
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-$as_echo "yes" >&6; }
-else
-  enable_manager=false
-	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-
-fi
-
-
 for ac_prog in seinfo
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
@@ -14291,12 +14233,10 @@ pcp_sysconf_dir=`eval echo $pcp_sysconf_dir`
 pcp_pmcdconf_path=$pcp_sysconf_dir/pmcd/pmcd.conf
 pcp_pmcdrclocal_path=$pcp_sysconf_dir/pmcd/rc.local
 pcp_pmcdoptions_path=$pcp_sysconf_dir/pmcd/pmcd.options
-pcp_pmmgroptions_path=$pcp_sysconf_dir/pmmgr/pmmgr.options
 pcp_pmproxyoptions_path=$pcp_sysconf_dir/pmproxy/pmproxy.options
 pcp_pmiecontrol_path=$pcp_sysconf_dir/pmie/control
 pcp_pmsnapcontrol_path=$pcp_sysconf_dir/pmsnap/control
 pcp_pmloggercontrol_path=$pcp_sysconf_dir/pmlogger/control
-
 
 
 
@@ -15114,6 +15054,19 @@ done
 if test x"$man_header" = "x'\\\" t" -o x"$man_header" = "x'\\\" te" ; then
     need_old_tbl_header=true
 fi
+
+if $have_manpages
+then
+    :
+else
+                        if test $target_distro = debian
+    then
+	have_manpages=true
+	have_gzipped_manpages=true
+	need_old_tbl_header=true
+    fi
+fi
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -3342,6 +3342,24 @@ done
 if test x"$man_header" = "x'\\\" t" -o x"$man_header" = "x'\\\" te" ; then
     need_old_tbl_header=true
 fi
+
+if $have_manpages
+then
+    :
+else
+    dnl We can get here ($have_manpages == false) for container-based
+    dnl builds.
+    dnl For Debian packaging, we _must_ include the man pages, so 
+    dnl take the known and good settings ...
+    dnl
+    if test $target_distro = debian
+    then
+	have_manpages=true
+	have_gzipped_manpages=true
+	need_old_tbl_header=true
+    fi
+fi
+
 AC_SUBST(pcp_man_dir)
 AC_SUBST(have_manpages)
 AC_SUBST(have_gzipped_manpages)

--- a/debian/GNUmakefile
+++ b/debian/GNUmakefile
@@ -25,9 +25,9 @@ PCPIMPORTSAR = pcp-import-sar2pcp
 PCPIMPORTSAR_FILES = pcp-import-sar2pcp.install
 PCPIMPORTSAR_DOC_DIR = $(PCP_DOC_DIR)/../pcp-import-sar2pcp
 
-PCPIMPORTSAR = pcp-import-ganglia2pcp
-PCPIMPORTSAR_FILES = pcp-import-ganglia2pcp.install
-PCPIMPORTSAR_DOC_DIR = $(PCP_DOC_DIR)/../pcp-import-ganglia2pcp
+PCPIMPORTGANGLIA = pcp-import-ganglia2pcp
+PCPIMPORTGANGLIA_FILES = pcp-import-ganglia2pcp.install
+PCPIMPORTGANGLIA_DOC_DIR = $(PCP_DOC_DIR)/../pcp-import-ganglia2pcp
 
 PCPIMPORTMRTG = pcp-import-mrtg2pcp
 PCPIMPORTMRTG_FILES = pcp-import-mrtg2pcp.install
@@ -105,7 +105,7 @@ LDIRT = *.debhelper *.substvars *.log pcp files pcp.postrm \
 	$(LIBIMPORTPCP) $(LIBIMPORTPCP)-dev \
 	$(LIBWEBPCP) $(LIBWEBPCP)-dev \
 	$(PCPIMPORTSAR) $(PCPIMPORTMRTG) $(PCPIMPORTSHEET) $(PCPIMPORTIOSTAT) \
-	$(PCPIMPORTCOLLECTL)
+	$(PCPIMPORTCOLLECTL) $(PCPIMPORTGANGLIA)
 
 default: pcp.preinst pcp.postinst pcp.postrm control pcp-gui.install
 
@@ -248,6 +248,13 @@ ifeq ($(PACKAGE_DISTRIBUTION), debian)
 	$(INSTALL) -m 755 -d $(PCPIMPORTSAR_DOC_DIR)
 	$(INSTALL) -m 644 copyright $(PCPIMPORTSAR_DOC_DIR)
 	$(INSTALL) -m 644 changelog $(PCPIMPORTSAR_DOC_DIR)/changelog.Debian
+endif
+
+install-pcpimportganglia: default
+ifeq ($(PACKAGE_DISTRIBUTION), debian)
+	$(INSTALL) -m 755 -d $(PCPIMPORTGANGLIA_DOC_DIR)
+	$(INSTALL) -m 644 copyright $(PCPIMPORTGANGLIA_DOC_DIR)
+	$(INSTALL) -m 644 changelog $(PCPIMPORTGANGLIA_DOC_DIR)/changelog.Debian
 endif
 
 install-pcpimportmrtg: default

--- a/qa/admin/myconfigure
+++ b/qa/admin/myconfigure
@@ -83,6 +83,23 @@ then
 	echo "Botch: cannot get configopts from configure_paths in debian/rules"
 	exit 1
     fi
+    if [ -f /etc/lsb-release ]
+    then
+	if grep -q 'DISTRIB_ID=Ubuntu' /etc/lsb-release
+	then
+	    eval `grep DISTRIB_RELEASE= /etc/lsb-release`
+	    XDISTRIB_RELEASE=`echo $DISTRIB_RELEASE | sed -e 's/[^0-9]//g'`
+	    [ -z "$XDISTRIB_RELEASE" ] && XDISTRIB_RELEASE=0000
+	    if [ $XDISTRIB_RELEASE -gt 2004 ]
+	    then
+		# As of Ubuntu 20.04 the Python2 dependency packages have
+		# been renamed (at least python-dev -> python-dev-is-python2)
+		# so try building without Python2
+		#
+		configopts='$configopts --without-python'
+	    fi
+	fi
+    fi
     # and optionally configure_tools from debian/rules also ...
     #
     configtools=`sed -n <debian/rules -e '/^configure_tools/s/^[^=]*= *//p'`

--- a/src/pmie/rc_pmie
+++ b/src/pmie/rc_pmie
@@ -117,7 +117,7 @@ _start_pmcheck()
 {
     bgstatus=0
     bgtmp=`mktemp -d $PCP_DIR/var/tmp/pcp.XXXXXXXXX` || exit 1
-    trap "rm -rf $bgtmp; exit \$bgstatus" 0 1 2 3 15
+    trap "rm -rf $tmp $bgtmp; exit \$bgstatus" 0 1 2 3 15
 
     wait_option=''
     [ ! -z "$PMCD_WAIT_TIMEOUT" ] && wait_option="-t $PMCD_WAIT_TIMEOUT" 

--- a/src/pmlogger/rc_pmlogger
+++ b/src/pmlogger/rc_pmlogger
@@ -94,7 +94,7 @@ _start_pmcheck()
 {
     bgstatus=0
     bgtmp=`mktemp -d $PCP_DIR/var/tmp/pcp.XXXXXXXXX` || exit 1
-    trap "rm -rf $bgtmp; exit \$bgstatus" 0 1 2 3 15
+    trap "rm -rf $tmp $bgtmp; exit \$bgstatus" 0 1 2 3 15
 
     pmlogger_check $VFLAG >$bgtmp/pmcheck.out 2>$bgtmp/pmcheck
     bgstatus=$?


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200607

Ken McDonell (4):
      Makepkgs: default configure --without-python for Ubuntu 20.04 (and later)
      configure.ac: Force man pages for Debian-style builds
      debian/GNUmakefile: fix cut-n-paste botch for ganglia2pcp packaging
      pmie/rc_pmie & pmlogger/rc_pmlogger: fix trap snarfoo

 Makepkgs                 |   17 ++++++++
 configure                |   99 ++++++++++++-----------------------------------
 configure.ac             |   18 ++++++++
 debian/GNUmakefile       |   15 +++++--
 qa/admin/myconfigure     |   17 ++++++++
 src/pmie/rc_pmie         |    2 
 src/pmlogger/rc_pmlogger |    2 
 7 files changed, 91 insertions(+), 79 deletions(-)

Details ...

commit 18d428197f23fac1cbdc546a0bfca3e4f9730585
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jun 7 09:44:25 2020 +1000

    pmie/rc_pmie & pmlogger/rc_pmlogger: fix trap snarfoo
    
    The nested trap was leaving behind directory turds in
    $PCP_DIR/var/tmp/pcp.XXXXXXXXX and there was a file called "tmp"
    therein that contained output from _get_pids_by_name().

commit 558d789726a8d6323595408421df7d3a50b3d271
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jun 7 09:42:21 2020 +1000

    debian/GNUmakefile: fix cut-n-paste botch for ganglia2pcp packaging
    
    PCPIMPORTSAR* macros defined twice (!), no macros for PCPIMPORTGANGLIA*.
    
    Also install-pcpimportganglia target and rules block was missing.

commit 22eff066489921a4071ba1d8bbdda7c213cbfc71
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jun 7 09:38:04 2020 +1000

    configure.ac: Force man pages for Debian-style builds
    
    The dpkg packaging rules expect the man pages to be present, but our
    "smart" configure logic for figuring out what style of man pages
    are required was failing on container-based builds in CI (presumably
    because there are no man pages installed there).
    
    Force the inclusion of the man pages by setting the relevant variables
    if the "smart" logic fails to set them.
    
    Also picked up that configure was not remade after last configure.ac
    change, so there are some changes in configure that are not caused
    by the configure.ac changes in this commit.

commit 9ce7e2dbb3bfc46dfee07652aea5a5f6cb08c3f5
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jun 7 09:30:10 2020 +1000

    Makepkgs: default configure --without-python for Ubuntu 20.04 (and later)
    
    In Ubuntu 20.04 the Python2 package names changed in ways that breaks
    our dpkg packaging ... so just don't use Python2 in the build here.
    
    Same change made in qa/admin/myconfigure (as this needs to track the
    configure logic from Makepkgs).