### PR TITLE
pmdaproc: acct: initialize acct file path with PCP_* variable and implement cleanup

### DIFF
--- a/configure
+++ b/configure
@@ -647,6 +647,7 @@ pcp_doc_dir
 pcp_tmp_dir
 pcp_tmpfile_dir
 pcp_run_dir
+pcp_psacct_system_path
 pcp_sa_dir
 pcp_archive_dir
 pcp_log_dir
@@ -15277,6 +15278,9 @@ pcp_archive_dir=$pcp_log_dir/pmlogger
 
 
 pcp_sa_dir=$pcp_log_dir/sa
+
+
+pcp_psacct_system_path="/var/account/pacct"
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -3480,6 +3480,9 @@ AC_SUBST(pcp_archive_dir)
 pcp_sa_dir=$pcp_log_dir/sa
 AC_SUBST(pcp_sa_dir)
 
+pcp_psacct_system_path="/var/account/pacct"
+AC_SUBST(pcp_psacct_system_path)
+
 AC_ARG_WITH(rundir,[AC_HELP_STRING([--with-rundir],[run directory [LOCALSTATEDIR/run/pcp]])],
                   [pcp_run_dir=$withval], [
 if test -d /run

--- a/src/include/pcp.conf.in
+++ b/src/include/pcp.conf.in
@@ -133,6 +133,10 @@ PCP_ARCHIVE_DIR=@pcp_archive_dir@
 # Standard path: /var/log/pcp/sa
 PCP_SA_DIR=@pcp_sa_dir@
 
+# path to acct file of psacct service
+# Standard path: /var/account/pacct
+PCP_PSACCT_SYSTEM_PATH=@pcp_psacct_system_path@
+
 # directory for PCP temp status files
 # Standard path: /var/lib/pcp/tmp
 # Subdirectories: pmie pmlogger

--- a/src/pmdas/linux_proc/acct.c
+++ b/src/pmdas/linux_proc/acct.c
@@ -22,14 +22,16 @@
 #define OPEN_RETRY_INTERVAL        60
 #define CHECK_ACCOUNTING_INTERVAL  600
 #define ACCT_FILE_SIZE_THRESHOLD   10485760
-#define PACCT_SYSTEM_FILE          "/var/account/pacct"
-#define PACCT_PCP_PRIVATE_FILE     "/tmp/pcp-pacct"
+
+static char pacct_system_file[1024];
+static char pacct_private_file[1024];
 
 int acct_lifetime = 60;
 struct timeval acct_update_interval = {
     .tv_sec = 600,
 };
 static int acct_timer_id = -1;
+static int is_child = 0;
 
 static struct {
     const char *path;
@@ -166,8 +168,10 @@ check_accounting(int fd)
 
     if (fstat(fd, &before) < 0)
 	return 0;
-    if (fork() == 0)
+    if (fork() == 0) {
+	is_child = 1;
 	exit(0);
+    }
     wait(0);
     if (fstat(fd, &after) < 0)
 	return 0;
@@ -189,11 +193,20 @@ close_pacct_file(void)
 	pmNotifyErr(LOG_DEBUG, "acct: close file=%s\n", acct_file.path);
 
     if (acct_file.fd >= 0) {
-	if (acct_file.acct_enabled)
-	    acct(0);
 	close(acct_file.fd);
+	if (acct_file.acct_enabled) {
+	    acct(0);
+	    unlink(acct_file.path);
+	}
     }
     init_acct_file_info();
+}
+
+static void
+acct_cleanup(void)
+{
+    if (!is_child)
+	close_pacct_file();
 }
 
 static int
@@ -215,7 +228,7 @@ open_and_acct(const char *path, int do_acct)
     if (acct_file.fd < 0)
 	goto err1;
 
-    if (stat(path, &file_stat) < 0)
+    if (fstat(acct_file.fd, &file_stat) < 0)
 	goto err2;
 
     if (do_acct && acct(path) < 0)
@@ -255,13 +268,13 @@ open_pacct_file(void)
 {
     int ret;
 
-    ret = open_and_acct(PACCT_SYSTEM_FILE, 0);
+    ret = open_and_acct(pacct_system_file, 0);
     if (ret) {
 	acct_file.acct_enabled = 0;
 	return 1;
     }
 
-    ret = open_and_acct(PACCT_PCP_PRIVATE_FILE, 1);
+    ret = open_and_acct(pacct_private_file, 1);
     if (ret) {
 	acct_file.acct_enabled = 1;
 	return 1;
@@ -345,11 +358,13 @@ copy_ringbuf_to_indom(pmdaIndom *indomp, time_t t)
     indomp->it_numinst = i;
 }
 
-static unsigned long long
-get_file_size(const char *path)
+static long long
+get_file_size(void)
 {
     struct stat statbuf;
-    if (stat(path, &statbuf) < 0)
+    if (acct_file.fd < 0)
+	return -1;
+    if (fstat(acct_file.fd, &statbuf) < 0)
 	return -1;
     return statbuf.st_size;
 }
@@ -366,7 +381,7 @@ acct_timer(int sig, void *ptr)
 {
     if (pmDebugOptions.libpmda && pmDebugOptions.desperate)
 	pmNotifyErr(LOG_DEBUG, "acct: timer called\n");
-    if (acct_file.fd >= 0 && acct_file.acct_enabled && get_file_size(acct_file.path) > ACCT_FILE_SIZE_THRESHOLD)
+    if (acct_file.fd >= 0 && acct_file.acct_enabled && get_file_size() > ACCT_FILE_SIZE_THRESHOLD)
 	reopen_pacct_file();
 }
 
@@ -384,9 +399,40 @@ init_acct_timer(void)
     acct_timer_id = sts;
 }
 
+static void
+init_pacct_system_file(void)
+{
+    char *tmppath;
+    if ((tmppath = pmGetOptionalConfig("PCP_PSACCT_SYSTEM_PATH")) == NULL) {
+	pacct_system_file[0] = '\0';
+    } else {
+	strncpy(pacct_system_file, tmppath, sizeof(pacct_system_file)-1);
+    }
+
+    if (pmDebugOptions.libpmda && pmDebugOptions.desperate)
+	pmNotifyErr(LOG_DEBUG, "acct: initialize pacct_system_file path to %s\n", pacct_system_file);
+}
+
+static void
+init_pacct_private_file(void)
+{
+    char *tmpdir;
+    if ((tmpdir = pmGetOptionalConfig("PCP_TMP_DIR")) == NULL) {
+	pacct_private_file[0] = '\0';
+    } else {
+	pmsprintf(pacct_private_file, sizeof(pacct_private_file), "%s/pmcd/pcp-pacct", tmpdir);
+    }
+
+    if (pmDebugOptions.libpmda && pmDebugOptions.desperate)
+	pmNotifyErr(LOG_DEBUG, "acct: initialize pacct_private_file path to %s\n", pacct_private_file);
+}
+
 void
 acct_init(proc_acct_t *proc_acct)
 {
+    init_pacct_system_file();
+    init_pacct_private_file();
+
     init_acct_timer();
 
     init_acct_file_info();
@@ -397,6 +443,8 @@ acct_init(proc_acct_t *proc_acct)
 
     proc_acct->indom->it_numinst = 0;
     proc_acct->indom->it_set = calloc(RINGBUF_SIZE, sizeof(pmdaInstid));
+
+    atexit(acct_cleanup);
 }
 
 void
@@ -404,7 +452,7 @@ refresh_acct(proc_acct_t *proc_acct)
 {
     char tmprec[MAX_ACCT_RECORD_SIZE_BYTES];
     void *acctp;
-    unsigned long long acct_file_size;
+    long long acct_file_size;
     int i, records, i_inst, need_update = 0;
     time_t now, process_end_time;
     acct_ringbuf_entry_t ringbuf_entry;
@@ -435,7 +483,7 @@ refresh_acct(proc_acct_t *proc_acct)
 	    pmNotifyErr(LOG_DEBUG, "acct: acct_gc n=%d\n", need_update);
     }
 
-    acct_file_size = get_file_size(acct_file.path);
+    acct_file_size = get_file_size();
     if (acct_file_size < 0) {
 	reopen_pacct_file();
 	return;


### PR DESCRIPTION
Related to: 
- https://github.com/performancecopilot/pcp/pull/962
- https://github.com/performancecopilot/pcp/issues/969