### PR TITLE
pmlogger_daily -k 0 fixes

### DIFF
--- a/man/man1/pmlogger_check.1
+++ b/man/man1/pmlogger_check.1
@@ -26,12 +26,12 @@
 .B $PCP_BINADM_DIR/pmlogger_daily
 [\f3\-KMNoprRV?\f1]
 [\f3\-c\f1 \f2control\f1]
-[\f3\-k\f1 \f2discard\f1]
+[\f3\-k\f1 \f2time\f1]
 [\f3\-l\f1 \f2logfile\f1]
 [\f3\-m\f1 \f2addresses\f1]
 [\f3\-s\f1 \f2size\f1]
 [\f3\-t\f1 \f2want\f1]
-[\f3\-x\f1 \f2compress\f1]
+[\f3\-x\f1 \f2time\f1]
 [\f3\-X\f1 \f2program\f1]
 [\f3\-Y\f1 \f2regex\f1]
 .SH DESCRIPTION
@@ -128,29 +128,62 @@ to query the system service runlevel information for
 .BR pmlogger ,
 and use that to determine whether to start processes or not.
 .TP
-\fB\-k\fR \fIperiod\fR, \fB\-\-discard\fR=\fIperiod\fR
+\fB\-k\fR \fItime\fR, \fB\-\-discard\fR=\fItime\fR
 After some period, old PCP archives are discarded.
-This period is 14 days by default, but may be changed using
+.I time
+is a time specification in the syntax of
+.BR find-filter (1),
+so
+\fIDD\fR[\fB:\fIHH\fR[\fB:\fIMM\fR]].
+The optional
+.I HH
+(hours) and
+.I MM
+(minutes) parts are 0 if not specified.
+By default the
+.I time
+is
+.B 14:0:0
+or 14 days, but may be changed using
 this option.
+.RS
+.PP
 Some special values are recognized for the
-.IR period ,
+.IR time ,
 namely
 .B 0
-to keep no archives beyond the current one, and
+to keep no archives beyond the the ones being currently written by
+.BR pmlogger (1),
+and
 .B forever
 or
 .B never
 to prevent any archives being discarded.
+.PP
+The
+.I time
+can also be set using the
+.B $PCP_CULLAFTER
+variable, set in either the environment or in a control file.
+If both
+.B $PCP_CULLAFTER
+and
+.B \-x
+specify different values for
+.I time
+then the environment variable value is used and a warning is issued.
+.PP
 Note that the semantics of
-.I discard
+.I time
 are that it is measured from the time of last modification of each
-archive, and not from the current day.
+archive, and not from the original archive creation date.
 This has subtle implications for compression (see below) \- the
 compression process results in the creation of new archive files
 which have new modification times.
 In this case, the
-.I discard
+.I time
 period (re)starts from the time of compression.
+.RE
 .TP
 \fB\-K\fR
 When this option is specified for
@@ -161,14 +194,14 @@ rotation, no culling, no rewriting, etc.
 When
 .B \-K
 is used and a
-.I compress
-value of
+.I period
+of
 .B 0
 is in effect
 (from
 .B \-x
 on the command line or
-.BR PCP_COMPRESSAFTER
+.B $PCP_COMPRESSAFTER
 in the environment or via the
 .I control
 file)
@@ -183,7 +216,7 @@ with just the
 .B \-K
 option.
 Provided
-.B PCP_COMPRESSAFTER
+.B $PCP_COMPRESSAFTER
 is set to
 .B 0
 along with any other required compression options to match the
@@ -408,13 +441,36 @@ in conjunction with
 .B \-V
 maximizes the diagnostic capabilities for debugging.
 .TP
-\fB\-x\fR \fIperiod\fR, \fB\-\-compress\-after\fR=\fIperiod\fR
+\fB\-x\fR \fItime\fR, \fB\-\-compress\-after\fR=\fItime\fR
 Archive data files can optionally be compressed after some period
 to conserve disk space.
 This is particularly useful for large numbers of
 .B pmlogger
 processes under the control of
 .BR pmlogger_check .
+.RS
+.PP
+.I time
+is a time specification in the syntax of
+.BR find-filter (1),
+so
+\fIDD\fR[\fB:\fIHH\fR[\fB:\fIMM\fR]].
+The optional
+.I HH
+(hours) and
+.I MM
+(minutes) parts are 0 if not specified.
+.PP
+Some special values are recognized for the
+.IR time ,
+namely
+.B 0
+to apply compression as soon as possible, and
+.B forever
+or
+.B never
+to prevent any compression being done.
+.PP
 If
 .B transparent_decompress
 is enabled when
@@ -422,50 +478,40 @@ is enabled when
 was built
 (can be checked with the
 .BR pmconfig (1)
-.BR \-L option),
+.B \-L
+option),
 then the default behaviour is compression ``as soon as possible''.
 Otherwise the default behaviour is to
 .B not
 compress files (which matches the historical default behaviour in
 earlier PCP releases).
+.PP
 The
-.B \-x
-option specifies the number of days after which to compress archive data
-and metadata files.
-If
-.I compress
-is
-.B 0
-then compression will be applied as soon as possible.
-If
-.I compress
-is
-.B never
-or
-.B forever
-then no compression will be done.
-The environment variable
-.B PCP_COMPRESSAFTER
-may be used as an alternative mechanism to define
-.IR compress .
+.I time
+can also be set using the
+.B $PCP_COMPRESSAFTER
+variable, set in either the environment or in a
+.I control
+file.
 If both
-.B PCP_COMPRESSAFTER
+.B $PCP_COMPRESSAFTER
 and
 .B \-x
 specify different values for
-.I compress
+.I time
 then the environment variable value is used and a warning is issued.
+.RE
 .TP
 \fB\-X\fR \fIprogram\fR, \fB\-\-compressor\fR=\fIprogram\fR
 This option specifies the program to use for compression \- by default
 this is
 .BR xz (1).
 The environment variable
-.B PCP_COMPRESS
+.B $PCP_COMPRESS
 may be used as an alternative mechanism to define
 .IR program .
 If both
-.B PCP_COMPRESS
+.B $PCP_COMPRESS
 and
 .B \-X
 specify different compression programs
@@ -484,11 +530,11 @@ filtered using the
 option to
 .BR egrep (1).
 The environment variable
-.B PCP_COMPRESSREGEX
+.B $PCP_COMPRESSREGEX
 may be used as an alternative mechanism to define
 .IR regex .
 If both
-.B PCP_COMPRESSREGEX
+.B $PCP_COMPRESSREGEX
 and
 .B \-Y
 specify different values for
@@ -501,15 +547,20 @@ Display usage message and exit.
 .BR Warning :
 The
 .B $PCP_PMLOGGERCONTROL_PATH
-and
+file and files within the
 .BR $PCP_PMLOGGERCONTROL_PATH .d
-files must not be writable by any user other than root.
+directory must not be writable by any user other than root.
 .PP
 The control file(s) should be customized according to the following rules
 that define for the current version (1.1)
 of the control file format.
 .IP 1. 4m
 Lines beginning with a ``#'' are comments.
