### PR TITLE
small pmlogctl changes

### DIFF
--- a/qa/1204
+++ b/qa/1204
@@ -46,12 +46,25 @@ _filter()
     # end
 }
 
+# Build filter for any existing non-qa and non-primary pmlogger instances.
+# The "pmcd Host" and "Class" fields from the pmlogctl status output
+# should suffice to uniquely identify each.
+#
+pmlogctl status 2>&1 \
+| $PCP_AWK_PROG >$tmp.awk '
+NR == 1	{ next }
+NF >= 5	{ if ($3 == "primary") next
+	  print "$1 == \"" $1 "\" && $3 == \"" $3 "\" { next }"
+	}
+END	{ print "{ print }" }'
+
 # Note status command output order is non-deterministic, hence the sort
 # at the end
 #
 _filter_status()
 {
     tee -a $seq.full \
+    | $PCP_AWK_PROG -f $tmp.awk \
     | sed >$tmp.tmp \
 	-e "/^`hostname` .* primary /d" \
 	-e 's/[ 	][ 	]*/ /g' \

--- a/qa/1205
+++ b/qa/1205
@@ -51,12 +51,25 @@ _filter()
     # end
 }
 
+# Build filter for any existing non-qa and non-primary pmlogger instances.
+# The "pmcd Host" and "Class" fields from the pmlogctl status output
+# should suffice to uniquely identify each.
+#
+pmlogctl status 2>&1 \
+| $PCP_AWK_PROG >$tmp.awk '
+NR == 1	{ next }
+NF >= 5	{ if ($3 == "primary") next
+	  print "$1 == \"" $1 "\" && $3 == \"" $3 "\" { next }"
+	}
+END	{ print "{ print }" }'
+
 # Note status command output order is non-deterministic, hence the sort
 # at the end
 #
 _filter_status()
 {
     tee -a $seq.full \
+    | $PCP_AWK_PROG -f $tmp.awk \
     | sed >$tmp.tmp \
 	-e "/^`hostname` .* primary /d" \
 	-e 's/[ 	][ 	]*/ /g' \

--- a/qa/1206
+++ b/qa/1206
@@ -51,12 +51,25 @@ _filter()
     # end
 }
 
+# Build filter for any existing non-qa and non-primary pmlogger instances.
+# The "pmcd Host" and "Class" fields from the pmlogctl status output
+# should suffice to uniquely identify each.
+#
+pmlogctl status 2>&1 \
+| $PCP_AWK_PROG >$tmp.awk '
+NR == 1	{ next }
+NF >= 5	{ if ($3 == "primary") next
+	  print "$1 == \"" $1 "\" && $3 == \"" $3 "\" { next }"
+	}
+END	{ print "{ print }" }'
+
 # Note status command output order is non-deterministic, hence the sort
 # at the end
 #
 _filter_status()
 {
     tee -a $seq.full \
+    | $PCP_AWK_PROG -f $tmp.awk \
     | sed >$tmp.tmp \
 	-e "/^`hostname` .* primary /d" \
 	-e 's/[ 	][ 	]*/ /g' \

--- a/qa/1208
+++ b/qa/1208
@@ -52,12 +52,25 @@ _filter()
     # end
 }
 
+# Build filter for any existing non-qa and non-primary pmlogger instances.
+# The "pmcd Host" and "Class" fields from the pmlogctl status output
+# should suffice to uniquely identify each.
+#
+pmlogctl status 2>&1 \
+| $PCP_AWK_PROG >$tmp.awk '
+NR == 1	{ next }
+NF >= 5	{ if ($3 == "primary") next
+	  print "$1 == \"" $1 "\" && $3 == \"" $3 "\" { next }"
+	}
+END	{ print "{ print }" }'
+
 # Note status command output order is non-deterministic, hence the sort
 # at the end
 #
 _filter_status()
 {
     tee -a $seq.full \
+    | $PCP_AWK_PROG -f $tmp.awk \
     | sed >$tmp.tmp \
 	-e "/^`hostname` .* primary /d" \
 	-e 's/[ 	][ 	]*/ /g' \

--- a/qa/1209
+++ b/qa/1209
@@ -51,12 +51,25 @@ _filter()
     # end
 }
 
