### PR TITLE
Fix of typos when referencing man pages in systemd unit files

### DIFF
--- a/src/pmcd/pmcd.service.in
+++ b/src/pmcd/pmcd.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Performance Metrics Collector Daemon
-Documentation=man:pmcd(8)
+Documentation=man:pmcd(1)
 Wants=avahi-daemon.service
 After=network-online.target avahi-daemon.service
 Before=zabbix-agent.service

--- a/src/pmproxy/pmproxy.service.in
+++ b/src/pmproxy/pmproxy.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Proxy for Performance Metrics Collector Daemon
-Documentation=man:pmproxy(8)
+Documentation=man:pmproxy(1)
 After=network-online.target pmcd.service
 
 [Service]


### PR DESCRIPTION
Resolves [bug 1876452](https://bugzilla.redhat.com/show_bug.cgi?id=1876452).