### PR TITLE
HMSET timeseries query expressions descriptor

### DIFF
--- a/man/man3/pmregisterderived.3
+++ b/man/man3/pmregisterderived.3
@@ -599,7 +599,7 @@ To prevent arbitrary and non-sensical combinations
 some restrictions apply to expressions that combine metrics with
 counter semantics to produce a result with counter semantics.
 For an arithmetic expression, if both operands have the semantics of
-a counter, then only addition or subraction is allowed, or if the
+a counter, then only addition or subtraction is allowed, or if the
 left operand is a counter and the right operand is not, then only
 multiplication or division are allowed, or if the left operand is
 not a counter and the right operand is a counter, then only multiplication

--- a/qa/1886
+++ b/qa/1886
@@ -109,9 +109,9 @@ pmseries $args 'min(kernel.all.load{instance.name == "5 minute"}[count:5])'
 echo;echo "== Verify min/max() functions for a singular metric"
 pmseries $args 'kernel.all.uptime[count:10]'
 echo Compared to max:
-pmseries $args 'min(kernel.all.uptime[count:10])'
-echo Compared to min:
 pmseries $args 'max(kernel.all.uptime[count:10])'
+echo Compared to min:
+pmseries $args 'min(kernel.all.uptime[count:10])'
 
 echo;echo "== Verify rescale() functions for a singular metric"
 pmseries $args 'kernel.all.uptime[count:2]'

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -3019,13 +3019,6 @@ series_calculate_binary_check(
     double		mult;
     char		*errmsg;
 
-    // For binary oepration, only support two single-metric operands
-    if (left->value_set.num_series != 1 || right->value_set.num_series != 1) {
-	infofmt(msg, "For binary oepration, only support two single-metric operands\n");
-	batoninfo(baton, PMLOG_ERROR, msg);
-	baton->error = -EPROTO;
-	return -1;
-    }
     // Operands should have the same instance domain for all of the binary operators.
     if (sdscmp(l_indom, r_indom) != 0) {
 	infofmt(msg, "Operands should have the same instance domain for all of the binary operators.\n");
@@ -3298,10 +3291,10 @@ series_bianry_meta_update(node_t *left, pmUnits *large_units, int *l_sem, int *r
      * will have semantics PM_SEM_INSTANT unless both operands are PM_SEM_DISCRETE in which case the result is 
      * also PM_SEM_DISCRETE.
     */
-    if (*l_sem != PM_SEM_COUNTER || *r_sem != PM_SEM_COUNTER) {
-	o_sem = PM_SEM_INSTANT;
-    } else if (*l_sem == PM_SEM_DISCRETE && *r_sem == PM_SEM_DISCRETE) {
+    if (*l_sem == PM_SEM_DISCRETE && *r_sem == PM_SEM_DISCRETE) {
 	o_sem = PM_SEM_DISCRETE;
+    } else if (*l_sem != PM_SEM_COUNTER || *r_sem != PM_SEM_COUNTER) {
+	o_sem = PM_SEM_INSTANT;
     } else {
 	o_sem = PM_SEM_COUNTER;
     }
@@ -3325,6 +3318,7 @@ series_calculate_plus(node_t *np)
     pmAtomValue		l_val, r_val;
     pmUnits		l_units, r_units, large_units;
 
+    if (left->value_set.num_series == 0 || right->value_set.num_series == 0) return;
     if (series_calculate_binary_check(N_PLUS, baton, left, right, &l_type, &r_type, &l_sem, &r_sem,
 		 &l_units, &r_units, &large_units, left->value_set.series_values[0].series_desc.indom,
 		 right->value_set.series_values[0].series_desc.indom) != 0) {
@@ -3369,6 +3363,7 @@ series_calculate_minus(node_t *np)
     pmAtomValue		l_val, r_val;
     pmUnits		l_units, r_units, large_units;
 
+    if (left->value_set.num_series == 0 || right->value_set.num_series == 0) return;
     if (series_calculate_binary_check(N_MINUS, baton, left, right, &l_type, &r_type, &l_sem, &r_sem,
 		 &l_units, &r_units, &large_units, left->value_set.series_values[0].series_desc.indom,
 		 right->value_set.series_values[0].series_desc.indom) != 0) {
@@ -3411,6 +3406,7 @@ series_calculate_star(node_t *np)
     pmAtomValue		l_val, r_val;
     pmUnits		l_units, r_units, large_units;
 
+    if (left->value_set.num_series == 0 || right->value_set.num_series == 0) return;
     if (series_calculate_binary_check(N_STAR, baton, left, right, &l_type, &r_type, &l_sem, &r_sem,
 		 &l_units, &r_units, &large_units, left->value_set.series_values[0].series_desc.indom,
 		 right->value_set.series_values[0].series_desc.indom) != 0) {
@@ -3453,6 +3449,7 @@ series_calculate_slash(node_t *np)
     pmAtomValue		l_val, r_val;
     pmUnits		l_units, r_units, large_units;
 
+    if (left->value_set.num_series == 0 || right->value_set.num_series == 0) return;
     if (series_calculate_binary_check(N_SLASH, baton, left, right, &l_type, &r_type, &l_sem, &r_sem,
 		 &l_units, &r_units, &large_units, left->value_set.series_values[0].series_desc.indom,
 		 right->value_set.series_values[0].series_desc.indom) != 0) {

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -3165,11 +3165,11 @@ calculate_minus(int *type, pmAtomValue *l_val, pmAtomValue *r_val, pmAtomValue *
 		return -1;
 	    }
 	case PM_TYPE_64:
-	    res->ll = l_val->ll + r_val->ll;
+	    res->ll = l_val->ll - r_val->ll;
 	    break;
 	case PM_TYPE_U64:
 	    if (l_val->ull >= r_val->ull) {
-		res->ull = l_val->ull + r_val->ull;
+		res->ull = l_val->ull - r_val->ull;
 	    } else {
 		return -1;
 	    }
@@ -3213,7 +3213,7 @@ calculate_star(int *type, pmAtomValue *l_val, pmAtomValue *r_val, pmAtomValue *r
 int
 calculate_slash(int *type, pmAtomValue *l_val, pmAtomValue *r_val, pmAtomValue *res)
 {
-        switch (*type) {
+    switch (*type) {
 	case PM_TYPE_32:
 	    res->l = l_val->l / r_val->l;
 	case PM_TYPE_U32:
@@ -3247,7 +3247,7 @@ series_calculate_order_bianry(int ope_type, int l_type, int r_type, int *otype,
 
     if (l_type == PM_TYPE_DOUBLE || r_type == PM_TYPE_DOUBLE) {
 	*otype = PM_TYPE_DOUBLE;
-    } else if (ope_type == N_STAR) {
+    } else if (ope_type == N_SLASH) {
 	*otype = PM_TYPE_DOUBLE;
     } else if (l_type == PM_TYPE_FLOAT || r_type == PM_TYPE_FLOAT) {
 	*otype = PM_TYPE_FLOAT;
@@ -3497,17 +3497,17 @@ series_calculate(seriesQueryBaton *baton, node_t *np, int level)
 	return 0;
     if ((sts = series_calculate(baton, np->left, level+1)) < 0)
 	return sts;
-    if ((sts = series_calculate(baton, np->right, level+1)) < 0)
+    if (sts > 0)
+	series_calculate(baton, np->right, level+1);
+    else if ((sts = series_calculate(baton, np->right, level+1)) < 0)
 	return sts;
 
     np->baton = baton;
     switch (np->type) {
 	case N_NOOP:
-	    /* Traverse the subtree of this node? */
+	    /* Traverse the subtree of this node */
 	    np->value_set = np->left->value_set;
 	    series_noop_traverse(baton, np, level);
-	    // Consider noop is not a function
-	    sts = 0;
 	    break;
 	case N_RATE:
 	    series_calculate_rate(np);

--- a/src/libpcp_web/src/query.h
+++ b/src/libpcp_web/src/query.h
@@ -117,6 +117,7 @@ typedef struct series_sample_set {
     sds				metric_name;
     pmSeriesDesc		series_desc;
     void			*baton;
+    int				compatibility;
     /* Number of series samples */
     int				num_samples;
     series_instance_set_t	*series_sample;


### PR DESCRIPTION
**Check compatibility between series**
For those metric name with multiple SIDs, check the units' compatibility between them and if three dimensions are identical but scales are different, use the larger scale and convert the values with the smaller scale. Data type is promoted to type PM_TYPE_DOUBLE. Otherwise, report an error and do not store descriptors of them.

**Update query expressions' descriptor**
- Store the computed semantics, type, and units into Redis
- Keep indom unchanged
- Set pmid to 511.0.0
- Leave source unchanged (should we change this field?)

**TODO**
- ~~expression of two "discrete" metrics give an "instant" result --> should be discrete~~
- ~~Fix: division seems to be giving an negative unsigned result:~~
> $ pmseries 'hinv.ncpu{hostname == "goblin"}[samples:1] / hinv.ncpu{hostname == "f32"}[samples:1]'
2ffb8da3697fd93d5d169467157e95f6e53e427d
    [Wed Sep  2 15:47:33.962186000 2020] 2147483652 719000c48da83c83a642a2fc54d41448f0d85558

goblin has 8 CPUs and f32 has 2.
- Update field source in the descriptor. Still do not have a definite method, maybe a source for a result of an expression involving multiple sources will become all zeros.
- ~~Fix: pmseries 'hinv.ncpu[samples:1] / hinv.ncpu{hostname == "Non-existent host"}[samples:1]' cause Segmentation fault (core dumped)~~
- ~~Fix: 'kernel.all.uptime[count:5] - kernel.all.uptime[count:5]', the results should all be 0~~

**Note**
This branch still need many tests! qa/1886 is under processing..