### PR TITLE
pmdaproc: add acct metrics

### DIFF
--- a/qa/031.out.linux
+++ b/qa/031.out.linux
@@ -65,6 +65,7 @@ children of "sample.longlong" ...
 pmid: PM_ID_NULL name: bozo.the.clown
 
 children of "" ...
+    acct                <s = 1>
     disk                <s = 1>
     event               <s = 1>
     filesys             <s = 1>

--- a/src/libpcp/src/hash.c
+++ b/src/libpcp/src/hash.c
@@ -126,6 +126,7 @@ __pmHashDel(unsigned int key, void *data, __pmHashCtl *hcp)
 	    else
 		lhp->next = hp->next;
 	    free(hp);
+	    hcp->nodes--;
 	    return 1;
 	}
 	lhp = hp;

--- a/src/pmdas/linux_proc/GNUmakefile
+++ b/src/pmdas/linux_proc/GNUmakefile
@@ -29,7 +29,7 @@ CFILES		= pmda.c cgroups.c proc_pid.c proc_runq.c proc_dynamic.c\
 		  getinfo.c contexts.c gram_node.c config.c error.c hotproc.c
 
 HFILES		= clusters.h indom.h \
-		  cgroups.h proc_pid.h proc_runq.h getinfo.h contexts.h hotproc.h gram_node.h config.h
+		  acct.h cgroups.h proc_pid.h proc_runq.h getinfo.h contexts.h hotproc.h gram_node.h config.h
 
 LFILES		= lex.l
 YFILES		= gram.y

--- a/src/pmdas/linux_proc/GNUmakefile
+++ b/src/pmdas/linux_proc/GNUmakefile
@@ -25,7 +25,7 @@ PMDAINIT	= proc_init
 PMDADIR		= $(PCP_PMDAS_DIR)/$(IAM)
 CONF_LINE	= "proc	3	pipe	binary		$(PMDADIR)/$(CMDTARGET) -d 3"
 
-CFILES		= pmda.c cgroups.c proc_pid.c proc_runq.c proc_dynamic.c\
+CFILES		= pmda.c acct.c cgroups.c proc_pid.c proc_runq.c proc_dynamic.c\
 		  getinfo.c contexts.c gram_node.c config.c error.c hotproc.c
 
 HFILES		= clusters.h indom.h \
@@ -103,6 +103,7 @@ proc_kernel_ulong.conf proc_jiffies.conf proc_kernel_ulong_migrate.conf: mk.rewr
 
 gram.tab.o:	hotproc.h
 lex.o:	hotproc.h
+acct.o pmda.o: acct.h
 cgroups.o pmda.o: clusters.h
 cgroups.o pmda.o:	cgroups.h
 cgroups.o pmda.o proc_pid.o proc_runq.o proc_dynamic.o:	proc_pid.h
@@ -113,7 +114,7 @@ pmda.o:	domain.h
 pmda.o:	getinfo.h
 pmda.o:	$(VERSION_SCRIPT)
 
-cgroups.o contexts.o pmda.o proc_dynamic.o proc_pid.o proc_runq.o:	$(TOPDIR)/src/include/pcp/libpcp.h
+acct.o cgroups.o contexts.o pmda.o proc_dynamic.o proc_pid.o proc_runq.o:	$(TOPDIR)/src/include/pcp/libpcp.h
 
 check::	$(CFILES) $(HFILES)
 	$(CLINT) $^

