### PR TITLE
libpcp_web: search edge case fix

### DIFF
--- a/src/libpcp_web/src/search.c
+++ b/src/libpcp_web/src/search.c
@@ -646,11 +646,9 @@ redis_search_text_query(redisSlots *slots, pmSearchTextRequest *request, void *a
     cmd = redis_param_str(cmd, FT_SEARCH, FT_SEARCH_LEN);
     cmd = redis_param_sds(cmd, key);
 
-    base_query = redis_search_text_prep(request->query, 0, NULL, NULL);
-    query = sdscatfmt(sdsempty(), "\'(%S)=>{$inorder:true}", base_query);
-    sdsfree(base_query);
+    query = sdscatlen(sdsempty(), "\'", 1);
     if (types) {
-	query = sdscatlen(query, " @TYPE:{", 8);
+	query = sdscatlen(query, "@TYPE:{", 7);
 	if (request->type_metric) {
 	    typestr = pmSearchTextTypeStr(PM_SEARCH_TYPE_METRIC);
 	    query = sdscat(query, typestr);
@@ -667,9 +665,11 @@ redis_search_text_query(redisSlots *slots, pmSearchTextRequest *request, void *a
 	    typestr = pmSearchTextTypeStr(PM_SEARCH_TYPE_INST);
 	    query = sdscat(query, typestr);
 	}
-	query = sdscatlen(query, "}", 1);
+	query = sdscatlen(query, "} ", 2);
     }
-    query = sdscatlen(query, "\'", 1);
+    base_query = redis_search_text_prep(request->query, 0, NULL, NULL);
+    query = sdscatfmt(query, "(%S)=>{$inorder:true}\'", base_query);
+    sdsfree(base_query);
     cmd = redis_param_sds(cmd, query);
     sdsfree(query);
 


### PR DESCRIPTION
Handles edge case, when multiple word queries seemed to be handled / parsed differently by RediSearch based on order of query parts.

Before:
```
127.0.0.1:6379> ft.explain pcp:text '(kernel)=>{$inorder:true} @TYPE:{indom|metric}'
INTERSECT {
  UNION {
    kernel
    +kernel(expanded)
  }
  TAG:@TYPE {
    indom
    metric
  }
}

127.0.0.1:6379> ft.explain pcp:text '(kernel cpu)=>{$inorder:true} @TYPE:{indom|metric}'
INTERSECT {
  UNION {
    kernel
    +kernel(expanded)
  }
  UNION {
    cpu
    +cpu(expanded)
  }
  TAG:@TYPE {
    indom
    metric
  }
} => { $inorder: true; }
```

After:
```

127.0.0.1:6379>  ft.explain pcp:text '@TYPE:{indom|metric} (kernel)=>{$inorder:true}'
INTERSECT {
  TAG:@TYPE {
    indom
    metric
  }
  UNION {
    kernel
    +kernel(expanded)
  }
}

127.0.0.1:6379>  ft.explain pcp:text '@TYPE:{indom|metric} (kernel cpu)=>{$inorder:true}'
INTERSECT {
  TAG:@TYPE {
    indom
    metric
  }
  INTERSECT {
    UNION {
      kernel
      +kernel(expanded)
    }
    UNION {
      cpu
      +cpu(expanded)
    }
  } => { $inorder: true; }
}
```
This could have caused multi-word queries to return 0 search results even though some were expected.