### PR TITLE
qa, pmie&systemd, pmie_check

### DIFF
--- a/qa/003
+++ b/qa/003
@@ -260,6 +260,7 @@ do
 	    -e "/network\.ip\.noect.*: $unavailable/d" \
 	    -e "/network\.ip\.outbcastoctets: $unavailable/d" \
 	    -e "/network\.ip\.outoctets: $unavailable/d" \
+	    -e "/network\.mptcp\..*: $unavailable/d" \
 	    -e "/network\.softnet\.flow_limit_count: $nosupport/d" \
 	    -e "/network\.softnet\..*: $nosupport/d" \
 	    -e "/network\.tcp\.autocork.*: $unavailable/d" \

--- a/qa/069
+++ b/qa/069
@@ -78,7 +78,7 @@ d
 	-e 's/ $//' \
     | $PCP_AWK_PROG '
 BEGIN				{ skip = 0 }
-/client connection from/	{ print; print "..."; skip=1; next }
+/client connection from/	{ print; print "+++"; skip=1; next }
 skip == 1 && NF == 0		{ skip = 0 }
 skip == 1			{ next }
 				{ print }' \

--- a/qa/069.out.ipv6
+++ b/qa/069.out.ipv6
@@ -44,7 +44,7 @@ pmcd RESTARTED at DATE
 
 Current PMCD clients ...
      fd  client connection from                    ipc ver  operations denied
-...
++++
 
 
 active agent dom   pid  in out ver protocol parameters

--- a/qa/069.out.nonipv6
+++ b/qa/069.out.nonipv6
@@ -43,7 +43,7 @@ pmcd RESTARTED at DATE
 
 Current PMCD clients ...
      fd  client connection from                    ipc ver  operations denied
-...
++++
 
 
 active agent dom   pid  in out ver protocol parameters

--- a/qa/115
+++ b/qa/115
@@ -115,7 +115,12 @@ _filter()
 	-e '/^Job for pmie.service failed because /d' \
 	-e '/^Job for pmie.service failed\. /d' \
 	-e '/^See "systemctl  *status pmie.service" and/d' \
-    # end
+	-e '/^Start: /s/ .*/ DATE/' \
+	-e '/^End: /s/ .*/ DATE/' \
+    | $PCP_AWK_PROG '
+/^Called from:/		{ skip = 1 }
+skip == 0		{ print }
+/end of pstree output/	{ skip = 0 }'
 }
 
 _count_pmies()

--- a/qa/115.out
+++ b/qa/115.out
@@ -9,6 +9,7 @@ pmie count after attempt without control file: 0
 
 === check pmie_check and custom configs ===
 --- v1.0 ---
+Start: DATE
 # $version=1.0
 + export version; version=1.0
 Check pmie -h REMOTEHOST -l /tmp/SEQ-PID.log1 ...
@@ -32,8 +33,10 @@ host = LOCALHOST
 log file = /tmp/SEQ-PID.log0
 Restarting pmie for host "LOCALHOST" ...
 + $PCP_BIN_DIR/pmie -b -h LOCALHOST -l /tmp/SEQ-PID.log0 -c /tmp/SEQ-PID.conf
+End: DATE
 
 --- v1.1 ---
+Start: DATE
 # $version=1.1
 + export version; version=1.1
 Check pmie -h REMOTEHOST -l /tmp/SEQ-PID.log1 ...
@@ -57,9 +60,11 @@ host = LOCALHOST
 log file = /tmp/SEQ-PID.log0
 Restarting pmie for host "LOCALHOST" ...
 + $PCP_BIN_DIR/pmie -b -F -P -l /tmp/SEQ-PID.log0 -c /tmp/SEQ-PID.conf
+End: DATE
 
 === warnings ... ===
 --- stale lock file ---
+Start: DATE
 # $version=1.1
 + export version; version=1.1
 Check pmie -h LOCALHOST -l /tmp/SEQ-PID.locker/ok.1 ...
@@ -72,8 +77,10 @@ host = LOCALHOST
 log file = /tmp/SEQ-PID.locker/ok.1
 Restarting pmie for host "LOCALHOST" ...
 + $PCP_BIN_DIR/pmie -b -h LOCALHOST -l /tmp/SEQ-PID.locker/ok.1 -c /tmp/SEQ-PID.conf
+End: DATE
 
 --- existing lock file ---
