### PR TITLE
man pages and man page build

### DIFF
--- a/man/Check
+++ b/man/Check
@@ -146,25 +146,26 @@ fi
 # these are excluded from the analysis below
 #
 cat <<'End-of-File' >$tmp.exclude
-man1/pmstat.1
 man1/pcp.1
 man1/pcpcompat.1
-man1/pcp-shping.1
 man1/pcpintro.1
 man1/pcp-python.1
-man3/pmwebapi.3
+man1/pcp-shping.1
+man1/pmdacisco.1
+man1/pmstat.1
 man3i/pmapi_internal.3
-man3/QmcIndom.3
-man3/QmcMetric.3
-man3/QmcDesc.3
-man3/QMC.3
+man3/logimport.3
 man3/pcpintro.3
 man3/pmapi.3
 man3/pmda.3
-man3/QmcSource.3
-man3/logimport.3
-man3/QmcGroup.3
+man3/pmwebapi.3
+man3/QMC.3
 man3/QmcContext.3
+man3/QmcDesc.3
+man3/QmcGroup.3
+man3/QmcIndom.3
+man3/QmcMetric.3
+man3/QmcSource.3
 man5/.*
 End-of-File
 

--- a/man/man1/pmdacisco.1
+++ b/man/man1/pmdacisco.1
@@ -16,9 +16,7 @@
 .\"
 .TH PMDACISCO 1 "PCP" "Performance Co-Pilot"
 .SH NAME
-\f3pmdacisco\f1,
-\f3parse\f1,
-\f3probe\f1 \- Cisco router performance metrics domain agent (PMDA)
+\f3pmdacisco\f1 \- Cisco router performance metrics domain agent (PMDA)
 .SH SYNOPSIS
 \f3$PCP_PMDAS_DIR/cisco/pmdacisco\f1
 [\f3\-d\f1 \f2domain\f1]

