### PR TITLE
qa/1768

### DIFF
--- a/qa/1768
+++ b/qa/1768
@@ -30,6 +30,8 @@ _filter()
 	-e '/^# created by pmiectl/s/ on .*/ on DATE/' \
 	-e "s;$PCP_TMPFILE_DIR/pmlogctl\.[^/]*;PCP_TMPFILE_DIR/pmlogctl.XXXXX;g" \
 	-e "s;$PCP_TMPFILE_DIR/pmiectl\.[^/]*;PCP_TMPFILE_DIR/pmiectl.XXXXX;g" \
+	-e "s;$PCP_BINADM_DIR/;PCP_BINADM_DIR/;g" \
+	-e "s;$PCP_ETC_DIR/;PCP_ETC_DIR/;g" \
     #end
 }
 

--- a/qa/1768.out
+++ b/qa/1768.out
@@ -1,6 +1,6 @@
 QA output created by 1768
 Discovered host pcp://slick:44321 [243f90596d76cf23e8da47476ec452a2adbe0b32]
-/etc/pcp/pmie/class.d/pmfind: host pcp://slick:44321 hostname(.*) true
+PCP_ETC_DIR/pcp/pmie/class.d/pmfind: host pcp://slick:44321 hostname(.*) true
 --- start control file ---
 # created by pmiectl on DATE
 # DO NOT REMOVE OR EDIT THE FOLLOWING LINE
@@ -8,10 +8,10 @@ $version=1.1
 $class=pmfind
 pcp://slick:44321 n n PCP_LOG_DIR/pmie/243f90596d76cf23e8da47476ec452a2adbe0b32/pmie.log -c ./243f90596d76cf23e8da47476ec452a2adbe0b32.config
 --- end control file ---
-Installing control file: /etc/pcp/pmie/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
-+ cp PCP_TMPFILE_DIR/pmiectl.XXXXX/control /etc/pcp/pmie/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
-+ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmie_check -c /etc/pcp/pmie/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
-/etc/pcp/pmlogger/class.d/pmfind: host pcp://slick:44321 hostname(.*) true
+Installing control file: PCP_ETC_DIR/pcp/pmie/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
++ cp PCP_TMPFILE_DIR/pmiectl.XXXXX/control PCP_ETC_DIR/pcp/pmie/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
++ sudo -u pcp -g pcp PCP_BINADM_DIR/pmie_check -c PCP_ETC_DIR/pcp/pmie/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
+PCP_ETC_DIR/pcp/pmlogger/class.d/pmfind: host pcp://slick:44321 hostname(.*) true
 --- start control file ---
 # created by pmlogctl on DATE
 # DO NOT REMOVE OR EDIT THE FOLLOWING LINE
@@ -19,11 +19,11 @@ $version=1.1
 $class=pmfind
 pcp://slick:44321 n n PCP_ARCHIVE_DIR/243f90596d76cf23e8da47476ec452a2adbe0b32 -c ./243f90596d76cf23e8da47476ec452a2adbe0b32.config
 --- end control file ---
-Installing control file: /etc/pcp/pmlogger/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
-+ cp PCP_TMPFILE_DIR/pmlogctl.XXXXX/control /etc/pcp/pmlogger/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
-+ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmlogger_check -c /etc/pcp/pmlogger/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
+Installing control file: PCP_ETC_DIR/pcp/pmlogger/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
++ cp PCP_TMPFILE_DIR/pmlogctl.XXXXX/control PCP_ETC_DIR/pcp/pmlogger/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
++ sudo -u pcp -g pcp PCP_BINADM_DIR/pmlogger_check -c PCP_ETC_DIR/pcp/pmlogger/control.d/243f90596d76cf23e8da47476ec452a2adbe0b32
 Discovered host pcp://slack:44321 [8d00c4cf51d11bb9dced8a0e7507542653635377]
-/etc/pcp/pmie/class.d/pmfind: host pcp://slack:44321 hostname(.*) true
+PCP_ETC_DIR/pcp/pmie/class.d/pmfind: host pcp://slack:44321 hostname(.*) true
 --- start control file ---
 # created by pmiectl on DATE
 # DO NOT REMOVE OR EDIT THE FOLLOWING LINE
@@ -31,10 +31,10 @@ $version=1.1
 $class=pmfind
 pcp://slack:44321 n n PCP_LOG_DIR/pmie/8d00c4cf51d11bb9dced8a0e7507542653635377/pmie.log -c ./8d00c4cf51d11bb9dced8a0e7507542653635377.config
 --- end control file ---