+Start: DATE
 # $version=1.1
 + export version; version=1.1
 Check pmie -h LOCALHOST -l /tmp/SEQ-PID.locker/ok.2 ...
@@ -83,8 +90,10 @@ Warning: is another PCP cron job running concurrently?
 ... ls output ... tmp/SEQ-PID.locker/ok.2.lock
 pmie_check [/tmp/SEQ-PID.warning.2:2]
 Warning: failed to acquire exclusive lock (/tmp/SEQ-PID.locker/ok.2.lock) ...
+End: DATE
 
 --- can't create lock file ---
+Start: DATE
 # $version=1.1
 + export version; version=1.1
 Check pmie -h LOCALHOST -l /tmp/SEQ-PID.locker/ok.3 ...
@@ -97,8 +106,10 @@ host = LOCALHOST
 log file = /tmp/SEQ-PID.locker/ok.3
 Restarting pmie for host "LOCALHOST" ...
 + $PCP_BIN_DIR/pmie -b -h LOCALHOST -l /tmp/SEQ-PID.locker/ok.3 -c /tmp/SEQ-PID.conf
+End: DATE
 
 --- bad in-line shell commands ---
+Start: DATE
 # $version=1.1
 + export version; version=1.1
 # $date
@@ -117,58 +128,74 @@ host = LOCALHOST
 log file = /tmp/SEQ-PID.ok.4
 Restarting pmie for host "LOCALHOST" ...
 + $PCP_BIN_DIR/pmie -b -h LOCALHOST -l /tmp/SEQ-PID.ok.4 -c /tmp/SEQ-PID.conf
+End: DATE
 
 --- missing $version but really v1.1 ... original control.local issue ---
+Start: DATE
 pmie_check [/tmp/SEQ-PID.warning.5:1]
 Warning: missing $version, assuming version 1.0 control format
 pmie_check: [/tmp/SEQ-PID.warning.5:1]
 Error: args field in control file must begin with a hyphen not "/tmp/SEQ-PID.ok.5 -c /tmp/SEQ-PID.conf"
 ... automated performance reasoning for host "LOCALHOSTNAME" unchanged
+End: DATE
 
 === errors ... ===
 --- bad version ---
+Start: DATE
 # $version=0.0
 + export version; version=0.0
 pmie_check: [/tmp/SEQ-PID.error.1:2]
 Error: bad version (0.0) in control file
 ... automated performance reasoning for host "LOCALHOSTNAME" unchanged
+End: DATE
 
 --- v1.0 socks != y|n ---
+Start: DATE
 # $version=1.0
 + export version; version=1.0
 pmie_check: [/tmp/SEQ-PID.error.2:2]
 Error: socks field in control file record must be y or n, not "x"
 ... automated performance reasoning for host "LOCALHOSTNAME" unchanged
+End: DATE
 
 --- v1.1 socks != y|n ---
+Start: DATE
 # $version=1.1
 + export version; version=1.1
 pmie_check: [/tmp/SEQ-PID.error.3:2]
 Error: socks field in control file record must be y or n, not "x"
 ... automated performance reasoning for host "LOCALHOSTNAME" unchanged
+End: DATE
 
 --- v1.1 primary != y|n ---
+Start: DATE
 # $version=1.1
 + export version; version=1.1
 pmie_check: [/tmp/SEQ-PID.error.4:2]
 Error: primary field in control file record must be y or n, not "x"
 ... automated performance reasoning for host "LOCALHOSTNAME" unchanged
+End: DATE
 
 --- v1.0 insufficient fields ---
+Start: DATE
 # $version=1.0
 + export version; version=1.0
 pmie_check: [/tmp/SEQ-PID.error.5:2]
 Error: insufficient fields in control file record
 ... automated performance reasoning for host "LOCALHOSTNAME" unchanged
+End: DATE
 
 --- v1.1 insufficient fields ---
+Start: DATE
 # $version=1.1
 + export version; version=1.1
 pmie_check: [/tmp/SEQ-PID.error.6:2]
 Error: insufficient fields in control file record
 ... automated performance reasoning for host "LOCALHOSTNAME" unchanged
+End: DATE
 
 --- can't create dir for logfile ---
+Start: DATE
 # $version=1.1
 + export version; version=1.1
 Check pmie -h LOCALHOST -l /tmp/SEQ-PID.nogo/subdir/bad.7 ...