+# Build filter for any existing non-qa and non-primary pmlogger instances.
+# The "pmcd Host" and "Class" fields from the pmlogctl status output
+# should suffice to uniquely identify each.
+#
+pmlogctl status 2>&1 \
+| $PCP_AWK_PROG >$tmp.awk '
+NR == 1	{ next }
+NF >= 5	{ if ($3 == "primary") next
+	  print "$1 == \"" $1 "\" && $3 == \"" $3 "\" { next }"
+	}
+END	{ print "{ print }" }'
+
 # Note status command output order is non-deterministic, hence the sort
 # at the end
 #
 _filter_status()
 {
     tee -a $seq.full \
+    | $PCP_AWK_PROG -f $tmp.awk \
     | sed >$tmp.tmp \
 	-e "/^`hostname` .* primary /d" \
 	-e 's/[ 	][ 	]*/ /g' \

--- a/qa/1210
+++ b/qa/1210
@@ -49,12 +49,25 @@ _filter()
     # end
 }
 
+# Build filter for any existing non-qa and non-primary pmlogger instances.
+# The "pmcd Host" and "Class" fields from the pmlogctl status output
+# should suffice to uniquely identify each.
+#
+pmlogctl status 2>&1 \
+| $PCP_AWK_PROG >$tmp.awk '
+NR == 1	{ next }
+NF >= 5	{ if ($3 == "primary") next
+	  print "$1 == \"" $1 "\" && $3 == \"" $3 "\" { next }"
+	}
+END	{ print "{ print }" }'
+
 # Note status command output order is non-deterministic, hence the sort
 # at the end
 #
 _filter_status()
 {
     tee -a $seq.full \
+    | $PCP_AWK_PROG -f $tmp.awk \
     | sed >$tmp.tmp \
 	-e "/^`hostname` .* primary /d" \
 	-e 's/[ 	][ 	]*/ /g' \

--- a/qa/1213
+++ b/qa/1213
@@ -59,12 +59,25 @@ _filter()
     # end
 }
 
+# Build filter for any existing non-qa and non-primary pmlogger instances.
+# The "pmcd Host" and "Class" fields from the pmlogctl status output
+# should suffice to uniquely identify each.
+#
+pmlogctl status 2>&1 \
+| $PCP_AWK_PROG >$tmp.awk '
+NR == 1	{ next }
+NF >= 5	{ if ($3 == "primary") next
+	  print "$1 == \"" $1 "\" && $3 == \"" $3 "\" { next }"
+	}
+END	{ print "{ print }" }'
+
 # Note status command output order is non-deterministic, hence the sort
 # at the end
 #
 _filter_status()
 {
     tee -a $seq.full \
+    | $PCP_AWK_PROG -f $tmp.awk \
     | sed >$tmp.tmp \
 	-e "/^`hostname` .* primary /d" \
 	-e 's/[ 	][ 	]*/ /g' \

--- a/qa/1215
+++ b/qa/1215
@@ -49,12 +49,25 @@ _filter()
     # end
 }
 
+# Build filter for any existing non-qa and non-primary pmlogger instances.
+# The "pmcd Host" and "Class" fields from the pmlogctl status output
+# should suffice to uniquely identify each.
+#
+pmlogctl status 2>&1 \
+| $PCP_AWK_PROG >$tmp.awk '
+NR == 1	{ next }
+NF >= 5	{ if ($3 == "primary") next
+	  print "$1 == \"" $1 "\" && $3 == \"" $3 "\" { next }"
+	}
+END	{ print "{ print }" }'
+
 # Note status command output order is non-deterministic, hence the sort
 # at the end
 #
 _filter_status()
 {
     tee -a $seq.full \
+    | $PCP_AWK_PROG -f $tmp.awk \
     | sed >$tmp.tmp \
 	-e "/^`hostname` .* primary /d" \
 	-e 's/[ 	][ 	]*/ /g' \

--- a/qa/1216
+++ b/qa/1216
@@ -50,12 +50,25 @@ _filter()
     # end
 }
 
