### PR TITLE
Force Python PMDAs to ensure domain.h.python and pmns.python exist for ./Remove

### DIFF
--- a/build/ci/platforms/centos6.yml
+++ b/build/ci/platforms/centos6.yml
@@ -30,10 +30,10 @@ tasks:
     sudo -i -u pcpqa ./check 002
   qa_sanity: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   qa: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   copy_test_artifacts: |
     cp /var/lib/pcp/testsuite/check.timings ./artifacts/test
     [ $(awk 'END{print NF}' ./artifacts/test/check.timings) = 2 ] && date '+%s' >> ./artifacts/test/check.timings

--- a/build/ci/platforms/centos7.yml
+++ b/build/ci/platforms/centos7.yml
@@ -31,10 +31,10 @@ tasks:
     sudo -i -u pcpqa ./check 002
   qa_sanity: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   qa: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   copy_test_artifacts: |
     cp /var/lib/pcp/testsuite/check.timings ./artifacts/test
     [ $(awk 'END{print NF}' ./artifacts/test/check.timings) = 2 ] && date '+%s' >> ./artifacts/test/check.timings

--- a/build/ci/platforms/centos8.yml
+++ b/build/ci/platforms/centos8.yml
@@ -39,10 +39,10 @@ tasks:
     sudo -i -u pcpqa ./check 002
   qa_sanity: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   qa: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   copy_test_artifacts: |
     cp /var/lib/pcp/testsuite/check.timings ./artifacts/test
     [ $(awk 'END{print NF}' ./artifacts/test/check.timings) = 2 ] && date '+%s' >> ./artifacts/test/check.timings

--- a/build/ci/platforms/debian10.yml
+++ b/build/ci/platforms/debian10.yml
@@ -44,10 +44,10 @@ tasks:
     sudo -i -u pcpqa ./check 002
   qa_sanity: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   qa: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   copy_test_artifacts: |
     cp /var/lib/pcp/testsuite/check.timings ./artifacts/test
     [ $(awk 'END{print NF}' ./artifacts/test/check.timings) = 2 ] && date '+%s' >> ./artifacts/test/check.timings

--- a/build/ci/platforms/debian11.yml
+++ b/build/ci/platforms/debian11.yml
@@ -43,10 +43,10 @@ tasks:
     sudo -i -u pcpqa ./check 002
   qa_sanity: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   qa: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   copy_test_artifacts: |
     cp /var/lib/pcp/testsuite/check.timings ./artifacts/test
     [ $(awk 'END{print NF}' ./artifacts/test/check.timings) = 2 ] && date '+%s' >> ./artifacts/test/check.timings

--- a/build/ci/platforms/fedora31.yml
+++ b/build/ci/platforms/fedora31.yml
@@ -32,10 +32,10 @@ tasks:
     sudo -i -u pcpqa ./check 002
   qa_sanity: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   qa: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   copy_test_artifacts: |
     cp /var/lib/pcp/testsuite/check.timings ./artifacts/test
     [ $(awk 'END{print NF}' ./artifacts/test/check.timings) = 2 ] && date '+%s' >> ./artifacts/test/check.timings

--- a/build/ci/platforms/fedora32.yml
+++ b/build/ci/platforms/fedora32.yml
@@ -32,10 +32,10 @@ tasks:
     sudo -i -u pcpqa ./check 002
   qa_sanity: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   qa: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   copy_test_artifacts: |
     cp /var/lib/pcp/testsuite/check.timings ./artifacts/test
     [ $(awk 'END{print NF}' ./artifacts/test/check.timings) = 2 ] && date '+%s' >> ./artifacts/test/check.timings

--- a/build/ci/platforms/fedora_rawhide.yml
+++ b/build/ci/platforms/fedora_rawhide.yml
@@ -24,10 +24,10 @@ tasks:
     sudo -i -u pcpqa ./check 002
   qa_sanity: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   qa: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   copy_test_artifacts: |
     cp /var/lib/pcp/testsuite/check.timings ./artifacts/test
     [ $(awk 'END{print NF}' ./artifacts/test/check.timings) = 2 ] && date '+%s' >> ./artifacts/test/check.timings

--- a/build/ci/platforms/ubuntu1604.yml
+++ b/build/ci/platforms/ubuntu1604.yml
@@ -48,10 +48,10 @@ tasks:
     sudo -i -u pcpqa ./check 002
   qa_sanity: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   qa: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   copy_test_artifacts: |
     cp /var/lib/pcp/testsuite/check.timings ./artifacts/test
     [ $(awk 'END{print NF}' ./artifacts/test/check.timings) = 2 ] && date '+%s' >> ./artifacts/test/check.timings