@@ -176,12 +203,15 @@ mkdir_and_chown: /tmp/SEQ-PID.nogo/subdir: mkdir -m 755 failed
 pmie_check: [/tmp/SEQ-PID.error.7:2]
 Error: cannot create directory (/tmp/SEQ-PID.nogo/subdir) for pmie log file
 ... automated performance reasoning for host "LOCALHOST" unchanged
+End: DATE
 
 --- can't chdir to dir for logfile ---
+Start: DATE
 # $version=1.1
 + export version; version=1.1
 Check pmie -h LOCALHOST -l /tmp/SEQ-PID.nogo/bad.8 ...
 pmie_check: [/tmp/SEQ-PID.error.8:2]
 Error: cannot chdir to directory (/tmp/SEQ-PID.nogo) for pmie log file
 ... automated performance reasoning for host "LOCALHOST" unchanged
+End: DATE
 

--- a/qa/common.check
+++ b/qa/common.check
@@ -251,6 +251,15 @@ _service()
 		    $sudo systemctl reset-failed $1.service 2>>$here/$seq.full
 		fi
 		$sudo systemctl $2 $1.service
+		if [ "$1" = pmie -a "$2" = stop ]
+		then
+		    # need to stop pmie_check.service and the pmie_check.timer
+		    # as well, else "start" may fail due to a pmie/pmie_check
+		    # race
+		    #
+		    $sudo systemctl stop pmie_check.service
+		    $sudo systemctl stop pmie_check.timer
+		fi
 		;;
 	esac
     elif [ -f $PCP_RC_DIR/$1 ]

--- a/src/pmie/pmie_check.service.in
+++ b/src/pmie/pmie_check.service.in
@@ -2,6 +2,7 @@
 Description=Check PMIE instances are running
 Documentation=man:pmie_check(1)
 ConditionPathExists=!@CRONTAB_PATH@
+PartOf=pmie.service
 
 [Service]
 Type=oneshot

--- a/src/pmie/pmie_check.timer
+++ b/src/pmie/pmie_check.timer
@@ -1,5 +1,6 @@
 [Unit]
 Description=Half-hourly check of PMIE instances
+PartOf=pmie.service
 
 [Timer]
 # if enabled, runs 1m after boot and every half hour


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200730

Miroslav Foltýn (14):
      libpcp_web: fixed redis search text endpoint handler, now correctly returns response
      pmproxy: correctly handling /search/text type params, updated response model for /search/suggest; libpcp_web: bunch of heuristics around querying Redisearch in /search related endpoints
      libpcp_web: search, updated minimum token length for querying RediSearch
      pmwebapi: extended pmSearchTextType, pmSearchTextRequest, /search corrected Redisearch query handling; pmproxy: reverted /search/suggest response model, updated /search/text response model, made all search result item fields optional, updated /search/text defaults
      libpcp_web: search: handling of some edge cases
      pmproxy: new /search/indom endpoint, simple response being names of entities, no edge-cases handling
      pmproxy: /search/indom better response model, now includes metrics and instances in response
      pmproxy: /search/indom response now same as /search/text; libpcp_web: removed forgotten sleep (whoopsie), pagination support for indom
      docs: updated some fulltext search related docs
      man: updated pmsearch.1, fixed linting issues; pmsearch: updated with --indom modifier; pmproxy: more consistent naming for /search endpoints param type, libpcp_web: always index indoms in 'pcp:text' with both name and indom fields
      libpcp_web: BM25 scorer for search related ops
      libpcp_web: sorting redis search indom by type
      libpcp_web: fix typo in comment of redis_search_text_query
      pmsearch: formatting output in a same way webapi responses are formatted - leaving out the fields that contain no value; qa: updated pmsearch testcase 1871

Ken McDonell (11):
      qa/1768: new filter and remade after pmfind_check changes
      src/pmlogctl/pmlogctl.sh: fix sed botch
      qa/1768: fix filter for /etc and .../bin/... paths
      debian/libpcp3-dev.install: fix pmSearchTextInDom man page
      man/man3/pmsearchtextindom.3: pmSearchTextIndom -> pmSearchTextInDom
      qa/003: filter out network.mptcp.* metrics when no values available
      qa/069: change ... -> +++ in filter to avoid ellipsis filtering elsewhere
      qa/common.check: changes in _service for systemctl and pmie
      src/pmie/pmie_check.*: make pmie_check PartOf pmie
      src/pmie/pmie_check.sh: use per-process log file
      qa/115: tweak filter and remade after pmie_check log/verbosity change

