### PR TITLE
pmlogger fix for repeated metric

### DIFF
--- a/qa/061.out
+++ b/qa/061.out
@@ -74,6 +74,8 @@ sample.colour
   inst [2 or "blue"]  0 (adv off)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNAN delta=0.000000
+compared to: optreq task=ADDR state=NNMY delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -136,6 +138,8 @@ sample.colour
   inst [2 or "blue"]  2 (mand off)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNMN delta=0.000000
+compared to: optreq task=ADDR state=NNMY delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -198,6 +202,8 @@ sample.colour
   inst [2 or "blue"]  15 (mand on, delta=0 msec, inlog, avail)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNAY delta=0.000000
+compared to: optreq task=ADDR state=NNMY delta=0.000000
 Warning [TMP.config, line 6]
 Incompatible request for metric "sample.colour" and instance "blue"
 Request for (advisory) ON conflicts with current (mandatory) ON state
@@ -269,6 +275,8 @@ sample.colour
   inst [2 or "blue"]  15 (mand on, delta=0 msec, inlog, avail)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNAN delta=0.000000
+compared to: optreq task=ADDR state=NNMY delta=0.000000
 Warning [TMP.config, line 6]
 Incompatible request for metric "sample.colour" and instance "blue"
 Request for (advisory) OFF conflicts with current (mandatory) ON state
@@ -340,6 +348,8 @@ sample.colour
   inst [2 or "blue"]  15 (mand on, delta=0 msec, inlog, avail)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNMY delta=0.000000
+compared to: optreq task=ADDR state=NNAN delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -469,6 +479,8 @@ sample.colour
   inst [2 or "blue"]  2 (mand off)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNMN delta=0.000000
+compared to: optreq task=ADDR state=NNAN delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -531,6 +543,8 @@ sample.colour
   inst [2 or "blue"]  13 (adv on, delta=0 msec, inlog, avail)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNAY delta=0.000000
+compared to: optreq task=ADDR state=NNAN delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -598,6 +612,8 @@ sample.colour
   inst [2 or "blue"]  0 (adv off)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNAN delta=0.000000
+compared to: optreq task=ADDR state=NNAN delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -660,6 +676,8 @@ sample.colour
   inst [2 or "blue"]  15 (mand on, delta=0 msec, inlog, avail)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNMY delta=0.000000
+compared to: optreq task=ADDR state=NNMN delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -727,6 +745,8 @@ sample.colour
   inst [2 or "blue"]  0 (adv off)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNAN delta=0.000000
+compared to: optreq task=ADDR state=NNMN delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -851,6 +871,8 @@ sample.colour
   inst [2 or "blue"]  2 (mand off)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNAY delta=0.000000
+compared to: optreq task=ADDR state=NNMN delta=0.000000
 Warning [TMP.config, line 6]
 Incompatible request for metric "sample.colour" and instance "blue"
 Request for (advisory) ON conflicts with current (mandatory) OFF state
@@ -917,6 +939,8 @@ sample.colour
   inst [2 or "blue"]  2 (mand off)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNAN delta=0.000000
+compared to: optreq task=ADDR state=NNMN delta=0.000000
 Warning [TMP.config, line 6]
 Incompatible request for metric "sample.colour" and instance "blue"
 Request for (advisory) OFF conflicts with current (mandatory) OFF state
@@ -983,6 +1007,8 @@ sample.colour
   inst [2 or "blue"]  15 (mand on, delta=0 msec, inlog, avail)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNMY delta=0.000000
+compared to: optreq task=ADDR state=NNAY delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -1050,6 +1076,8 @@ sample.colour
   inst [2 or "blue"]  0 (adv off)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNAN delta=0.000000
+compared to: optreq task=ADDR state=NNAY delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -1112,6 +1140,8 @@ sample.colour
   inst [2 or "blue"]  2 (mand off)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNMN delta=0.000000
+compared to: optreq task=ADDR state=NNAY delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -1241,6 +1271,8 @@ sample.colour
   inst [2 or "blue"]  0 (adv off)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNAN delta=0.000000
+compared to: optreq task=ADDR state=NNAY delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -1303,6 +1335,8 @@ sample.colour
   inst [2 or "blue"]  15 (mand on, delta=0 msec, inlog, avail)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNMY delta=0.000000
+compared to: optreq task=ADDR state=NNAN delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -1370,6 +1404,8 @@ sample.colour
   inst [2 or "blue"]  0 (adv off)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNAN delta=0.000000
+compared to: optreq task=ADDR state=NNAN delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -1432,6 +1468,8 @@ sample.colour
   inst [2 or "blue"]  2 (mand off)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNMN delta=0.000000