-Installing control file: /etc/pcp/pmie/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
-+ cp PCP_TMPFILE_DIR/pmiectl.XXXXX/control /etc/pcp/pmie/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
-+ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmie_check -c /etc/pcp/pmie/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
-/etc/pcp/pmlogger/class.d/pmfind: host pcp://slack:44321 hostname(.*) true
+Installing control file: PCP_ETC_DIR/pcp/pmie/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
++ cp PCP_TMPFILE_DIR/pmiectl.XXXXX/control PCP_ETC_DIR/pcp/pmie/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
++ sudo -u pcp -g pcp PCP_BINADM_DIR/pmie_check -c PCP_ETC_DIR/pcp/pmie/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
+PCP_ETC_DIR/pcp/pmlogger/class.d/pmfind: host pcp://slack:44321 hostname(.*) true
 --- start control file ---
 # created by pmlogctl on DATE
 # DO NOT REMOVE OR EDIT THE FOLLOWING LINE
@@ -42,11 +42,11 @@ $version=1.1
 $class=pmfind
 pcp://slack:44321 n n PCP_ARCHIVE_DIR/8d00c4cf51d11bb9dced8a0e7507542653635377 -c ./8d00c4cf51d11bb9dced8a0e7507542653635377.config
 --- end control file ---
-Installing control file: /etc/pcp/pmlogger/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
-+ cp PCP_TMPFILE_DIR/pmlogctl.XXXXX/control /etc/pcp/pmlogger/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
-+ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmlogger_check -c /etc/pcp/pmlogger/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
+Installing control file: PCP_ETC_DIR/pcp/pmlogger/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
++ cp PCP_TMPFILE_DIR/pmlogctl.XXXXX/control PCP_ETC_DIR/pcp/pmlogger/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
++ sudo -u pcp -g pcp PCP_BINADM_DIR/pmlogger_check -c PCP_ETC_DIR/pcp/pmlogger/control.d/8d00c4cf51d11bb9dced8a0e7507542653635377
 Discovered host pcp://localhost:44321?container=b0cd2cc912a3 [7745e45ed37ca712f418ec7b871c04fc898b9276]
-/etc/pcp/pmie/class.d/pmfind: host pcp://localhost:44321?container=b0cd2cc912a3 hostname(.*) true
+PCP_ETC_DIR/pcp/pmie/class.d/pmfind: host pcp://localhost:44321?container=b0cd2cc912a3 hostname(.*) true
 --- start control file ---
 # created by pmiectl on DATE
 # DO NOT REMOVE OR EDIT THE FOLLOWING LINE
@@ -54,10 +54,10 @@ $version=1.1
 $class=pmfind
 pcp://localhost:44321?container=b0cd2cc912a3 n n PCP_LOG_DIR/pmie/7745e45ed37ca712f418ec7b871c04fc898b9276/pmie.log -c ./7745e45ed37ca712f418ec7b871c04fc898b9276.config
 --- end control file ---
-Installing control file: /etc/pcp/pmie/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
-+ cp PCP_TMPFILE_DIR/pmiectl.XXXXX/control /etc/pcp/pmie/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
-+ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmie_check -c /etc/pcp/pmie/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
-/etc/pcp/pmlogger/class.d/pmfind: host pcp://localhost:44321?container=b0cd2cc912a3 hostname(.*) true
+Installing control file: PCP_ETC_DIR/pcp/pmie/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
++ cp PCP_TMPFILE_DIR/pmiectl.XXXXX/control PCP_ETC_DIR/pcp/pmie/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
++ sudo -u pcp -g pcp PCP_BINADM_DIR/pmie_check -c PCP_ETC_DIR/pcp/pmie/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
+PCP_ETC_DIR/pcp/pmlogger/class.d/pmfind: host pcp://localhost:44321?container=b0cd2cc912a3 hostname(.*) true
 --- start control file ---
 # created by pmlogctl on DATE
 # DO NOT REMOVE OR EDIT THE FOLLOWING LINE
@@ -65,11 +65,11 @@ $version=1.1
 $class=pmfind
 pcp://localhost:44321?container=b0cd2cc912a3 n n PCP_ARCHIVE_DIR/7745e45ed37ca712f418ec7b871c04fc898b9276 -c ./7745e45ed37ca712f418ec7b871c04fc898b9276.config
 --- end control file ---
-Installing control file: /etc/pcp/pmlogger/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
-+ cp PCP_TMPFILE_DIR/pmlogctl.XXXXX/control /etc/pcp/pmlogger/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
-+ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmlogger_check -c /etc/pcp/pmlogger/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
+Installing control file: PCP_ETC_DIR/pcp/pmlogger/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
++ cp PCP_TMPFILE_DIR/pmlogctl.XXXXX/control PCP_ETC_DIR/pcp/pmlogger/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
++ sudo -u pcp -g pcp PCP_BINADM_DIR/pmlogger_check -c PCP_ETC_DIR/pcp/pmlogger/control.d/7745e45ed37ca712f418ec7b871c04fc898b9276
 Discovered host pcp://localhost:44321?container=77475e5fa09c [68dcffbdd4111d3ee82bb855286e3e35da828ca2]