Nathan Scott (2):
      pmsearch: very minor code consistency tweaks on review
      build: fix deb builds with addition of devel man page

 debian/libpcp3-dev.install     |   24 +-
 man/man1/pmsearch.1            |   14 -
 man/man3/pmsearchtextindom.3   |   41 +++
 man/man3/pmsearchtextsuggest.3 |    2 
 man/man3/pmwebapi.3            |   63 +++---
 qa/003                         |    1 
 qa/069                         |    2 
 qa/069.out.ipv6                |    2 
 qa/069.out.nonipv6             |    2 
 qa/115                         |    7 
 qa/115.out                     |   30 ++
 qa/1768                        |    9 
 qa/1768.out                    |  160 +++++++++++----
 qa/1871                        |   12 +
 qa/1871.out                    |   54 +++++
 qa/common.check                |    9 
 src/include/pcp/pmwebapi.h     |   13 -
 src/libpcp_web/src/exports     |    3 
 src/libpcp_web/src/search.c    |  421 ++++++++++++++++++++++++++++++-----------
 src/libpcp_web/src/search.h    |   16 -
 src/pmie/pmie_check.service.in |    1 
 src/pmie/pmie_check.sh         |   27 ++
 src/pmie/pmie_check.timer      |    1 
 src/pmlogctl/pmlogctl.sh       |    6 
 src/pmproxy/src/search.c       |  262 ++++++++++++++++---------
 src/pmsearch/pmsearch.c        |   40 ++-
 26 files changed, 887 insertions(+), 335 deletions(-)

Details ...

commit 88b3c2a262330861a3ab232af701ec76ae337da8
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Fri Jul 31 08:09:16 2020 +1000

    qa/115: tweak filter and remade after pmie_check log/verbosity change

commit 6563dc59bd6bc7a4606c581286a30cad36e4a36f
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Fri Jul 31 08:06:23 2020 +1000

    src/pmie/pmie_check.sh: use per-process log file
    
    Same change as was made some time ago in pmlogger_check, namely
    use a temp file for the log and rename at the end.

commit 7fdcb968b890ca178bf6e035ace7bb93884fea18
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Fri Jul 31 07:43:55 2020 +1000

    src/pmie/pmie_check.*: make pmie_check PartOf pmie
    
    When pmie is stopped by systemctl we need to also stop both the
    pmie_check.service and pmie_check.timer.  If this does not happen
    the next start pmie may report errors due to a race between
    pmie.service and pmie_check.timer to get the primary pmie running
    (pmie.service needs to win this race).

commit e97791dcad00f271618fbc26744428913a2a5fa8
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Fri Jul 31 07:34:22 2020 +1000

    qa/common.check: changes in _service for systemctl and pmie
    
    When stopping pmie with systemctl, it is necessary to also stop
    pmie_check.service and pmie_check.timer, otherwise a subsequent
    start for pmie is likely to fail.
    
    This probably should be fixed in the systemd control files!

commit daf719797a6e6b4dae5cf0ab65e80a85e8e4a499
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Fri Jul 31 07:33:30 2020 +1000

    qa/069: change ... -> +++ in filter to avoid ellipsis filtering elsewhere

commit 6c8196b4bf82fb2525e7fa56c7a8dc38fd510c65
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Fri Jul 31 07:31:32 2020 +1000

    qa/003: filter out network.mptcp.* metrics when no values available

commit 646e2dc5d419e8edff29c1bffc122984d1018429
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Fri Jul 31 06:30:56 2020 +1000

    man/man3/pmsearchtextindom.3: pmSearchTextIndom -> pmSearchTextInDom
    
    The function name was wrong (Indom not InDom) in the NAME section
    which broke the Debian build.

commit 76102b0da15e8bdfc5f87725b3f20e81a9de5eee
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Jul 30 21:29:06 2020 +1000

    debian/libpcp3-dev.install: fix pmSearchTextInDom man page
    
    "Text" was missing in the name here.
    Also sort -f to maintain order.

commit 6999b8eaab2975b5eecf8879da83cdb853ea1cb1
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Jul 30 18:09:50 2020 +1000

    qa/1768: fix filter for /etc and .../bin/... paths

commit bc4284e9c045a67265a3adca33ebfcc81b06ee53
Author: Nathan Scott <nathans@redhat.com>
Date:   Thu Jul 30 17:21:53 2020 +1000

    build: fix deb builds with addition of devel man page