--- a/src/pmdas/linux_proc/acct.c
+++ b/src/pmdas/linux_proc/acct.c
@@ -1,0 +1,27 @@
+/*
+ * Linux acct metrics cluster
+ *
+ * Copyright (c) 2020 Fujitsu.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#include "acct.h"
+
+void acct_init(proc_acct_t *proc_acct) {
+}
+
+void refresh_acct(proc_acct_t *proc_acct) {
+}
+
+int acct_fetchCallBack(int i_inst, int item, proc_acct_t* proc_acct, pmAtomValue *atom) {
+	return 0;
+}

--- a/src/pmdas/linux_proc/acct.c
+++ b/src/pmdas/linux_proc/acct.c
@@ -16,7 +16,45 @@
 
 #include "acct.h"
 
+#define RINGBUF_SIZE			5000
+unsigned long hertz;
+
+static struct {
+	const char* path;
+	int fd;
+	int prev_size;
+	int acct_enabled;
+	int version;
+	int record_size;
+	time_t last_fail_open;
+	time_t last_check_accounting;
+} acct_file;
+
+typedef struct {
+	time_t time;
+	struct pmdaInstid instid;
+} acct_ringbuf_entry_t;
+
+static struct {
+	acct_ringbuf_entry_t *buf;
+	int next_index;
+} acct_ringbuf;
+
+static void init_acct_file_info(void) {
+	memset(&acct_file, 0, sizeof(acct_file));
+	acct_file.fd = -1;
+}
+
 void acct_init(proc_acct_t *proc_acct) {
+	init_acct_file_info();
+
+	acct_ringbuf.next_index = 0;
+	acct_ringbuf.buf = calloc(RINGBUF_SIZE, sizeof(acct_ringbuf_entry_t));
+
+	proc_acct->indom->it_numinst = 0;
+	proc_acct->indom->it_set = calloc(RINGBUF_SIZE, sizeof(pmdaInstid));
+
+	hertz = sysconf(_SC_CLK_TCK);
 }
 
 void refresh_acct(proc_acct_t *proc_acct) {

--- a/src/pmdas/linux_proc/acct.h
+++ b/src/pmdas/linux_proc/acct.h
@@ -14,6 +14,35 @@
  * for more details.
  */
 
