### PR TITLE
fix of incomplete initialization of __pmHashCtl struct of F_REGEX node

### DIFF
--- a/src/libpcp/src/derive_parser.y.in
+++ b/src/libpcp/src/derive_parser.y.in
@@ -2594,6 +2594,7 @@ regexpr	: opt_bang L_PATTERN
 		  }
 		  np->data.pattern->invert = $1;
 		  np->data.pattern->used = 0;
+		  np->data.pattern->hash.hsize = 0;
 		  np->data.pattern->hash.hash = NULL;
 		  $$ = np;
 		}


### PR DESCRIPTION
This is a follow up of f8b0886ba5027d29aeec5223da7866c62084cb2b commit.
The commit above delivered initialization of hash structure for a node. Unfortunately
hsize field was not set during the initialization. The unset hsize is causing intermittent
crashes of pminfo when the hash table is walked through.
This fix delivers initialization of the hsize field.