+compared to: optreq task=ADDR state=NNAN delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 
@@ -1494,6 +1532,8 @@ sample.colour
   inst [2 or "blue"]  13 (adv on, delta=0 msec, inlog, avail)
 Log for pmlogger on HOST started DATE
 
+chk_one: pmid=29.0.5 task=ADDR state=NNAY delta=0.000000
+compared to: optreq task=ADDR state=NNAN delta=0.000000
 Config parsed
 optFetch Cost Parameters: pmid=4 indom=1 fetch=15 scope=1
 

--- a/src/libpcp/src/optfetch.c
+++ b/src/libpcp/src/optfetch.c
@@ -376,6 +376,8 @@ __pmOptFetchAdd(fetchctl_t **root, optreq_t *new)
     pmidctl_t		*pmp = NULL;
     int			mincost;
     int			change;
+    int			j;
+    int			tj;
     pmInDom		indom = new->r_desc->indom;
     pmID		pmid = new->r_desc->pmid;
 
@@ -388,7 +390,7 @@ __pmOptFetchAdd(fetchctl_t **root, optreq_t *new)
     fp->f_next = *root;
     *root = fp;
 
-    for (fp = *root; fp != NULL; fp = fp->f_next) {
+    for (j = 0, fp = *root; fp != NULL; j++, fp = fp->f_next) {
 	fp->f_cost = optCost(fp);
 
 	change = OPT_STATE_XINDOM | OPT_STATE_XPMID | OPT_STATE_XREQ;
@@ -437,7 +439,7 @@ __pmOptFetchAdd(fetchctl_t **root, optreq_t *new)
 	    fp->f_newcost += optcost.c_fetch;
 	if (pmDebugOptions.optfetch && pmDebugOptions.desperate) {
 	    char	strbuf[100];
-	    fprintf(stderr, "__pmOptFetchAdd: fp=" PRINTF_P_PFX "%p cost=", fp);
+	    fprintf(stderr, "__pmOptFetchAdd: [%d] fp=" PRINTF_P_PFX "%p cost=", j, fp);
 	    if (fp->f_cost == OPT_COST_INFINITY)
 		fprintf(stderr, "INFINITY");
 	    else
@@ -447,8 +449,8 @@ __pmOptFetchAdd(fetchctl_t **root, optreq_t *new)
 		fprintf(stderr, "INFINITY");
 	    else
 		fprintf(stderr, "%d", fp->f_newcost);
-	    fprintf(stderr, ", for %s @ grp " PRINTF_P_PFX "%p,",
-		pmIDStr_r(pmid, strbuf, sizeof(strbuf)), fp);
+	    fprintf(stderr, " for %s,",
+		pmIDStr_r(pmid, strbuf, sizeof(strbuf)));
 	    fprintf(stderr, " state %s\n",
 		statestr(fp->f_state, strbuf));
 	}
@@ -456,7 +458,7 @@ __pmOptFetchAdd(fetchctl_t **root, optreq_t *new)
 
     tfp = NULL;
     mincost = OPT_COST_INFINITY;
-    for (fp = *root; fp != NULL; fp = fp->f_next) {
+    for (j = 0, fp = *root; fp != NULL; j++, fp = fp->f_next) {
 	int		cost;
 	if (optcost.c_scope)
 	    /* global */
@@ -467,13 +469,14 @@ __pmOptFetchAdd(fetchctl_t **root, optreq_t *new)
 	if (cost < mincost) {
 	    mincost = cost;
 	    tfp = fp;
+	    tj = j;
 	}
     }
     if (pmDebugOptions.optfetch && pmDebugOptions.desperate) {
 	char	strbuf[100];
-	fprintf(stderr, "__pmOptFetchAdd: fp=" PRINTF_P_PFX "%p chose %s cost=%d for %s @ grp " PRINTF_P_PFX "%p,",
-		tfp, optcost.c_scope ? "global" : "incremental",
-		mincost, pmIDStr_r(pmid, strbuf, sizeof(strbuf)), tfp);
+	fprintf(stderr, "__pmOptFetchAdd: choose [%d] fp=" PRINTF_P_PFX "%p, %s cost=%d for %s",
+		tj, tfp, optcost.c_scope ? "global" : "incremental",
+		mincost, pmIDStr_r(pmid, strbuf, sizeof(strbuf)));
 	fprintf(stderr, " change %s\n", statestr(tfp->f_state, strbuf));
     }
 
@@ -497,6 +500,9 @@ __pmOptFetchAdd(fetchctl_t **root, optreq_t *new)
 	    /*
 	     * The chosen one ...
 	     */
+	    if (pmDebugOptions.optfetch && pmDebugOptions.desperate) {
+		fprintf(stderr, "__pmOptFetchAdd: chosen one is OK\n");
+	    }
 	    if (fp->f_state & OPT_STATE_XFETCH)
 		fp->f_state |= OPT_STATE_NEW;
 	    if (addpmid(tfp, pmid))

--- a/src/pmlogger/src/gram.y
+++ b/src/pmlogger/src/gram.y
@@ -549,10 +549,17 @@ activate_cached_metric(const char *name, int index)
 
 	    skip = 1;
 	}
+	else if (sts == 1)
+	    skip = 1;
     }
 
     if (!skip) {
 	__pmOptFetchAdd(&tp->t_fetch, rqp);
+	linkback(tp);
+	if (pmDebugOptions.optfetch && pmDebugOptions.desperate) {
+	    fprintf(stderr, "Task " PRINTF_P_PFX "%p -> t_fetch ...\n", tp);
+	    __pmOptFetchDump(stderr, tp->t_fetch);
+	}
 	if ((sts = __pmHashAdd(pmid, (void *)rqp, &pm_hash)) < 0) {
 	    pmsprintf(emess, sizeof(emess), "__pmHashAdd failed "
 		    "for metric \"%s\" ... logging not activated", name);


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20200904

Ken McDonell (5):
      src/libpcp/src/optfetch.c: improve diagnositics
      src/pmlogger/src/fetch.c: improve -Dfetch diagnostics
      src/pmlogger/src/gram.y: fix for repeated metric problem
      src/pmlogger/src/checks.c: fix for repeated metric problem
      qa/061.out: remade after opFetch diagnostic change in libpcp

 qa/061.out                |   40 +++++++++++++++
 src/libpcp/src/optfetch.c |   22 +++++---
 src/pmlogger/src/checks.c |  122 ++++++++++++++++++++++++++++++++++++----------
 src/pmlogger/src/fetch.c  |   97 ++++++++++++++++++++++++++++++++++++
 src/pmlogger/src/gram.y   |    7 ++
 5 files changed, 255 insertions(+), 33 deletions(-)

Details ...

commit 7deb4e7a980384286a04a178fda1d32388d537f8
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Fri Sep 4 16:27:23 2020 +1000

    qa/061.out: remade after opFetch diagnostic change in libpcp

commit 824e9ef51a1a85dcb980f281ef7367eb9d200125
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Fri Sep 4 16:20:23 2020 +1000

    src/pmlogger/src/checks.c: fix for repeated metric problem
    
    In this part of the fix, chk_one() and chk_all() are given
    a make over.
    
    chk_one() had a small "same group" logic error (benign I think),
    but was missing any useful diagnostics.
    
    chk_all() had the useful diagnostics, but the logic was grossly incomplete
    (as in missing) ... this in the code
            /*TODO, not right!*/
    should have been a warning!  Arrrgh.
    So the routine has been rewritten ... and in so doing now returns 1
    correctly for a replicated metric (and no instances specified) in the
    same config file logging group, which means we don't call optFetch()
    again back in the caller.

commit dc1edae0b8e4bf332dccf824bd9808d5ad81b2d2
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Fri Sep 4 16:09:14 2020 +1000

    src/pmlogger/src/gram.y: fix for repeated metric problem
    
    If we were really lucky and had a pmlogger config like:
    
    .... {
            ...[A]
            metric-a
            ...[B]
            metric-a
    }
    then metric-a could end up in two fetchctl_t groups, meaning it
    would be fetched twice as often as expected, in back-to-back fetches
    each time the associated upper-level task was run.
    
    The critical issue is that if the metrics in the [B] group cause
    optFetch to split the task's work into two (or more) fetchctl_t
    groups, we "lose" track of the first metric-a, and when the second
    metric-a is encountered we feed it to optFetch again instead of
    skipping it.
    
    This part of the fix ensures that after calling __pmOptFetchAdd() we
    then call linkback(tp) to ensure _all_ of the fetchctl_t groups
    are linked back to the associated upper level task (tp).
    
    There is also an additional diagnostic here to dump out all of the
    fetchctl_t groups after calling __pmOptFetchAdd() when -Doptfetch
    and -Ddesperate are in play.

commit 2b5232bf3913ab3d9a6d57582a06dd4d5e4b126d
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Fri Sep 4 16:05:26 2020 +1000

    src/pmlogger/src/fetch.c: improve -Dfetch diagnostics
    
    For most (everyhting except the prologue and epilogue), pmlogger
    uses a provide myFetch() routine instead of pmFetch().
    
    This change lifts the pmFetch() -Dfetch diagnostics from libpcp
    and splices them into pmlogger, so pmlogger -Dfetch shows all the
    pmResults coming back from pmcd.
    
    There is no functional code change in this commit.

commit 51be935a9f498fecd36c2e7e03ab48b37d95d465
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Fri Sep 4 16:03:40 2020 +1000

    src/libpcp/src/optfetch.c: improve diagnositics
    
    No functional code change here.