### PR TITLE
pmlogctl & qa/1768

### DIFF
--- a/qa/1768
+++ b/qa/1768
@@ -26,9 +26,10 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 _filter()
 {
     sed \
-	-e "s,$PCP_SYSCONF_DIR,PCP_SYSCONF_DIR,g" \
-	-e "s,$tmp\.pmfind,PMFIND,g" \
-	-e "/^+ cp /s, $PCP_TMPFILE_DIR/pmfind_check.[^/]*/, TMPDIR/," \
+	-e '/^# created by pmlogctl/s/ on .*/ on DATE/' \
+	-e '/^# created by pmiectl/s/ on .*/ on DATE/' \
+	-e "s;$PCP_TMPFILE_DIR/pmlogctl\.[^/]*;PCP_TMPFILE_DIR/pmlogctl.XXXXX;g" \
+	-e "s;$PCP_TMPFILE_DIR/pmiectl\.[^/]*;PCP_TMPFILE_DIR/pmiectl.XXXXX;g" \
     #end
 }
 

--- a/qa/1768.out
+++ b/qa/1768.out
@@ -1,13 +1,93 @@
 QA output created by 1768
 Discovered host pcp://slick:44321 [243f90596d76cf23e8da47476ec452a2adbe0b32]
-+ cp TMPDIR/243f90596d76cf23e8da47476ec452a2adbe0b32 PCP_SYSCONF_DIR/pmie/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
-+ cp TMPDIR/243f90596d76cf23e8da47476ec452a2adbe0b32 PCP_SYSCONF_DIR/pmlogger/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
+/etc/pcp/pmie/class.d/pmfind: host pcp://slick:44321 hostname(.*) true
+--- start control file ---
+# created by pmiectl on DATE
+# DO NOT REMOVE OR EDIT THE FOLLOWING LINE
+$version=1.1
+$class=pmfind
+pcp://slick:44321 n n PCP_LOG_DIR/pmie/243f90596d76cf23e8da47476ec452a2adbe0b32/pmie.log -c ./243f90596d76cf23e8da47476ec452a2adbe0b32.config
+--- end control file ---
+Installing control file: /etc/pcp/pmie/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
++ cp PCP_TMPFILE_DIR/pmiectl.XXXXX/control /etc/pcp/pmie/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
++ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmie_check -c /etc/pcp/pmie/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
+/etc/pcp/pmlogger/class.d/pmfind: host pcp://slick:44321 hostname(.*) true
+--- start control file ---
+# created by pmlogctl on DATE
+# DO NOT REMOVE OR EDIT THE FOLLOWING LINE
+$version=1.1
+$class=pmfind
+pcp://slick:44321 n n PCP_ARCHIVE_DIR/243f90596d76cf23e8da47476ec452a2adbe0b32 -c ./243f90596d76cf23e8da47476ec452a2adbe0b32.config
+--- end control file ---
+Installing control file: /etc/pcp/pmlogger/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
++ cp PCP_TMPFILE_DIR/pmlogctl.XXXXX/control /etc/pcp/pmlogger/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
++ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmlogger_check -c /etc/pcp/pmlogger/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
 Discovered host pcp://slack:44321 [8d00c4cf51d11bb9dced8a0e7507542653635377]