--- a/build/ci/platforms/ubuntu1804.yml
+++ b/build/ci/platforms/ubuntu1804.yml
@@ -45,10 +45,10 @@ tasks:
     sudo -i -u pcpqa ./check 002
   qa_sanity: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   qa: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   copy_test_artifacts: |
     cp /var/lib/pcp/testsuite/check.timings ./artifacts/test
     [ $(awk 'END{print NF}' ./artifacts/test/check.timings) = 2 ] && date '+%s' >> ./artifacts/test/check.timings

--- a/build/ci/platforms/ubuntu2004.yml
+++ b/build/ci/platforms/ubuntu2004.yml
@@ -43,10 +43,10 @@ tasks:
     sudo -i -u pcpqa ./check 002
   qa_sanity: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   qa: |
     set -o pipefail
-    sudo -i -u pcpqa ./check -TT -x not_in_container |& tee ./artifacts/test/test.log
+    sudo -i -u pcpqa ./check -TT -x not_in_ci -x not_in_container |& tee ./artifacts/test/test.log
   copy_test_artifacts: |
     cp /var/lib/pcp/testsuite/check.timings ./artifacts/test
     [ $(awk 'END{print NF}' ./artifacts/test/check.timings) = 2 ] && date '+%s' >> ./artifacts/test/check.timings

--- a/qa/1067
+++ b/qa/1067
@@ -90,6 +90,18 @@ then
     _save_config $derived
 fi
 
+# pcp.sample.float.hundred                      [d|100.000000]
+# pcp.sample.double.ten                         [d|10.000000]
+#                 the decimal part may not be reported^^^^^^
+#
+_filter_float()
+{
+    sed \
+	-e '/pcp.sample.float.hundred/s/100\.00*/100/' \
+	-e '/pcp.sample.double.ten/s/10\.00*/10/' \
+    # end
+}
+
 _filter_values()
 {
     # expect lines like:
@@ -98,15 +110,10 @@ _filter_values()
 # pcp.sample.bad.novalues      [m|ZBX_NOTSUPPORTED] [No value available.]
     # d|u|s -> zabbix types;
     # m is error encodings -> allow through
-# pcp.sample.float.hundred                      [d|100.000000]
-# pcp.sample.double.ten                         [d|10.000000]
-#                 the decimal part may not be reported^^^^^^
 
     sed \
 	-e 's/\[[dus]|.*\]$/VALUE/g' \
 	-e '/sample\.scramble/d' \
-	-e '/pcp.sample.float.hundred/s/100\.00*/100/' \
-	-e '/pcp.sample.double.ten/s/10\.00*/10/' \
     #end
 }
 
@@ -123,8 +130,8 @@ echo "== request specific values"
 $zabbix_agentd -t pcp.sample.long.one
 $zabbix_agentd -t 'pcp.sample.long.bin[bin-100]'
 $zabbix_agentd -t pcp.sample.ulonglong.million
-$zabbix_agentd -t pcp.sample.float.hundred
-$zabbix_agentd -t pcp.sample.double.ten
+$zabbix_agentd -t pcp.sample.float.hundred | _filter_float
+$zabbix_agentd -t pcp.sample.double.ten | _filter_float
 
 # string metrics
 $zabbix_agentd -t pcp.sample.string.null

--- a/qa/1102
+++ b/qa/1102
@@ -46,7 +46,11 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 _stop_auto_restart pmcd
 
 _pmdaopenmetrics_save_config
-_pmdaopenmetrics_remove | sed -e 's/not found in Name Space, this is OK/done/'
+_pmdaopenmetrics_remove \
+| sed \
+    -e '/ Info: /d' \
+    -e 's/not found in Name Space, this is OK/done/' \
+# end
 _pmdaopenmetrics_install
 
 port=`_find_free_port 10000`
@@ -105,7 +109,10 @@ do
     pminfo -f `pminfo openmetrics.source4 | LC_COLLATE=POSIX sort`
 done
 
-_pmdaopenmetrics_remove
+_pmdaopenmetrics_remove \
+| sed \
+    -e '/ Info: /d' \
+# end
 
 # success, all done
 status=0

--- a/qa/1120
+++ b/qa/1120
@@ -93,7 +93,10 @@ do
     pmsleep 0.0005
 done
 