+# Build filter for any existing non-qa and non-primary pmlogger instances.
+# The "pmcd Host" and "Class" fields from the pmlogctl status output
+# should suffice to uniquely identify each.
+#
+pmlogctl status 2>&1 \
+| $PCP_AWK_PROG >$tmp.awk '
+NR == 1	{ next }
+NF >= 5	{ if ($3 == "primary") next
+	  print "$1 == \"" $1 "\" && $3 == \"" $3 "\" { next }"
+	}
+END	{ print "{ print }" }'
+
 # Note status command output order is non-deterministic, hence the sort
 # at the end
 #
 _filter_status()
 {
     tee -a $seq.full \
+    | $PCP_AWK_PROG -f $tmp.awk \
     | sed >$tmp.tmp \
 	-e "/^`hostname` .* primary /d" \
 	-e 's/[ 	][ 	]*/ /g' \

--- a/qa/1223
+++ b/qa/1223
@@ -1,0 +1,160 @@
+#!/bin/sh
+# PCP QA Test No. 1223
+# pmlogctl - multiple pmloggers per control file tests
+# (migration from an existing config, or hand-edited, as pmlogctl create
+# will not set it up this way)
+#
+# Copyright (c) 2020 Ken McDonell.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+_cleanup()
+{
+    echo "_cleanup: ..." >>$seq.full
+    cd $here
+    $sudo pmlogctl -af -c $seq destroy >>$seq.full 2>&1
+    for dir in $seq-localhost $seq-$localhost $seq-local:
+    do
+	[ -d "$PCP_ARCHIVE_DIR/$dir" ] && $sudo rm -rf "$PCP_ARCHIVE_DIR/$dir"
+    done
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+localhost=`hostname`
+
+_filter()
+{
+    tee -a $seq.full \
+    | sed \
+	-e '/^# created by pmlogctl/s/ on .*/ on DATE/' \
+	-e "s;$tmp\.;TMP.;g" \
+	-e "s;$PCP_BINADM_DIR/;PCP_BINADM_DIR/;g" \
+	-e "s;$PCP_ARCHIVE_DIR/;PCP_ARCHIVE_DIR/;g" \
+	-e "s;$PCP_TMP_DIR/;PCP_TMP_DIR/;g" \
+	-e "s;$PCP_TMPFILE_DIR/pmlogctl\.[^/]*;PCP_TMPFILE_DIR/pmlogctl.XXXXX;g" \
+	-e "s;$PCP_ETC_DIR/;PCP_ETC_DIR/;g" \
+	-e 's/PID=[0-9][0-9]*/PID=<somepid>/' \
+	-e 's/PID [0-9][0-9]*/PID <somepid>/' \
+	-e 's/TERM [0-9][0-9]*/TERM <somepid>/' \
+    # end
+}
+
+# Build filter for any existing non-qa and non-primary pmlogger instances.
+# The "pmcd Host" and "Class" fields from the pmlogctl status output
+# should suffice to uniquely identify each.
+#
+pmlogctl status 2>&1 \
+| $PCP_AWK_PROG >$tmp.awk '
+NR == 1	{ next }
+NF >= 5	{ if ($3 == "primary") next
+	  print "$1 == \"" $1 "\" && $3 == \"" $3 "\" { next }"
+	}
+END	{ print "{ print }" }'
+
+# Note status command output order is non-deterministic, hence the sort
+# at the end
+#
+_filter_status()
+{
+    tee -a $seq.full \
+    | $PCP_AWK_PROG -f $tmp.awk \
+    | sed >$tmp.tmp \
+	-e "/^`hostname` .* primary /d" \
+	-e 's/[ 	][ 	]*/ /g' \
+	-e 's/2[0-9][0-9][0-9][01][0-9][0-3][0-9]\...\.[^ ]*/<archivename>/' \
+	-e "s/^$localhost /LOCALHOSTNAME /" \
+	-e "s/ $seq / <seq> /" \
+	-e 's/ [0-9][0-9]* / <pid> /' \
+    # end
+    head -1 $tmp.tmp
+    sed -e '1d' $tmp.tmp | LC_COLLATE=POSIX sort
+}
+
+cat <<End-of-File >$tmp.policy
+name:
+$seq-%h
+control:
+\$version=1.1
+%h n n PCP_ARCHIVE_DIR/$seq-%h -c $tmp.config
+End-of-File
+
+cat <<End-of-File >$tmp.config
+log mandatory on default { pmcd.pmlogger }
+End-of-File
+
+cat <<End-of-File >$tmp.control
+# Installed by PCP QA test $seq on `date`
+\$class=$seq
+\$version=1.1
+
+# eeny
+local: n n PCP_ARCHIVE_DIR/$seq-local: -r -c $tmp.config
+
+# meeny
+localhost n n PCP_ARCHIVE_DIR/$seq-localhost -r -c $tmp.config
+
+# miney
+LOCALHOSTNAME n n PCP_ARCHIVE_DIR/$seq-LOCALHOSTNAME -r -c $tmp.config
+
+# mo
+End-of-File
+
+_setup()
+{
+    $sudo cp $tmp.control $PCP_ETC_DIR/pcp/pmlogger/control.d/$seq
+    # copying this file may trigger a race with the systemd (I hate you)
+    # pmlogger_check.path trigger which can result in our QA pmloggers
+    # being killed ... so sleep for a while
+    #
+    #sleep 3
+    $sudo pmlogctl -c $seq restart >>$seq.full 2>&1
+}
+
+# real QA test starts here
+_setup
+
+for host in LOCALHOSTNAME local: localhost
+do
+    echo "== stop $host" | _filter
+    $sudo pmlogctl -c $seq stop "$host" 2>&1 | _filter
+    diff $tmp.control $PCP_ETC_DIR/pcp/pmlogger/control.d/$seq | _filter
+    pmlogctl -v status | _filter_status
+done
+
+echo
+for host in LOCALHOSTNAME local: localhost
+do
+    echo "== start $host" | _filter
+    $sudo pmlogctl -c $seq start "$host" 2>&1 | _filter
+    diff $tmp.control $PCP_ETC_DIR/pcp/pmlogger/control.d/$seq | _filter
+    pmlogctl -v status | _filter_status
+done
+
+echo
+for host in LOCALHOSTNAME local: localhost
+do
+    echo "== destroy $host" | _filter
+    $sudo pmlogctl -f -c $seq destroy "$host" 2>&1 | _filter
+    if [ -f $PCP_ETC_DIR/pcp/pmlogger/control.d/$seq ]
+    then
+	diff $tmp.control $PCP_ETC_DIR/pcp/pmlogger/control.d/$seq | _filter
+    else
+	echo "PCP_ETC_DIR/pcp/pmlogger/control.d/$seq has gone away"
+    fi
+    pmlogctl -v status | _filter_status
+done
+
+# success, all done
+status=0
+exit

--- a/qa/1223.out
+++ b/qa/1223.out
@@ -1,0 +1,85 @@
+QA output created by 1223
+== stop LOCALHOSTNAME
+12c12
+< LOCALHOSTNAME n n PCP_ARCHIVE_DIR/1223-LOCALHOSTNAME -r -c TMP.config
+---
+> #!#LOCALHOSTNAME n n PCP_ARCHIVE_DIR/1223-LOCALHOSTNAME -r -c TMP.config
+pmcd Host Archive Class PID State 
+LOCALHOSTNAME ? <seq> ? stopped by pmlogctl
+local: <archivename> <seq> <pid> running 
+localhost <archivename> <seq> <pid> running 
+== stop local:
+6c6
+< local: n n PCP_ARCHIVE_DIR/1223-local: -r -c TMP.config
+---
+> #!#local: n n PCP_ARCHIVE_DIR/1223-local: -r -c TMP.config
+12c12
+< LOCALHOSTNAME n n PCP_ARCHIVE_DIR/1223-LOCALHOSTNAME -r -c TMP.config
+---
+> #!#LOCALHOSTNAME n n PCP_ARCHIVE_DIR/1223-LOCALHOSTNAME -r -c TMP.config
+pmcd Host Archive Class PID State 
+LOCALHOSTNAME ? <seq> ? stopped by pmlogctl
+local: ? <seq> ? stopped by pmlogctl
+localhost <archivename> <seq> <pid> running 
+== stop localhost
+6c6
+< local: n n PCP_ARCHIVE_DIR/1223-local: -r -c TMP.config
+---
+> #!#local: n n PCP_ARCHIVE_DIR/1223-local: -r -c TMP.config
+9c9
+< localhost n n PCP_ARCHIVE_DIR/1223-localhost -r -c TMP.config
+---
+> #!#localhost n n PCP_ARCHIVE_DIR/1223-localhost -r -c TMP.config
+12c12
+< LOCALHOSTNAME n n PCP_ARCHIVE_DIR/1223-LOCALHOSTNAME -r -c TMP.config
+---
+> #!#LOCALHOSTNAME n n PCP_ARCHIVE_DIR/1223-LOCALHOSTNAME -r -c TMP.config
+pmcd Host Archive Class PID State 
+LOCALHOSTNAME ? <seq> ? stopped by pmlogctl
+local: ? <seq> ? stopped by pmlogctl
+localhost ? <seq> ? stopped by pmlogctl
+
+== start LOCALHOSTNAME
+6c6
+< local: n n PCP_ARCHIVE_DIR/1223-local: -r -c TMP.config
+---
+> #!#local: n n PCP_ARCHIVE_DIR/1223-local: -r -c TMP.config
+9c9
+< localhost n n PCP_ARCHIVE_DIR/1223-localhost -r -c TMP.config
+---
+> #!#localhost n n PCP_ARCHIVE_DIR/1223-localhost -r -c TMP.config
+pmcd Host Archive Class PID State 
+LOCALHOSTNAME <archivename> <seq> <pid> running 
+local: ? <seq> ? stopped by pmlogctl
+localhost ? <seq> ? stopped by pmlogctl
+== start local:
+9c9
+< localhost n n PCP_ARCHIVE_DIR/1223-localhost -r -c TMP.config
+---
+> #!#localhost n n PCP_ARCHIVE_DIR/1223-localhost -r -c TMP.config
+pmcd Host Archive Class PID State 
+LOCALHOSTNAME <archivename> <seq> <pid> running 
+local: <archivename> <seq> <pid> running 
+localhost ? <seq> ? stopped by pmlogctl
+== start localhost
+pmcd Host Archive Class PID State 
+LOCALHOSTNAME <archivename> <seq> <pid> running 
+local: <archivename> <seq> <pid> running 
+localhost <archivename> <seq> <pid> running 
+
+== destroy LOCALHOSTNAME
+12d11
+< LOCALHOSTNAME n n PCP_ARCHIVE_DIR/1223-LOCALHOSTNAME -r -c TMP.config
+pmcd Host Archive Class PID State 
+local: <archivename> <seq> <pid> running 
+localhost <archivename> <seq> <pid> running 
+== destroy local:
+6d5
+< local: n n PCP_ARCHIVE_DIR/1223-local: -r -c TMP.config
+12d10
+< LOCALHOSTNAME n n PCP_ARCHIVE_DIR/1223-LOCALHOSTNAME -r -c TMP.config
+pmcd Host Archive Class PID State 
+localhost <archivename> <seq> <pid> running 
+== destroy localhost
+PCP_ETC_DIR/pcp/pmlogger/control.d/1223 has gone away
+pmcd Host Archive Class PID State 

--- a/qa/admin/pcp-daily
+++ b/qa/admin/pcp-daily
@@ -198,7 +198,7 @@ cp VERSION.pcp.daily VERSION.pcp
 if which systemctl >/dev/null 2>&1
 then
     echo "Info: stopping PCP services" | tee -a $HOME/daily.log
-    for svc in pmie pmlogger pmmgr pmproxy pmcd
+    for svc in pmie pmlogger pmproxy pmcd
     do
 	sudo systemctl stop $svc
     done
@@ -543,7 +543,7 @@ fi
 if which systemctl >/dev/null 2>&1
 then
     systemctl list-unit-files >\$tmp.systemctl
-    for svc in pmcd pmproxy pmie pmlogger_daily_report pmlogger pmmgr
+    for svc in pmcd pmproxy pmie pmlogger_daily_report pmlogger
     do
 	if grep "\$svc.service[ 	]*enabled" <\$tmp.systemctl >/dev/null
 	then

--- a/qa/group
+++ b/qa/group
@@ -1618,7 +1618,7 @@ not_in_container
 1201 logutil remote
 1202 pmda.dm local pmrep python
 1203 derive pmval libpcp local
-1204 pmlogctl local
+1204 pmlogctl local sanity
 1205 pmlogctl local
 1206 pmlogctl local
 1207 pcp dstat python local
@@ -1637,6 +1637,7 @@ not_in_container
 1220 pmda.proc local
 1221 labels pmda.openmetrics local python
 1222 pmda.linux pmda.proc local valgrind
+1223 pmlogctl local
 1224 pcp dstat python local
 1225:retired pmwebd local pmrep python pcp kernel
 1227 derive local


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200701

Ken McDonell (5):
      qa/1223: (new) pmlogctl tests with multile pmloggers per control file
      qa/group: add 1204 to sanity, add 1223 (new)
      qa/admin/pcp-daily: remove a couple of references to pmmgr
      qa: pmlogctl tests - extend filter to remove any non-qa pmloggers
      src/pmlogctl/pmlogctl.sh: more small changes

 qa/1204                  |   13 +++
 qa/1205                  |   13 +++
 qa/1206                  |   13 +++
 qa/1208                  |   13 +++
 qa/1209                  |   13 +++
 qa/1210                  |   13 +++
 qa/1213                  |   13 +++
 qa/1215                  |   13 +++
 qa/1216                  |   13 +++
 qa/1223                  |  160 +++++++++++++++++++++++++++++++++++++++++++++++
 qa/1223.out              |   85 ++++++++++++++++++++++++
 qa/admin/pcp-daily       |    4 -
 qa/group                 |    3 
 src/pmlogctl/pmlogctl.sh |   66 +++++++++++++------
 14 files changed, 412 insertions(+), 23 deletions(-)

Details ...

commit df2e8c765a0ab6710da4c18384f929603e1c99ab
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Jul 1 07:12:53 2020 +1000

    src/pmlogctl/pmlogctl.sh: more small changes
    
    - refine handling of primary pmlogger to reduce warning chatter in some
      cases
    - add rudimentary pmlogger.log dredging for "dead" loggers with -v and
      status command
    - cull TODO list (multiple pmloggers per control file "just works"(tm))

commit 13f988c4339cf1af3c15972f9bd97d2b4b995c87
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Jul 1 07:08:43 2020 +1000

    qa: pmlogctl tests - extend filter to remove any non-qa pmloggers
    
    If there are non-primary pmlogger instances running on the qa machines
    (like I have), then these need to be excluded from the pmlogctl "status"
    output so the QA tests pass.
    
    Use awk to create an awk program that is run in _filter_status().

commit aadb0f0e44e5fdd406423bd9d338909cb8ad8eda
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Jul 1 07:07:01 2020 +1000

    qa/admin/pcp-daily: remove a couple of references to pmmgr

commit 426c1888f5296d7ded2e03770dc942f4c3a10106
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Jul 1 07:06:16 2020 +1000

    qa/group: add 1204 to sanity, add 1223 (new)

commit 22473e25fd5148e324f12e789c6dd7b893b7fb0a
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Jul 1 07:04:42 2020 +1000

    qa/1223: (new) pmlogctl tests with multile pmloggers per control file
    
    This covers the migration plan (none needed) for pre-existing control
    files that might have multiple pmloggers specified within a single
    file.