### PR TITLE
check exit status

### DIFF
--- a/qa/check
+++ b/qa/check
@@ -81,6 +81,7 @@ END	{ if (NR > 0) {
 		else
 		    echo "Aborted! [running $seq]" | tee -a check.log
 		fi
+		status=1
 	    fi
 
 	    if [ ! -z "$notrun" ]


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200714

Mark Goodwin (3):
      qa/group: mark 1886 reserved until new code merged
      selinux: allow pmdaxfs quotaget permissions
      qa/917: update 917.out.in for new pmcd quotaget rule

Ken McDonell (2):
      sec/pmcd/pmdaproc.sh: silence derived metrics warnings from Remove
      qa/check: make exit status 1 if the run is aborted

Andreas Gerstmayr (1):
      ci: add debug info for flaky centos8 build

 build/ci/platforms/centos8.yml |    3 +++
 qa/917.out.in                  |    1 +
 qa/check                       |    1 +
 qa/group                       |    2 +-
 src/pmcd/pmdaproc.sh           |    2 +-
 src/selinux/pcpupstream.te.in  |    6 +++++-
 6 files changed, 12 insertions(+), 3 deletions(-)

Details ...

commit d5a53b5b4519b43d192c2c8e28d35ba61b9b7a71
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Wed Jul 15 07:23:00 2020 +1000

    qa/check: make exit status 1 if the run is aborted

commit acc219fdda5ed0e4eb4783530b54d1316d5e5d4f
Author: Mark Goodwin <mgoodwin@redhat.com>
Date:   Tue Jul 14 22:04:47 2020 +1000

    qa/917: update 917.out.in for new pmcd quotaget rule

commit 0ed530382cc3b28f49522624293b23891c964654
Author: Andreas Gerstmayr <andreas@gerstmayr.me>
Date:   Tue Jul 14 12:24:37 2020 +0200

    ci: add debug info for flaky centos8 build

commit c32156c65056a3865228883212e3ced17736d1cb
Author: Mark Goodwin <mgoodwin@redhat.com>
Date:   Tue Jul 14 18:23:33 2020 +1000

    selinux: allow pmdaxfs quotaget permissions
    
    The XFS PMDA needs quotaget permissions on F32 with kernel
    5.7.8-200.fc32 or later and xfsprogs-5.4.0-3.fc32 or later.
    
    qa/876 exercises the relevant XFS quota calls, and is now
    passing again (on a system running the above kernel and
    userland).

commit ff9feb43537a7a45b1530cced63c11fa8fd22528
Author: Mark Goodwin <mgoodwin@redhat.com>
Date:   Tue Jul 14 18:20:53 2020 +1000

    qa/group: mark 1886 reserved until new code merged
    
    qa/1886 tests GSoC work to add expression evaluation to
    the libpcp_web query language, which has not been merged
    yet.

commit affcfacc1a84cd19a64f064fc915add0c21036c4
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Jul 14 16:30:09 2020 +1000

    sec/pmcd/pmdaproc.sh: silence derived metrics warnings from Remove