### PR TITLE
help text for derived metrics, temp file/dir renaming, misc stuff

### DIFF
--- a/man/man3/pmloadderivedconfig.3
+++ b/man/man3/pmloadderivedconfig.3
@@ -58,22 +58,72 @@ that is used for PCP performance metrics, see
 .BR PCPIntro (1)
 and
 .BR PMNS (5).
+.PD 0
 .IP * 2n
 an equals sign (``='')
 .IP * 2n
 a valid expression for a derived metric, as described in
 .BR pmRegisterDerived (3).
-.PP
-White space is ignored in the lines.
+.PD
 .PP
 For each line containing a derived metric definition,
 .BR pmRegisterDerived (3)
 is called to register the new derived metric.
 .PP
+Once a derived metric has been declared, it may be assigned additional
+attributes with a line of the form:
+.IP * 2n
+the name of the derived metric,
+.PD 0
+.IP * 2n
+a left parenthesis, an
+.I attribute
+.I type
+and a right parenthesis,
+.IP * 2n
+an equals sign (``=''),
+.IP * 2n
+an
+.I attribute
+.IR value .
+.PD
+.PP
+Currently,
+.I attribute
+.I type
+may be either
+.B oneline
+or
+.B helptext
+to designate the ``one line'' or expanded help text to be associated with
+the derived metric, see
+.BR pmLookupText (3).
+.PP
+The
+.I attribute
+.I value
+may be either arbitrary text following the ``='' and ending at the end
+of the line, else a string enclosed in either single quotes (') or
+double quotes (").  In the latter case, the
+.I attribute
+.I value
+may span multiple lines, and a simple escape mechanism is supported,
+namely for any character ``x'', ``\ex'' is replaced by ``x'' (this
+allows quotes to be escaped within a string, for example), and there
+is a special case when the ``\e'' comes at the end of the line in
+which case the following newline is not included in the
+.I attribute
+.IR value .
+.PP
+Outside of
+.I attribute
+.IR values ,
+white space is ignored in the lines, and blank lines are ignored altogether.
+.PP
 Because
 .B pmLoadDerivedConfig
 may process many files, each of which may contain many derived metric
-specifications, it is not possible to provide very specific error
+specifications, it is not possible to provide a specific error
 status on return.
 Hence the result from
 .B pmLoadDerivedConfig
@@ -100,11 +150,16 @@ bad_in_pkts = network.interface.in.errors + network.interface.in.drops
 # note the following would need to be on a single line ...
 disk.dev.read_pct = 100 * delta(disk.dev.read) /
             (delta(disk.dev.read) + delta(disk.dev.write))
+disk.dev.read_pct(oneline) = percentage of disk reads
+disk.dev.read_pct(helptext) = '\e
+Percentage of disk reads compared to the total number of
+disk reads and disk writes.'
 .fi
 .SH SEE ALSO
 .BR sh (1),
 .BR PCPIntro (1),
 .BR PMAPI (3),
+.BR pmLookupText (3),
 .BR pmRegisterDerived (3),
 .BR pmprintf (3)
 and

--- a/qa/031.out.linux
+++ b/qa/031.out.linux
@@ -65,7 +65,6 @@ children of "sample.longlong" ...
 pmid: PM_ID_NULL name: bozo.the.clown
 
 children of "" ...
-    acct                <s = 1>
     disk                <s = 1>
     event               <s = 1>
     filesys             <s = 1>

--- a/qa/1001
+++ b/qa/1001
@@ -24,7 +24,7 @@ End-of-File
 
 echo
 echo "=== view with non-existant archive ==="
-PCP_STDERR=$tmp.err pmchart -c CPU -a /no/such/archive
+PCP_STDERR=$tmp.err pmchart -c CPU -a /no/such/archive 2>&1 | _filter_views
 cat $tmp.err
 
 exit

--- a/qa/1102
+++ b/qa/1102
@@ -46,7 +46,7 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 _stop_auto_restart pmcd
 
 _pmdaopenmetrics_save_config
-_pmdaopenmetrics_remove
+_pmdaopenmetrics_remove | sed -e 's/not found in Name Space, this is OK/done/'
 _pmdaopenmetrics_install
 
 port=`_find_free_port 10000`

--- a/qa/1199
+++ b/qa/1199
@@ -26,7 +26,7 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 
 _stop_auto_restart pmcd
 _service pmcd restart 2>&1 | _filter_pcp_start
-pminfo -v sample >/dev/null
+pminfo -v -b 1000 >/dev/null
 
 # real QA test starts here
 pmprobe -v pmcd.datasize | tee -a $here/$seq.full >$tmp.tmp

--- a/qa/1233
+++ b/qa/1233
@@ -1,0 +1,112 @@
+#!/bin/sh
+# PCP QA Test No. 1233
+# name(attr) = string testing for derived metrics - error cases
+#
+# Copyright (c) 2020 Ken McDonell.  All Rights Reserved.
+#
+
+seq=`basename $0`
+if [ $# -eq 0 ]
+then
+    echo "QA output created by $seq"
+else
+    echo "QA output created by $seq $*"
+fi
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+if [ "$1" = "--valgrind" ]
+then
+    _check_valgrind
+fi
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_filter()
+{
+    sed \
+	-e "s;$tmp;TMP;g" \
+    # end
+}
+
+# real QA test starts here
+cat <<End-of-File >$tmp.config.1
+# missing <name>
+( = "foo"
+(oneline  = "foo"
+(oneline)="foo"
+
+# missing )
+qa( = "foo"
+qa.a(oneline="foo"
+
+# missing ( => illegal metric name
+) = "bar"
+qa)= "bar"
+qa.a) ="bar"
+
+# missing <attr>
+qa.seconds = sample.milliseconds / 1000
+qa.seconds()="foo"
+qa.seconds ()  = "foo"
+qa.seconds (	)	=	"foo"
+
+# missing <value>
+qa.seconds(oneline)=
+
+# illegal <attr>
+qa.seconds(foo) = bar;
+
+# bad metric
+qa.notdefined.yet ( foo ) = bar;
+
+# terminated value ... check to see if line number is updated correctly
+# for next error
+qa.seconds(helptext) = 'foo
+bar
+fratz'
+
+# next line is line number
+qa.seconds(oneline) = "expect this error to be at line number ...
+37
+was it?
+End-of-File
+
+cat <<End-of-File >$tmp.config.2
+qa.seconds = sample.milliseconds / 1000
+qa.seconds(oneline) = "a string with extra text after the quote"extra stuff oneline
+qa.seconds(helptext) = 'a block
+with extra
+text after
+the quote'extra stuff helptext
+End-of-File
+
+for config in $tmp.config.*
+do
+    echo
+    echo "=== `echo $config | sed -e 's;.*config\.;config.;'` ==="
+    export PCP_DERIVED_CONFIG=$config
+
+    if [ "$1" = "--valgrind" ]
+    then
+	_run_valgrind `which pminfo` -dtT -Dderive qa | _filter
+    else
+	pminfo -dtT -Dderive qa 2>&1 \
+	| _filter
+    fi
+done
+
+# success, all done
+status=0
+exit

--- a/qa/1233.out
+++ b/qa/1233.out
@@ -1,0 +1,68 @@
+QA output created by 1233
+
+=== config.1 ===
+pmRegisterDerived: register metric[0] event.flags = anon(PM_TYPE_U32)
+pmRegisterDerived: register metric[1] event.missed = anon(PM_TYPE_U32)
+Derived metric initialization from $PCP_DERIVED_CONFIG
+pmLoadDerivedConfig("TMP.config.1")
+[TMP.config.1:2] Error: pmLoadDerivedConfig: derived metric name missing
+( = "foo"
+[TMP.config.1:3] Error: pmLoadDerivedConfig: derived metric name missing
+(oneline  = "foo"
+[TMP.config.1:4] Error: pmLoadDerivedConfig: derived metric name missing
+(oneline)="foo"
+[TMP.config.1:7] Error: pmLoadDerivedConfig: missing ')' after attribute
+qa( = "foo"
+[TMP.config.1:8] Error: pmLoadDerivedConfig: missing ')' after attribute
+qa.a(oneline="foo"
+[TMP.config.1:11] Error: pmLoadDerivedConfig: illegal derived metric name ())
+[TMP.config.1:12] Error: pmLoadDerivedConfig: illegal derived metric name (qa))
+[TMP.config.1:13] Error: pmLoadDerivedConfig: illegal derived metric name (qa.a))
+pmRegisterDerived: register metric[2] qa.seconds = sample.milliseconds / 1000
+[TMP.config.1:17] Error: pmLoadDerivedConfig: attribute name missing
+qa.seconds()="foo"
+[TMP.config.1:18] Error: pmLoadDerivedConfig: attribute name missing
+qa.seconds ()  = "foo"
+[TMP.config.1:19] Error: pmLoadDerivedConfig: attribute name missing
+qa.seconds (	)	=	"foo"
+[TMP.config.1:22] Error: pmLoadDerivedConfig: attribute value missing
+qa.seconds(oneline)=
+[TMP.config.1:25] Error: pmLoadDerivedConfig: attribute (foo) is unknown for metric (qa.seconds)
+qa.seconds(foo) = bar;
+[TMP.config.1:28] Error: pmLoadDerivedConfig: cannot set attribute, derived metric (qa.notdefined.yet) not defined
+qa.notdefined.yet ( foo ) = bar;
+[TMP.config.1:38] Error: pmLoadDerivedConfig: missing termination (") for value
+__dmgetpmid: metric "qa.seconds" -> PMID 511.0.3
+__dmbind: bind metric[2] qa.seconds
+__dmtraverse: name="qa" added "qa.seconds"
+__dmgetpmid: metric "qa.seconds" -> PMID 511.0.3
+
+qa.seconds One-line Help: Error: One-line or help text is not available
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: millisec
+Help:
+foo
+bar
+fratz
+
+=== config.2 ===
+pmRegisterDerived: register metric[0] event.flags = anon(PM_TYPE_U32)
+pmRegisterDerived: register metric[1] event.missed = anon(PM_TYPE_U32)
+Derived metric initialization from $PCP_DERIVED_CONFIG
+pmLoadDerivedConfig("TMP.config.2")
+pmRegisterDerived: register metric[2] qa.seconds = sample.milliseconds / 1000
+[TMP.config.2:2] Warning: pmLoadDerivedConfig: extra text (extra stuff oneline) after attribute value will be ignored
+[TMP.config.2:5] Warning: pmLoadDerivedConfig: extra text (xtra stuff helptext) after attribute value will be ignored
+__dmgetpmid: metric "qa.seconds" -> PMID 511.0.3
+__dmbind: bind metric[2] qa.seconds
+__dmtraverse: name="qa" added "qa.seconds"
+__dmgetpmid: metric "qa.seconds" -> PMID 511.0.3
+
+qa.seconds [a string with extra text after the quote]
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: millisec
+Help:
+a block
+with extra
+text after
+the quote

--- a/qa/1235
+++ b/qa/1235
@@ -1,0 +1,32 @@
+#!/bin/sh
+# PCP QA Test No. 1235
+# name(attr) = string testing for derived metrics - error cases
+# - valgrind version of qa/1233
+#
+# Copyright (c) 2020 Ken McDonell.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+# real QA test starts here
+./1233 --valgrind
+
+# success, all done
+status=0
+exit

--- a/qa/1235.out
+++ b/qa/1235.out
@@ -1,0 +1,87 @@
+QA output created by 1235
+QA output created by 1233 --valgrind
+
+=== config.1 ===
+=== std out ===
+
+qa.seconds One-line Help: Error: One-line or help text is not available
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: millisec
+Help:
+foo
+bar
+fratz
+=== std err ===
+pmRegisterDerived: register metric[0] event.flags = anon(PM_TYPE_U32)
+pmRegisterDerived: register metric[1] event.missed = anon(PM_TYPE_U32)
+Derived metric initialization from $PCP_DERIVED_CONFIG
+pmLoadDerivedConfig("TMP.config.1")
+[TMP.config.1:2] Error: pmLoadDerivedConfig: derived metric name missing
+( = "foo"
+[TMP.config.1:3] Error: pmLoadDerivedConfig: derived metric name missing
+(oneline  = "foo"
+[TMP.config.1:4] Error: pmLoadDerivedConfig: derived metric name missing
+(oneline)="foo"
+[TMP.config.1:7] Error: pmLoadDerivedConfig: missing ')' after attribute
+qa( = "foo"
+[TMP.config.1:8] Error: pmLoadDerivedConfig: missing ')' after attribute
+qa.a(oneline="foo"
+[TMP.config.1:11] Error: pmLoadDerivedConfig: illegal derived metric name ())
+[TMP.config.1:12] Error: pmLoadDerivedConfig: illegal derived metric name (qa))
+[TMP.config.1:13] Error: pmLoadDerivedConfig: illegal derived metric name (qa.a))
+pmRegisterDerived: register metric[2] qa.seconds = sample.milliseconds / 1000
+[TMP.config.1:17] Error: pmLoadDerivedConfig: attribute name missing
+qa.seconds()="foo"
+[TMP.config.1:18] Error: pmLoadDerivedConfig: attribute name missing
+qa.seconds ()  = "foo"
+[TMP.config.1:19] Error: pmLoadDerivedConfig: attribute name missing
+qa.seconds (	)	=	"foo"
+[TMP.config.1:22] Error: pmLoadDerivedConfig: attribute value missing
+qa.seconds(oneline)=
+[TMP.config.1:25] Error: pmLoadDerivedConfig: attribute (foo) is unknown for metric (qa.seconds)
+qa.seconds(foo) = bar;
+[TMP.config.1:28] Error: pmLoadDerivedConfig: cannot set attribute, derived metric (qa.notdefined.yet) not defined
+qa.notdefined.yet ( foo ) = bar;
+[TMP.config.1:38] Error: pmLoadDerivedConfig: missing termination (") for value
+__dmgetpmid: metric "qa.seconds" -> PMID 511.0.3
+__dmbind: bind metric[2] qa.seconds
+__dmtraverse: name="qa" added "qa.seconds"
+__dmgetpmid: metric "qa.seconds" -> PMID 511.0.3
+=== filtered valgrind report ===
+Memcheck, a memory error detector
+Command: /usr/bin/pminfo -dtT -Dderive qa
+LEAK SUMMARY:
+definitely lost: 0 bytes in 0 blocks
+indirectly lost: 0 bytes in 0 blocks
+ERROR SUMMARY: 0 errors from 0 contexts ...
+
+=== config.2 ===
+=== std out ===
+
+qa.seconds [a string with extra text after the quote]
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: millisec
+Help:
+a block
+with extra
+text after
+the quote
+=== std err ===
+pmRegisterDerived: register metric[0] event.flags = anon(PM_TYPE_U32)
+pmRegisterDerived: register metric[1] event.missed = anon(PM_TYPE_U32)
+Derived metric initialization from $PCP_DERIVED_CONFIG
+pmLoadDerivedConfig("TMP.config.2")
+pmRegisterDerived: register metric[2] qa.seconds = sample.milliseconds / 1000
+[TMP.config.2:2] Warning: pmLoadDerivedConfig: extra text (extra stuff oneline) after attribute value will be ignored
+[TMP.config.2:5] Warning: pmLoadDerivedConfig: extra text (xtra stuff helptext) after attribute value will be ignored
+__dmgetpmid: metric "qa.seconds" -> PMID 511.0.3
+__dmbind: bind metric[2] qa.seconds
+__dmtraverse: name="qa" added "qa.seconds"
+__dmgetpmid: metric "qa.seconds" -> PMID 511.0.3
+=== filtered valgrind report ===
+Memcheck, a memory error detector
+Command: /usr/bin/pminfo -dtT -Dderive qa
+LEAK SUMMARY:
+definitely lost: 0 bytes in 0 blocks
+indirectly lost: 0 bytes in 0 blocks
+ERROR SUMMARY: 0 errors from 0 contexts ...

--- a/qa/1236
+++ b/qa/1236
@@ -1,0 +1,92 @@
+#!/bin/sh
+# PCP QA Test No. 1236
+# name(attr) = string testing for derived metrics - string handling cases
+#
+# Copyright (c) 2020 Ken McDonell.  All Rights Reserved.
+#
+
+seq=`basename $0`
+if [ $# -eq 0 ]
+then
+    echo "QA output created by $seq"
+else
+    echo "QA output created by $seq $*"
+fi
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+if [ "$1" = "--valgrind" ]
+then
+    _check_valgrind
+fi
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_filter()
+{
+    sed \
+	-e "s;$tmp;TMP;g" \
+    # end
+}
+
+# real QA test starts here
+cat <<'End-of-File' >$tmp.config
+qa.one.simple = sample.milliseconds / 1000
+qa.one.string = sample.milliseconds / 1000
+qa.one.escape = sample.milliseconds / 1000
+qa.help.simple = sample.milliseconds / 1000
+qa.help.string = sample.milliseconds / 1000
+qa.help.escape = sample.milliseconds / 1000
+qa.both.simple = sample.milliseconds / 1000
+qa.both.string = sample.milliseconds / 1000
+qa.both.escape = sample.milliseconds / 1000
+
+qa.one.simple(oneline) = words without quotes
+qa.one.string(oneline) = "a string"
+qa.one.escape(oneline) = "embedded escapes, >>>\f\o\o\\\"<<< expect foo<backslash><doublequote>"
+
+qa.help.simple(helptext) = longer words, but still no ' nor any "
+qa.help.string(helptext) = "string with quote (') and double quote (\") embedded"
+qa.help.escape(helptext) ='embedded escapes, >>>\f
+\o
+\o
+\\
+\'
+<<< expect f\\no\\no\\n<backslash>\\n<single quote\\n where \\n is a newline'
+
+qa.both.simple(oneline) = fubar
+qa.both.simple(helptext) = fouled up beyond all recognition
+qa.both.string(oneline) = ''
+qa.both.string(helptext) = 'string with quote (\') and double quote (") embedded'
+qa.both.escape(oneline) = "'"
+qa.both.escape(helptext) = 'just quotes ...
+\' " \' " \'
+" \' " \' "
+\' " \' " \'
+" \' " \' "'
+End-of-File
+
+export PCP_DERIVED_CONFIG=$tmp.config
+
+if [ "$1" = "--valgrind" ]
+then
+    _run_valgrind `which pminfo` -tT qa | _filter
+else
+    pminfo -tT qa 2>&1 \
+    | _filter
+fi
+
+# success, all done
+status=0
+exit

--- a/qa/1236.out
+++ b/qa/1236.out
@@ -1,0 +1,46 @@
+QA output created by 1236
+
+qa.one.simple [words without quotes]
+Help:
+words without quotes
+
+qa.one.string [a string]
+Help:
+a string
+
+qa.one.escape [embedded escapes, >>>foo\"<<< expect foo<backslash><doublequote>]
+Help:
+embedded escapes, >>>foo\"<<< expect foo<backslash><doublequote>
+
+qa.help.simple One-line Help: Error: One-line or help text is not available
+Help:
+longer words, but still no ' nor any "
+
+qa.help.string One-line Help: Error: One-line or help text is not available
+Help:
+string with quote (') and double quote (") embedded
+
+qa.help.escape One-line Help: Error: One-line or help text is not available
+Help:
+embedded escapes, >>>f
+o
+o
+\
+'
+<<< expect f\no\no\n<backslash>\n<single quote\n where \n is a newline
+
+qa.both.simple [fubar]
+Help:
+fouled up beyond all recognition
+
+qa.both.string []
+Help:
+string with quote (') and double quote (") embedded
+
+qa.both.escape [']
+Help:
+just quotes ...
+' " ' " '
+" ' " ' "
+' " ' " '
+" ' " ' "

--- a/qa/1237
+++ b/qa/1237
@@ -1,0 +1,32 @@
+#!/bin/sh
+# PCP QA Test No. 1237
+# name(attr) = string testing for derived metrics - string handling cases
+# - valgrind version of qa/1236
+#
+# Copyright (c) 2020 Ken McDonell.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+# real QA test starts here
+./1236 --valgrind
+
+# success, all done
+status=0
+exit

--- a/qa/1237.out
+++ b/qa/1237.out
@@ -1,0 +1,56 @@
+QA output created by 1237
+QA output created by 1236 --valgrind
+=== std out ===
+
+qa.one.simple [words without quotes]
+Help:
+words without quotes
+
+qa.one.string [a string]
+Help:
+a string
+
+qa.one.escape [embedded escapes, >>>foo\"<<< expect foo<backslash><doublequote>]
+Help:
+embedded escapes, >>>foo\"<<< expect foo<backslash><doublequote>
+
+qa.help.simple One-line Help: Error: One-line or help text is not available
+Help:
+longer words, but still no ' nor any "
+
+qa.help.string One-line Help: Error: One-line or help text is not available
+Help:
+string with quote (') and double quote (") embedded
+
+qa.help.escape One-line Help: Error: One-line or help text is not available
+Help:
+embedded escapes, >>>f
+o
+o
+\
+'
+<<< expect f\no\no\n<backslash>\n<single quote\n where \n is a newline
+
+qa.both.simple [fubar]
+Help:
+fouled up beyond all recognition
+
+qa.both.string []
+Help:
+string with quote (') and double quote (") embedded
+
+qa.both.escape [']
+Help:
+just quotes ...
+' " ' " '
+" ' " ' "
+' " ' " '
+" ' " ' "
+=== std err ===
+=== filtered valgrind report ===
+Memcheck, a memory error detector
+Command: /usr/bin/pminfo -tT qa
+LEAK SUMMARY:
+definitely lost: 0 bytes in 0 blocks
+indirectly lost: 0 bytes in 0 blocks
+ERROR SUMMARY: 0 errors from 0 contexts ...

--- a/qa/1695
+++ b/qa/1695
@@ -37,7 +37,10 @@ EOF
 port=`_find_free_port`
 _filter_port()
 {
-    sed -e "s/ FD $port / FD PORT /g"
+    sed \
+	-e "s/ FD $port / FD PORT /g" \
+	-e '/PORT ipv6 /d' \
+    # end
 }
 
 # real QA test starts here

--- a/qa/1695.out
+++ b/qa/1695.out
@@ -15,7 +15,6 @@ pmproxy request port(s):
   === ==== ===== ====== =======
 ok FD unix UNIX_DOMAIN_SOCKET
 ok FD PORT inet INADDR_ANY
-ok FD PORT ipv6 INADDR_ANY
 [DATE] pmproxy(PID) Info: pmproxy caught SIGTERM
 [DATE] pmproxy(PID) Info: pmproxy Shutdown
 

--- a/qa/1696
+++ b/qa/1696
@@ -41,7 +41,10 @@ EOF
 port=`_find_free_port`
 _filter_port()
 {
-    sed -e "s/ FD $port / FD PORT /g"
+    sed \
+	-e "s/ FD $port / FD PORT /g" \
+	-e '/PORT ipv6 /d' \
+    # end
 }
 
 # real QA test starts here

--- a/qa/1696.out
+++ b/qa/1696.out
@@ -14,7 +14,6 @@ pmproxy request port(s):
   === ==== ===== ====== =======
 ok FD unix UNIX_DOMAIN_SOCKET
 ok FD PORT inet INADDR_ANY
-ok FD PORT ipv6 INADDR_ANY
 [DATE] pmproxy(PID) Info: pmproxy caught SIGTERM
 [DATE] pmproxy(PID) Info: pmproxy Shutdown
 

--- a/qa/1768
+++ b/qa/1768
@@ -28,7 +28,7 @@ _filter()
     sed \
 	-e "s,$PCP_SYSCONF_DIR,PCP_SYSCONF_DIR,g" \
 	-e "s,$tmp\.pmfind,PMFIND,g" \
-	-e "s,cp .*tmp.pcp\........../,cp TMPDIR/,g" \
+	-e "/^+ cp /s, $PCP_TMPFILE_DIR/pmfind_check.[^/]*/, TMPDIR/," \
     #end
 }
 

--- a/qa/623.out
+++ b/qa/623.out
@@ -30,13 +30,13 @@ TMP/DATE.index
 TMP/DATE.meta.compressed
 
 some error cases
-Error: -x value (bozo) must be numeric, "forever" or "never"
-Error: $PCP_COMPRESSAFTER value (bozo) must be numeric, "forever" or "never"
+Error: -x value (bozo) must be number, time, "forever" or "never"
+Error: $PCP_COMPRESSAFTER value (bozo) must be number, time, "forever" or "never"
 Warning: skipping log rotation because we don't know which pmlogger to signal
 Error: no-such-compression-tool: compression program not found
 Warning: skipping log rotation because we don't know which pmlogger to signal
 Error: no-such-compression-tool: compression program not found
-Error: $PCP_COMPRESSAFTER value (bozo) must be numeric, "forever" or "never"
+Error: $PCP_COMPRESSAFTER value (bozo) must be number, time, "forever" or "never"
 Warning: skipping log rotation because we don't know which pmlogger to signal
 
 some warning cases

--- a/qa/679.out
+++ b/qa/679.out
@@ -83,7 +83,6 @@ Info: pmlogrewrite all archives in TMP/empty
 Error: no pmlogger instance running for host "localhost"
 ... logging for host "localhost" unchanged
 Warning: skipping log rotation because we don't know which pmlogger to signal
-pmlogger_daily: Warning: no archives found to merge
 oldsem0/20011002:
     Semantics: instant  Units: none
     Semantics: counter  Units: byte

--- a/qa/admin/check-vm
+++ b/qa/admin/check-vm
@@ -1225,8 +1225,29 @@ if which dpkg >/dev/null 2>&1
 then
     # Debian based
     #
+    # Borrowed from Makepkgs ... we don't use Python2 on some recent
+    # Ubuntu versions
+    #
+    pkgs="python-all python-all-dev python3-all python3-all-dev"
+    if [ -f /etc/lsb-release ]
+    then
+	if grep -q 'DISTRIB_ID=Ubuntu' /etc/lsb-release
+	then
+	    eval `grep DISTRIB_RELEASE= /etc/lsb-release`
+	    XDISTRIB_RELEASE=`echo $DISTRIB_RELEASE | sed -e 's/[^0-9]//g' -e 's/\.//'`
+	    [ -z "$XDISTRIB_RELEASE" ] && XDISTRIB_RELEASE=0000
+	    if [ $XDISTRIB_RELEASE -ge 2004 ]
+	    then
+		# As of Ubuntu 20.04 the Python2 dependency packages have
+		# been renamed (at least python-dev -> python-dev-is-python2)
+		# so try building without Python2
+		#
+		pkgs=`echo "$pkgs" | sed -e 's/python-[^ ]*//g'`
+	    fi
+	fi
+    fi
     dpkg -l >$tmp.tmp
-    for pkg in python-all python-all-dev python3-all python3-all-dev
+    for pkg in $pkgs
     do
 	if grep "^ii *$pkg" <$tmp.tmp >/dev/null
 	then

--- a/qa/admin/other-packages/require
+++ b/qa/admin/other-packages/require
@@ -20,5 +20,6 @@ Debian       -        -       python-setuptools python-all python-all-dev
 LinuxMint    -        -       python-setuptools python-all python-all-dev
 NetBSD       -        -       py27-setuptools
 SUSE         -        -       python-setuptools
-Ubuntu       -        -       python-setuptools python-all python-all-dev
+# Python2 retired from PCP builds as of Ubunutu version 20.04
+Ubuntu       [01].*   -       python-setuptools python-all python-all-dev
 OpenBSD      6.4      -       autoconf-- python-2.7.15p0 python-3.6.6p1

--- a/qa/admin/other-packages/skip
+++ b/qa/admin/other-packages/skip
@@ -77,6 +77,8 @@ Slackware    14\.2    -       python3-.*
 # we're using python3
 SUSE         12-SP.*  -       python-.*
 #-- Ubuntu
+# Python2 retired from PCP builds as of Ubunutu version 20.04
+Ubuntu       2.*      -       python-.*
 # observed on vm01
 # python3-bpfcc : Depends: libbpfcc (>= 0.5.0-5ubuntu1) but it is not installable
 Ubuntu       18\.04   i.86    python3-bpfcc

--- a/qa/common.config
+++ b/qa/common.config
@@ -51,28 +51,13 @@ PCPQA_CISCO_ROUTER=${PCPQA_CISCO_ROUTER:-''}
 
 case "$domain"
 in
-    engr.sgi.com)
-	PCPQA_CLOSE_X_SERVER=${PCPQA_CLOSE_X_SERVER:-groan:0}
-	PCPQA_FAR_PMCD=${PCPQA_FAR_PMCD:-snort.melbourne.sgi.com}
-	PCPQA_HYPHEN_HOST=${PCPQA_HYPHEN_HOST:-gate-babylon}
-	PCPQA_SOCKS_SERVER=sgigate.sgi.com
-	PCPQA_CISCO_ROUTER=melbourne-l0.wan.sgi.com
-	;;
-
-    melbourne.sgi.com)
-	PCPQA_CLOSE_X_SERVER=${PCPQA_CLOSE_X_SERVER:-rattle:0}
-	PCPQA_FAR_PMCD=${PCPQA_FAR_PMCD:-babylon.engr.sgi.com}
-	# foo-bar.melbourne is also known as ptg-gate.melbourne
-	PCPQA_HYPHEN_HOST=${PCPQA_HYPHEN_HOST:-foo-bar.melbourne.sgi.com}
-	PCPQA_SOCKS_SERVER=sgigate.sgi.com
-	PCPQA_CISCO_ROUTER=melbourne-l0.wan.sgi.com
-	;;
     engr.acx)
 	PCPQA_CLOSE_X_SERVER=:0
 	PCPQA_FAR_PMCD=${PCPQA_FAR_PMCD:-web1.drp.acx}
 	PCPQA_HYPHEN_HOST=${PCPQA_HYPHEN_HOST:-nathan-laptop}
 	PCPQA_CISCO_ROUTER=${PCPQA_CISCO_ROUTER:-cisco}
 	;;
+
     scott.net.au)
 	PCPQA_CLOSE_X_SERVER=:0
 	PCPQA_FAR_PMCD=${PCPQA_FAR_PMCD:-verge}
@@ -83,8 +68,8 @@ in
     localdomain|localhost|local|\(none\))
 	case "`hostname | sed -e 's/\..*//'`"
 	in
-	    bozo|bozo-laptop|bozo-vm|vm*|comma)
-		PCPQA_HYPHEN_HOST=bozo-vm
+	    bozo|bozo-vm|vm*)
+		PCPQA_HYPHEN_HOST=bozo-vm.localdomain
 		# use bozo for socks and X11 server (unless set already and
 		# working)
 		#

--- a/qa/common.filter
+++ b/qa/common.filter
@@ -966,6 +966,7 @@ _filter_views()
 	-e '/QGtkStyle was unable to detect the current GTK+ theme\./d' \
 	-e '/GConf-WARNING \*\*: Client failed to connect to the D-BUS/d' \
 	-e '/Failed to connect to socket .*dbus.*: Connection refused/d' \
+	-e '/^Qt: Session management error: Authentication Rejected/d' \
 	-e '/^$/d'
 }
 

--- a/qa/common.filter
+++ b/qa/common.filter
@@ -393,6 +393,7 @@ _filter_top_pmns()
 {
     sed \
 	-e 's/$/ /' \
+	-e '/^    acct /d' \
 	-e '/^    aim /d' \
 	-e '/^    array /d' \
 	-e '/^    ash /d' \

--- a/qa/group
+++ b/qa/group
@@ -1650,7 +1650,11 @@ not_in_container
 1230 pmiectl local
 1231 pmlogrewrite labels help pmdumplog local
 1232 logutil pmlogctl local
+1233 derive local
 1234 libpcp_web local
+1235 derive local
+1236 derive local
+1237 derive local
 1238 iostat archive multi-archive decompress-xz local pmlogextract pcp python
 1239 pmlogrewrite labels pmdumplog local
 1240 libpcp pmrep local python

--- a/qa/new
+++ b/qa/new
@@ -222,7 +222,12 @@ cat <<End-of-File >>$id
 #
 
 seq=\`basename \$0\`
-echo "QA output created by \$seq"
+if [ \$# -eq 0 ]
+then
+    echo "QA output created by \$seq"
+else
+    echo "QA output created by \$seq \$*"
+fi
 
 # get standard environment, filters and checks
 . ./common.product

--- a/src/derived/cpu-util.conf
+++ b/src/derived/cpu-util.conf
@@ -1,9 +1,29 @@
 # derived metrics for cpu utilization
 
 kernel.cpu.util.user = (100 * rate(kernel.all.cpu.user)) / hinv.ncpu
+kernel.cpu.util.user(oneline) = percentage of user time across all CPUs, including guest CPU time
+
 kernel.cpu.util.nice = (100 * rate(kernel.all.cpu.nice)) / hinv.ncpu
+kernel.cpu.util.nice(oneline) = percentage of nice user time across all CPUs, including guest nice CPU time
+
 kernel.cpu.util.sys = (100 * rate(kernel.all.cpu.sys)) / hinv.ncpu
+kernel.cpu.util.sys(oneline) = percentage of sys time across all CPUs
+
 kernel.cpu.util.idle = (100 * rate(kernel.all.cpu.idle)) / hinv.ncpu
+kernel.cpu.util.idle(oneline) = percentage of idle time across all CPUs
+
 kernel.cpu.util.intr = (100 * rate(kernel.all.cpu.intr)) / hinv.ncpu
+kernel.cpu.util.intr(oneline) = percentage of interrupt time across all CPUs
+kernel.cpu.util.intr(helptext) = '\
+Percentage of time spent processing interrupts across all CPUs.
+This value includes both soft and hard interrupt processing time.'
+
 kernel.cpu.util.wait = (100 * rate(kernel.all.cpu.wait.total)) / hinv.ncpu
+kernel.cpu.util.wait(oneline) = percentage of wait time across all CPUs
+
 kernel.cpu.util.steal = (100 * rate(kernel.all.cpu.steal)) / hinv.ncpu
+kernel.cpu.util.steal(oneline) = percentage of virtualization CPU steal time across all CPUs
+kernel.cpu.util.steal(helptext) = '\
+Percentage of time across all CPUs when a CPU had a runnable process,
+but the hypervisor (virtualisation layer) chose to run something else
+instead.'

--- a/src/libpcp/src/check-statics
+++ b/src/libpcp/src/check-statics
@@ -6,7 +6,7 @@
 
 set -e # detect syntax errors or subsidiary command failures
 sts=1  # presume failure, in case of an unexpected early exit
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pcp-build-check-statics.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit \$sts" 0 1 2 3 15
 
 NM=nm

--- a/src/libpcp/src/check-statics
+++ b/src/libpcp/src/check-statics
@@ -6,7 +6,7 @@
 
 set -e # detect syntax errors or subsidiary command failures
 sts=1  # presume failure, in case of an unexpected early exit
-tmp=`mktemp -d "$PCP_TMPFILE_DIR/pcp-build-check-statics.XXXXXXXXX"` || exit 1
+tmp=`mktemp -d /tmp/pcp-build-check-statics.XXXXXXXXX` || exit 1
 trap "rm -rf $tmp; exit \$sts" 0 1 2 3 15
 
 NM=nm

--- a/src/libpcp/src/derive.h
+++ b/src/libpcp/src/derive.h
@@ -76,6 +76,8 @@ typedef struct {		/* one derived metric */
     pmID	pmid;
     int		bind;		/* 0/1 if bind_expr() has been called */
     node_t	*expr;		/* NULL => invalid, e.g. dup or missing operands */
+    const char	*oneline;	/* help text for PM_TEXT_ONELINE */
+    const char	*helptext;	/* help text for PM_TEXT_HELP */
 } dm_t;
 
 /*
@@ -146,5 +148,6 @@ extern int __dmprefetch(__pmContext *, int, const pmID *, pmID **) _PCP_HIDDEN;
 extern void __dmpostfetch(__pmContext *, pmResult **) _PCP_HIDDEN;
 extern void __dmdumpexpr(node_t *, int) _PCP_HIDDEN;
 extern char *__dmnode_type_str(int) _PCP_HIDDEN;
+extern int __dmhelptext(pmID, int, char **) _PCP_HIDDEN;
 
 #endif	/* _DERIVE_H */

--- a/src/libpcp/src/derive_parser.y.in
+++ b/src/libpcp/src/derive_parser.y.in
@@ -1566,6 +1566,8 @@ registerderived(int derive_locked, const char *name, const char *expr, int isano
     registered.mlist[registered.nmetric-1].pmid = *((pmID *)&pmid);
     registered.mlist[registered.nmetric-1].expr = np;
     registered.mlist[registered.nmetric-1].bind = 0;
+    registered.mlist[registered.nmetric-1].oneline = NULL;
+    registered.mlist[registered.nmetric-1].helptext = NULL;
 
     if (pmDebugOptions.derive) {
 	fprintf(stderr, "pmRegisterDerived: register metric[%d] %s = %s\n", registered.nmetric-1, name, expr);
@@ -1576,6 +1578,68 @@ registerderived(int derive_locked, const char *name, const char *expr, int isano
     if (derive_locked == PM_NOT_LOCKED)
 	PM_UNLOCK(registered.mutex);
     return NULL;
+}
+
+#define ATTR_BAD_METRIC	-1
+#define ATTR_BAD_ATTR	-2
+#define ATTR_DUP_VALUE	-3
+
+/*
+ * set attribute values for derived metrics
+ */
+static int
+setattr(int derive_locked, const char *name, const char *attr, const char *value)
+{
+    int			i;
+    int			sts = 0;
+
+    if (derive_locked == PM_NOT_LOCKED) {
+	PM_INIT_LOCKS();
+	PM_LOCK(registered.mutex);
+    }
+    else {
+	PM_ASSERT_IS_LOCKED(registered.mutex);
+    }
+
+    if (pmDebugOptions.derive && pmDebugOptions.appl0) {
+	fprintf(stderr, "setattr: name=\"%s\" attr=\"%s\" value=\"%s\"\n", name, attr, value);
+    }
+
+    for (i = 0; i < registered.nmetric; i++) {
+	if (strcmp(name, registered.mlist[i].name) == 0) {
+	    /* found it! */
+	    break;
+	}
+    }
+
+    if (i == registered.nmetric) {
+	/* oops, derived metric name not defined (yet) */
+	sts = ATTR_BAD_METRIC;
+	goto done;
+    }
+
+    if (strcmp(attr, "oneline") == 0) {
+	if (registered.mlist[i].oneline == NULL)
+	    registered.mlist[i].oneline = value;
+	else
+	    sts = ATTR_DUP_VALUE;
+    }
+    else if (strcmp(attr, "helptext") == 0) {
+	if (registered.mlist[i].helptext == NULL)
+	    registered.mlist[i].helptext = value;
+	else
+	    sts = ATTR_DUP_VALUE;
+    }
+    else {
+	/* not one of the attributes we recognize */
+	sts = ATTR_BAD_ATTR;
+	goto done;
+    }
+
+done:
+    if (derive_locked == PM_NOT_LOCKED)
+	PM_UNLOCK(registered.mutex);
+    return sts;
 }
 
 /* The original, and still the best. */
@@ -1670,6 +1734,7 @@ PM_FAULT_RETURN(PM_FAULT_PMAPI);
 int
 pmLoadDerivedConfig(const char *fname)
 {
+
     int		sts;
 
     PM_INIT_LOCKS();
@@ -1681,6 +1746,16 @@ pmLoadDerivedConfig(const char *fname)
     return sts;
 }
 
+/*
+ * process a derived metric configuration file
+ * - skip comments (leading #) and blank lines
+ * - split each line into either
+ *   <name> = <expr>
+ *   or
+ *   <name>(<attr>) = <string>
+ * - remove white space around name and (optionally) attr
+ * - build <string> which includes \x handling and multi-line <string>s
+ */  
 static int
 __dminit_configfile(const char *fname)
 {
@@ -1690,7 +1765,9 @@ __dminit_configfile(const char *fname)
     char	*p;
     int		c;
     int		sts = 0;
-    int		eq = -1;
+    int		eq = -1;	/* offset to =, start of <expr> or <value> */
+    int		lp = -1;	/* offset to (, start of <attr> */
+    int		rp = -1;	/* offset to ), end of <attr> */
     int		lineno = 1;
 
     if (pmDebugOptions.derive) {
@@ -1717,12 +1794,29 @@ __dminit_configfile(const char *fname)
 	    p = &buf[buflen];
 	    buflen *= 2;
 	}
-	if (c == '=' && eq == -1) {
-	    /*
-	     * mark first = in line ... metric name to the left and
-	     * expression to the right
-	     */
-	    eq = p - buf;
+	if (eq == -1) {
+	    /* no = yet ... */
+	    if (c == '=') {
+		/*
+		 * mark first = in line ... <name> or <name>(<attr>) to the
+		 * left and <expr> or <value> to the right
+		 */
+		eq = p - buf;
+	    }
+	    else if (c == '(' && lp == -1) {
+		/*
+		 * mark first ( in line before = ... <name> to the
+		 * left and <attr> to the right
+		 */
+		lp = p - buf;
+	    }
+	    else if (c == ')' && rp == -1) {
+		/*
+		 * mark first ) in line before = ... <attr> to the
+		 * left and = <value> to the right
+		 */
+		rp = p - buf;
+	    }
 	}
 	if (c == '\n') {
 	    if (p == buf || buf[0] == '#') {
@@ -1731,63 +1825,261 @@ __dminit_configfile(const char *fname)
 	    }
 	    *p = '\0';
 	    if (eq != -1) {
-		char	*np;	/* copy of name */
-		char	*ep;	/* start of expression */
+		char	*dupbuf;	/* copy of <name> */
+		char	*np;		/* start of <name> or <name>(<attr>) */
 		char	*q;
 		char	*errp;
 		buf[eq] = '\0';
-		if ((np = strdup(buf)) == NULL) {
+		if ((dupbuf = strdup(buf)) == NULL) {
 		    /* registered.mutex not locked in this case */
 		    pmNoMem("pmLoadDerivedConfig: dupname", strlen(buf), PM_FATAL_ERR);
 		    /*NOTREACHED*/
 		}
-		/* trim white space from tail of metric name */
-		q = &np[eq-1];
-		while (q >= np && isspace((int)*q))
+		buf[eq] = '=';
+		/* trim white space from tail of <name> */
+		if (lp != -1) {
+		    /* <name> ends at or before ( */
+		    q = &dupbuf[lp];
 		    *q-- = '\0';
-		/* trim white space from head of metric name */
-		q = np;
-		while (*q && isspace((int)*q))
-		    q++;
-		if (*q == '\0') {
-		    buf[eq] = '=';
+		}
+		else {
+		    /* <name> ends at or before = */
+		    q = &dupbuf[eq-1];
+		}
+		while (q >= dupbuf && isspace((int)*q))
+		    *q-- = '\0';
+		/* trim white space from head of <name> */
+		np = dupbuf;
+		while (*np && isspace((int)*np))
+		    np++;
+		if (*np == '\0') {
 		    pmprintf("[%s:%d] Error: pmLoadDerivedConfig: derived metric name missing\n%s\n", fname, lineno, buf);
 		    pmflush();
-		    free(np);
+		    free(dupbuf);
 		    goto next_line;
 		}
-		if (checkname(q) < 0) {
-		    pmprintf("[%s:%d] Error: pmLoadDerivedConfig: illegal derived metric name (%s)\n", fname, lineno, q);
+		if (checkname(np) < 0) {
+		    pmprintf("[%s:%d] Error: pmLoadDerivedConfig: illegal derived metric name (%s)\n", fname, lineno, np);
 		    pmflush();
-		    free(np);
+		    free(dupbuf);
 		    goto next_line;
 		}
-		ep = &buf[eq+1];
-		while (*ep != '\0' && isspace((int)*ep))
-		    ep++;
-		if (*ep == '\0') {
-		    buf[eq] = '=';
-		    pmprintf("[%s:%d] Error: pmLoadDerivedConfig: expression missing\n%s\n", fname, lineno, buf);
+		if (lp >= 0 && rp == -1) {
+		    pmprintf("[%s:%d] Error: pmLoadDerivedConfig: missing ')' after attribute\n%s\n", fname, lineno, buf);
 		    pmflush();
-		    free(np);
+		    free(dupbuf);
 		    goto next_line;
 		}
-		errp = registerderived(PM_LOCKED, q, ep, 0);
-		if (errp != NULL) {
-		    pmprintf("[%s:%d] Error: pmRegisterDerived(%s, ...) syntax error\n", fname, lineno, q);
-		    pmprintf("%s\n", &buf[eq+1]);
-		    for (q = &buf[eq+1]; *q; q++) {
-			if (q == errp) *q = '^';
-			else if (!isspace((int)*q)) *q = ' ';
+		if (rp >= 0 && lp == -1) {
+		    pmprintf("[%s:%d] Error: pmLoadDerivedConfig: missing '(' before attribute\n%s\n", fname, lineno, buf);
+		    pmflush();
+		    free(dupbuf);
+		    goto next_line;
+		}
+		if (lp == -1 && rp == -1) {
+		    /* <name> = ... */
+		    char	*ep;	/* start of <expr> */
+		    ep = &buf[eq+1];
+		    while (*ep != '\0' && isspace((int)*ep))
+			ep++;
+		    if (*ep == '\0') {
+			pmprintf("[%s:%d] Error: pmLoadDerivedConfig: expression missing\n%s\n", fname, lineno, buf);
+			pmflush();
+			free(dupbuf);
+			goto next_line;
 		    }
-		    pmprintf("%s\n", &buf[eq+1]);
-		    q = pmDerivedErrStr();
-		    if (q != NULL) pmprintf("%s\n", q);
-		    pmflush();
+		    errp = registerderived(PM_LOCKED, np, ep, 0);
+		    if (errp != NULL) {
+			pmprintf("[%s:%d] Error: pmRegisterDerived(%s, ...) syntax error\n", fname, lineno, np);
+			pmprintf("%s\n", &buf[eq+1]);
+			for (q = &buf[eq+1]; *q; q++) {
+			    if (q == errp) *q = '^';
+			    else if (!isspace((int)*q)) *q = ' ';
+			}
+			pmprintf("%s\n", &buf[eq+1]);
+			q = pmDerivedErrStr();
+			if (q != NULL) pmprintf("%s\n", q);
+			pmflush();
+		    }
+		    else
+			sts++;
 		}
-		else
-		    sts++;
-		free(np);
+		else {
+		    /* <name>(<attr>) = ... */
+		    char	*ap;		/* start of <attr> */
+		    char	*vp;		/* start of <value> */
+		    char	*value;		/* accumulated <value> */
+		    int		vlen = 0;	/* length of value */
+		    char	delim = '\0';	/* string delimiter, if any */
+		    int		lsts;
+		    /* trim white space from tail of <attr> */
+		    q = &dupbuf[rp];
+		    *q-- = '\0';
+		    while (q >= &dupbuf[lp] && isspace((int)*q))
+			*q-- = '\0';
+		    /* trim white space from head of <attr> */
+		    ap = &dupbuf[lp+1];
+		    while (*ap && isspace((int)*ap))
+			ap++;
+		    if (*ap == '\0') {
+			pmprintf("[%s:%d] Error: pmLoadDerivedConfig: attribute name missing\n%s\n", fname, lineno, buf);
+			pmflush();
+			free(dupbuf);
+			goto next_line;
+		    }
+		    /* trim white space from head of <value> */
+		    vp = &buf[eq+1];
+		    while (*vp != '\0' && isspace((int)*vp))
+			vp++;
+		    if (*vp == '"' || *vp == '\'') {
+			/* string delimiter found */
+			delim = *vp;
+			vp++;
+		    }
+		    if (*vp == '\0') {
+			pmprintf("[%s:%d] Error: pmLoadDerivedConfig: attribute value missing\n%s\n", fname, lineno, buf);
+			pmflush();
+			free(dupbuf);
+			goto next_line;
+		    }
+		    vlen = strlen(vp);
+		    if ((value = strdup(vp)) == NULL) {
+			/* registered.mutex not locked in this case */
+			pmNoMem("pmLoadDerivedConfig: value", vlen, PM_FATAL_ERR);
+			/*NOTREACHED*/
+		    }
+		    if (delim == 0) {
+			/* no string delimiter, so <value> is complete */
+			;
+		    }
+		    else {
+			/*
+			 * process the <value>, handling any \x escape
+			 * sequences ... may need more input for multi-line
+			 * <value>s
+			 */
+			char	*q = value;
+			int	esc = 0;
+			int	xtralines = 0;
+			for ( ; ; ) {
+			    if (*vp)
+				c = *vp++;
+			    else if (xtralines == 0)
+				c = '\n';
+			    else {
+				c = fgetc(fp);
+				if (c == EOF) {
+				    /* string value not terminated */
+				    break;
+				}
+			    }
+			    if (c == '\n')
+				xtralines++;
+			    if (q >= &value[vlen]) {
+				/*
+				 * out the end of the value buffer ... use
+				 * a "doubling" algorithm
+				 */
+				char	*tmp_value;
+
+				tmp_value = realloc(value, 2*vlen);
+				if (tmp_value == NULL) {
+				    /* registered.mutex not locked in this case */
+				    pmNoMem("pmLoadDerivedConfig: expand value", 2*vlen, PM_FATAL_ERR);
+				    /*NOTREACHED*/
+				}
+				q = &tmp_value[q - value];
+				value = tmp_value;
+				vlen *= 2;
+			    }
+			    if (esc) {
+				esc = 0;
+				/*
+				 * \ at the end of the line is a special case,
+				 * ... don't emit the newline (so treat as
+				 * "continuation"
+				 */
+				if (c != '\n')
+				    *q++ = c;
+				continue;
+			    }
+			    if (c == '\\') {
+				esc = 1;
+				continue;
+			    }
+			    if (c == delim) {
+				*q++ = '\0';
+				break;
+			    }
+			    *q++ = c;
+			}
+			if (xtralines > 1)
+			    lineno += xtralines - 1;
+			if (c == EOF) {
+			    pmprintf("[%s:%d] Error: pmLoadDerivedConfig: missing termination (%c) for value\n", fname, lineno, delim);
+			    pmflush();
+			    free(value);
+			    vp = NULL;
+			}
+			else {
+			    /*
+			     * expect no text on same line after string
+			     * terminator
+			     */
+			    if (*vp) {
+				while (*vp && isspace((int)*vp))
+				    vp++;
+				if (*vp) {
+				    pmprintf("[%s:%d] Warning: pmLoadDerivedConfig: extra text (%s) after attribute value will be ignored\n", fname, lineno, vp);
+				    pmflush();
+				}
+			    }
+			    else if (xtralines == 0) {
+				/* all ok, <value> is end of one line of input */
+				;
+			    }
+			    else {
+				c = fgetc(fp);
+				while (c != EOF && c != '\n') {
+				    c = fgetc(fp);
+				    if (!isspace(c))
+					break;
+				}
+				if (c != EOF && c != '\n') {
+				    pmprintf("[%s:%d] Warning: pmLoadDerivedConfig: extra text (%c", fname, lineno, c);
+				    while ((c = fgetc(fp)) != EOF && c != '\n')
+					pmprintf("%c", c);
+				    pmprintf(") after attribute value will be ignored\n");
+				    pmflush();
+				}
+			    }
+			    vp = value;
+			}
+		    }
+
+		    if (vp != NULL) {
+			/*
+			 * value[] is guaranteed to be a malloc'd array at
+			 * this point ... settattr() will permanently hold
+			 * a pointer to this memory on succes (so nothing to
+			 * do there), but we need to free on error
+			 */
+			if ((lsts = setattr(PM_LOCKED, np, ap, value)) < 0) {
+			    free(value);
+			    if (lsts == ATTR_BAD_METRIC)
+				pmprintf("[%s:%d] Error: pmLoadDerivedConfig: cannot set attribute, derived metric (%s) not defined\n", fname, lineno, np);
+			    else if (lsts == ATTR_BAD_ATTR)
+				pmprintf("[%s:%d] Error: pmLoadDerivedConfig: attribute (%s) is unknown for metric (%s)\n", fname, lineno, ap, np);
+			    else if (lsts == ATTR_DUP_VALUE)
+				pmprintf("[%s:%d] Error: pmLoadDerivedConfig: duplicate value for attribute (%s) of metric (%s)\n", fname, lineno, ap, np);
+			    else
+				pmprintf("[%s:%d] Error: pmLoadDerivedConfig: cannot set attribute, reason unknown\n", fname, lineno);
+			    pmprintf("%s\n", buf);
+			    pmflush();
+			}
+		    }
+		}
+		free(dupbuf);
 	    }
 	    else {
 		/*
@@ -1799,7 +2091,7 @@ __dminit_configfile(const char *fname)
 next_line:
 	    lineno++;
 	    p = buf;
-	    eq = -1;
+	    eq = lp = rp = -1;
 	}
 	else
 	    *p++ = c;
@@ -2222,6 +2514,8 @@ __dmopencontext(__pmContext *ctxp)
 	cp->mlist[i].anon = registered.mlist[i].anon;
 	cp->mlist[i].expr = NULL;
 	cp->mlist[i].bind = 0;
+	cp->mlist[i].oneline = registered.mlist[i].oneline;
+	cp->mlist[i].helptext = registered.mlist[i].helptext;
 	assert(registered.mlist[i].expr != NULL);
     }
     PM_UNLOCK(registered.mutex);
@@ -2271,6 +2565,48 @@ __dmdesc(__pmContext *ctxp, int derive_locked, pmID pmid, pmDesc *desc)
 	    return 0;
 	}
     }
+    return PM_ERR_PMID;
+}
+
+int
+__dmhelptext(pmID pmid, int level, char **buffer)
+{
+    int		i;
+    int		sts = 0;
+
+    PM_LOCK(registered.mutex);
+    __dminit();
+
+    for (i = 0; i < registered.nmetric; i++) {
+	if (pmid == registered.mlist[i].pmid) {
+	    if (level == PM_TEXT_ONELINE ||
+	        (level == PM_TEXT_HELP && registered.mlist[i].helptext == NULL)) {
+		if (registered.mlist[i].oneline == NULL)
+		    sts = PM_ERR_TEXT;
+		else {
+		    *buffer = strdup(registered.mlist[i].oneline);
+		    if (*buffer == NULL) {
+			pmNoMem("__dmhelptext oneline", strlen(registered.mlist[i].oneline)+1, PM_RECOV_ERR);
+			sts = -oserror();
+		    }
+		}
+	    }
+	    else if (level == PM_TEXT_HELP) {
+		if (registered.mlist[i].helptext == NULL)
+		    sts = PM_ERR_TEXT;
+		else {
+		    *buffer = strdup(registered.mlist[i].helptext);
+		    if (*buffer == NULL) {
+			pmNoMem("__dmhelptext helptext", strlen(registered.mlist[i].helptext)+1, PM_RECOV_ERR);
+			sts = -oserror();
+		    }
+		    }
+	    }
+	    PM_UNLOCK(registered.mutex);
+	    return sts;
+	}
+    }
+    PM_UNLOCK(registered.mutex);
     return PM_ERR_PMID;
 }
 

--- a/src/libpcp/src/help.c
+++ b/src/libpcp/src/help.c
@@ -123,8 +123,13 @@ again_archive:
 int
 pmLookupText(pmID pmid, int level, char **buffer)
 {
-    if (IS_DERIVED(pmid))
-	return PM_ERR_TEXT;
+    if (IS_DERIVED(pmid)) {
+	/*
+	 * for derived metrics there is no indom help text, only metric
+	 * help text, so don't need | PM_TEXT_PMID
+	 */
+	return __dmhelptext(pmid, level, buffer);
+    }
     return lookuptext((int)pmid, level | PM_TEXT_PMID, buffer);
 }
 

--- a/src/libpcp/src/mk.exports
+++ b/src/libpcp/src/mk.exports
@@ -13,7 +13,7 @@ fi
 
 . ../../include/pcp.conf
 
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pcp-build-mk.exports.XXXXXXXXX"` || exit 1
 sts=0
 trap "rm -rf $tmp; exit \$sts" 0 1 2 3 15
 

--- a/src/libpcp/src/mk.pmdbg
+++ b/src/libpcp/src/mk.pmdbg
@@ -45,7 +45,7 @@ then
     exit 1
 fi
 
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pcp-build-mk.pmdbg.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit 0" 0 1 2 3 15
 
 rm -f pmdbg.h

--- a/src/pcp/pcp.sh
+++ b/src/pcp/pcp.sh
@@ -16,7 +16,7 @@
 . $PCP_DIR/etc/pcp.env
 
 sts=2
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pcp.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit \$sts" 0 1 2 3 15
 
 progname=`basename $0`

--- a/src/pcp/shping/pcp-shping.sh
+++ b/src/pcp/shping/pcp-shping.sh
@@ -19,7 +19,7 @@
 
 sts=2
 progname=`basename $0`
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pcp-shping.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit \$sts" 0 1 2 3 15
 
 _usage()

--- a/src/pcp/summary/pcp-summary.sh
+++ b/src/pcp/summary/pcp-summary.sh
@@ -20,7 +20,7 @@
 . $PCP_DIR/etc/pcp.env
 
 sts=2
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pcp-summary.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit \$sts" 0 1 2 3 15
 
 errors=0

--- a/src/pcp/vmstat/pcp-vmstat.sh
+++ b/src/pcp/vmstat/pcp-vmstat.sh
@@ -19,7 +19,7 @@
 
 sts=2
 progname=`basename $0`
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pcp-vmstat.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit \$sts" 0 1 2 3 15
 
 _usage()

--- a/src/pmafm/mkaf
+++ b/src/pmafm/mkaf
@@ -48,7 +48,7 @@ then
     exit 1
 fi
 
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pm_mkaf.XXXXXXXXX"` || exit 1
 status=0
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15
 findopts=""

--- a/src/pmafm/pmafm
+++ b/src/pmafm/pmafm
@@ -133,7 +133,7 @@ do
     fi
 done
 
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmafm.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit" 0 1 2 3 15
 
 _archive2filename()

--- a/src/pmcd/rc_pcp
+++ b/src/pmcd/rc_pcp
@@ -48,7 +48,7 @@
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pcp.log
 #debug# env >>$PCP_LOG_DIR/rc_pcp.log
 
-tmp=`mktemp -d $PCP_DIR/var/tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pcp_rc.XXXXXXXXX"` || exit 1
 status=0
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15
 prog=$PCP_RC_DIR/pcp

--- a/src/pmcd/rc_pmcd
+++ b/src/pmcd/rc_pmcd
@@ -56,7 +56,7 @@ PMCDENVS=$PCP_SYSCONFIG_DIR/pmcd
 RUNDIR=$PCP_LOG_DIR/pmcd
 prog=$PCP_RC_DIR/`basename $0`
 
-tmp=`mktemp -d $PCP_DIR/var/tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmcd_rc.XXXXXXXXX"` || exit 1
 status=1
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15
 

--- a/src/pmchart/views/BusyCPU
+++ b/src/pmchart/views/BusyCPU
@@ -10,7 +10,7 @@
 # a token attempt to make this general
 . /etc/pcp.env
 
-tmp=`mktemp -d /var/tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmchart-BusyCPU.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit" 0 1 2 3 15
 
 # bad stuff ...

--- a/src/pmdas/infiniband/Install
+++ b/src/pmdas/infiniband/Install
@@ -14,7 +14,7 @@
 # for more details.
 # 
 
-. /etc/pcp.env
+. $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=infiniband

--- a/src/pmdas/infiniband/Remove
+++ b/src/pmdas/infiniband/Remove
@@ -13,7 +13,7 @@
 # for more details.
 # 
 
-. /etc/pcp.env
+. $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=infiniband

--- a/src/pmdas/linux_proc/config.c
+++ b/src/pmdas/linux_proc/config.c
@@ -102,7 +102,7 @@ parse_config(bool_node **tree)
     /* Return 1 on success, 0 on empty config, sts on error (negative)*/
     int sts;
     FILE *file = NULL;
-    char tmpname[] = "/var/tmp/pcp.XXXXXX";
+    char tmpname[] = "/var/tmp/linux_proc.XXXXXX";
     mode_t cur_umask;
     int fid = -1;
     struct stat stat_buf;

--- a/src/pmdas/lustrecomm/Remove
+++ b/src/pmdas/lustrecomm/Remove
@@ -20,7 +20,7 @@
 #
 
 # source the PCP configuration environment variables
-. /etc/pcp.env
+. $PCP_DIR/etc/pcp.env
 
 # Get the common procedures and variable assignments
 #

--- a/src/pmdas/weblog/Web.Allservers.pmchart
+++ b/src/pmdas/weblog/Web.Allservers.pmchart
@@ -2,7 +2,7 @@
 
 . $PCP_DIR/etc/pcp.env
 
-tmp=`mktemp -d /var/tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmchart_web_all.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit" 0 1 2 3 15
 
 echo "/\"/s///g" >$tmp/sed

--- a/src/pmdas/weblog/Web.Perserver.Bytes.pmchart
+++ b/src/pmdas/weblog/Web.Perserver.Bytes.pmchart
@@ -2,7 +2,7 @@
 
 . $PCP_DIR/etc/pcp.env
 
-tmp=`mktemp -d /var/tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmchart_web_per_byte.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit" 0 1 2 3 15
 
 echo "/\"/s///g" >$tmp/sed

--- a/src/pmdas/weblog/Web.Perserver.Requests.pmchart
+++ b/src/pmdas/weblog/Web.Perserver.Requests.pmchart
@@ -2,7 +2,7 @@
 
 . $PCP_DIR/etc/pcp.env
 
-tmp=`mktemp -d /var/tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmchart_web_per_req.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit" 0 1 2 3 15
 
 echo "/\"/s///g" >$tmp/sed

--- a/src/pmdas/weblog/server.sh
+++ b/src/pmdas/weblog/server.sh
@@ -60,7 +60,7 @@ file2="planning.html"
 file3="tasks.html"
 pfx="  "
 skipping="${pfx}skipping..."
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmda_weblog.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit" 0 1 2 3 15
 
 # Duplicate entry check file

--- a/src/pmfind/pmfind_check.sh
+++ b/src/pmfind/pmfind_check.sh
@@ -32,7 +32,7 @@ PMLOGGER_SERVICE_ARGS=${PMLOGGER_SERVICE_PARAMS:-$PMLOGGER_ARGS}
 # error messages should go to stderr, not the GUI notifiers
 unset PCP_STDERR
 
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmfind_check.XXXXXXXXX"` || exit 1
 status=0
 prog=`basename $0`
 PROGLOG=$PCP_LOG_DIR/pmfind/$prog.log

--- a/src/pmgadgets/pmgcisco.sh
+++ b/src/pmgadgets/pmgcisco.sh
@@ -17,7 +17,7 @@
 . $PCP_DIR/etc/pcp.env
 
 status=1
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmgcisco.XXXXXXXXX"` || exit 1
 trap "rm -fr $tmp; exit \$status" 0 1 2 3 15
 
 # usage - print out the usage of program

--- a/src/pmgadgets/pmgcluster.sh
+++ b/src/pmgadgets/pmgcluster.sh
@@ -22,7 +22,7 @@
 . $PCP_DIR/etc/pcp.env
 
 status=1
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmgcluster.XXXXXXXXX"` || exit 1
 trap "rm -fr $tmp; exit \$status" 0 1 2 3 15
 verbose="false"
 prog=`basename $0`

--- a/src/pmgadgets/pmgshping.sh
+++ b/src/pmgadgets/pmgshping.sh
@@ -18,7 +18,7 @@
 . $PCP_DIR/etc/pcp.env
 
 status=1
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmgshping.XXXXXXXXX"` || exit 1
 trap "rm -fr $tmp; exit \$status" 0 1 2 3 15
 
 # usage - print out the usage of program

--- a/src/pmie/pmie2col.sh
+++ b/src/pmie/pmie2col.sh
@@ -22,7 +22,7 @@
 # Get standard environment
 . $PCP_DIR/etc/pcp.env
 
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmie2col.XXXXXXXXX"` || exit 1
 status=1
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15
 prog=`basename $0`

--- a/src/pmie/pmie_check.sh
+++ b/src/pmie/pmie_check.sh
@@ -47,7 +47,7 @@ _unsymlink_path()
 
 # constant setup
 #
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmie_check.XXXXXXXXX"` || exit 1
 status=0
 echo >$tmp/lock
 prog=`basename $0`

--- a/src/pmie/pmie_daily.sh
+++ b/src/pmie/pmie_daily.sh
@@ -43,7 +43,7 @@ unset PCP_STDERR
 
 # constant setup
 #
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmie_daily.XXXXXXXXX"` || exit 1
 status=0
 echo >$tmp/lock
 prog=`basename $0`

--- a/src/pmie/rc_pmie
+++ b/src/pmie/rc_pmie
@@ -52,7 +52,7 @@ rcprog=$PCP_DIR/etc/init.d/pmie
 pmprog=$PCP_RC_DIR/pmie
 prog=$PCP_RC_DIR/`basename $0`
 
-tmp=`mktemp -d $PCP_DIR/var/tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmie_rc.XXXXXXXXX"` || exit 1
 status=1
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15
 
@@ -116,7 +116,7 @@ _reboot_setup()
 _start_pmcheck()
 {
     bgstatus=0
-    bgtmp=`mktemp -d $PCP_DIR/var/tmp/pcp.XXXXXXXXX` || exit 1
+    bgtmp=`mktemp -d "$PCP_TMPFILE_DIR/pmie_rc_start.XXXXXXXXX"` || exit 1
     trap "rm -rf $tmp $bgtmp; exit \$bgstatus" 0 1 2 3 15
 
     wait_option=''

--- a/src/pmieconf/xtractnames
+++ b/src/pmieconf/xtractnames
@@ -29,7 +29,7 @@ do
     fi
 done
 
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmieconf-xtract.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit" 0 1 2 3 15
 
 _usage()

--- a/src/pmlogctl/pmlogctl.sh
+++ b/src/pmlogctl/pmlogctl.sh
@@ -1063,7 +1063,7 @@ _do_stop()
     _skip_control_update=false
     [ "$1" = '-q' ] && _skip_control_update=true
     sts=0
-    rm -f $tmp.sts
+    rm -f $tmp/sts
     cat $tmp/args \
     | while read control class args_host primary socks args_dir args
     do
@@ -1087,7 +1087,7 @@ _do_stop()
 	    then
 		:
 	    else
-		echo 1 >$tmp.sts
+		echo 1 >$tmp/sts
 		continue
 	    fi
 	fi
@@ -1095,7 +1095,7 @@ _do_stop()
 	if [ ! -f "$control" ]
 	then
 	    _warning "control file $control for host $args_host ${IAM} has vanished"
-	    echo 1 >$tmp.sts
+	    echo 1 >$tmp/sts
 	    continue
 	fi
 	dir=`echo "$args_dir" | _unexpand_control`
@@ -1118,7 +1118,7 @@ $1 == "'"$host"'" && $4 == "'"$dir"'"	{ $1 = "#!#" $1 }
 	fi
     done
 
-    [ -f $tmp.sts ] && sts="`cat $tmp.sts`"
+    [ -f $tmp/sts ] && sts="`cat $tmp/sts`"
 
     return $sts
 }

--- a/src/pmlogger/pmlogger_check.sh
+++ b/src/pmlogger/pmlogger_check.sh
@@ -31,7 +31,7 @@ unset PCP_STDERR
 
 # constant setup
 #
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmlogger_check.XXXXXXXXX"` || exit 1
 status=0
 echo >$tmp/lock
 prog=`basename $0`

--- a/src/pmlogger/pmlogger_daily.sh
+++ b/src/pmlogger/pmlogger_daily.sh
@@ -26,7 +26,7 @@ unset PCP_STDERR
 
 # constant setup
 #
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmlogger_daily.XXXXXXXXX"` || exit 1
 status=0
 echo >$tmp/lock
 prog=`basename $0`

--- a/src/pmlogger/pmlogger_daily_report.sh
+++ b/src/pmlogger/pmlogger_daily_report.sh
@@ -39,7 +39,7 @@ unset PCP_STDERR
 # default message log file
 PROGLOG=$PCP_LOG_DIR/pmlogger/$prog.log
 USE_SYSLOG=true
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmlogger_daily_report.XXXXXXXXX"` || exit 1
 
 _cleanup()
 {

--- a/src/pmlogger/pmlogger_merge.sh
+++ b/src/pmlogger/pmlogger_merge.sh
@@ -25,8 +25,8 @@
 
 
 prog=`basename $0`
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
-tmpmerge=`mktemp -d $PCP_TMPFILE_DIR/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmlogger_merge.XXXXXXXXX"` || exit 1
+tmpmerge=`mktemp -d $PCP_TMPFILE_DIR/pmlogger_merge.XXXXXXXXX` || exit 1
 status=0
 trap "rm -rf $tmp $tmpmerge; exit \$status" 0 1 2 3 15
 

--- a/src/pmlogger/pmlogger_rewrite.sh
+++ b/src/pmlogger/pmlogger_rewrite.sh
@@ -29,7 +29,7 @@
 . $PCP_SHARE_DIR/lib/utilproc.sh
 
 prog=`basename $0`
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmlogger_rewrite.XXXXXXXXX"` || exit 1
 status=0
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15
 

--- a/src/pmlogger/pmlogmv.sh
+++ b/src/pmlogger/pmlogmv.sh
@@ -22,7 +22,7 @@
 . $PCP_DIR/etc/pcp.env
 
 status=1
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmlogmv.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit \$status" 0
 trap "_cleanup; rm -rf $tmp; exit \$status" 1 2 3 15
 prog=`basename $0`

--- a/src/pmlogger/rc_pmlogger
+++ b/src/pmlogger/rc_pmlogger
@@ -55,7 +55,7 @@ rcprog=$PCP_DIR/etc/init.d/pmlogger
 pmprog=$PCP_RC_DIR/pmlogger
 prog=$PCP_RC_DIR/`basename $0`
 
-tmp=`mktemp -d $PCP_DIR/var/tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmlogger_rc.XXXXXXXXX"` || exit 1
 status=1
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15
 
@@ -93,7 +93,7 @@ esac
 _start_pmcheck()
 {
     bgstatus=0
-    bgtmp=`mktemp -d $PCP_DIR/var/tmp/pcp.XXXXXXXXX` || exit 1
+    bgtmp=`mktemp -d "$PCP_TMPFILE_DIR/pmlogger_rc_start.XXXXXXXXX"` || exit 1
     trap "rm -rf $tmp $bgtmp; exit \$bgstatus" 0 1 2 3 15
 
     pmlogger_check --quick $VFLAG >$bgtmp/pmcheck.out 2>$bgtmp/pmcheck

--- a/src/pmlogger/utilproc.sh
+++ b/src/pmlogger/utilproc.sh
@@ -109,7 +109,7 @@ _save_prev_file()
 	# concurrent executions, quietly do the best you can
 	#
 	rm -f "$1.prev" 2>/dev/null
-	cp -f-p "$1" "$1.prev" 2>/dev/null
+	cp -f -p "$1" "$1.prev" 2>/dev/null
 	rm -f "$1" 2>/dev/null
 	return 0
     else

--- a/src/pmlogsummary/pmdiff.sh
+++ b/src/pmlogsummary/pmdiff.sh
@@ -19,7 +19,7 @@
 # Get standard environment
 . $PCP_DIR/etc/pcp.env
 
-tmp=`mktemp -d /var/tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmlogsummary.XXXXXXXXX"` || exit 1
 status=1
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15
 prog=`basename $0`

--- a/src/pmns/Make.stdpmid
+++ b/src/pmns/Make.stdpmid
@@ -18,12 +18,12 @@
 
 if [ -d "$PCP_TMPFILE_DIR" ]
 then
-    tmp=`mktemp -d "$PCP_TMPFILE_DIR/pcp.XXXXXXXXX"` || exit 1
+    tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmns_stdpmid.XXXXXXXXX"` || exit 1
 else
     # if configure --prefix is used in a the build, then $PCP_TMPFILE_DIR
     # may not yet exist ... /tmp is a safe bet
     #
-    tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+    tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmns_stdpmid.XXXXXXXXX"` || exit 1
 fi
 status=1
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15

--- a/src/pmns/Rebuild
+++ b/src/pmns/Rebuild
@@ -26,7 +26,7 @@
 # source the PCP configuration environment variables
 . $PCP_DIR/etc/pcp.env
 
-tmp=`mktemp -d ./pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d ./pmns_rebuild.XXXXXXXXX` || exit 1
 status=1
 
 $PCP_SHARE_DIR/lib/lockpmns root

--- a/src/pmns/pmnsadd
+++ b/src/pmns/pmnsadd
@@ -20,7 +20,7 @@
 
 umask 22		# anything else is pretty silly
 exitsts=1
-tmp=`mktemp -d $PCP_TMPFILE_DIR/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d $PCP_TMPFILE_DIR/pmnsadd.XXXXXXXXX` || exit 1
 prog=`basename $0`
 trap "rm -rf $tmp; exit \$exitsts" 0 1 2 3 15
 

--- a/src/pmproxy/rc_pmproxy
+++ b/src/pmproxy/rc_pmproxy
@@ -289,6 +289,7 @@ Error: pmproxy options file "$PMPROXYOPTS" is missing, cannot start pmproxy.'
 		# Called from systemd with need to preserve the pid and
 		# systemd has already done the necessary daemonizing
 		#
+		rm -rf $tmp
 		exec $PMPROXY -F $OPTS
 		# NOTREACHED
 		#
@@ -301,7 +302,13 @@ Error: pmproxy options file "$PMPROXYOPTS" is missing, cannot start pmproxy.'
 
 
 	    # finally, stop here if running in a container
-	    [ -z "$PCP_CONTAINER_IMAGE" ] || exec $PCP_BINADM_DIR/pmpause
+	    if [ -z "$PCP_CONTAINER_IMAGE" ]
+	    then
+		:
+	    else
+		rm -rf $tmp
+		exec $PCP_BINADM_DIR/pmpause
+	    fi
 	fi
 	status=0
         ;;
@@ -334,7 +341,13 @@ Error: pmproxy options file "$PMPROXYOPTS" is missing, cannot start pmproxy.'
 	;;
 
   *)
-	[ -z "$PCP_CONTAINER_IMAGE" ] || exec "$@"
+	if [ -z "$PCP_CONTAINER_IMAGE" ]
+	then
+	    :
+	else
+	    rm -rf $tmp
+	    exec "$@"
+	fi
 	_usage
         ;;
 esac

--- a/src/pmproxy/rc_pmproxy
+++ b/src/pmproxy/rc_pmproxy
@@ -56,7 +56,7 @@ RUNDIR=$PCP_LOG_DIR/pmproxy
 pmprog=$PCP_RC_DIR/pmproxy
 prog=$PCP_RC_DIR/`basename $0`
 
-tmp=`mktemp -d $PCP_DIR/var/tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmproxy_rc.XXXXXXXXX"` || exit 1
 status=1
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15
 

--- a/src/pmsignal/pmsignal.sh
+++ b/src/pmsignal/pmsignal.sh
@@ -20,7 +20,7 @@
 . $PCP_DIR/etc/pcp.env
 
 status=1
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmsignal.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15
 prog=`basename $0`
 sigs="HUP USR1 USR2 TERM KILL"

--- a/src/pmsnap/pmsnap.sh
+++ b/src/pmsnap/pmsnap.sh
@@ -20,7 +20,7 @@
 
 . $PCP_DIR/etc/pcp.env
 
-tmp=`mktemp -d /tmp/pcp.XXXXXXXXX` || exit 1
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmsnap.XXXXXXXXX"` || exit 1
 trap "rm -rf $tmp; exit 0" 0 1 2 3 15
 prog=`basename $0`
 


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200711

Ken McDonell (20):
      qa/common.filter: tweak _filter_views() for recent Qt warning
      qa/1001: need _filter_views in one more place
      qa/623.out: remade after -k 0 change to pmlogger_daily
      Add help text support for derived metrics
      qa: 1233, 1235, 1236, 1237 (all new) derived metric help text tests
      qa/new: tweak the preamble output to include args if any
      qa/common.config: bozo-vm now has a FQDN, cull some old junk
      src: cleanup temp file naming
      src/pmproxy/rc_pmproxy: remove $tmp (dir) before exec
      qa/1102: openmetrics may NOT be installed at the beginning
      qa/1199: fetch _every_ metric first
      qa/common.filter: cull acct from top-level pmns
      qa/031.out.linux: acct no longer appears in the output
      qa/679.out: Warning: no archives found to merge moved to -V guard
      qa/1768: change to match recent temp file/dir name changes
      src/pmlogger/utilproc.sh: fix typo in last round of changes
      qa/1695 & 1696: ipv6 is optional ... filter out
      qa/admin/check-vm: updates for Ubuntu 20.04
      src/libpcp/src/check-statics: bit over-enthusiastic with the pcp.XXXXXX changes
      infiband and lustrecomm PMDAs: use $PCP_DIR as prefix to /etc/pcp.env

 man/man3/pmloadderivedconfig.3                  |   61 +++
 qa/031.out.linux                                |    1 
 qa/1001                                         |    2 
 qa/1102                                         |    2 
 qa/1199                                         |    2 
 qa/1233                                         |  112 ++++++
 qa/1233.out                                     |   68 +++
 qa/1235                                         |   32 +
 qa/1235.out                                     |   87 ++++
 qa/1236                                         |   92 +++++
 qa/1236.out                                     |   46 ++
 qa/1237                                         |   32 +
 qa/1237.out                                     |   56 +++
 qa/1695                                         |    5 
 qa/1695.out                                     |    1 
 qa/1696                                         |    5 
 qa/1696.out                                     |    1 
 qa/1768                                         |    2 
 qa/623.out                                      |    6 
 qa/679.out                                      |    1 
 qa/admin/check-vm                               |   23 +
 qa/admin/other-packages/require                 |    3 
 qa/admin/other-packages/skip                    |    2 
 qa/common.config                                |   21 -
 qa/common.filter                                |    2 
 qa/group                                        |    4 
 qa/new                                          |    7 
 src/derived/cpu-util.conf                       |   20 +
 src/libpcp/src/check-statics                    |    4 
 src/libpcp/src/derive.h                         |    3 
 src/libpcp/src/derive_parser.y.in               |  426 +++++++++++++++++++++---
 src/libpcp/src/help.c                           |    9 
 src/libpcp/src/mk.exports                       |    2 
 src/libpcp/src/mk.pmdbg                         |    2 
 src/pcp/pcp.sh                                  |    2 
 src/pcp/shping/pcp-shping.sh                    |    2 
 src/pcp/summary/pcp-summary.sh                  |    2 
 src/pcp/vmstat/pcp-vmstat.sh                    |    2 
 src/pmafm/mkaf                                  |    2 
 src/pmafm/pmafm                                 |    2 
 src/pmcd/rc_pcp                                 |    2 
 src/pmcd/rc_pmcd                                |    2 
 src/pmchart/views/BusyCPU                       |    2 
 src/pmdas/infiniband/Install                    |    2 
 src/pmdas/infiniband/Remove                     |    2 
 src/pmdas/linux_proc/config.c                   |    2 
 src/pmdas/lustrecomm/Remove                     |    2 
 src/pmdas/weblog/Web.Allservers.pmchart         |    2 
 src/pmdas/weblog/Web.Perserver.Bytes.pmchart    |    2 
 src/pmdas/weblog/Web.Perserver.Requests.pmchart |    2 
 src/pmdas/weblog/server.sh                      |    2 
 src/pmfind/pmfind_check.sh                      |    2 
 src/pmgadgets/pmgcisco.sh                       |    2 
 src/pmgadgets/pmgcluster.sh                     |    2 
 src/pmgadgets/pmgshping.sh                      |    2 
 src/pmie/pmie2col.sh                            |    2 
 src/pmie/pmie_check.sh                          |    2 
 src/pmie/pmie_daily.sh                          |    2 
 src/pmie/rc_pmie                                |    4 
 src/pmieconf/xtractnames                        |    2 
 src/pmlogctl/pmlogctl.sh                        |    8 
 src/pmlogger/pmlogger_check.sh                  |    2 
 src/pmlogger/pmlogger_daily.sh                  |    2 
 src/pmlogger/pmlogger_daily_report.sh           |    2 
 src/pmlogger/pmlogger_merge.sh                  |    4 
 src/pmlogger/pmlogger_rewrite.sh                |    2 
 src/pmlogger/pmlogmv.sh                         |    2 
 src/pmlogger/rc_pmlogger                        |    4 
 src/pmlogger/utilproc.sh                        |    2 
 src/pmlogsummary/pmdiff.sh                      |    2 
 src/pmns/Make.stdpmid                           |    4 
 src/pmns/Rebuild                                |    2 
 src/pmns/pmnsadd                                |    2 
 src/pmproxy/rc_pmproxy                          |   19 -
 src/pmsignal/pmsignal.sh                        |    2 
 src/pmsnap/pmsnap.sh                            |    2 
 76 files changed, 1118 insertions(+), 139 deletions(-)

Details ...

commit b0fd04b3ed9029d440da62d34e1f23b11b5e2c1f
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jul 12 11:44:54 2020 +1000

    infiband and lustrecomm PMDAs: use $PCP_DIR as prefix to /etc/pcp.env
    
    Fixes https://github.com/performancecopilot/pcp/issues/968

commit 41870dcd10f80ac364124adda0c4b11a559ff559
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jul 12 11:41:34 2020 +1000

    src/libpcp/src/check-statics: bit over-enthusiastic with the pcp.XXXXXX changes
    
    Need to use /tmp not $PCP_TMPFILE_DIR here.

commit 680b26d13f4d6e968916efc62234a94ea19647d5
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jul 12 11:40:10 2020 +1000

    qa/admin/check-vm: updates for Ubuntu 20.04
    
    Continuation of the PCP build --without-python (2) changes for Ubunutu,
    starting with version 20.04

commit 12729d92a843f47944f78d1eb7feeae01a1d4940
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jul 12 07:56:56 2020 +1000

    qa/1695 & 1696: ipv6 is optional ... filter out

commit fe72bffb6f8f33a8eff3dedab038de4fefb45a84
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jul 12 07:54:43 2020 +1000

    src/pmlogger/utilproc.sh: fix typo in last round of changes
    
    -f-p => -f -p
    
    Found by qa/630.

commit 4e2f0d7aa41afc7cb470b83b6cbe266d5accc880
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jul 12 07:50:44 2020 +1000

    qa/1768: change to match recent temp file/dir name changes

commit 8660007385c54537e8d38189dafa4f746a357572
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jul 12 07:49:20 2020 +1000

    qa/679.out: Warning: no archives found to merge moved to -V guard
    
    Fallout from recent pmlogger_daily changes.

commit 291e423c635568fdd3b28eaa51566393298cf6ae
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jul 12 07:48:31 2020 +1000

    qa/031.out.linux: acct no longer appears in the output

commit b90fab45109535a2fa8482c7ed763499330a342e
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jul 12 07:47:47 2020 +1000

    qa/common.filter: cull acct from top-level pmns
    
    This won't be there on the non-linux platforms.

commit 7c6a10cee50a5301ddc98bc0c1f1cca3b0700f6a
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jul 12 07:27:33 2020 +1000

    qa/1199: fetch _every_ metric first
    
    Force as many of the dynamic allocations in pmcd to happen as possible
    before we go belting the context churn test looking for leaks.
    
    Increase the batch for pminfo so this first step is a little faster.

commit f7d81559284fdf478bb96a66f168355ff78b7fa1
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sun Jul 12 07:24:30 2020 +1000

    qa/1102: openmetrics may NOT be installed at the beginning
    
    Add filtering for initial Remove.

commit 466afbe8bf95dc181e1e9d1f7370e6c1db0e080b
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Jul 11 12:49:38 2020 +1000

    src/pmproxy/rc_pmproxy: remove $tmp (dir) before exec
    
    We were leaving behind /var/tmp/pcp.XXXXX (or after the most recent
    change /var/tmp/pmproxy_rc.XXXXX) directories.
    
    When using "exec" we cannot expect the old process' trap to clean up,
    so need to do it explicitly before (each) exec.

commit 029add427a42344ea7129452c9e0fb286d3cf881
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Jul 11 07:51:25 2020 +1000

    src: cleanup temp file naming
    
    - change pcp.XXXXXXX -> pm<something>.XXXXXXX or pcp-<something>.XXXXXX
      so we can see who's not cleaning up properly
    - use $PCP_TMPFILE_DIR throughout for all temp files

commit dc1f309fc0ce76812c3b3ab3850c7100002c0358
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Jul 11 07:12:47 2020 +1000

    qa/common.config: bozo-vm now has a FQDN, cull some old junk

commit a51d17d8bddfd304ade1111b8addd954c4e11da6
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Jul 11 07:10:21 2020 +1000

    qa/new: tweak the preamble output to include args if any
    
    Intended for use with --valgrind, as in qa/1236 and qa/1237.

commit 7c0c2ced3176ce8acfcfa7ec01bd2f9bcfa5125a
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Jul 11 07:07:36 2020 +1000

    qa: 1233, 1235, 1236, 1237 (all new) derived metric help text tests
    
    Also demonstrates how to build a QA test for some functionality and
    then easily wrap that same test in a valgrind test cloak (we want
    both sorts of testing, but valgrind is not universally available).

commit 1f73f48fee1d493e1f88c1f9359241c5de6ca64d
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Jul 11 07:03:57 2020 +1000

    Add help text support for derived metrics
    
    This commit includes:
    - libpcp changes
    - man page
    - help text for the kernel.cpu.util derived metrics (by way
      of an example, I'll leave it to the owners of the other
      derived metrics to add help text if they wish).

commit cbb40e26c0c725179955dd316884cd09eb14cd99
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Jul 11 06:58:45 2020 +1000

    qa/623.out: remade after -k 0 change to pmlogger_daily
    
    Error message text is slightly different.

commit f98be11e54d2df4329c95beda8c3510aa9251d9c
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Jul 11 06:57:40 2020 +1000

    qa/1001: need _filter_views in one more place

commit 995fb50c274a041749dff6be7c0ed3caceb3e9c3
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Sat Jul 11 06:57:02 2020 +1000

    qa/common.filter: tweak _filter_views() for recent Qt warning