### PR TITLE
pmproxy: /search/* endpoints tweaks; man: pmwebapi.3; qa: simple pmproxy /search/* test

### DIFF
--- a/man/man3/pmwebapi.3
+++ b/man/man3/pmwebapi.3
@@ -560,13 +560,7 @@ at the time
 .B pmproxy
 is started, such that metrics, instances and help text it
 discovers can be automatically indexed.
-.PP
-All requests in this group can be accompanied by an optional
-.IR client
-parameter.
-The value passed in the request will be sent back in the
-response \- all responses will be in JSON object form in
-this case, with top level "client" and "result" fields.
+
 .SS GET \fI/search/text\fR \- \fBpmSearchTextQuery\fR(3)
 .TS
 box;
@@ -580,8 +574,7 @@ offset	number	Result offset cursor for pagination
 limit	number	Maximum results to include in response
 field	fields	Queried fields (defaults to all)
 return	fields	Fields to actually return (defaults to all)
-type	types	entity Types to filter (defaults to all)
-client	string	Request identifier sent back with response
+type	types	Entity types to filter (defaults to all)
 .TE
 .PP
 Performs a text search query across metrics and instance
@@ -597,12 +590,11 @@ $ curl -s http://localhost:44322/search/text?\\
 	query=halt | pmjson
 {
   "total": 2,
+  "offset": 0,
+  "limit": 10,
   "elapsed": 0.000504,
   "results": [
     {
-      "docid": "ae2bba4478a916efe60c46132562d1f6ee53dc66",
-      "count": 1,
-      "score": 3.300000,
       "name": "kvm.halt_exits",
       "type": "metric",
       "indom": "95.0.4",
@@ -610,9 +602,6 @@ $ curl -s http://localhost:44322/search/text?\\
       "helptext": "This type of exit is usually seen when a guest is idle."
     },
     {
-      "docid": "5be7a38f204235a77d11f646b4f528388509ac91",
-      "count": 2,
-      "score": 3.300000,
       "name": "kvm.halt_wakeup",
       "type": "metric",
       "indom": "95.0.6",
@@ -622,10 +611,6 @@ $ curl -s http://localhost:44322/search/text?\\
 }
 .ESAMPLE
 .PP
-Every response has a unique document identifier associated
-with it, returned as a convenience (consider these opaque,
-they cannot be passed to the search engine).
-.PP
 The available search entity
 .I types
 are
@@ -633,8 +618,27 @@ are
 .IR indom
 and
 .IR instance .
+Query parameters
+.IR highlight
+and
+.IR field
+take
+.IR name ,
+.IR oneline
+and
+.IR helptext .
+.PP
+Query parameter
+.IR return
+takes
+.IR name ,
+.IR type ,
+.IR oneline ,
+.IR helptext ,
+.IR indom .
 There is typically both a name and help text associated with
-metrics.
+metrics. Contents of these are then matched against
+.IR query .
 An instance domain has help text and a numeric identifier,
 while instances have a name only (which can be searched).
 .SS GET \fI/search/suggest\fR \- \fBpmSearchTextSuggest\fR(3)
@@ -679,18 +683,8 @@ limit	number	M results to include in response
 .PP
 Provides all entities (instances, metrics) related to indom, including itself, that is passed to the server via the
 .I query
-parameter (HTTP GET).
+parameter.
 .SS GET \fI/search/info\fR \- \fBpmSearchInfo\fR(3)
-.TS
-box;
-c | c | cw(2.4i)
-lf(CW) | l | l.
-Parameters	Type	Explanation
-_
-key	string	Metrics for search engine (default "text")
-client	string	Request identifier sent back with response
-.TE
-.PP
 Provides metrics relating to operation of the search engine,
 in particular showing document and text record counts.
 .SAMPLE

--- a/qa/1872
+++ b/qa/1872
@@ -1,0 +1,340 @@
+#!/bin/sh
+# PCP QA Test No. 1872
+# Exercise pmsearch REST API endpoints using curl(1).
+#
+# Copyright (c) 2020 Red Hat.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+_check_series
+_check_search
+
+_cleanup()
+{
+    cd $here
+    [ -n "$pmproxy_pid" ] && $signal -s TERM $pmproxy_pid
+    [ -n "$port" ] && redis-cli $port shutdown
+    if $need_restore
+    then
+        need_restore=false
+        _restore_config $PCP_SYSCONF_DIR/pmproxy
+        _restore_config $PCP_SYSCONF_DIR/pmseries
+    fi
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+signal=$PCP_BINADM_DIR/pmsignal
+
+userid=`id -u`
+groupid=`id -g`
+username=`id -u -n`
+hostname=`hostname`
+machineid=`_machine_id`
+domainname=`_domain_name`
+
+need_restore=false
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_filter_source()
+{
+    sed \
+        -e "s,$here,PATH,g" \
+        -e "s,$hostname,QAHOST,g" \
+    #end
+}
+
+_filter_archive()
+{
+    pmjson | \
+    sed \
+        -e "s,bozo-laptop,QALOGHOST,g" \
+    #end
+}
+
+# real QA test starts here
+_save_config $PCP_SYSCONF_DIR/pmproxy
+_save_config $PCP_SYSCONF_DIR/pmseries
+$sudo rm -f $PCP_SYSCONF_DIR/pmseries/*
+$sudo rm -f $PCP_SYSCONF_DIR/pmproxy/*
+need_restore=true
+
+echo "=== Start test Redis server ==="
+redisport=`_find_free_port`
+redispath=`_find_redis_modules`
+redisearch="$redispath/redisearch.$DSO_SUFFIX"
+$sudo redis-server --port $redisport --loadmodule $redisearch > $tmp.redis 2>&1 &
+echo "PING"
+pmsleep 0.125
+port="-p $redisport"
+redis-cli $port ping
+echo
+
+# import some well-known test data into Redis
+_filter_load()
+{
+    sed \
+	-e "s,$here,PATH,g" \
+    #end
+}
+
+_filter_elapsed()
+{
+    sed \
+	-e 's/\(\"elapsed\":\) 0\.[0-9][0-9]*/\1 XXX/g' \
+    #end
+}
+
+_filter_date()
+{
+    sed \
+	-e 's/\(Date:\).*/\1 XXX/g' \
+    #end
+}
+
+_filter_info()
+{
+    # These change slightly accross runs.
+    # I assume that they are affected by different order of indexing of each
+    # record which may build underlying Redis data structures differently
+    sed \
+	-e 's/\(\"records\":\).*/\1 XXX,/g' \
+	-e 's/\(\"bytes_per_record_avg\":\).*/\1 XXX,/g' \
+	-e 's/\(\"records_per_doc_avg\":\).*/\1 XXX,/g' \
+	-e 's/\(\"offsets_per_term_avg\":\).*/\1 XXX,/g' \
+    #end
+}
+
+echo "=== Load deterministic search content ==="
+pmseries $port --load $here/archives/sample-labels | _filter_load
+
+# start pmproxy
+proxyport=`_find_free_port`
+proxyopts="-p $proxyport -r $redisport -t" # -Dseries,http,af
+pmproxy -f -U $username -x $seq.full -l $tmp.pmproxy.log $proxyopts &
+pmproxy_pid=$!
+
+# check pmproxy has started and is available for requests
+pmcd_wait -h localhost@localhost:$proxyport -v -t 5sec
+
+# have to wait until everything is properly indexed in Redis
+pmsleep 10s
+
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep pmproxy >> $seq.full
+redis-cli $options keys pcp:text >> $seq.full
+cat $tmp.pmproxy.log >> $seq.full
+
+echo "=== /search/text - query for '99' 'random' 'interesting' 'result' ==="
+search_terms="99 random interesting result"
+for term in $search_terms
+do
+    url="http://localhost:$proxyport/search/text?query=$term"
+    echo "== verify request - $url"
+    echo "$url" >> $seq.full
+    curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+done
+
+echo "=== /search/text - no match response ==="
+
+url="http://localhost:$proxyport/search/text?query=bazinga"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+echo "=== /search/text - query param is required ==="
+
+url="http://localhost:$proxyport/search/text"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent -s -o /dev/null -w "%{http_code}\n" "$url" | tee -a $seq.full 
+
+echo "=== /search/text - highlighting is supported on 'name', 'oneline' and 'helptext' by using 'highlight' param ==="
+
+url="http://localhost:$proxyport/search/text?query=domain&highlight=name,oneline,helptext"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=sample&highlight=name"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=counter&highlight=oneline,helptext"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+# url query returns 2 results
+echo "=== /search/text  - pagination is supported using cursor params 'limit' and 'offset'"
+
+url="http://localhost:$proxyport/search/text?query=random&limit=1"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=random&limit=1&offset=1"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+echo "=== /search/text - its possible to query only specific fields (name, oneline, helptext, indom) using 'field' param ==="
+
+url="http://localhost:$proxyport/search/text?query=99&field=name"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=99&field=oneline"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=99&field=helptext"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+echo "=== /search/text - filtering out fields from response (name, oneline, helptext, type, indom) using 'return' param ==="
+
+url="http://localhost:$proxyport/search/text?query=99&return=name"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=99&return=type"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=99&return=oneline"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=99&return=helptext"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=99&return=indom"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=random&return=name,type,indom"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+echo "=== /search/text - filtering based on entity type (metric, instance, indom) using 'type' param ==="
+
+url="http://localhost:$proxyport/search/text?query=random&type=metric"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=random&type=indom"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=random&type=instance"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/text?query=random&type=metric,indom"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+echo "=== /search/suggest - generic request ==="
+
+url="http://localhost:$proxyport/search/suggest?query=sam"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/suggest?query=sample.r"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+echo "=== /search/suggest - limit is supported"
+
+url="http://localhost:$proxyport/search/suggest?query=sam&limit=2"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+echo "=== /search/suggest - query param is required ==="
+
+url="http://localhost:$proxyport/search/suggest"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent -s -o /dev/null -w "%{http_code}\n" "$url" | tee -a $seq.full 
+
+echo "=== /search/suggest - no match response ==="
+
+url="http://localhost:$proxyport/search/suggest?query=xxx"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+echo "=== /search/indom - generic request ==="
+
+url="http://localhost:$proxyport/search/indom?query=29.1"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/indom?query=29.3"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+echo "=== /search/indom - no match response ==="
+
+url="http://localhost:$proxyport/search/indom?query=x"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+echo "=== /search/indom - query param is required ==="
+
+url="http://localhost:$proxyport/search/indom"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent -s -o /dev/null -w "%{http_code}\n" "$url" | tee -a $seq.full 
+
+echo "=== /search/indom  - pagination is supported using cursor params 'limit' and 'offset'"
+
+url="http://localhost:$proxyport/search/indom?query=29.1&limit=2&offset=0"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+url="http://localhost:$proxyport/search/indom?query=29.1&limit=2&offset=2"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_elapsed
+
+echo "=== /search/info ==="
+
+url="http://localhost:$proxyport/search/info"
+echo "== verify request - $url"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | pmjson | _filter_info
+
+# success, all done
+status=0
+exit