commit 72b4e79677e883b6dfdd2d3b26aef9f3724aeddd
Author: Nathan Scott <nathans@redhat.com>
Date:   Thu Jul 30 17:10:29 2020 +1000

    pmsearch: very minor code consistency tweaks on review

commit 90e8fcea1512e236afb9a16b4ee4f6379375811f
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Jul 30 16:49:29 2020 +1000

    src/pmlogctl/pmlogctl.sh: fix sed botch
    
    hostspecs like pcp://slick:44321 were tripping up the %h expansion
    because of the embedded / ... changed the sed pattern delimiter from
    / to ; (; seems unlikely in a hostspec, but if it can occur I'll
    need some additional embedded escaping goo)

commit 11e3ee819afd284e592e162979a837632770f1ab
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Thu Jul 30 16:42:36 2020 +1000

    qa/1768: new filter and remade after pmfind_check changes
    
    pmfind_check now uses pm{log,ie}ctl, rather than making direct changes
    to the control files.

commit b7ed73b0e3650139bbb9f767d69511400aaecca1
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Tue Jul 28 16:01:27 2020 +0200

    pmsearch: formatting output in a same way webapi responses are formatted - leaving out the fields that contain no value; qa: updated pmsearch testcase 1871

commit 736f30896bb0c55fe12c6721eb0f0fd5a32ca153
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Tue Jul 28 14:15:30 2020 +0200

    libpcp_web: fix typo in comment of redis_search_text_query

commit cc80cba72b556981479b4892e40f4959fb31447c
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Tue Jul 28 14:06:07 2020 +0200

    libpcp_web: sorting redis search indom by type

commit cfc06eb00a859a0dcf830e598dd5df2531d938b8
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Mon Jul 27 19:56:49 2020 +0200

    libpcp_web: BM25 scorer for search related ops

commit dcd2bed5070b7ea078485721d0f4608f0339e4be
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Mon Jul 27 12:50:19 2020 +0200

    man: updated pmsearch.1, fixed linting issues; pmsearch: updated with --indom modifier; pmproxy: more consistent naming for /search endpoints param type, libpcp_web: always index indoms in 'pcp:text' with both name and indom fields

commit b25d9add1d3ea8c9f9e75bfe4cf9e3b0343154f9
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Fri Jul 24 19:59:55 2020 +0200

    docs: updated some fulltext search related docs

commit 528a197ad9ea7fb1f1e6cc2a6ad966300e237c86
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Fri Jul 24 19:51:34 2020 +0200

    pmproxy: /search/indom response now same as /search/text; libpcp_web: removed forgotten sleep (whoopsie), pagination support for indom

commit 40ced65d4ba5e6b9b497866ca628843a2e0cc244
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Fri Jul 24 18:08:12 2020 +0200

    pmproxy: /search/indom better response model, now includes metrics and instances in response

commit 70f02686a6a5ead1e5686e56ec29f74a3dd339c1
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Fri Jul 24 17:52:40 2020 +0200

    pmproxy: new /search/indom endpoint, simple response being names of entities, no edge-cases handling

commit 19f0033fadb8ec3500139d9f655563e87b95e737
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Fri Jul 24 15:34:03 2020 +0200

    libpcp_web: search: handling of some edge cases

commit d17d9e4a6de0f35a88f24b45389a854d64dacc3e
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Thu Jul 23 19:17:37 2020 +0200

    pmwebapi: extended pmSearchTextType, pmSearchTextRequest, /search corrected Redisearch query handling; pmproxy: reverted /search/suggest response model, updated /search/text response model, made all search result item fields optional, updated /search/text defaults

commit 76c87995e4e2963f6e4c41c705636664b08d9e4e
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Wed Jul 22 23:31:43 2020 +0200

    libpcp_web: search, updated minimum token length for querying RediSearch

commit 56138d3fe6e8d90b8e92411a5763a5bf254f2e1f
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Wed Jul 22 23:03:53 2020 +0200

    pmproxy: correctly handling /search/text type params, updated response model for /search/suggest; libpcp_web: bunch of heuristics around querying Redisearch in /search related endpoints

commit 7914e3d491706203e005473db31beb6ea95927a3
Author: Miroslav Foltýn <miroslav.foltyn64@gmail.com>
Date:   Tue Jul 21 20:01:38 2020 +0200

    libpcp_web: fixed redis search text endpoint handler, now correctly returns response