+#include <linux/types.h>
+
+typedef __u16	comp_t;
+typedef __u32	comp2_t;
+
+#define ACCT_COMM	16
+
+struct acct_v3 {
+	char		ac_flag;		/* Flags */
+	char		ac_version;		/* Always set to ACCT_VERSION */
+	__u16		ac_tty;			/* Control Terminal */
+	__u32		ac_exitcode;		/* Exitcode */
+	__u32		ac_uid;			/* Real User ID */
+	__u32		ac_gid;			/* Real Group ID */
+	__u32		ac_pid;			/* Process ID */
+	__u32		ac_ppid;		/* Parent Process ID */
+	__u32		ac_btime;		/* Process Creation Time */
+	float		ac_etime;		/* Elapsed Time */
+	comp_t		ac_utime;		/* User Time */
+	comp_t		ac_stime;		/* System Time */
+	comp_t		ac_mem;			/* Average Memory Usage */
+	comp_t		ac_io;			/* Chars Transferred */
+	comp_t		ac_rw;			/* Blocks Read or Written */
+	comp_t		ac_minflt;		/* Minor Pagefaults */
+	comp_t		ac_majflt;		/* Major Pagefaults */
+	comp_t		ac_swaps;		/* Number of Swaps */
+	char		ac_comm[ACCT_COMM];	/* Command Name */
+};
+
 enum {
 	ACCT_TTY      = 0,
 	ACCT_EXITCODE = 1,

--- a/src/pmdas/linux_proc/acct.h
+++ b/src/pmdas/linux_proc/acct.h
@@ -25,6 +25,11 @@ typedef __u32	comp2_t;
 
 #define ACCT_COMM	16
 
+struct acct_header {
+	char		ac_flag;		/* Flags */
+	char		ac_version;		/* Always set to ACCT_VERSION */
+};
+
 struct acct_v3 {
 	char		ac_flag;		/* Flags */
 	char		ac_version;		/* Always set to ACCT_VERSION */

--- a/src/pmdas/linux_proc/acct.h
+++ b/src/pmdas/linux_proc/acct.h
@@ -15,6 +15,10 @@
  */
 
 #include <linux/types.h>
+#include <sys/stat.h>
+#include <pcp/pmapi.h>
+#include <pcp/pmda.h>
+#include "libpcp.h"
 
 typedef __u16	comp_t;
 typedef __u32	comp2_t;
@@ -43,6 +47,11 @@ struct acct_v3 {
 	char		ac_comm[ACCT_COMM];	/* Command Name */
 };
 
+typedef struct {
+	__pmHashCtl	accthash;		/* hash table for acct */
+	pmdaIndom	*indom;			/* instance domain table */
+} proc_acct_t;
+
 enum {
 	ACCT_TTY      = 0,
 	ACCT_EXITCODE = 1,
@@ -61,3 +70,7 @@ enum {
 	ACCT_MAJFLT   = 14,
 	ACCT_SWAPS    = 15,
 };
+
+extern void acct_init(proc_acct_t *);
+extern void refresh_acct(proc_acct_t *);
+extern int acct_fetchCallBack(int i_inst, int item, proc_acct_t* proc_acct, pmAtomValue *atom);

--- a/src/pmdas/linux_proc/acct.h
+++ b/src/pmdas/linux_proc/acct.h
@@ -1,0 +1,34 @@
+/*
+ * Linux acct metrics cluster
+ *
+ * Copyright (c) 2020 Fujitsu.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+enum {
+	ACCT_TTY      = 0,
+	ACCT_EXITCODE = 1,
+	ACCT_UID      = 2,
+	ACCT_GID      = 3,
+	ACCT_PID      = 4,
+	ACCT_PPID     = 5,
+	ACCT_BTIME    = 6,
+	ACCT_ETIME    = 7,
+	ACCT_UTIME    = 8,
+	ACCT_STIME    = 9,
+	ACCT_MEM      = 10,
+	ACCT_IO       = 11,
+	ACCT_RW       = 12,
+	ACCT_MINFLT   = 13,
+	ACCT_MAJFLT   = 14,
+	ACCT_SWAPS    = 15,
+};

--- a/src/pmdas/linux_proc/clusters.h
+++ b/src/pmdas/linux_proc/clusters.h
@@ -61,7 +61,9 @@
 #define CLUSTER_CGROUP2_CPU_STAT	67
 #define CLUSTER_CGROUP2_IO_STAT		68
 
+#define CLUSTER_ACCT                    70
+
 #define MIN_CLUSTER  8		/* first cluster number we use here */
-#define MAX_CLUSTER 69		/* one more than highest cluster number used */
+#define MAX_CLUSTER 71		/* one more than highest cluster number used */
 
 #endif /* _CLUSTERS_H */

--- a/src/pmdas/linux_proc/help
+++ b/src/pmdas/linux_proc/help
@@ -48,6 +48,8 @@
 @ 3.37 control group (cgroup) subsystems
 @ 3.38 control group (cgroup) mount points
 
+@ 3.40 process accounting information
+
 @ proc.nprocs instantaneous number of processes
 @ hotproc.nprocs instantaneous number of interesting ("hot") processes
 
@@ -532,3 +534,20 @@ refresh interval.
 @ hotproc.predicate.schedwait time in secs waiting on run queue per second over refresh interval
 The fraction of time waiting on the run queue for each "interesting"
 process over the last refresh interval.
+
+@ acct.tty Controlling terminal
+@ acct.exitcode Process termination status
+@ acct.uid Real user ID
+@ acct.gid Real group ID
+@ acct.pid Process ID
+@ acct.ppid Parent process ID
+@ acct.btime Process creation time
+@ acct.etime Elapsed time
+@ acct.utime User CPU time
+@ acct.stime System CPU time
+@ acct.mem Average memory usage
+@ acct.io Characters transferred
+@ acct.rw Blocks read or written
+@ acct.minflt Minor page faults
+@ acct.majflt Major page faults
+@ acct.swaps Number of swaps

--- a/src/pmdas/linux_proc/indom.h
+++ b/src/pmdas/linux_proc/indom.h
@@ -44,9 +44,10 @@
 #define CGROUP_MOUNTS_INDOM	38 /* - control group mounts */
 
 #define HOTPROC_INDOM		39 /* - hot procs */
+#define ACCT_INDOM		40 /* - acct */
 
 #define MIN_INDOM  9		/* first indom number we use here */
-#define NUM_INDOMS 40		/* one more than highest indom number we use here */
+#define NUM_INDOMS 41		/* one more than highest indom number we use here */
 
 extern pmInDom proc_indom(int);
 #define INDOM(i) proc_indom(i)

--- a/src/pmdas/linux_proc/pmda.c
+++ b/src/pmdas/linux_proc/pmda.c
@@ -43,6 +43,7 @@
 #include "proc_runq.h"
 #include "proc_dynamic.h"
 #include "cgroups.h"
+#include "acct.h"
 
 /* globals */
 static int			_isDSO = 1;	/* =0 I am a daemon */
@@ -1404,6 +1405,58 @@ static pmdaMetric metrictab[] = {
     /* hotproc.predicate.cpuburn */
     { NULL, {PMDA_PMID(CLUSTER_HOTPROC_PRED,ITEM_HOTPROC_P_CPUBURN),
       PM_TYPE_FLOAT, HOTPROC_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0, 0,0,0)} },
+
+/*
+ * acct cluster
+ */
+    /* acct.tty */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_TTY),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    /* acct.exitcode */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_EXITCODE),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    /* acct.uid */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_UID),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    /* acct.gid */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_GID),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    /* acct.pid */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_PID),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    /* acct.ppid */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_PPID),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    /* acct.btime */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_BTIME),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    /* acct.etime */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_ETIME),
+      PM_TYPE_FLOAT, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,1,0,0,PM_TIME_MSEC,0) }, },
+    /* acct.utime */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_UTIME),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,1,0,0,PM_TIME_MSEC,0) }, },
+    /* acct.stime */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_STIME),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,1,0,0,PM_TIME_MSEC,0) }, },
+    /* acct.mem */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_MEM),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0) }, },
+    /* acct.io */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_IO),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    /* acct.rw */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_RW),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    /* acct.minflt */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_MINFLT),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    /* acct.majflt */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_MAJFLT),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    /* acct.swaps */
+    { NULL, { PMDA_PMID(CLUSTER_ACCT,ACCT_SWAPS),
+      PM_TYPE_U32, ACCT_INDOM, PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) }, },
 
 };
 