+A special case is lines beginning ``#!#''; these are control lines
+for a
+.BR pmlogger (1)
+that has been stopped using
+.BR pmlogctl (1).
 .PD 0
 .IP 2.
 Lines beginning with a ``$'' are assumed to be
@@ -710,7 +761,15 @@ is used instead.
 .SH FILES
 .TP 5
 .I $PCP_PMLOGGERCONTROL_PATH
-the PCP logger control file
+the PCP logger control file.
+For a new installation
+this file contains no
+.BR pmlogger (1)
+control lines (the real control files are all
+in the
+.I $PCP_PMLOGGERCONTROL_PATH.d
+directory), but this file is still processed to support any
+legacy configurations therein from earlier PCP releases.
 .br
 .BR Warning :
 this file must not be writable by any user other than root.
@@ -827,12 +886,35 @@ and setting
 to
 .B yes
 disables the regeneration and checking.
+.SH "COMPATIBILITY ISSUES"
+Earlier versions of
+.B pmlogger_daily
+used
+.BR find (1)
+to locate files for compressing or culling and the
+.B \-k
+and
+.B \-x
+options took only integer values to mean ``days''.
+The semantics of this was quite loose given that
+.BR find (1)
+offers different precision and semantics across platforms.
+.PP
+The current implementation of
+.B pmlogger_daily
+uses
+.BR find-filter (1)
+which provides high precision intervals and semantics that are
+relative to the time of execution and are consistent across
+platforms.
 .SH SEE ALSO
 .BR egrep (1),
+.BR find-filter (1),
 .BR PCPIntro (1),
 .BR pmconfig (1),
 .BR pmlc (1),
 .BR pmlogconf (1),
+.BR pmlogctl (1),
 .BR pmlogger (1),
 .BR pmlogger_daily_report (1),
 .BR pmlogger_merge (1),

--- a/qa/119
+++ b/qa/119
@@ -62,21 +62,6 @@ _filter()
     | _filter_pmlogger_log
 }
 
-$sudo cp $PCP_PMLOGGERCONTROL_PATH $tmp.control
-$sudo mv $PCP_PMLOGGERCONTROL_PATH.d $tmp.control.d
-
-cat <<End-of-File >$tmp.tmp
-# dummy file created by qa/$seq on `date`
-# the goal here is to have just two pmlogger instances running and
-# a third one that will never run ...
-#
-\$version=1.1
-LOCALHOSTNAME	y n $LOGGING_DIR/LOCALHOSTNAME-one -c /dev/null
-LOCALHOSTNAME	n n $LOGGING_DIR/LOCALHOSTNAME-two -c /dev/null -L
-no.such.host.pcp.io	n n $LOGGING_DIR/no.such.host.pcp.io -c /dev/null
-End-of-File
-$sudo cp $tmp.tmp $PCP_PMLOGGERCONTROL_PATH
-
 # stop pmcd, primary pmlogger, create the archive directories,
 # start pmcd ...
 #
@@ -93,6 +78,21 @@ then
 	_wait_pmlogger_end $pid
     done
 fi
+
+$sudo cp $PCP_PMLOGGERCONTROL_PATH $tmp.control
+$sudo mv $PCP_PMLOGGERCONTROL_PATH.d $tmp.control.d
+
+cat <<End-of-File >$tmp.tmp
+# dummy file created by qa/$seq on `date`
+# the goal here is to have just two pmlogger instances running and
+# a third one that will never run ...
+#
+\$version=1.1
+LOCALHOSTNAME	y n $LOGGING_DIR/LOCALHOSTNAME-one -c /dev/null
+LOCALHOSTNAME	n n $LOGGING_DIR/LOCALHOSTNAME-two -c /dev/null -L
+no.such.host.pcp.io	n n $LOGGING_DIR/no.such.host.pcp.io -c /dev/null
+End-of-File
+$sudo cp $tmp.tmp $PCP_PMLOGGERCONTROL_PATH
 
 $sudo mkdir -p $LOGGING_DIR/${myhost}-one >/dev/null 2>&1
 $sudo mkdir -p $LOGGING_DIR/${myhost}-two >/dev/null 2>&1

--- a/qa/1232
+++ b/qa/1232
@@ -1,0 +1,107 @@
+#!/bin/sh
+# PCP QA Test No. 1232
+# pmlogger_daily -k 0 tests
+#
+# Copyright (c) 2020 Ken McDonell.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+if pmlogctl -c default status 2>/dev/null | grep ' default ' >/dev/null
+then
+    _notrun "at least one pmlogger already defined for \"default\" class"
+fi
+
+_cleanup()
+{
+    echo "_cleanup: ..." >>$seq.full
+    cd $here
+    $sudo pmlogctl -f -c default destroy localhost >>$seq.full 2>&1
+    $sudo rm -rf $tmp $tmp.*
+    $sudo rm -rf $PCP_ARCHIVE_DIR/localhost
+
+}
+
+status=1	# failure is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_filter()
+{
+    tee -a $seq.full \
+    | sed \
+	-e '/^# created by pmlogctl/s/ on .*/ on DATE/' \
+	-e "s;$tmp\.;TMP.;g" \
+	-e "s;$PCP_BINADM_DIR/;PCP_BINADM_DIR/;g" \
+	-e "s;$PCP_ARCHIVE_DIR/;PCP_ARCHIVE_DIR/;g" \
+	-e "s;$PCP_TMP_DIR/;PCP_TMP_DIR/;g" \
+	-e "s;$PCP_TMPFILE_DIR/pmlogctl\.[^/]*;PCP_TMPFILE_DIR/pmlogctl.XXXXX;g" \
+	-e "s;$PCP_ETC_DIR/;PCP_ETC_DIR/;g" \
+    # end
+}
+
+_filter_log()
+{
+    cat \
+    | _filter \
+    | sed \
+	-e '1,/=== daily /d' \
+	-e '/^Start:/d' \
+	-e '/^End:/d' \
+	-e '/^COMPRESSAFTER=/d' \
+	-e '/^\+ /d' \
+	-e '/^\.\.\. try /d' \
+	-e '/^\.\.\. logging for /d' \
+	-e '/no pmlogger instance running /d' \
+	-e '/skipping log rotation/d' \
+	-e '/[0-9][0-9]* identified/s//PID identified/' \
+	-e '/current [0-9][0-9.-]* archive/s//current DATE archive/' \
+	-e 's/ [0-9][0-9.-]*.index/ DATE.index/g' \
+	-e 's/ [0-9][0-9.-]*.meta/ DATE.meta/g' \
+	-e 's/ [0-9][0-9.-]*.0/ DATE.0/g' \
+    # done
+}
+
+# get our pmlogger running
+#
+$sudo pmlogctl -v create localhost | _filter
+
+# real QA test starts here
+control=$PCP_ETC_DIR/pcp/pmlogger/control.d/localhost
+
+echo
+echo "only one current archive, expect no culling"
+$sudo -u $PCP_USER -g $PCP_GROUP $PCP_BINADM_DIR/pmlogger_daily -c $control \
+    -N -VV -k 0 -x never 2>&1 \
+| _filter_log
+
+echo
+echo "one archive, cull it"
+$sudo pmlogctl stop localhost
+$sudo -u $PCP_USER -g $PCP_GROUP $PCP_BINADM_DIR/pmlogger_daily -c $control \
+    -N -VV -k 0 -x never 2>&1 \
+| _filter_log
+
+echo
+echo "cull old archive, skip current one"
+$sudo pmlogctl start localhost
+$sudo -u $PCP_USER -g $PCP_GROUP $PCP_BINADM_DIR/pmlogger_daily -c $control \
+    -N -VV -k 0 -x never 2>&1 \
+| _filter_log
+
+echo
+echo "two archives, cull 'em"
+$sudo pmlogctl stop localhost
+$sudo -u $PCP_USER -g $PCP_GROUP $PCP_BINADM_DIR/pmlogger_daily -c $control \
+    -N -VV -k 0 -x never 2>&1 \
+| _filter_log
+
+# success, all done
+status=0
+exit