--- a/qa/1872.out
+++ b/qa/1872.out
@@ -1,0 +1,552 @@
+QA output created by 1872
+=== Start test Redis server ===
+PING
+PONG
+
+=== Load deterministic search content ===
+pmseries: [Info] processed 4 archive records from PATH/archives/sample-labels
+=== /search/text - query for '99' 'random' 'interesting' 'result' ===
+== verify request - http://localhost:54322/search/text?query=99
+{
+    "total": 1,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "29.3",
+            "type": "indom",
+            "indom": "29.3",
+            "oneline": "Instance domain \"mirage\" for sample PMDA",
+            "helptext": "Random number of instances, that change with time.  Instance \"m-00\" (0)\nis always present, while the others are numbered 1 .. 49 and named \"m-01\"\n.. \"m-99\""
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=random
+{
+    "total": 2,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "29.3",
+            "type": "indom",
+            "indom": "29.3",
+            "oneline": "Instance domain \"mirage\" for sample PMDA",
+            "helptext": "Random number of instances, that change with time.  Instance \"m-00\" (0)\nis always present, while the others are numbered 1 .. 49 and named \"m-01\"\n.. \"m-99\""
+        },
+        {
+            "name": "sample.mirage",
+            "type": "metric",
+            "indom": "29.3",
+            "oneline": "Simple saw-tooth rate, but instances come and go",
+            "helptext": "The metric is a rate (Kbytes/sec) that varies in a saw-tooth distribution\nover time.  Different instances of the metric have different baselines\nfor the saw-tooth, but all have an max-to-min range of 100.\n\nWhat makes this metric interesting is that instances come and go although\nnot more often than once every 10 seconds by default.  Use pmstore to\nchange sample.controller.mirage and the frequency of instance domain\nchanges can be varied.\n\nInstance 0 is always present, but the other instances 1 thru 49 come\nand go in a cyclic pattern with a large random component influencing\nwhen each instance appears and disappears.\n\nThe underlying counter starts at 0 and is incremented once\nfor each pmFetch() to this metric and/or sample.colour and/or\nsample.mirage_longlong.\n\nUse pmStore() to modify the underlying counter (independent of which\ninstance or instances are used)."
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=interesting
+{
+    "total": 1,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "sample.mirage",
+            "type": "metric",
+            "indom": "29.3",
+            "oneline": "Simple saw-tooth rate, but instances come and go",
+            "helptext": "The metric is a rate (Kbytes/sec) that varies in a saw-tooth distribution\nover time.  Different instances of the metric have different baselines\nfor the saw-tooth, but all have an max-to-min range of 100.\n\nWhat makes this metric interesting is that instances come and go although\nnot more often than once every 10 seconds by default.  Use pmstore to\nchange sample.controller.mirage and the frequency of instance domain\nchanges can be varied.\n\nInstance 0 is always present, but the other instances 1 thru 49 come\nand go in a cyclic pattern with a large random component influencing\nwhen each instance appears and disappears.\n\nThe underlying counter starts at 0 and is incremented once\nfor each pmFetch() to this metric and/or sample.colour and/or\nsample.mirage_longlong.\n\nUse pmStore() to modify the underlying counter (independent of which\ninstance or instances are used)."
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=result
+{
+    "total": 1,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "sample.rapid",
+            "type": "metric",
+            "indom": "none",
+            "oneline": "count very quickly",
+            "helptext": "Base counter increments by 8*10^7 per fetch.  Result is 10 x base counter."
+        }
+    ]
+}
+=== /search/text - no match response ===
+== verify request - http://localhost:54322/search/text?query=bazinga
+{
+    "success": true
+}
+=== /search/text - query param is required ===
+== verify request - http://localhost:54322/search/text
+400
+=== /search/text - highlighting is supported on 'name', 'oneline' and 'helptext' by using 'highlight' param ===
+== verify request - http://localhost:54322/search/text?query=domain&highlight=name,oneline,helptext
+{
+    "total": 2,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "29.1",
+            "type": "indom",
+            "indom": "29.1",
+            "oneline": "Instance <b>domain</b> \"colour\" for sample PMDA",
+            "helptext": "Universally 3 instances, \"red\" (0), \"green\" (1) and \"blue\" (3)."
+        },
+        {
+            "name": "29.3",
+            "type": "indom",
+            "indom": "29.3",
+            "oneline": "Instance <b>domain</b> \"mirage\" for sample PMDA",
+            "helptext": "Random number of instances, that change with time.  Instance \"m-00\" (0)\nis always present, while the others are numbered 1 .. 49 and named \"m-01\"\n.. \"m-99\""
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=sample&highlight=name
+{
+    "total": 5,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "<b>sample</b>.mirage",
+            "type": "metric",
+            "indom": "29.3",
+            "oneline": "Simple saw-tooth rate, but instances come and go",
+            "helptext": "The metric is a rate (Kbytes/sec) that varies in a saw-tooth distribution\nover time.  Different instances of the metric have different baselines\nfor the saw-tooth, but all have an max-to-min range of 100.\n\nWhat makes this metric interesting is that instances come and go although\nnot more often than once every 10 seconds by default.  Use pmstore to\nchange sample.controller.mirage and the frequency of instance domain\nchanges can be varied.\n\nInstance 0 is always present, but the other instances 1 thru 49 come\nand go in a cyclic pattern with a large random component influencing\nwhen each instance appears and disappears.\n\nThe underlying counter starts at 0 and is incremented once\nfor each pmFetch() to this metric and/or sample.colour and/or\nsample.mirage_longlong.\n\nUse pmStore() to modify the underlying counter (independent of which\ninstance or instances are used)."
+        },
+        {
+            "name": "<b>sample</b>.colour",
+            "type": "metric",
+            "indom": "29.1",
+            "oneline": "Metrics with a \"saw-tooth\" trend over time",
+            "helptext": "This metric has 3 instances, designated \"red\", \"green\" and \"blue\".\n\nThe value of the metric is monotonic increasing in the range N to\nN+100, then back to N.  The different instances have different N\nvalues, namely 100 (red), 200 (green) and 300 (blue).\n\nThe underlying counter starts at 0 and is incremented once\nfor each pmFetch() to this metric and/or sample.mirage and/or\nsample.mirage_longlong.\n\nUse pmStore() to modify the underlying counter (independent of which\ninstance or instances are used)."
+        },
+        {
+            "name": "<b>sample</b>.rapid",
+            "type": "metric",
+            "indom": "none",
+            "oneline": "count very quickly",
+            "helptext": "Base counter increments by 8*10^7 per fetch.  Result is 10 x base counter."
+        },
+        {
+            "name": "29.1",
+            "type": "indom",
+            "indom": "29.1",
+            "oneline": "Instance domain \"colour\" for sample PMDA",
+            "helptext": "Universally 3 instances, \"red\" (0), \"green\" (1) and \"blue\" (3)."
+        },
+        {
+            "name": "29.3",
+            "type": "indom",
+            "indom": "29.3",
+            "oneline": "Instance domain \"mirage\" for sample PMDA",
+            "helptext": "Random number of instances, that change with time.  Instance \"m-00\" (0)\nis always present, while the others are numbered 1 .. 49 and named \"m-01\"\n.. \"m-99\""
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=counter&highlight=oneline,helptext
+{
+    "total": 3,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "sample.colour",
+            "type": "metric",
+            "indom": "29.1",
+            "oneline": "Metrics with a \"saw-tooth\" trend over time",
+            "helptext": "This metric has 3 instances, designated \"red\", \"green\" and \"blue\".\n\nThe value of the metric is monotonic increasing in the range N to\nN+100, then back to N.  The different instances have different N\nvalues, namely 100 (red), 200 (green) and 300 (blue).\n\nThe underlying <b>counter</b> starts at 0 and is incremented once\nfor each pmFetch() to this metric and/or sample.mirage and/or\nsample.mirage_longlong.\n\nUse pmStore() to modify the underlying <b>counter</b> (independent of which\ninstance or instances are used)."
+        },
+        {
+            "name": "sample.mirage",
+            "type": "metric",
+            "indom": "29.3",
+            "oneline": "Simple saw-tooth rate, but instances come and go",
+            "helptext": "The metric is a rate (Kbytes/sec) that varies in a saw-tooth distribution\nover time.  Different instances of the metric have different baselines\nfor the saw-tooth, but all have an max-to-min range of 100.\n\nWhat makes this metric interesting is that instances come and go although\nnot more often than once every 10 seconds by default.  Use pmstore to\nchange sample.controller.mirage and the frequency of instance domain\nchanges can be varied.\n\nInstance 0 is always present, but the other instances 1 thru 49 come\nand go in a cyclic pattern with a large random component influencing\nwhen each instance appears and disappears.\n\nThe underlying <b>counter</b> starts at 0 and is incremented once\nfor each pmFetch() to this metric and/or sample.colour and/or\nsample.mirage_longlong.\n\nUse pmStore() to modify the underlying <b>counter</b> (independent of which\ninstance or instances are used)."
+        },
+        {
+            "name": "sample.rapid",
+            "type": "metric",
+            "indom": "none",
+            "oneline": "count very quickly",
+            "helptext": "Base <b>counter</b> increments by 8*10^7 per fetch.  Result is 10 x base <b>counter</b>."
+        }
+    ]
+}
+=== /search/text  - pagination is supported using cursor params 'limit' and 'offset'
+== verify request - http://localhost:54322/search/text?query=random&limit=1
+{
+    "total": 2,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 1,
+    "results": [
+        {
+            "name": "29.3",
+            "type": "indom",
+            "indom": "29.3",
+            "oneline": "Instance domain \"mirage\" for sample PMDA",
+            "helptext": "Random number of instances, that change with time.  Instance \"m-00\" (0)\nis always present, while the others are numbered 1 .. 49 and named \"m-01\"\n.. \"m-99\""
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=random&limit=1&offset=1
+{
+    "total": 2,
+    "elapsed": XXX,
+    "offset": 1,
+    "limit": 1,
+    "results": [
+        {
+            "name": "sample.mirage",
+            "type": "metric",
+            "indom": "29.3",
+            "oneline": "Simple saw-tooth rate, but instances come and go",
+            "helptext": "The metric is a rate (Kbytes/sec) that varies in a saw-tooth distribution\nover time.  Different instances of the metric have different baselines\nfor the saw-tooth, but all have an max-to-min range of 100.\n\nWhat makes this metric interesting is that instances come and go although\nnot more often than once every 10 seconds by default.  Use pmstore to\nchange sample.controller.mirage and the frequency of instance domain\nchanges can be varied.\n\nInstance 0 is always present, but the other instances 1 thru 49 come\nand go in a cyclic pattern with a large random component influencing\nwhen each instance appears and disappears.\n\nThe underlying counter starts at 0 and is incremented once\nfor each pmFetch() to this metric and/or sample.colour and/or\nsample.mirage_longlong.\n\nUse pmStore() to modify the underlying counter (independent of which\ninstance or instances are used)."
+        }
+    ]
+}
+=== /search/text - its possible to query only specific fields (name, oneline, helptext, indom) using 'field' param ===
+== verify request - http://localhost:54322/search/text?query=99&field=name
+{
+    "success": true
+}
+== verify request - http://localhost:54322/search/text?query=99&field=oneline
+{
+    "success": true
+}
+== verify request - http://localhost:54322/search/text?query=99&field=helptext
+{
+    "total": 1,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "29.3",
+            "type": "indom",
+            "indom": "29.3",
+            "oneline": "Instance domain \"mirage\" for sample PMDA",
+            "helptext": "Random number of instances, that change with time.  Instance \"m-00\" (0)\nis always present, while the others are numbered 1 .. 49 and named \"m-01\"\n.. \"m-99\""
+        }
+    ]
+}
+=== /search/text - filtering out fields from response (name, oneline, helptext, type, indom) using 'return' param ===
+== verify request - http://localhost:54322/search/text?query=99&return=name
+{
+    "total": 1,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "29.3"
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=99&return=type
+{
+    "total": 1,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "type": "indom"
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=99&return=oneline
+{
+    "total": 1,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "oneline": "Instance domain \"mirage\" for sample PMDA"
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=99&return=helptext
+{
+    "total": 1,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "helptext": "Random number of instances, that change with time.  Instance \"m-00\" (0)\nis always present, while the others are numbered 1 .. 49 and named \"m-01\"\n.. \"m-99\""
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=99&return=indom
+{
+    "total": 1,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "indom": "29.3"
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=random&return=name,type,indom
+{
+    "total": 2,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "29.3",
+            "type": "indom",
+            "indom": "29.3"
+        },
+        {
+            "name": "sample.mirage",
+            "type": "metric",
+            "indom": "29.3"
+        }
+    ]
+}
+=== /search/text - filtering based on entity type (metric, instance, indom) using 'type' param ===
+== verify request - http://localhost:54322/search/text?query=random&type=metric
+{
+    "total": 1,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "sample.mirage",
+            "type": "metric",
+            "indom": "29.3",
+            "oneline": "Simple saw-tooth rate, but instances come and go",
+            "helptext": "The metric is a rate (Kbytes/sec) that varies in a saw-tooth distribution\nover time.  Different instances of the metric have different baselines\nfor the saw-tooth, but all have an max-to-min range of 100.\n\nWhat makes this metric interesting is that instances come and go although\nnot more often than once every 10 seconds by default.  Use pmstore to\nchange sample.controller.mirage and the frequency of instance domain\nchanges can be varied.\n\nInstance 0 is always present, but the other instances 1 thru 49 come\nand go in a cyclic pattern with a large random component influencing\nwhen each instance appears and disappears.\n\nThe underlying counter starts at 0 and is incremented once\nfor each pmFetch() to this metric and/or sample.colour and/or\nsample.mirage_longlong.\n\nUse pmStore() to modify the underlying counter (independent of which\ninstance or instances are used)."
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=random&type=indom
+{
+    "total": 1,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "29.3",
+            "type": "indom",
+            "indom": "29.3",
+            "oneline": "Instance domain \"mirage\" for sample PMDA",
+            "helptext": "Random number of instances, that change with time.  Instance \"m-00\" (0)\nis always present, while the others are numbered 1 .. 49 and named \"m-01\"\n.. \"m-99\""
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/text?query=random&type=instance
+{
+    "success": true
+}
+== verify request - http://localhost:54322/search/text?query=random&type=metric,indom
+{
+    "total": 2,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "29.3",
+            "type": "indom",
+            "indom": "29.3",
+            "oneline": "Instance domain \"mirage\" for sample PMDA",
+            "helptext": "Random number of instances, that change with time.  Instance \"m-00\" (0)\nis always present, while the others are numbered 1 .. 49 and named \"m-01\"\n.. \"m-99\""
+        },
+        {
+            "name": "sample.mirage",
+            "type": "metric",
+            "indom": "29.3",
+            "oneline": "Simple saw-tooth rate, but instances come and go",
+            "helptext": "The metric is a rate (Kbytes/sec) that varies in a saw-tooth distribution\nover time.  Different instances of the metric have different baselines\nfor the saw-tooth, but all have an max-to-min range of 100.\n\nWhat makes this metric interesting is that instances come and go although\nnot more often than once every 10 seconds by default.  Use pmstore to\nchange sample.controller.mirage and the frequency of instance domain\nchanges can be varied.\n\nInstance 0 is always present, but the other instances 1 thru 49 come\nand go in a cyclic pattern with a large random component influencing\nwhen each instance appears and disappears.\n\nThe underlying counter starts at 0 and is incremented once\nfor each pmFetch() to this metric and/or sample.colour and/or\nsample.mirage_longlong.\n\nUse pmStore() to modify the underlying counter (independent of which\ninstance or instances are used)."
+        }
+    ]
+}
+=== /search/suggest - generic request ===
+== verify request - http://localhost:54322/search/suggest?query=sam
+[
+    "sample.mirage",
+    "sample.colour",
+    "sample.rapid"
+]
+== verify request - http://localhost:54322/search/suggest?query=sample.r
+[
+    "sample.mirage",
+    "sample.rapid",
+    "sample.colour"
+]
+=== /search/suggest - limit is supported
+== verify request - http://localhost:54322/search/suggest?query=sam&limit=2
+[
+    "sample.mirage",
+    "sample.colour"
+]
+=== /search/suggest - query param is required ===
+== verify request - http://localhost:54322/search/suggest
+400
+=== /search/suggest - no match response ===
+== verify request - http://localhost:54322/search/suggest?query=xxx
+{
+    "success": true
+}
+=== /search/indom - generic request ===
+== verify request - http://localhost:54322/search/indom?query=29.1
+{
+    "total": 5,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "blue",
+            "type": "instance",
+            "indom": "29.1"
+        },
+        {
+            "name": "green",
+            "type": "instance",
+            "indom": "29.1"
+        },
+        {
+            "name": "red",
+            "type": "instance",
+            "indom": "29.1"
+        },
+        {
+            "name": "29.1",
+            "type": "indom",
+            "indom": "29.1",
+            "oneline": "Instance domain \"colour\" for sample PMDA",
+            "helptext": "Universally 3 instances, \"red\" (0), \"green\" (1) and \"blue\" (3)."
+        },
+        {
+            "name": "sample.colour",
+            "type": "metric",
+            "indom": "29.1",
+            "oneline": "Metrics with a \"saw-tooth\" trend over time",
+            "helptext": "This metric has 3 instances, designated \"red\", \"green\" and \"blue\".\n\nThe value of the metric is monotonic increasing in the range N to\nN+100, then back to N.  The different instances have different N\nvalues, namely 100 (red), 200 (green) and 300 (blue).\n\nThe underlying counter starts at 0 and is incremented once\nfor each pmFetch() to this metric and/or sample.mirage and/or\nsample.mirage_longlong.\n\nUse pmStore() to modify the underlying counter (independent of which\ninstance or instances are used)."
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/indom?query=29.3
+{
+    "total": 5,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 10,
+    "results": [
+        {
+            "name": "29.3",
+            "type": "indom",
+            "indom": "29.3",
+            "oneline": "Instance domain \"mirage\" for sample PMDA",
+            "helptext": "Random number of instances, that change with time.  Instance \"m-00\" (0)\nis always present, while the others are numbered 1 .. 49 and named \"m-01\"\n.. \"m-99\""
+        },
+        {
+            "name": "m-04",
+            "type": "instance",
+            "indom": "29.3"
+        },
+        {
+            "name": "m-01",
+            "type": "instance",
+            "indom": "29.3"
+        },
+        {
+            "name": "m-00",
+            "type": "instance",
+            "indom": "29.3"
+        },
+        {
+            "name": "sample.mirage",
+            "type": "metric",
+            "indom": "29.3",
+            "oneline": "Simple saw-tooth rate, but instances come and go",
+            "helptext": "The metric is a rate (Kbytes/sec) that varies in a saw-tooth distribution\nover time.  Different instances of the metric have different baselines\nfor the saw-tooth, but all have an max-to-min range of 100.\n\nWhat makes this metric interesting is that instances come and go although\nnot more often than once every 10 seconds by default.  Use pmstore to\nchange sample.controller.mirage and the frequency of instance domain\nchanges can be varied.\n\nInstance 0 is always present, but the other instances 1 thru 49 come\nand go in a cyclic pattern with a large random component influencing\nwhen each instance appears and disappears.\n\nThe underlying counter starts at 0 and is incremented once\nfor each pmFetch() to this metric and/or sample.colour and/or\nsample.mirage_longlong.\n\nUse pmStore() to modify the underlying counter (independent of which\ninstance or instances are used)."
+        }
+    ]
+}
+=== /search/indom - no match response ===
+== verify request - http://localhost:54322/search/indom?query=x
+{
+    "success": true
+}
+=== /search/indom - query param is required ===
+== verify request - http://localhost:54322/search/indom
+400
+=== /search/indom  - pagination is supported using cursor params 'limit' and 'offset'
+== verify request - http://localhost:54322/search/indom?query=29.1&limit=2&offset=0
+{
+    "total": 5,
+    "elapsed": XXX,
+    "offset": 0,
+    "limit": 2,
+    "results": [
+        {
+            "name": "blue",
+            "type": "instance",
+            "indom": "29.1"
+        },
+        {
+            "name": "green",
+            "type": "instance",
+            "indom": "29.1"
+        }
+    ]
+}
+== verify request - http://localhost:54322/search/indom?query=29.1&limit=2&offset=2
+{
+    "total": 5,
+    "elapsed": XXX,
+    "offset": 2,
+    "limit": 2,
+    "results": [
+        {
+            "name": "red",
+            "type": "instance",
+            "indom": "29.1"
+        },
+        {
+            "name": "29.1",
+            "type": "indom",
+            "indom": "29.1",
+            "oneline": "Instance domain \"colour\" for sample PMDA",
+            "helptext": "Universally 3 instances, \"red\" (0), \"green\" (1) and \"blue\" (3)."
+        }
+    ]
+}
+=== /search/info ===
+== verify request - http://localhost:54322/search/info
+{
+    "docs": 18,
+    "terms": 174,
+    "records": XXX,
+    "records_per_doc_avg": XXX,
+    "bytes_per_record_avg": XXX,
+    "inverted_sz_mb": 0.00,
+    "inverted_cap_mb": 0.00,
+    "inverted_cap_ovh": 0.00,
+    "skip_index_size_mb": 0.00,
+    "score_index_size_mb": 0.00,
+    "offsets_per_term_avg": XXX,
+    "offset_bits_per_record_avg": 8.00
+}

--- a/qa/group
+++ b/qa/group
@@ -1810,6 +1810,7 @@ not_in_container
 1837 pmproxy local
 1855 pmda.rabbitmq local
 1871 pmsearch local
+1872 pmproxy local
 1886:reserved pmseries local libpcp_web local
 1896 pmlogger logutil pmlc local
 4751 libpcp threads valgrind local pcp

--- a/src/include/pcp/pmwebapi.h
+++ b/src/include/pcp/pmwebapi.h
@@ -382,7 +382,7 @@ typedef enum pmSearchTextType {
 } pmSearchTextType;
 
 typedef struct pmSearchTextRequest {
-    sds			query;		/* query string */
+    sds			    query;		/* query string */
     pmSearchFlags	flags;		/* query control bits */
     unsigned int	count;		/* maximum results to return */
     unsigned int	offset;		/* results pagination offset */
@@ -392,11 +392,9 @@ typedef struct pmSearchTextRequest {
     unsigned int	type_inst : 1;
     unsigned int	type_pad : 1;
     unsigned int	highlight_name : 1;	/* highlight results */
-    unsigned int	highlight_indom : 1;
     unsigned int	highlight_oneline : 1;
     unsigned int	highlight_helptext : 1;
     unsigned int	infields_name : 1;	/* restrict query fields */
-    unsigned int	infields_indom : 1;
     unsigned int	infields_oneline : 1;
     unsigned int	infields_helptext : 1;
     unsigned int	return_name : 1;	/* restrict returned fields */
@@ -405,7 +403,7 @@ typedef struct pmSearchTextRequest {
     unsigned int	return_helptext : 1;
     unsigned int	return_type : 1;
 
-    unsigned int	reserved: 15;	/* zero padding */
+    unsigned int	reserved: 17;	/* zero padding */
 } pmSearchTextRequest;
 
 typedef struct pmSearchTextResult {

--- a/src/libpcp_web/src/search.c
+++ b/src/libpcp_web/src/search.c
@@ -597,12 +597,10 @@ redis_search_text_query(redisSlots *slots, pmSearchTextRequest *request, void *a
     types += request->type_inst;
 
     highlights += request->highlight_name;
-    highlights += request->highlight_indom;
     highlights += request->highlight_oneline;
     highlights += request->highlight_helptext;
 
     infields += request->infields_name;
-    infields += request->infields_indom;
     infields += request->infields_oneline;
     infields += request->infields_helptext;
     if (infields == 0) {
@@ -648,9 +646,8 @@ redis_search_text_query(redisSlots *slots, pmSearchTextRequest *request, void *a
     cmd = redis_param_str(cmd, FT_SEARCH, FT_SEARCH_LEN);
     cmd = redis_param_sds(cmd, key);
 
-    query = sdsnewlen("\'", 1);
     base_query = redis_search_text_prep(request->query, 0, NULL, NULL);
-    query = sdscatsds(query, base_query);
+    query = sdscatfmt(sdsempty(), "\'(%S)=>{$inorder:true}", base_query);
     sdsfree(base_query);
     if (types) {
 	query = sdscatlen(query, " @TYPE:{", 8);
@@ -685,8 +682,6 @@ redis_search_text_query(redisSlots *slots, pmSearchTextRequest *request, void *a
 	cmd = redis_param_str(cmd, buffer, length);
 	if (request->infields_name)
 	    cmd = redis_param_str(cmd, FT_NAME, FT_NAME_LEN);
-	if (request->infields_indom)
-	    cmd = redis_param_str(cmd, FT_INDOM, FT_INDOM_LEN);
 	if (request->infields_oneline)
 	    cmd = redis_param_str(cmd, FT_ONELINE, FT_ONELINE_LEN);
 	if (request->infields_helptext)
@@ -716,8 +711,6 @@ redis_search_text_query(redisSlots *slots, pmSearchTextRequest *request, void *a
 	cmd = redis_param_str(cmd, buffer, length);
 	if (request->highlight_name)
 	    cmd = redis_param_str(cmd, FT_NAME, FT_NAME_LEN);
-	if (request->highlight_indom)
-	    cmd = redis_param_str(cmd, FT_INDOM, FT_INDOM_LEN);
 	if (request->highlight_oneline)
 	    cmd = redis_param_str(cmd, FT_ONELINE, FT_ONELINE_LEN);
 	if (request->highlight_helptext)


### PR DESCRIPTION
pmproxy: 
- /search/* - removed client param from all endpoints
- /search/text - query params are now in singular form
- /search/info - removed ?key param as it did nothing anyway, all RediSearch stuff is in single index
- /search/text - removed indom opts for ?field and ?highlight params as RediSearch indom field is no longer fulltext searchable
- /search/text - made search query look for tokens in index in order (helps with some heuristics for fetching helptexts)

man:
- updated search related docs

qa:
- /search endpoints request->response test 1872