-_pmdaopenmetrics_remove
+_pmdaopenmetrics_remove \
+| sed \
+    -e '/ Info: /d' \
+# end
 
 # success, all done
 status=0

--- a/qa/1160
+++ b/qa/1160
@@ -52,7 +52,10 @@ pmda_remove()
     echo
     echo "=== remove netcheck agent ==="
     $sudo ./Remove >$tmp.out 2>&1
-    _filter_pmda_remove <$tmp.out
+    _filter_pmda_remove <$tmp.out \
+    | sed \
+	-e '/ Info: /d' \
+    # end
 }
 
 pmda_install()

--- a/qa/1161
+++ b/qa/1161
@@ -44,7 +44,10 @@ pmda_remove()
     echo
     echo "=== remove netcheck agent ==="
     $sudo ./Remove >$tmp.out 2>&1
-    _filter_pmda_remove <$tmp.out
+    _filter_pmda_remove <$tmp.out \
+    | sed \
+	-e '/ Info: /d' \
+    # end
 }
 
 pmda_install()

--- a/qa/1186
+++ b/qa/1186
@@ -4,6 +4,13 @@
 #
 # Copyright (c) 2017 Ken McDonell.  All Rights Reserved.
 #
+# :not_in_ci:
+# 	This test depends on reasonable platform scheduler performance
+# 	and when pmie yields for the waiting for a back-off timeout,
+# 	pmie needs to run shortly after the timeout expires.
+#	We've seen evidence of a back-off of 5 seconds leading to a
+#	16 second delay before pmie runs again, and the test is doomed
+#	if this happens.
 
 seq=`basename $0`
 echo "QA output created by $seq"