--- a/qa/1232.out
+++ b/qa/1232.out
@@ -1,0 +1,36 @@
+QA output created by 1232
+Installing control file: PCP_ETC_DIR/pcp/pmlogger/control.d/localhost
+
+only one current archive, expect no culling
+
+Check pmlogger -h localhost ... in PCP_ARCHIVE_DIR/localhost ...
+non-primary pmlogger process(es) PID identified, OK
+[control.d/localhost:5] skip cull for current DATE archive
+Warning: no archive files found to cull
+
+one archive, cull it
+
+Check pmlogger -h localhost ... in PCP_ARCHIVE_DIR/localhost ...
+No non-primary pmlogger process(es) found
+pmlogger_daily: [control.d/localhost:5]
+pmlogger_daily: [control.d/localhost:5]
+Archive files older than 0 days being removed ...
+    DATE.0 DATE.index DATE.meta
+
+cull old archive, skip current one
+
+Check pmlogger -h localhost ... in PCP_ARCHIVE_DIR/localhost ...
+non-primary pmlogger process(es) PID identified, OK
+[control.d/localhost:5] skip cull for current DATE archive
+Archive files older than 0 days being removed ...
+    DATE.0.xz DATE.index DATE.meta.xz
+
+two archives, cull 'em
+
+Check pmlogger -h localhost ... in PCP_ARCHIVE_DIR/localhost ...
+No non-primary pmlogger process(es) found
+pmlogger_daily: [control.d/localhost:5]
+pmlogger_daily: [control.d/localhost:5]
+Archive files older than 0 days being removed ...
+    DATE.0 DATE.index DATE.meta
+    DATE.0.xz DATE.index DATE.meta.xz

--- a/qa/151
+++ b/qa/151
@@ -160,13 +160,13 @@ ls -l $tmp >>$seq.full
 # complexity at the end of this pipeline
 #
 echo
-echo "pmlogger_daily -k 4 -x never -V ..." >>$seq.full
-$sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -c $tmp/control -k 4 -x never -V -l $tmp.log"
+echo "pmlogger_daily -k 5 -x never -V ..." >>$seq.full
+$sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -c $tmp/control -k 5 -x never -V -l $tmp.log"
 $sudo cat $tmp.log \
 | _filter \
 | $PCP_AWK_PROG '
 state == 0		{ print >"'$tmp.out.0'"
-			  if ($0 ~ /older than 4 days/) state = 1
+			  if ($0 ~ /older than /) state = 1
 			  next
 			}
 state == 1 && $0 ~ /Input archives to be merged:/	{ state = 2 }

--- a/qa/151.out
+++ b/qa/151.out
@@ -73,7 +73,7 @@ Error: no pmlogger instance running for host "HOST"
 ... logging for host "HOST" unchanged
 PMLOGGER.DAILY: [TMP/control:2]
 Warning: skipping log rotation because we don't know which pmlogger to signal
-Archive files older than 4 days being removed ...
+Archive files older than 5 days being removed ...
 TODAY-5.0
 TODAY-5.index
 TODAY-5.meta

--- a/qa/338
+++ b/qa/338
@@ -174,7 +174,7 @@ LOCALHOSTNAME	n   n	'"$tmp"'	./config'
     echo "=== [$verbose_text] regular show ==="
     echo "=== [$verbose_text] regular show ===" >>$seq.full
     _fixperms
-    $sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -x forever -c $tmp.control -k 3 $verbose -l $tmp.log"
+    $sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -x forever -c $tmp.control -k 4 $verbose -l $tmp.log"
 
     $sudo cat $tmp.log | _filter
     ls -lt $tmp >>$seq.full
@@ -188,7 +188,7 @@ LOCALHOSTNAME	n   n	'"$tmp"'	./config'
 	$sudo mv $tmp/$yesterday.$ext $tmp/save.$ext
     done
     _fixperms
-    $sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -x forever -c $tmp.control -k 2 $verbose -l $tmp.log"
+    $sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -x forever -c $tmp.control -k 3 $verbose -l $tmp.log"
     $sudo cat $tmp.log | _filter
     ls -lt $tmp >>$seq.full
     ls $tmp | sed -f $tmp.sed | tee -a $seq.full | LC_COLLATE=POSIX sort
@@ -202,7 +202,7 @@ LOCALHOSTNAME	n   n	'"$tmp"'	./config'
 	$sudo mv $tmp/save.$ext $tmp/$yesterday.$ext
     done
     _fixperms
-    $sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -x forever -c $tmp.control -k 2 $verbose -l $tmp.log"
+    $sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -x forever -c $tmp.control -k 3 $verbose -l $tmp.log"
     $sudo cat $tmp.log | _filter
     ls -lt $tmp >>$seq.full
     ls $tmp | sed -f $tmp.sed | tee -a $seq.full | LC_COLLATE=POSIX sort

--- a/qa/338.out
+++ b/qa/338.out
@@ -86,7 +86,7 @@ Error: no pmlogger instance running for host "HOST"
 ... logging for host "HOST" unchanged
 PMLOGGER.DAILY: [TMP.control:2]
 Warning: skipping log rotation because we don't know which pmlogger to signal
-Archive files older than 3 days being removed ...
+Archive files older than 4 days being removed ...
     NOW-5.00.02.0 NOW-5.00.02.index NOW-5.00.02.meta
     NOW-5.00.04.0 NOW-5.00.04.index NOW-5.00.04.meta
     NOW-4.00.02.0 NOW-4.00.02.index NOW-4.00.02.meta
@@ -130,10 +130,10 @@ Error: no pmlogger instance running for host "HOST"
 ... logging for host "HOST" unchanged
 PMLOGGER.DAILY: [TMP.control:2]
 Warning: skipping log rotation because we don't know which pmlogger to signal
-Archive files older than 2 days being removed ...
+Archive files older than 3 days being removed ...
     NOW-3.00.02.0 NOW-3.00.02.index NOW-3.00.02.meta
     NOW-3.00.04.0 NOW-3.00.04.index NOW-3.00.04.meta
-PMLOGGER.DAILY: Warning: no archives found to merge
+Warning: no archives found to merge
 NOW-2.00.02.0
 NOW-2.00.02.index
 NOW-2.00.02.meta