-+ cp TMPDIR/8d00c4cf51d11bb9dced8a0e7507542653635377 PCP_SYSCONF_DIR/pmie/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
-+ cp TMPDIR/8d00c4cf51d11bb9dced8a0e7507542653635377 PCP_SYSCONF_DIR/pmlogger/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
+/etc/pcp/pmie/class.d/pmfind: host pcp://slack:44321 hostname(.*) true
+--- start control file ---
+# created by pmiectl on DATE
+# DO NOT REMOVE OR EDIT THE FOLLOWING LINE
+$version=1.1
+$class=pmfind
+pcp://slack:44321 n n PCP_LOG_DIR/pmie/8d00c4cf51d11bb9dced8a0e7507542653635377/pmie.log -c ./8d00c4cf51d11bb9dced8a0e7507542653635377.config
+--- end control file ---
+Installing control file: /etc/pcp/pmie/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
++ cp PCP_TMPFILE_DIR/pmiectl.XXXXX/control /etc/pcp/pmie/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
++ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmie_check -c /etc/pcp/pmie/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
+/etc/pcp/pmlogger/class.d/pmfind: host pcp://slack:44321 hostname(.*) true
+--- start control file ---
+# created by pmlogctl on DATE
+# DO NOT REMOVE OR EDIT THE FOLLOWING LINE
+$version=1.1
+$class=pmfind
+pcp://slack:44321 n n PCP_ARCHIVE_DIR/8d00c4cf51d11bb9dced8a0e7507542653635377 -c ./8d00c4cf51d11bb9dced8a0e7507542653635377.config
+--- end control file ---
+Installing control file: /etc/pcp/pmlogger/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
++ cp PCP_TMPFILE_DIR/pmlogctl.XXXXX/control /etc/pcp/pmlogger/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
++ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmlogger_check -c /etc/pcp/pmlogger/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
 Discovered host pcp://localhost:44321?container=b0cd2cc912a3 [7745e45ed37ca712f418ec7b871c04fc898b9276]
-+ cp TMPDIR/7745e45ed37ca712f418ec7b871c04fc898b9276 PCP_SYSCONF_DIR/pmie/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
-+ cp TMPDIR/7745e45ed37ca712f418ec7b871c04fc898b9276 PCP_SYSCONF_DIR/pmlogger/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
+/etc/pcp/pmie/class.d/pmfind: host pcp://localhost:44321?container=b0cd2cc912a3 hostname(.*) true
+--- start control file ---
+# created by pmiectl on DATE
+# DO NOT REMOVE OR EDIT THE FOLLOWING LINE
+$version=1.1
+$class=pmfind
+pcp://localhost:44321?container=b0cd2cc912a3 n n PCP_LOG_DIR/pmie/7745e45ed37ca712f418ec7b871c04fc898b9276/pmie.log -c ./7745e45ed37ca712f418ec7b871c04fc898b9276.config
+--- end control file ---
+Installing control file: /etc/pcp/pmie/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
++ cp PCP_TMPFILE_DIR/pmiectl.XXXXX/control /etc/pcp/pmie/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
++ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmie_check -c /etc/pcp/pmie/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
+/etc/pcp/pmlogger/class.d/pmfind: host pcp://localhost:44321?container=b0cd2cc912a3 hostname(.*) true
+--- start control file ---
+# created by pmlogctl on DATE
+# DO NOT REMOVE OR EDIT THE FOLLOWING LINE
+$version=1.1
+$class=pmfind
+pcp://localhost:44321?container=b0cd2cc912a3 n n PCP_ARCHIVE_DIR/7745e45ed37ca712f418ec7b871c04fc898b9276 -c ./7745e45ed37ca712f418ec7b871c04fc898b9276.config
+--- end control file ---
+Installing control file: /etc/pcp/pmlogger/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
++ cp PCP_TMPFILE_DIR/pmlogctl.XXXXX/control /etc/pcp/pmlogger/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
++ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmlogger_check -c /etc/pcp/pmlogger/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
 Discovered host pcp://localhost:44321?container=77475e5fa09c [68dcffbdd4111d3ee82bb855286e3e35da828ca2]