--- a/qa/580
+++ b/qa/580
@@ -60,6 +60,7 @@ s,/etc/init,init,g;
 s,/sbin/init,init,g;
 s, /usr/lib/systemd/systemd\([ ">]\), init\1,;
 s, /lib/systemd/systemd\([ ">]\), init\1,;
+s, /bin/systemd\([ ">]\), init\1,;
 s,init[^>]*,init,g;'
    # Irix 6.2 has a space after the init, linux may have extra arguments
    # And on some Linux systems (e.g. Fedora 18), pid 1 is not init, but

--- a/qa/check-group
+++ b/qa/check-group
@@ -114,6 +114,10 @@ do
 	    group_list="`echo $1 | sed -e 's/-/ /'`"
 	    ;;
 
+	not_in_ci)
+	    ( grep '^#.*:not_in_ci:' $seq >$tmp.debug  \
+	    )  && echo $seq >>$tmp.tmp
+	    ;;
 	*)
 	    ( grep -v '^#' $seq \
 	      | egrep "(^[ 	]*$1([ '\"]|$))|([ '\"\`]$1([ '\"\`]|$))" >$tmp.debug \

--- a/qa/common.bcc
+++ b/qa/common.bcc
@@ -160,7 +160,10 @@ _pmdabcc_remove()
     echo
     echo "=== remove bcc agent ==="
     $sudo ./Remove >$tmp.out 2>&1
-    _filter_pmda_remove <$tmp.out
+    _filter_pmda_remove <$tmp.out \
+    | sed \
+	-e '/ Info: /d' \
+    # end
 }
 
 _pmdabcc_cleanup()

--- a/qa/common.openmetrics
+++ b/qa/common.openmetrics
@@ -29,10 +29,19 @@ _have_python266()
 _pmdaopenmetrics_remove()
 {
     echo
-    echo "=== remove openmetrics agent ==="
+    echo "=== remove openmetrics agent ===" | tee -a $here/$seq.full
     cd $PCP_PMDAS_DIR/openmetrics
     $sudo ./Remove >$tmp.out 2>&1
-    _filter_pmda_remove <$tmp.out
+    cat $tmp.out >>$here/$seq.full
+    _filter_pmda_remove <$tmp.out \
+    | $PCP_AWK_PROG '
+BEGIN		{ state = 0 }
+/ Xferd /	{ state = 1; next }
+state == 1 && /^\[/	{ state = 0 }
+state == 0	{ print }' \
+    | sed \
+	-e '/ Info: /d' \
+    # end
 }
 
 _pmdaopenmetrics_install()

--- a/qa/group
+++ b/qa/group
@@ -19,6 +19,23 @@ other
 ## NOTE: used by testing orgs beyond developers, must pass!
 sanity
 
+# not_in_ci ... tests that will not work in the fully automated
+# CI environment (github actions this week), where the following
+# analysis and protocols have been followed:
+# (a) the test has repeatedly failed on most hosts in the daily CI QA
+#     run
+# (b) the test is not a candidates for some _notrun medicine
+# (c) failures have been analyzed and it has been determined that the
+#     failure is an artifact of the CI setup (not the code and not
+#     the QA test)
+# (d) the test is passing universally elsewhere outside CI
+# and the test is annotated with a comment like
+# # :not_in_ci:
+# explaining the reason for assigning this one to the not_in_ci
+# group (./check-group not_in_ci can be used to check for the
+# presence of the explanation in the test)
+not_in_ci
+
 # local check ... runs on localhost alone, no remotes used
 ## NOTE: used by testing orgs beyond developers, do not add
 ## tests here that are known to fail - goal is for 100% pass
@@ -1603,7 +1620,7 @@ not_in_container
 1183 pmrep python archive local
 1184 pminfo pmseries local
 1185 pmrep python archive local
-1186 pmie local
+1186 pmie local not_in_ci
 1187 python pcp dstat local
 1188 pmda.dm local valgrind
 1189 find-filter local

--- a/src/pmcd/pmdaproc.sh
+++ b/src/pmcd/pmdaproc.sh
@@ -798,8 +798,24 @@ _setup()
 	    perl -e 'use PCP::PMDA' >$tmp/out 2>&1
 	    if test $? -eq 0
 	    then
-		eval PCP_PERL_DOMAIN=1 perl "$perl_name" > "$perl_dom"
-		eval PCP_PERL_PMNS=1 perl "$perl_name" > "$perl_pmns"
+		if eval PCP_PERL_DOMAIN=1 perl "$perl_name" >"$perl_dom" 2>$tmp/err
+		then
+		    :
+		else
+		    echo "Arrgh! failed to create $perl_dom from $perl_name"
+		    cat $tmp/err
+		    status=1
+		    exit
+		fi
+		if eval PCP_PERL_PMNS=1 perl "$perl_name" >"$perl_pmns" 2>$tmp/err
+		then
+		    :
+		else
+		    echo "Arrgh! failed to create $perl_pmns from $perl_name"
+		    cat $tmp/err
+		    status=1
+		    exit
+		fi
 	    elif $dso_opt || $daemon_opt
 	    then
 		:	# we have an alternative, so continue on
@@ -842,8 +858,24 @@ _setup()
 	    __syntax=$?
 	    if test $__module -eq 0 -a $__syntax -eq 0
 	    then
-		eval PCP_PYTHON_DOMAIN=1 $python "$python_name" > "$python_dom"
-		eval PCP_PYTHON_PMNS=1 $python "$python_name" > "$python_pmns"
+		if eval PCP_PYTHON_DOMAIN=1 $python "$python_name" >"$python_dom" 2>$tmp/err
+		then
+		    :
+		else
+		    echo "Arrgh! failed to create $python_dom from $python_name"
+		    cat $tmp/err
+		    status=1
+		    exit
+		fi
+		if eval PCP_PYTHON_PMNS=1 $python "$python_name" >"$python_pmns" 2>$tmp/err
+		then
+		    :
+		else
+		    echo "Arrgh! failed to create $python_pmns from $python_name"
+		    cat $tmp/err
+		    status=1
+		    exit
+		fi
 	    elif $dso_opt || $daemon_opt
 	    then
 		:	# we have an alternative, so continue on

--- a/src/pmcd/pmdaproc.sh
+++ b/src/pmcd/pmdaproc.sh
@@ -798,21 +798,19 @@ _setup()
 	    perl -e 'use PCP::PMDA' >$tmp/out 2>&1
 	    if test $? -eq 0
 	    then
-		if eval PCP_PERL_DOMAIN=1 perl "$perl_name" >"$perl_dom" 2>$tmp/err
+		if eval PCP_PERL_DOMAIN=1 perl "$perl_name" >"$perl_dom"
 		then
 		    :
 		else
 		    echo "Arrgh! failed to create $perl_dom from $perl_name"
-		    cat $tmp/err
 		    status=1
 		    exit
 		fi
-		if eval PCP_PERL_PMNS=1 perl "$perl_name" >"$perl_pmns" 2>$tmp/err
+		if eval PCP_PERL_PMNS=1 perl "$perl_name" >"$perl_pmns"
 		then
 		    :
 		else
 		    echo "Arrgh! failed to create $perl_pmns from $perl_name"
-		    cat $tmp/err
 		    status=1
 		    exit
 		fi
@@ -858,21 +856,19 @@ _setup()
 	    __syntax=$?
 	    if test $__module -eq 0 -a $__syntax -eq 0
 	    then
-		if eval PCP_PYTHON_DOMAIN=1 $python "$python_name" >"$python_dom" 2>$tmp/err
+		if eval PCP_PYTHON_DOMAIN=1 $python "$python_name" >"$python_dom"
 		then
 		    :
 		else
 		    echo "Arrgh! failed to create $python_dom from $python_name"
-		    cat $tmp/err
 		    status=1
 		    exit
 		fi
-		if eval PCP_PYTHON_PMNS=1 $python "$python_name" >"$python_pmns" 2>$tmp/err
+		if eval PCP_PYTHON_PMNS=1 $python "$python_name" >"$python_pmns"
 		then
 		    :
 		else
 		    echo "Arrgh! failed to create $python_pmns from $python_name"
-		    cat $tmp/err
 		    status=1
 		    exit
 		fi

--- a/src/pmdas/bcc/Remove
+++ b/src/pmdas/bcc/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=bcc
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/bpftrace/Remove
+++ b/src/pmdas/bpftrace/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=bpftrace
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/elasticsearch/Remove
+++ b/src/pmdas/elasticsearch/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=elasticsearch
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/gluster/Remove
+++ b/src/pmdas/gluster/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=gluster
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/haproxy/Remove
+++ b/src/pmdas/haproxy/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=haproxy
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/json/Remove
+++ b/src/pmdas/json/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=json
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/libvirt/Remove
+++ b/src/pmdas/libvirt/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=libvirt
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/lio/Remove
+++ b/src/pmdas/lio/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=lio
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/lmsensors/Remove
+++ b/src/pmdas/lmsensors/Remove
@@ -29,6 +29,7 @@
 # The name of the PMDA
 #
 iam=lmsensors
+python_opt=true
 
 # Do it
 #

--- a/src/pmdas/mic/Remove
+++ b/src/pmdas/mic/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=mic
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/mssql/Remove
+++ b/src/pmdas/mssql/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=mssql
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/netcheck/Remove
+++ b/src/pmdas/netcheck/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=netcheck
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/nfsclient/Remove
+++ b/src/pmdas/nfsclient/Remove
@@ -18,6 +18,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=nfsclient
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/openmetrics/Remove
+++ b/src/pmdas/openmetrics/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=openmetrics
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/openvswitch/Remove
+++ b/src/pmdas/openvswitch/Remove
@@ -25,6 +25,7 @@
 # The name of the PMDA
 #
 iam=openvswitch
+python_opt=true
 
 # Do it
 

--- a/src/pmdas/perfevent/Remove
+++ b/src/pmdas/perfevent/Remove
@@ -25,7 +25,8 @@
 # The name of the PMDA
 #
 iam=perfevent
-perl_opt=true
+perl_opt=false
+python_opt=false
 
 # Do it
 #

--- a/src/pmdas/postgresql/Remove
+++ b/src/pmdas/postgresql/Remove
@@ -20,6 +20,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=postgresql
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/rabbitmq/Remove
+++ b/src/pmdas/rabbitmq/Remove
@@ -25,6 +25,7 @@
 # The name of the PMDA
 #
 iam=rabbitmq
+python_opt=true
 
 # Do it
 #

--- a/src/pmdas/simple/Remove
+++ b/src/pmdas/simple/Remove
@@ -20,6 +20,8 @@
 
 iam=simple
 perl_opt=true
+python_opt=true
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/trivial/Remove
+++ b/src/pmdas/trivial/Remove
@@ -30,6 +30,7 @@
 #
 iam=trivial
 perl_opt=true
+python_opt=true
 
 # Do it
 #

--- a/src/pmdas/unbound/Remove
+++ b/src/pmdas/unbound/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=unbound
+python_opt=true
 
 pmdaSetup
 pmdaRemove

--- a/src/pmdas/zswap/Remove
+++ b/src/pmdas/zswap/Remove
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=zswap
+python_opt=true
 
 pmdaSetup
 pmdaRemove


### PR DESCRIPTION
Same change as I made for Perl PMDAs a day or so ago.
Although the code change is simple, this one had quite a bit more QA fallout than the Perl change ... most of this is rework in the filtering associated with PMDA ./Remove in the QA tests or their associated common routiines.