--- a/qa/530
+++ b/qa/530
@@ -134,7 +134,7 @@ LOCALHOSTNAME	n   n	'"$tmp"'	./config'
     echo
     echo "=== [${verbose+verbose}] regular show ==="
     echo "=== [${verbose+verbose}] regular show ===" >>$seq.full
-    $sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -x never -c $tmp.control -k 3 $verbose -l $tmp.log"
+    $sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -x never -c $tmp.control -k 4 $verbose -l $tmp.log"
     $sudo cat $tmp.log | _filter
     ls $tmp | sed -f $tmp.sed | LC_COLLATE=POSIX sort
 
@@ -145,7 +145,7 @@ LOCALHOSTNAME	n   n	'"$tmp"'	./config'
     do
 	$sudo mv $tmp/$yesterday.$ext $tmp/save.$ext
     done
-    $sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -x never -c $tmp.control -k 2 $verbose -l $tmp.log"
+    $sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -x never -c $tmp.control -k 3 $verbose -l $tmp.log"
     $sudo cat $tmp.log | _filter
     ls $tmp | sed -f $tmp.sed | LC_COLLATE=POSIX sort
 
@@ -158,7 +158,7 @@ LOCALHOSTNAME	n   n	'"$tmp"'	./config'
 	$sudo chown $PCP_USER:$PCP_GROUP $tmp/$yesterday.17.18.$ext
 	$sudo mv $tmp/save.$ext $tmp/$yesterday.$ext
     done
-    $sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -x never -c $tmp.control -k 2 $verbose -l $tmp.log"
+    $sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -x never -c $tmp.control -k 3 $verbose -l $tmp.log"
     $sudo cat $tmp.log | _filter
     ls $tmp | sed -f $tmp.sed | LC_COLLATE=POSIX sort
 

--- a/qa/530.out
+++ b/qa/530.out
@@ -86,7 +86,7 @@ Error: no pmlogger instance running for host "HOST"
 ... logging for host "HOST" unchanged
 PMLOGGER.DAILY: [TMP.control:2]
 Warning: skipping log rotation because we don't know which pmlogger to signal
-Archive files older than 3 days being removed ...
+Archive files older than 4 days being removed ...
     NOW-5.00.02.0 NOW-5.00.02.index NOW-5.00.02.meta NOW-5.00.04.0
     NOW-5.00.04.index NOW-5.00.04.meta NOW-4.00.02.0 NOW-4.00.02.index
     NOW-4.00.02.meta NOW-4.00.04.0 NOW-4.00.04.index NOW-4.00.04.meta
@@ -129,10 +129,10 @@ Error: no pmlogger instance running for host "HOST"
 ... logging for host "HOST" unchanged
 PMLOGGER.DAILY: [TMP.control:2]
 Warning: skipping log rotation because we don't know which pmlogger to signal
-Archive files older than 2 days being removed ...
+Archive files older than 3 days being removed ...
     NOW-3.00.02.0 NOW-3.00.02.index NOW-3.00.02.meta NOW-3.00.04.0
     NOW-3.00.04.index NOW-3.00.04.meta
-PMLOGGER.DAILY: Warning: no archives found to merge
+Warning: no archives found to merge
 NOW-2.00.02.0
 NOW-2.00.02.index
 NOW-2.00.02.meta

--- a/qa/532
+++ b/qa/532
@@ -126,12 +126,12 @@ ls -l $tmp >>$seq.full
 # complexity at the end of this pipeline
 #
 echo
-$sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -c $tmp/control -x never -k 2 $verbose -l $tmp.log"
+$sudo -u $PCP_USER -g $PCP_GROUP sh -c "umask 022; $PCP_BINADM_DIR/pmlogger_daily -o -c $tmp/control -x never -k 3 $verbose -l $tmp.log"
 $sudo cat $tmp.log \
 | _filter \
 | $PCP_AWK_PROG '
 state == 0		{ print >"'$tmp.out.0'"
-			  if ($0 ~ /older than 2 days/) state = 1
+			  if ($0 ~ /older than /) state = 1
 			  next
 			}
 state == 1 && $0 ~ /Input archives to be merged:/	{ state = 2 }

--- a/qa/532.out
+++ b/qa/532.out
@@ -64,7 +64,7 @@ Error: no pmlogger instance running for host "HOST"
 ... logging for host "HOST" unchanged
 PMLOGGER.DAILY: [TMP/control:2]
 Warning: skipping log rotation because we don't know which pmlogger to signal
-Archive files older than 2 days being removed ...
+Archive files older than 3 days being removed ...
 NOW-3.1H.MM-00.0
 NOW-3.1H.MM-00.index
 NOW-3.1H.MM-00.meta

--- a/qa/679.out
+++ b/qa/679.out
@@ -8,7 +8,7 @@ QA output created by 679
 
 + cd TMP/oldsem0
 + get mutex lock
-pmlogger_daily: Info: pmlogrewrite all archives in TMP/oldsem0
+Info: pmlogrewrite all archives in TMP/oldsem0
 + PCP_BINADM_DIR/pmlogger_rewrite  -c TMP/oldsem0/pmlogrewrite -V TMP/oldsem0
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
@@ -22,7 +22,7 @@ Warning: skipping log rotation because we don't know which pmlogger to signal
 
 + cd TMP/oldsem1
 + get mutex lock
-pmlogger_daily: Info: pmlogrewrite all archives in TMP/oldsem1
+Info: pmlogrewrite all archives in TMP/oldsem1
 + PCP_BINADM_DIR/pmlogger_rewrite  -c TMP/oldsem1/pmlogrewrite -V TMP/oldsem1
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
@@ -35,7 +35,7 @@ Warning: skipping log rotation because we don't know which pmlogger to signal
 
 + cd TMP/oldsem2
 + get mutex lock
-pmlogger_daily: Info: pmlogrewrite all archives in TMP/oldsem2
+Info: pmlogrewrite all archives in TMP/oldsem2
 + PCP_BINADM_DIR/pmlogger_rewrite  -c TMP/oldsem2/pmlogrewrite -V TMP/oldsem2
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
@@ -47,7 +47,7 @@ Warning: skipping log rotation because we don't know which pmlogger to signal
 
 + cd TMP/newsem0
 + get mutex lock
-pmlogger_daily: Info: pmlogrewrite all archives in TMP/newsem0
+Info: pmlogrewrite all archives in TMP/newsem0
 + PCP_BINADM_DIR/pmlogger_rewrite -c $PCP_VAR_DIR/config/pmlogrewrite -V TMP/newsem0
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
@@ -64,7 +64,7 @@ Warning: skipping log rotation because we don't know which pmlogger to signal
 
 + cd TMP/newsem1
 + get mutex lock
-pmlogger_daily: Info: pmlogrewrite all archives in TMP/newsem1
+Info: pmlogrewrite all archives in TMP/newsem1
 + PCP_BINADM_DIR/pmlogger_rewrite -c $PCP_VAR_DIR/config/pmlogrewrite -V TMP/newsem1
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
@@ -78,7 +78,7 @@ Warning: skipping log rotation because we don't know which pmlogger to signal
 
 + cd TMP/empty
 + get mutex lock