--- a/qa/1251
+++ b/qa/1251
@@ -1,0 +1,98 @@
+#!/bin/sh
+# PCP QA Test No. 1251
+# basic man(1) workout for man pages
+#
+# Copyright (c) 2020 Ken McDonell.  All Rights Reserved.
+#
+
+seq=`basename $0`
+if [ $# -eq 0 ]
+then
+    echo "QA output created by $seq"
+else
+    echo "QA output created by $seq $*"
+fi
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+which man >/dev/null 2>&1 || _notrun "No man(1) command?"
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+# real QA test starts here
+cat <<'End-of-File' | sed -e '/^#/d' -e '/^[ 	]*$/d' | while read key pat
+# keyword	egrep for text in man page
+# for keyword, avoid case aliasing (different man's have different rules)
+# and use (one of) the .SH NAME names
+#
+
+# no man page, check logic
+fubar		beyond all recognition
+# no matching text, check logic
+pminfo		fubar
+
+# simple section 1 entry
+pminfo		.-T, *--helptext
+# composite section 1 entry
+pmconfirm	button-name
+pmmessage	button-name
+pmquery		button-name
+# aliased (xM) section 1 entry
+KERNEL_PMDAS	usually running as shared libraries
+# special case section 1 and 3 entry
+PCPIntro	Co-Pilot
+
+# simple section 3 entry
+pmNewContext	PM_CTXFLAG_SECURE
+# composite and aliased (xM) section 3 entry
+pmRecord	pmRecordHost
+pmRecordSetup	pmRecordHost
+pmRecordControl	pmRecordHost
+
+# weirdos
+PCP::MMV	MMV Perl module
+pcp.env		\.pcp/pcp.conf
+# from src/pmdas/json (Python), not man/man?
+pmdajson	generating  *JavaScript
+End-of-File
+do
+    echo | tee -a $seq.full
+    echo "=== $key ===" | tee -a $seq.full
+    man -k "$key" | sed -e 's/).*//' -e 's/.*(//' 2>$tmp.err \
+    | LC_COLLATE=POSIX sort \
+    | uniq >$tmp.sect
+    if [ -s $tmp.sect ]
+    then
+	echo >$tmp.last
+	for sect in `cat $tmp.sect`
+	do
+	    echo "--- ($sect) ---" | tee -a $seq.full
+	    TERM=dumb man $sect $key >$tmp.out 2>&1
+	    if egrep "$pat" $tmp.out >/dev/null
+	    then
+		echo OK
+	    else
+		cat $tmp.out >>$seq.full
+		echo "No match for pattern $pat"
+	    fi
+	done
+    else
+	cat $tmp.err >>$seq.full
+	echo "No man entry in any section!"
+    fi
+done
+
+# success, all done
+status=0
+exit

--- a/qa/1251
+++ b/qa/1251
@@ -31,66 +31,90 @@ $sudo rm -rf $tmp $tmp.* $seq.full
 trap "_cleanup; exit \$status" 0 1 2 3 15
 
 # real QA test starts here
-cat <<'End-of-File' | sed -e '/^#/d' -e '/^[ 	]*$/d' | while read key pat
-# keyword	egrep for text in man page
+cat <<'End-of-File' | sed -e '/^#/d' -e '/^[ 	]*$/d' | while read sect key altname pat
+# section	keyword	altname	egrep for text in man page
 # for keyword, avoid case aliasing (different man's have different rules)
 # and use (one of) the .SH NAME names
 #
 
 # no man page, check logic
-fubar		beyond all recognition
+1	really_fubar	-	beyond all recognition
 # no matching text, check logic
-pminfo		fubar
+1	pminfo		-	fubar
 
 # simple section 1 entry
-pminfo		.-T, *--helptext
+1	pminfo		-	.-T, *--helptext
 # composite section 1 entry
-pmconfirm	button-name
-pmmessage	button-name
-pmquery		button-name
+1	pmconfirm	-	button-name
+1	pmmessage	pmconfirm	button-name
+1	pmquery		pmconfirm	button-name
 # aliased (xM) section 1 entry
-KERNEL_PMDAS	usually running as shared libraries
+1	KERNEL_PMDAS	-	usually running as shared libraries
 # special case section 1 and 3 entry
-PCPIntro	Co-Pilot
+1	PCPIntro	-	Co-Pilot
+3	PCPIntro	-	Co-Pilot
 
 # simple section 3 entry
-pmNewContext	PM_CTXFLAG_SECURE
+3	pmNewContext	-	PM_CTXFLAG_SECURE
 # composite and aliased (xM) section 3 entry
-pmRecord	pmRecordHost
-pmRecordSetup	pmRecordHost
-pmRecordControl	pmRecordHost
+3	pmRecord	-	pmRecordHost
+3	pmRecordSetup	pmRecord	pmRecordHost
+3	pmRecordControl	pmRecord	pmRecordHost
 
 # weirdos
-PCP::MMV	MMV Perl module
-pcp.env		\.pcp/pcp.conf
+3	PCP::MMV	-	MMV Perl module
+5	pcp.env		-	\.pcp/pcp.conf
 # from src/pmdas/json (Python), not man/man?
-pmdajson	generating  *JavaScript
+1	pmdajson	-	generating  *JavaScript
 End-of-File
 do
+    # *BSD man(1) really uses apropos(1) for man -k which uses a full
+    # text searching, so all we can try to match on here is 
+    # for each man section
+    #
     echo | tee -a $seq.full
     echo "=== $key ===" | tee -a $seq.full
-    man -k "$key" | sed -e 's/).*//' -e 's/.*(//' 2>$tmp.err \
-    | LC_COLLATE=POSIX sort \
-    | uniq >$tmp.sect
-    if [ -s $tmp.sect ]
+    lc_key=`echo "$key" | tr '[A-Z]' '[a-z']`
+    lc_altname=`echo "$altname" | tr '[A-Z]' '[a-z']`
+    man -k "$key" 2>$tmp.err \
+    | sed >$tmp.out \
+	-e "/$key: nothing appropriate./d" \
+    # end
+    if [ -s $tmp.out ]
     then
-	echo >$tmp.last
-	for sect in `cat $tmp.sect`
-	do
-	    echo "--- ($sect) ---" | tee -a $seq.full
-	    TERM=dumb man $sect $key >$tmp.out 2>&1
-	    if egrep "$pat" $tmp.out >/dev/null
-	    then
-		echo OK
-	    else
-		cat $tmp.out >>$seq.full
-		echo "No match for pattern $pat"
-	    fi
-	done
+	tr '[A-Z]' '[a-z'] <$tmp.out >$tmp.tmp
+	if grep "^$lc_key *($sect" $tmp.tmp >/dev/null
+	then
+	    # matching entry found from man -k
+	    :
+	elif [ X"$altname" != X- ] && grep "^$lc_altname *($sect" $tmp.tmp >/dev/null
+	then
+	    # matching altname entry found from man -k ... needed for
+	    # *BSD where man -k is really apropos and *BSD apropos does
+	    # not build index entries for symlink'd man pages
+	    #
+	    :
+	else
+	    # no matching entry from man -k
+	    cat $tmp.err >>$seq.full
+	    echo "No matching man entry for section $sect"
+	fi
     else
+	# no output from man -k
 	cat $tmp.err >>$seq.full
-	echo "No man entry in any section!"
+	echo "No matching man entry in any section!"
     fi
+    echo "--- ($sect) ---" | tee -a $seq.full
+    TERM=dumb man $sect $key 2>&1 \
+    | sed -e 's/_//g' -e 's/.//g' >$tmp.out
+    if egrep "$pat" $tmp.out >/dev/null
+    then
+	echo OK
+    else
+	cat $tmp.out >>$seq.full
+	echo "No match for pattern $pat"
+    fi
+
 done
 
 # success, all done