-+ cp TMPDIR/68dcffbdd4111d3ee82bb855286e3e35da828ca2 PCP_SYSCONF_DIR/pmie/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
-+ cp TMPDIR/68dcffbdd4111d3ee82bb855286e3e35da828ca2 PCP_SYSCONF_DIR/pmlogger/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
+/etc/pcp/pmie/class.d/pmfind: host pcp://localhost:44321?container=77475e5fa09c hostname(.*) true
+--- start control file ---
+# created by pmiectl on DATE
+# DO NOT REMOVE OR EDIT THE FOLLOWING LINE
+$version=1.1
+$class=pmfind
+pcp://localhost:44321?container=77475e5fa09c n n PCP_LOG_DIR/pmie/68dcffbdd4111d3ee82bb855286e3e35da828ca2/pmie.log -c ./68dcffbdd4111d3ee82bb855286e3e35da828ca2.config
+--- end control file ---
+Installing control file: /etc/pcp/pmie/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
++ cp PCP_TMPFILE_DIR/pmiectl.XXXXX/control /etc/pcp/pmie/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
++ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmie_check -c /etc/pcp/pmie/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
+/etc/pcp/pmlogger/class.d/pmfind: host pcp://localhost:44321?container=77475e5fa09c hostname(.*) true
+--- start control file ---
+# created by pmlogctl on DATE
+# DO NOT REMOVE OR EDIT THE FOLLOWING LINE
+$version=1.1
+$class=pmfind
+pcp://localhost:44321?container=77475e5fa09c n n PCP_ARCHIVE_DIR/68dcffbdd4111d3ee82bb855286e3e35da828ca2 -c ./68dcffbdd4111d3ee82bb855286e3e35da828ca2.config
+--- end control file ---
+Installing control file: /etc/pcp/pmlogger/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
++ cp PCP_TMPFILE_DIR/pmlogctl.XXXXX/control /etc/pcp/pmlogger/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
++ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmlogger_check -c /etc/pcp/pmlogger/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2

--- a/src/pmlogctl/pmlogctl.sh
+++ b/src/pmlogctl/pmlogctl.sh
@@ -1252,7 +1252,7 @@ End-of-File
 	    _get_policy_section "$POLICY" ident >$tmp/tmp
 	    if [ -s $tmp/tmp ]
 	    then
-		ident=`sed -e "s/%h/$host/g" <$tmp/tmp`
+		ident=`sed -e "s;%h;$host;g" <$tmp/tmp`
 	    else
 		ident="$host"
 	    fi
@@ -1301,7 +1301,7 @@ _do_create()
 		check=`wc -w <$tmp/tmp | sed -e 's/ //g'`
 		[ "$check" -ne 1 ] &&
 		    _error "[ident] section is invalid in $POLICY policy file (expect a single word, not $check words)"
-		ident=`sed -e "s/%h/$host/g" <$tmp/tmp`
+		ident=`sed -e "s;%h;$host;g" <$tmp/tmp`
 	    else
 		ident="$host"
 	    fi
@@ -1338,7 +1338,7 @@ End-of-File
 	    echo '#DO NOT REMOVE OR EDIT THE FOLLOWING LINE' >>$tmp/control
 	    echo '$version=1.1' >>$tmp/control
 	fi
-	sed -e "s/%h/$host/g" -e "s/%i/$ident/g" <$tmp/tmp >>$tmp/control
+	sed -e "s;%h;$host;g" -e "s;%i;$ident;g" <$tmp/tmp >>$tmp/control
 	primary=`$PCP_AWK_PROG <$tmp/control '
 $1 == "'"$host"'"	{ print $2 }'`
 	if [ -z "$primary" ]


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200730

Ken McDonell (2):
      qa/1768: new filter and remade after pmfind_check changes
      src/pmlogctl/pmlogctl.sh: fix sed botch

 qa/1768                  |    7 +--
 qa/1768.out              |   96 +++++++++++++++++++++++++++++++++++++++++++----
 src/pmlogctl/pmlogctl.sh |    6 +-
 3 files changed, 95 insertions(+), 14 deletions(-)

Details ...

commit 90e8fcea1512e236afb9a16b4ee4f6379375811f
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Jul 30 16:49:29 2020 +1000

    src/pmlogctl/pmlogctl.sh: fix sed botch
    
    hostspecs like pcp://slick:44321 were tripping up the %h expansion
    because of the embedded / ... changed the sed pattern delimiter from
    / to ; (; seems unlikely in a hostspec, but if it can occur I'll
    need some additional embedded escaping goo)

commit 11e3ee819afd284e592e162979a837632770f1ab
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Jul 30 16:42:36 2020 +1000

    qa/1768: new filter and remade after pmfind_check changes
    
    pmfind_check now uses pm{log,ie}ctl, rather than making direct changes
    to the control files.