-pmlogger_daily: Info: pmlogrewrite all archives in TMP/empty
+Info: pmlogrewrite all archives in TMP/empty
 + PCP_BINADM_DIR/pmlogger_rewrite -c $PCP_VAR_DIR/config/pmlogrewrite -V TMP/empty
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
@@ -176,7 +176,7 @@ newsem1/20011008:
 
 === daily maintenance of PCP archives for host localhost ===
 
-pmlogger_daily: Info: pmlogrewrite all archives in TMP/oldsem0
+Info: pmlogrewrite all archives in TMP/oldsem0
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
 Warning: skipping log rotation because we don't know which pmlogger to signal
@@ -192,7 +192,7 @@ Removing input archive files ......... done
 
 === daily maintenance of PCP archives for host localhost ===
 
-pmlogger_daily: Info: pmlogrewrite all archives in TMP/oldsem1
+Info: pmlogrewrite all archives in TMP/oldsem1
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
 Warning: skipping log rotation because we don't know which pmlogger to signal
@@ -207,7 +207,7 @@ Removing input archive files ...... done
 
 === daily maintenance of PCP archives for host localhost ===
 
-pmlogger_daily: Info: pmlogrewrite all archives in TMP/oldsem2
+Info: pmlogrewrite all archives in TMP/oldsem2
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
 Warning: skipping log rotation because we don't know which pmlogger to signal
@@ -220,7 +220,7 @@ remove 20011005.00.10.meta
 
 === daily maintenance of PCP archives for host localhost ===
 
-pmlogger_daily: Info: pmlogrewrite all archives in TMP/newsem0
+Info: pmlogrewrite all archives in TMP/newsem0
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
 Warning: skipping log rotation because we don't know which pmlogger to signal
@@ -239,7 +239,7 @@ Removing input archive files .................. done
 
 === daily maintenance of PCP archives for host localhost ===
 
-pmlogger_daily: Info: pmlogrewrite all archives in TMP/newsem1
+Info: pmlogrewrite all archives in TMP/newsem1
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
 Warning: skipping log rotation because we don't know which pmlogger to signal
@@ -255,12 +255,12 @@ Removing input archive files ......... done
 
 === daily maintenance of PCP archives for host localhost ===
 
-pmlogger_daily: Info: pmlogrewrite all archives in TMP/empty
+Info: pmlogrewrite all archives in TMP/empty
 Warning: no PCP archives found
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
 Warning: skipping log rotation because we don't know which pmlogger to signal
-pmlogger_daily: Warning: no archives found to merge
+Warning: no archives found to merge
 oldsem0/20011002:
     Semantics: discrete  Units: none
     Semantics: counter  Units: Kbyte

--- a/qa/793.out
+++ b/qa/793.out
@@ -24,15 +24,15 @@ pmlogger_daily
 
 === daily maintenance of PCP archives for host LOCALHOST ===
 
-PMLOGGER.DAILY: Warning: no archives found to merge
+Warning: no archives found to merge
 
 === daily maintenance of PCP archives for host LOCALHOST ===
 
-PMLOGGER.DAILY: Warning: no archives found to merge
+Warning: no archives found to merge
 
 === daily maintenance of PCP archives for host LOCALHOST ===
 
-PMLOGGER.DAILY: Warning: no archives found to merge
+Warning: no archives found to merge
 3 archives in TMP/A
 3 archives in TMP/B
 3 archives in TMP/C

--- a/qa/925.out
+++ b/qa/925.out
@@ -9,7 +9,7 @@ Error: no pmlogger instance running for host "local:"
 ... logging for host "local:" unchanged
 pmlogger_daily: [TMP.control:5]
 Warning: skipping log rotation because we don't know which pmlogger to signal
-pmlogger_daily: Warning: no archives found to merge
+Warning: no archives found to merge
 mode=drwxr-xr-x user=pcp group=pcp name=myhost
 
 pmlogger/myhost:

--- a/qa/group
+++ b/qa/group
@@ -1649,6 +1649,7 @@ not_in_container
 1229 pmlogextract pmdumplog labels help local sanity
 1230 pmiectl local
 1231 pmlogrewrite labels help pmdumplog local
+1232 logutil pmlogctl local
 1234 libpcp_web local
 1238 iostat archive multi-archive decompress-xz local pmlogextract pcp python
 1239 pmlogrewrite labels pmdumplog local

--- a/src/pmlogger/pmlogger_daily.sh
+++ b/src/pmlogger/pmlogger_daily.sh
@@ -48,9 +48,100 @@ _cleanup()
     lockfile=`cat $tmp/lock 2>/dev/null`
     rm -f "$lockfile" "$PCP_RUN_DIR/pmlogger_daily.pid"
     rm -rf $tmp
-    $VERY_VERBOSE && echo "End: `date '+%F %T.%N'`"
+    $VERY_VERBOSE && echo >&2 "End: `date '+%F %T.%N'`"
 }
 trap "_cleanup; exit \$status" 0 1 2 3 15
+
+# pretty format a find-filter timespec
+#
+_timespec()
+{
+    echo "$1" | sed -e 's/:/ /g' \
+    | while read _d _h _m
+    do
+	case "$_d:$_h:$_m"
+	in
+	    0::)
+		echo "0 days"
+		;;
+	    0::1)
+		echo "1 minute"
+		;;
+	    0::*)
+		echo "$_m minutes"
+		;;
+	    0:1:)
+		echo "1 hour"
+		;;
+	    0:*:)
+		echo "$_h hours"
+		;;
+	    0:1:1)
+		echo "1 hour and 1 minute"
+		;;
+	    0:1:*)
+		echo "1 hour and $_m minutes"
+		;;
+	    0:*:*)
+		echo "$_h hours and $_m minutes"
+		;;
+	    1::)
+		echo "1 day"
+		;;
+	    1::1)
+		echo "1 day and 1 minute"
+		;;
+	    1::*)
+		echo "1 day and $_m minutes"
+		;;
+	    1:1:)
+		echo "1 day and 1 hour"
+		;;
+	    1:*:)
+		echo "1 day and $_h hours"
+		;;
+	    1:1:1)
+		echo "1 day, 1 hour and 1 minute"
+		;;
+	    1:1:*)
+		echo "1 day, 1 hour and $_m minutes"
+		;;
+	    1:*:1)
+		echo "1 day, $_h hours and 1 minute"
+		;;
+	    1:*:*)
+		echo "1 day, $_h hours and $_m minutes"
+		;;
+	    *::)
+		echo "$_d days"
+		;;
+	    *::1)
+		echo "$_d days and 1 minute"
+		;;
+	    *::*)
+		echo "$_d days and $_m minutes"
+		;;
+	    *:1:)
+		echo "$_d days and 1 hour"
+		;;
+	    *:*:)
+		echo "$_d days and $_h hours"
+		;;
+	    *:1:1)
+		echo "$_d days, 1 hour and 1 minute"
+		;;
+	    *:1:*)
+		echo "$_d days, 1 hour and $_m minutes"
+		;;
+	    *:*:1)
+		echo "$_d days, $_h hours and 1 minute"
+		;;
+	    *:*:*)
+		echo "$_d days, $_h hours and $_m minutes"
+		;;
+	esac
+    done
+}
 
 if is_chkconfig_on pmlogger
 then