--- a/qa/1251.out
+++ b/qa/1251.out
@@ -1,8 +1,9 @@
 QA output created by 1251
 
-=== fubar ===
-fubar: nothing appropriate.
-No man entry in any section!
+=== really_fubar ===
+No matching man entry in any section!
+--- (1) ---
+No match for pattern beyond all recognition
 
 === pminfo ===
 --- (1) ---
@@ -31,6 +32,8 @@ OK
 === PCPIntro ===
 --- (1) ---
 OK
+
+=== PCPIntro ===
 --- (3) ---
 OK
 
@@ -51,7 +54,7 @@ OK
 OK
 
 === PCP::MMV ===
---- (3pm) ---
+--- (3) ---
 OK
 
 === pcp.env ===

--- a/qa/1251.out
+++ b/qa/1251.out
@@ -1,0 +1,63 @@
+QA output created by 1251
+
+=== fubar ===
+fubar: nothing appropriate.
+No man entry in any section!
+
+=== pminfo ===
+--- (1) ---
+No match for pattern fubar
+
+=== pminfo ===
+--- (1) ---
+OK
+
+=== pmconfirm ===
+--- (1) ---
+OK
+
+=== pmmessage ===
+--- (1) ---
+OK
+
+=== pmquery ===
+--- (1) ---
+OK
+
+=== KERNEL_PMDAS ===
+--- (1) ---
+OK
+
+=== PCPIntro ===
+--- (1) ---
+OK
+--- (3) ---
+OK
+
+=== pmNewContext ===
+--- (3) ---
+OK
+
+=== pmRecord ===
+--- (3) ---
+OK
+
+=== pmRecordSetup ===
+--- (3) ---
+OK
+
+=== pmRecordControl ===
+--- (3) ---
+OK
+
+=== PCP::MMV ===
+--- (3pm) ---
+OK
+
+=== pcp.env ===
+--- (5) ---
+OK
+
+=== pmdajson ===
+--- (1) ---
+OK

--- a/qa/group
+++ b/qa/group
@@ -1668,6 +1668,7 @@ not_in_container
 1248 pmlogctl local
 1249 pmlogctl local
 1250 selinux local
+1251 other local
 1255 libpcp local kernel
 1257 libpcp python local
 1258 pmda.linux local valgrind

--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -554,7 +554,6 @@ state==1 { for (i=1;i<=NF;i++) { \
 	     print $$i \
 	   } \
 	 }' \
-	| LC_COLLATE=POSIX $(PCP_SORT_PROG) -u \
 	| while read m; do \
 	    [ -z "$$m" -o "$$m" = "\\" ] && continue; \
 	    t=$(PCP_MAN_DIR)/man$$section/$$m.$$section; \


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200803

Ken McDonell (4):
      qa/1251: (new) basic checkout for man(1) plumbing for PCP man pages
      qa/1251: tweaks after *BSD adventure
      src/include/builddefs.in: tweak INSTALL_MAN
      man/man1/pmdacisco.1: remove the probe.1 and parse.1 aliases

 man/Check                |   21 ++---
 man/man1/pmdacisco.1     |    4 
 qa/1251                  |  192 ++++++++++++++++++++++++++++++++++++++---------
 qa/1251.out              |   74 +++++++++++++++++-
 qa/group                 |    1 
 src/include/builddefs.in |    1 
 6 files changed, 240 insertions(+), 53 deletions(-)

Details ...

commit e406df38def9b3994c7b4e7bb7e07364c76b4d02
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Aug 4 08:06:02 2020 +1000

    man/man1/pmdacisco.1: remove the probe.1 and parse.1 aliases
    
    These names are just too common to be polluting the man1 namespace,
    and the commands are rarely used.
    
    Needs an extra inclusion in Check to not enforce the NAME and SYNOPSIS
    consistency checks for pmdacisco.1.

commit fbf197bc0338c550840f22e737fa0983fc37e631
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Aug 4 07:55:34 2020 +1000

    src/include/builddefs.in: tweak INSTALL_MAN
    
    We really don't need the sort here, and it leads to some slightly
    odd relationships between the installed files and the symlinks, e.g.
    for pmdacisco with the sort
            parse.1 is a file
            pmdacisco.1 -> parse.1
            probe.1 -> parse.1
    without the sort
            pmdacisco.1 is a file
            parse.1 -> pmdacisco.1
            probe.1 -> pmdacisco.1
    
    There is of course another whole can of worms about these specific
    man pages, but that's another topic.

commit 5b792da4e15176944d1d5837db41ba11cfc25657
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Aug 4 07:32:11 2020 +1000

    qa/1251: tweaks after *BSD adventure
    
    Still not quite right on NetBSD, but closer

commit 041e44df0f2c09ab514743bce162f6a3d89b6f2f
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Mon Aug 3 16:41:11 2020 +1000

    qa/1251: (new) basic checkout for man(1) plumbing for PCP man pages