-/etc/pcp/pmie/class.d/pmfind: host pcp://localhost:44321?container=77475e5fa09c hostname(.*) true
+PCP_ETC_DIR/pcp/pmie/class.d/pmfind: host pcp://localhost:44321?container=77475e5fa09c hostname(.*) true
 --- start control file ---
 # created by pmiectl on DATE
 # DO NOT REMOVE OR EDIT THE FOLLOWING LINE
@@ -77,10 +77,10 @@ $version=1.1
 $class=pmfind
 pcp://localhost:44321?container=77475e5fa09c n n PCP_LOG_DIR/pmie/68dcffbdd4111d3ee82bb855286e3e35da828ca2/pmie.log -c ./68dcffbdd4111d3ee82bb855286e3e35da828ca2.config
 --- end control file ---
-Installing control file: /etc/pcp/pmie/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
-+ cp PCP_TMPFILE_DIR/pmiectl.XXXXX/control /etc/pcp/pmie/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
-+ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmie_check -c /etc/pcp/pmie/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
-/etc/pcp/pmlogger/class.d/pmfind: host pcp://localhost:44321?container=77475e5fa09c hostname(.*) true
+Installing control file: PCP_ETC_DIR/pcp/pmie/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
++ cp PCP_TMPFILE_DIR/pmiectl.XXXXX/control PCP_ETC_DIR/pcp/pmie/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
++ sudo -u pcp -g pcp PCP_BINADM_DIR/pmie_check -c PCP_ETC_DIR/pcp/pmie/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
+PCP_ETC_DIR/pcp/pmlogger/class.d/pmfind: host pcp://localhost:44321?container=77475e5fa09c hostname(.*) true
 --- start control file ---
 # created by pmlogctl on DATE
 # DO NOT REMOVE OR EDIT THE FOLLOWING LINE
@@ -88,6 +88,6 @@ $version=1.1
 $class=pmfind
 pcp://localhost:44321?container=77475e5fa09c n n PCP_ARCHIVE_DIR/68dcffbdd4111d3ee82bb855286e3e35da828ca2 -c ./68dcffbdd4111d3ee82bb855286e3e35da828ca2.config
 --- end control file ---
-Installing control file: /etc/pcp/pmlogger/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
-+ cp PCP_TMPFILE_DIR/pmlogctl.XXXXX/control /etc/pcp/pmlogger/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
-+ sudo -u pcp -g pcp /usr/lib/pcp/bin/pmlogger_check -c /etc/pcp/pmlogger/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
+Installing control file: PCP_ETC_DIR/pcp/pmlogger/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
++ cp PCP_TMPFILE_DIR/pmlogctl.XXXXX/control PCP_ETC_DIR/pcp/pmlogger/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2
++ sudo -u pcp -g pcp PCP_BINADM_DIR/pmlogger_check -c PCP_ETC_DIR/pcp/pmlogger/control.d/68dcffbdd4111d3ee82bb855286e3e35da828ca2


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200730

Ken McDonell (3):
      qa/1768: new filter and remade after pmfind_check changes
      src/pmlogctl/pmlogctl.sh: fix sed botch
      qa/1768: fix filter for /etc and .../bin/... paths

 qa/1768                  |    9 +-
 qa/1768.out              |  160 +++++++++++++++++++++++++++++++++++------------
 src/pmlogctl/pmlogctl.sh |    6 -
 3 files changed, 129 insertions(+), 46 deletions(-)

Details ...

commit 6999b8eaab2975b5eecf8879da83cdb853ea1cb1
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Jul 30 18:09:50 2020 +1000

    qa/1768: fix filter for /etc and .../bin/... paths

commit 90e8fcea1512e236afb9a16b4ee4f6379375811f
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Jul 30 16:49:29 2020 +1000

    src/pmlogctl/pmlogctl.sh: fix sed botch
    
    hostspecs like pcp://slick:44321 were tripping up the %h expansion
    because of the embedded / ... changed the sed pattern delimiter from
    / to ; (; seems unlikely in a hostspec, but if it can occur I'll
    need some additional embedded escaping goo)

commit 11e3ee819afd284e592e162979a837632770f1ab
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Jul 30 16:42:36 2020 +1000

    qa/1768: new filter and remade after pmfind_check changes
    
    pmfind_check now uses pm{log,ie}ctl, rather than making direct changes
    to the control files.