@@ -98,10 +189,10 @@ else
 fi
 if [ -n "$PCP_COMPRESSAFTER" ]
 then
-    check=`echo "$PCP_COMPRESSAFTER" | sed -e 's/[0-9]//g'`
-    if [ ! -z "$check" -a X"$check" != Xforever -a X"$check" != Xnever ]
+    $PCP_BINADM_DIR/find-filter </dev/null >/dev/null 2>&1 mtime "+$PCP_COMPRESSAFTER"
+    if [ $? != 0 -a X"$PCP_COMPRESSAFTER" != Xforever -a X"$PCP_COMPRESSAFTER" != Xnever ]
     then
-	echo "Error: \$PCP_COMPRESSAFTER value ($PCP_COMPRESSAFTER) must be numeric, \"forever\" or \"never\""
+	echo "Error: \$PCP_COMPRESSAFTER value ($PCP_COMPRESSAFTER) must be number, time, \"forever\" or \"never\""
 	status=1
 	exit
     fi
@@ -149,7 +240,7 @@ cat >> $tmp/usage <<EOF
 Options:
   -c=FILE,--control=FILE  pmlogger control file
   -f,--force              force actions (intended for QA, not production)
-  -k=N,--discard=N        remove archives after N days
+  -k=TIME,--discard=TIME  remove archives after TIME (format DD[:HH[:MM]])
   -K                      compress, but no other changes
   -l=FILE,--logfile=FILE  send important diagnostic messages to FILE
   -m=ADDRs,--mail=ADDRs   send daily NOTICES entries to email addresses
@@ -162,7 +253,7 @@ Options:
   -s=SIZE,--rotate=SIZE   rotate NOTICES file after reaching SIZE bytes
   -t=WANT                 implies -VV, keep verbose output trace for WANT days
   -V,--verbose            verbose output (multiple times for very verbose)
-  -x=N,--compress-after=N  compress archive data files after N days
+  -x=TIME,--compress-after=TIME  compress archive data files after TIME (format DD[:HH[:MM]])
   -X=PROGRAM,--compressor=PROGRAM  use PROGRAM for archive data file compression
   -Y=REGEX,--regex=REGEX  egrep filter when compressing files ["$COMPRESSREGEX_DEFAULT"]
   --help
@@ -207,10 +298,10 @@ do
 		;;
 	-k)	CULLAFTER="$2"
 		shift
-		check=`echo "$CULLAFTER" | sed -e 's/[0-9]//g'`
-		if [ ! -z "$check" -a X"$check" != Xforever -a X"$check" != Xnever ]
+		$PCP_BINADM_DIR/find-filter </dev/null >/dev/null 2>&1 mtime "+$CULLAFTER"
+		if [ $? != 0 -a X"$CULLAFTER" != Xforever -a X"$CULLAFTER" != Xnever ]
 		then
-		    echo "Error: -k value ($CULLAFTER) must be numeric, \"forever\" or \"never\""
+		    echo "Error: -k value ($CULLAFTER) must be number, time, \"forever\" or \"never\""
 		    status=1
 		    exit
 		fi
@@ -309,10 +400,10 @@ do
 		    COMPRESSAFTER_CMDLINE=""
 		    continue
 		fi
-		check=`echo "$COMPRESSAFTER_CMDLINE" | sed -e 's/[0-9]//g'`
-		if [ ! -z "$check" -a X"$check" != Xforever -a X"$check" != Xnever ]
+		$PCP_BINADM_DIR/find-filter </dev/null >/dev/null 2>&1 mtime "+$COMPRESSAFTER_CMDLINE"
+		if [ $? != 0 -a X"$COMPRESSAFTER_CMDLINE" != Xforever -a X"$COMPRESSAFTER_CMDLINE" != Xnever ]
 		then
-		    echo "Error: -x value ($COMPRESSAFTER_CMDLINE) must be numeric, \"forever\" or \"never\""
+		    echo "Error: -x value ($COMPRESSAFTER_CMDLINE) must be number, time, \"forever\" or \"never\""
 		    status=1
 		    exit
 		fi
@@ -436,11 +527,11 @@ fi
 
 if $VERY_VERBOSE
 then
-    echo "Start: `date '+%F %T.%N'`"
+    echo >&2 "Start: `date '+%F %T.%N'`"
     if which pstree >/dev/null 2>&1
     then
-	echo "Called from:"
-	pstree -spa $$
+	echo >&2 "Called from:"
+	pstree >&2 -spa $$
     fi
 fi
 
@@ -794,16 +885,22 @@ _parse_control()
 	then
 	    case "$host"
 	    in
+		\#!#*)	# stopped by pmlogctl ... we'll be checking this one
+			echo >&2 "[$filename:$line] host=\"$host\" primary=\"$primary\" socks=\"$socks\" dir=\"$dir\" args=\"$args\""
+			;;
 		\#*|'')	# comment or empty
 			;;
 		*)
-			echo "[$filename:$line] host=\"$host\" primary=\"$primary\" socks=\"$socks\" dir=\"$dir\" args=\"$args\""
+			echo >&2 "[$filename:$line] host=\"$host\" primary=\"$primary\" socks=\"$socks\" dir=\"$dir\" args=\"$args\""
 			;;
 	    esac
 	fi
 
 	case "$host"
 	in
+	    \#!#*)	# stopped by pmlogctl ... need to check this one
+		host=`echo "$host" | sed -e 's/^#!#//'`
+		;;
 	    \#*|'')	# comment or empty
 		continue
 		;;
@@ -852,10 +949,11 @@ s/^\([A-Za-z][A-Za-z0-9_]*\)=/export \1; \1=/p
 
 			'export PCP_COMPRESSAFTER;'*)
 			    old_value="$PCP_COMPRESSAFTER"
-			    check=`echo "$cmd" | sed -e 's/.*=//' -e 's/[0-9]//g' -e 's/  *$//'`
-			    if [ ! -z "$check" -a X"$check" != Xforever -a X"$check" != Xnever ]
+			    check=`echo "$cmd" | sed -e 's/.*=//' -e 's/  *$//'`
+			    $PCP_BINADM_DIR/find-filter </dev/null >/dev/null 2>&1 mtime "+$check"
+			    if [ $? != 0 -a -n "$check" -a X"$check" != Xforever -a X"$check" != Xnever ]
 			    then
-				_error "\$PCP_COMPRESSAFTER value ($check) must be numeric, \"forever\" or \"never\""
+				_error "\$PCP_COMPRESSAFTER value ($check) must be number, time, \"forever\" or \"never\""
 			    else
 				$SHOWME && echo "+ $cmd"
 				echo eval $cmd >>$tmp/cmd
@@ -948,7 +1046,7 @@ s/^\([A-Za-z][A-Za-z0-9_]*\)=/export \1; \1=/p
 	then
 	    pflag=''
 	    [ $primary = y ] && pflag=' -P'
-	    echo "Check pmlogger$pflag -h $host ... in $dir ..."
+	    echo >&2 "Check pmlogger$pflag -h $host ... in $dir ..."
 	fi
 
 	# make sure output directory hierarchy exists and $PCP_USER