--- a/src/pmdas/linux_proc/root_proc
+++ b/src/pmdas/linux_proc/root_proc
@@ -14,6 +14,7 @@ root {
     cgroup
     proc
     hotproc
+    acct
 }
 
 cgroup {
@@ -508,6 +509,25 @@ hotproc.predicate {
     iowait         PROC:61:5
     schedwait      PROC:61:6
     cpuburn        PROC:61:7
+}
+
+acct {
+    tty         PROC:70:0
+    exitcode    PROC:70:1
+    uid         PROC:70:2
+    gid         PROC:70:3
+    pid         PROC:70:4
+    ppid        PROC:70:5
+    btime       PROC:70:6
+    etime       PROC:70:7
+    utime       PROC:70:8
+    stime       PROC:70:9
+    mem         PROC:70:10
+    io          PROC:70:11
+    rw          PROC:70:12
+    minflt      PROC:70:13
+    majflt      PROC:70:14
+    swaps       PROC:70:15
 }
 
 #undef PROC


### PR DESCRIPTION
Collect accounting information from process accounting file (see acct(5)).
pmdaproc(acct) will try to read data from /var/account/pacct if it is effective,
or use private accounting file (/tmp/pcp-pacct).
Currently version 3 format (struct acct_v3) is available.

Related to https://github.com/performancecopilot/pcp/issues/922