### PR TITLE
Add dstat plugin for GPFS. Requires the GPFS PMDA.

### DIFF
--- a/src/pcp/dstat/pcp-dstat.1
+++ b/src/pcp/dstat/pcp-dstat.1
@@ -422,6 +422,12 @@ configuration files require the installation of optional
 Performance Metric Domain Agents, above and beyond the
 default installed set.
 .TP 5
+\fB\-\-gpfs\fR
+GPFS read/write I/O (needs the GPFS PMDA)
+.TP
+\fB\-\-gpfs\-ops\fR
+GPFS filesystem operations (needs the GPFS PMDA)
+.TP
 \fB\-\-innodb\-buffer\fR
 show innodb buffer stats (needs the MySQL PMDA)
 .TP
@@ -497,12 +503,6 @@ number of dbus connections (needs a python\-dbus PMDA)
 .TP
 \fB\-\-fan\fR
 fan speed (needs an ACPI PMDA)
-.TP
-\fB\-\-gpfs\fR
-GPFS read/write I/O (needs mmpmon and a GPFS PMDA)
-.TP
-\fB\-\-gpfs\-ops\fR
-GPFS filesystem operations (needs mmpmon and a GPFS PMDA)
 .TP
 \fB\-\-md\-status\fR
 show software raid (MD driver) progress and speed

--- a/src/pcp/dstat/plugins/gpfs
+++ b/src/pcp/dstat/plugins/gpfs
@@ -1,0 +1,27 @@
+#
+# pcp-dstat(1) configuration file - see pcp-dstat(5)
+#
+# Requires the GPFS PMDA
+#
+
+[gpfs]
+label = fs/%I
+printtype = b
+precision = 0
+grouptype = 2
+width = 4
+reads = gpfs.fsios.read_bytes
+writes = gpfs.fsios.write_bytes
+
+[gpfs-ops]
+label = gpfs-ops/%I
+printtype = b
+precision = 0
+grouptype = 2
+width = 9
+opens = gpfs.fsios.opens
+reads = gpfs.fsios.reads
+writes = gpfs.fsios.writes
+inode_updates = gpfs.fsios.inode_updates
+readdir = gpfs.fsios.readdir
+closes = gpfs.fsios.closes


### PR DESCRIPTION
Gives GPFS throughput and file operation stats.

Output looks like this:         

```
> # pcp dstat  --gpfs
> -fs/total
> read writ
> 156M 155M
> 227M 228M
> 232M 232M
> 153M 153M
> 72M  72M
> 70M  70M
> 75M  75M^C

```


>  
```
> # pcp dstat  --gpfs-ops
> -----------------------gpfs-ops/total----------------------
>   opens     reads     writes  inode_upd  readdir    closes
>        0         0         0         0         0         0
>        0         0         0         0         0         0
>        0         0         0         0         0         0
>        0         0         0         0         0         0
>       17        49         0         0         0        16
>       99       297         0         0         0        99
>       91       274         0         0         0        92
>      105       316         0         0         0       105
>       94       281         0         0         0        93
>       89       265         0         0         0        89
>       86       260         0         0         0        87 ^C
```