@@ -1010,7 +1108,7 @@ s/^\([A-Za-z][A-Za-z0-9_]*\)=/export \1; \1=/p
 	    rewrite_args="$rewrite"
 	    if $VERBOSE
 	    then
-		echo "$prog: Info: pmlogrewrite all archives in $dir"
+		echo "Info: pmlogrewrite all archives in $dir"
 		rewrite_args="$rewrite_args -V"
 	    fi
 	    $VERY_VERBOSE && rewrite_args="$rewrite_args -V"
@@ -1034,22 +1132,22 @@ s/^\([A-Za-z][A-Za-z0-9_]*\)=/export \1; \1=/p
 	    then
 		_host=`sed -n 2p <"$PCP_TMP_DIR/pmlogger/primary"`
 		_arch=`sed -n 3p <"$PCP_TMP_DIR/pmlogger/primary"`
-		$VERY_VERBOSE && echo "... try $PCP_TMP_DIR/pmlogger/primary: host=$_host arch=$_arch"
+		$VERY_VERBOSE && echo >&2 "... try $PCP_TMP_DIR/pmlogger/primary: host=$_host arch=$_arch"
 		pid=`_get_primary_logger_pid`
 	    fi
 	    if [ -z "$pid" ]
 	    then
 		if $VERY_VERBOSE
 		then
-		    echo "primary pmlogger process PID not found"
-		    ls -l "$PCP_TMP_DIR/pmlogger"
-		    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger'
+		    echo >&2 "primary pmlogger process PID not found"
+		    ls >&2 -l "$PCP_TMP_DIR/pmlogger"
+		    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep >&2 '[P]ID|[p]mlogger'
 		fi
 	    elif _get_pids_by_name pmlogger | grep "^$pid\$" >/dev/null
 	    then
-		$VERY_VERBOSE && echo "primary pmlogger process $pid identified, OK"
+		$VERY_VERBOSE && echo >&2 "primary pmlogger process $pid identified, OK"
 	    else
-		$VERY_VERBOSE && echo "primary pmlogger process $pid not running"
+		$VERY_VERBOSE && echo >&2 "primary pmlogger process $pid not running"
 		pid=''
 	    fi
 	else
@@ -1060,9 +1158,9 @@ s/^\([A-Za-z][A-Za-z0-9_]*\)=/export \1; \1=/p
 	    then
 		if [ -z "$pid" ]
 		then
-		    $VERY_VERBOSE && echo "No non-primary pmlogger process(es) found"
+		    $VERY_VERBOSE && echo >&2 "No non-primary pmlogger process(es) found"
 		else
-		    $VERY_VERBOSE && echo "non-primary pmlogger process(es) $pid identified, OK"
+		    $VERY_VERBOSE && echo >&2 "non-primary pmlogger process(es) $pid identified, OK"
 		fi
 	    fi
 	fi
@@ -1099,27 +1197,57 @@ s/^\([A-Za-z][A-Za-z0-9_]*\)=/export \1; \1=/p
 	    #
 	    if [ X"$CULLAFTER" != Xforever -a X"$CULLAFTER" != Xnever ]
 	    then
+		# *BSD semantics for find(1) -mtime +N are "rounded up to
+		# the next full 24-hour period", compared to GNU/Linux
+		# semantics "any fractional part is ignored".  So, these are
+		# almost always off by one day in terms of the files selected.
+		# 
+		# For GNU/Linux reduce the number of days by one (opens up
+		# the window).
+		#
+		# The real filtering is done by find-filter, we just want to
+		# be sure that we include all of the candidate files in the
+		# find(1) part.
+		#
+		CULLDAYS=`echo $CULLAFTER | sed -e 's/:.*//'`
 		if [ "$PCP_PLATFORM" = freebsd -o "$PCP_PLATFORM" = netbsd -o "$PCP_PLATFORM" = openbsd ]
 		then
-		    # *BSD semantics for find(1) -mtime +N are "rounded up to
-		    # the next full 24-hour period", compared to GNU/Linux
-		    # semantics "any fractional part is ignored".  So, these are
-		    # almost always off by one day in terms of the files selected.
-		    # For consistency, try to match the GNU/Linux semantics by
-		    # using one MORE day.
-		    #
-		    mtime=`expr $CULLAFTER + 1`
+		    :
 		else
-		    mtime=$CULLAFTER
+		    # decrement, unless already zero
+		    #
+		    [ "$CULLDAYS" -gt 0 ] && CULLDAYS=`expr "$CULLDAYS" - 1`
 		fi
-		find . -type f -mtime +$mtime \
+		if [ "$CULLDAYS" -gt 0 ]
+		then
+		    find . -type f -mtime +$CULLDAYS
+		else
+		    find . -type f
+		fi \
+		| $PCP_BINADM_DIR/find-filter mtime +$CULLAFTER \
 		| _filter_filename \
 		| sort >$tmp/list
+		if [ -n "$pid" ]
+		then
+		    # pmlogger is running, make sure we don't cull the current
+		    # archive
+		    #
+		    if [ -f "$PCP_TMP_DIR/pmlogger/$pid" ]
+		    then
+			current_base=`sed -n -e '3s;.*/;;p' <"$PCP_TMP_DIR/pmlogger/$pid"`
+			if [ -n "$current_base" ]
+			then
+			    $VERY_VERBOSE && echo >&2 "[$filename:$line] skip cull for current $current_base archive"
+			    sed -e "/^$current_base/d" <$tmp/list >$tmp/tmp
+			    mv $tmp/tmp $tmp/list
+			fi
+		    fi
+		fi
 		if [ -s $tmp/list ]
 		then
 		    if $VERBOSE
 		    then
-			echo "Archive files older than $CULLAFTER days being removed ..."
+			echo "Archive files older than `_timespec $CULLAFTER` being removed ..."
 			fmt <$tmp/list | sed -e 's/^/    /'
 		    fi
 		    if $SHOWME
@@ -1129,7 +1257,7 @@ s/^\([A-Za-z][A-Za-z0-9_]*\)=/export \1; \1=/p
 			cat $tmp/list | xargs rm -f
 		    fi
 		else
-		    $VERY_VERBOSE && echo "$prog: Warning: no archive files found to cull"
+		    $VERY_VERBOSE && echo >&2 "Warning: no archive files found to cull"
 		fi
 	    fi
 
@@ -1198,10 +1326,15 @@ END	{ if (inlist != "") print lastdate,inlist }' >$tmp/list
 	    else
 		if [ ! -s $tmp/list ]
 		then
-		    if $VERBOSE
+		    if $SHOWME
 		    then
-			echo "$prog: Warning: no archives found to merge"
-			$VERY_VERBOSE && ls -l
+			:
+		    else
+			if $VERBOSE
+			then
+			    echo "Warning: no archives found to merge"
+			    $VERY_VERBOSE && ls >&2 -l
+			fi
 		    fi
 		else
 		    cat $tmp/list \
@@ -1212,7 +1345,7 @@ END	{ if (inlist != "") print lastdate,inlist }' >$tmp/list
 			    _skipping "output archive ($outfile) already exists"
 			    continue
 			else
-			    $VERY_VERBOSE && echo "Rewriting input archives using $rewrite"
+			    $VERY_VERBOSE && echo >&2 "Rewriting input archives using $rewrite"
 			    if $RFLAG
 			    then
 				:
@@ -1238,12 +1371,12 @@ END	{ if (inlist != "") print lastdate,inlist }' >$tmp/list
 			    then
 				for arch in $inlist
 				do
-				    echo "Input archive $arch ..."
+				    echo >&2 "Input archive $arch ..."
 				    if $SHOWME
 				    then
 					echo "+ pmdumplog -L $arch"
 				    else
-					pmdumplog -L $arch
+					pmdumplog >&2 -L $arch
 				    fi
 				done
 			    fi
@@ -1259,8 +1392,8 @@ END	{ if (inlist != "") print lastdate,inlist }' >$tmp/list
 				then
 				    if $VERY_VERBOSE
 				    then
-					echo "Renamed output archive $outfile ..."
-					pmdumplog -L $outfile
+					echo >&2 "Renamed output archive $outfile ..."
+					pmdumplog >&2 -L $outfile
 				    fi
 				else
 				    _error "problems executing pmlogmv for host \"$host\""
@@ -1275,8 +1408,8 @@ END	{ if (inlist != "") print lastdate,inlist }' >$tmp/list
 				then
 				    if $VERY_VERBOSE
 				    then
-					echo "Merged output archive $outfile ..."
-					pmdumplog -L $outfile
+					echo >&2 "Merged output archive $outfile ..."
+					pmdumplog >&2 -L $outfile
 				    fi
 				else
 				    _error "problems executing pmlogger_merge for host \"$host\""
@@ -1294,7 +1427,7 @@ END	{ if (inlist != "") print lastdate,inlist }' >$tmp/list
 	COMPRESSAFTER="$PCP_COMPRESSAFTER"
 	[ -z "$COMPRESSAFTER" ] && COMPRESSAFTER="$COMPRESSAFTER_CMDLINE"
 	[ -z "$COMPRESSAFTER" ] && COMPRESSAFTER="$COMPRESSAFTER_DEFAULT"
-	$VERY_VERBOSE && echo "$prog: COMPRESSAFTER=$COMPRESSAFTER"
+	$VERY_VERBOSE && echo >&2 "COMPRESSAFTER=$COMPRESSAFTER"
 	if [ -n "$COMPRESSAFTER" -a X"$COMPRESSAFTER" != Xforever -a X"$COMPRESSAFTER" != Xnever ]
 	then
 	    # may have some compression to do ...
@@ -1384,7 +1517,7 @@ p
 			# either the current index or the current metadata
 			# files
 			#
-			$VERY_VERBOSE && echo "[$filename:$line] skip current vol $current_base.$current_vol"
+			$VERY_VERBOSE && echo >&2 "[$filename:$line] skip compress for current $current_base.$current_vol volume"
 			rm -f $tmp/out
 			touch $tmp/out
 			# need to handle both the year 2000 and the old name
@@ -1438,7 +1571,7 @@ p
 			    cat $tmp/list | xargs $COMPRESS
 			fi
 		    else
-			$VERY_VERBOSE && echo "$prog: Warning: no archive files found to compress"
+			$VERY_VERBOSE && echo >&2 "Warning: no archive files found to compress"
 		    fi
 		elif [ -z "$COMPRESSAFTER" -o X"$COMPRESSAFTER" = Xforever -o X"$COMPRESSAFTER" = Xnever ]
 		then
@@ -1481,7 +1614,7 @@ p
 		    cat $tmp/list | xargs rm -f
 		fi
 	    else
-		$VERY_VERBOSE && echo "$prog: Warning: no trace files found to cull"
+		$VERY_VERBOSE && echo >&2 "Warning: no trace files found to cull"
 	    fi
 	fi
 
@@ -1497,7 +1630,7 @@ p
 if [ -f $PCP_LOG_DIR/pmlogger/.NeedRewrite ]
 then
     REWRITEALL=true
-    $VERBOSE && echo "$prog: Info: found .NeedRewrite => rewrite all archives"
+    $VERBOSE && echo "Info: found .NeedRewrite => rewrite all archives"
 fi
 
 _parse_control $CONTROL


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200706

Ken McDonell (4):
      qa/119: re-order setup
      pmlogger_daily: -k 0 fixes
      qa/1232: (new) check pmlogger_daily -k 0
      qa: assorted changes/remakes to match changed pmlogger_daily -k semantics

 man/man1/pmlogger_check.1      |  168 ++++++++++++++++++++--------
 qa/119                         |   30 ++---
 qa/1232                        |  107 +++++++++++++++++
 qa/1232.out                    |   36 ++++++
 qa/151                         |    6 -
 qa/151.out                     |    2 
 qa/338                         |    6 -
 qa/338.out                     |    6 -
 qa/530                         |    6 -
 qa/530.out                     |    6 -
 qa/532                         |    4 
 qa/532.out                     |    2 
 qa/679.out                     |   26 ++--
 qa/793.out                     |    6 -
 qa/925.out                     |    2 
 qa/group                       |    1 
 src/pmlogger/pmlogger_daily.sh |  245 +++++++++++++++++++++++++++++++----------
 17 files changed, 509 insertions(+), 150 deletions(-)

Details ...

commit 4bb6a878e7a6458b2ebfc6bd099a77432cfc19b4
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Jul 7 12:57:07 2020 +1000

    qa: assorted changes/remakes to match changed pmlogger_daily -k semantics
    
    Since -k now has robust semantics relative to "now", not some midnight
    in the past or future, we need to tweak some of these tests a little.

commit ee9e6291e996e30533f7c369ee6b2c03cd8cffa1
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Jul 7 12:56:36 2020 +1000

    qa/1232: (new) check pmlogger_daily -k 0

commit 27a818f9937a9c074a339f63e0ff36b849f5cd0e
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Jul 7 08:22:26 2020 +1000

    pmlogger_daily: -k 0 fixes
    
    This commit completes the work started a while ago, but interrupted
    by the "signal pmlogger to rotate logs" work, the wrestling with systemd
    and the pmlogctl development.
    
    Included in this commit is:
    
    - consistent use of stderr for all verbose, very verbose, warning and
      error output
    - complete implementation of the extended DD[:MM[:HH]] notation for the
      -x and -k options to allow specification of "periods" other than an
      integral number of days, and in particular less than 1 day
    - integration of the pmlogctl #!# protcol in the control files for instances
      stopped by pmlogctl
    - removing redundant "pmlogger_check:" preamble for some messages to reduce
      output clutter with -V and -VV
    - proper handling of -k 0 (or indeed any period less than one day)
    - change in -k semantics to match the recent changes to -x semantics, namely
      the "period" is measured from _now_, not some arbitrary midnight as chosen
      by find(1) ... this removes a cross-platform inconsistency that has been
      there since day one

commit 8e7ebe9ab2ae70ce69ee22f0ebaf2912ff5c1baf
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Mon Jul 6 15:43:57 2020 +1000

    qa/119: re-order setup
    
    Need to stop current pmlogger BEFORE dinking with
    /etc/pcp/pmlogger/control.d