### PR TITLE
build: rename python-dev to python2-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 on:
   push:
-    branches:
-      - master
   pull_request:
     branches:
       - master

--- a/Makepkgs
+++ b/Makepkgs
@@ -225,23 +225,6 @@ then
     # $(configure_tools)
     #
     configopts=''
-    if [ -f /etc/lsb-release ]
-    then
-	if grep -q 'DISTRIB_ID=Ubuntu' /etc/lsb-release
-	then
-	    eval `grep DISTRIB_RELEASE= /etc/lsb-release`
-	    XDISTRIB_RELEASE=`echo $DISTRIB_RELEASE | sed -e 's/[^0-9]//g' -e 's/\.//'`
-	    [ -z "$XDISTRIB_RELEASE" ] && XDISTRIB_RELEASE=0000
-	    if [ $XDISTRIB_RELEASE -ge 2004 ]
-	    then
-		# As of Ubuntu 20.04 the Python2 dependency packages have
-		# been renamed (at least python-dev -> python-dev-is-python2)
-		# so try building without Python2
-		#
-		configopts="$configopts --without-python"
-	    fi
-	fi
-    fi
 elif $dorpm
 then
     # On RPM-based platforms, rpm macros provide an excellent set of defaults.

--- a/configure
+++ b/configure
@@ -7417,10 +7417,42 @@ enable_python2=false
 if test "x$do_python" != "xno"; then :
 
     enable_python2=true
-    if test -z "$PYTHON"
+
+    if test "$do_python" = "check" -a -f /etc/os-release
+    then
+    (
+	. /etc/os-release
+	case "$ID"
+	in
+	    debian)
+		if test -z "$VERSION_ID" -o "$VERSION_ID" -ge 11; then
+		    touch config.python2_eol
+		fi
+		;;
+	    ubuntu)
+		VERSION_NO=`echo "$VERSION_ID" | sed 's/[^0-9]//'`
+		if test "$VERSION_NO" -ge 2004; then
+		    touch config.python2_eol
+		fi
+		;;
+	esac
+    )
+    fi
+
+    if test -f config.python2_eol
+    then
+	rm config.python2_eol
+	echo "WARNING: Python 2 is not supported anymore (EOL since 2020), please use Python 3 instead."
+	enable_python2=false
+    fi
+
+    if test "$enable_python2" = "true" -a -z "$PYTHON"
     then
 	enable_python2=false
-    else
+    fi
+
+    if $enable_python2
+    then
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking Python2 version" >&5
 $as_echo_n "checking Python2 version... " >&6; }
 	eval `$PYTHON -V 2>&1 | awk '/^Python/ { ver=2; print $ver }' | awk -F. '{ major=1; minor=2; point=3; printf "export PY_MAJOR=%d PY_MINOR=%d PY_POINT=%d\n",$major,$minor,$point }'`

--- a/configure.ac
+++ b/configure.ac
@@ -857,10 +857,42 @@ dnl check if python tools/packages wanted (need python >= 2.6)
 enable_python2=false
 AS_IF([test "x$do_python" != "xno"], [
     enable_python2=true
-    if test -z "$PYTHON"
+
+    if test "$do_python" = "check" -a -f /etc/os-release
+    then
+    (
+	. /etc/os-release
+	case "$ID"
+	in
+	    debian)
+		if test -z "$VERSION_ID" -o "$VERSION_ID" -ge 11; then
+		    touch config.python2_eol
+		fi
+		;;
+	    ubuntu)
+		VERSION_NO=`echo "$VERSION_ID" | sed 's/[[^0-9]]//'`
+		if test "$VERSION_NO" -ge 2004; then
+		    touch config.python2_eol
+		fi
+		;;
+	esac
+    )
+    fi
+
+    if test -f config.python2_eol
+    then
+	rm config.python2_eol
+	echo "WARNING: Python 2 is not supported anymore (EOL since 2020), please use Python 3 instead."
+	enable_python2=false
+    fi
+
+    if test "$enable_python2" = "true" -a -z "$PYTHON"
     then
 	enable_python2=false
-    else
+    fi
+
+    if $enable_python2
+    then
 	AC_MSG_CHECKING([Python2 version])
 	eval `$PYTHON -V 2>&1 | awk '/^Python/ { ver=2; print $ver }' | awk -F. '{ major=1; minor=2; point=3; printf "export PY_MAJOR=%d PY_MINOR=%d PY_POINT=%d\n",$major,$minor,$point }'`
 	AC_MSG_RESULT([$PY_MAJOR.$PY_MINOR.$PY_POINT])

--- a/debian/fixcontrol.master
+++ b/debian/fixcontrol.master
@@ -115,7 +115,27 @@ fi
 if $ENABLE_PYTHON2
 then
     echo "s/?{python-all}, /python-all, /" >>$tmp.sed
-    echo "s/?{python-dev}, /python-dev, /" >>$tmp.sed
+    (
+	. /etc/os-release
+	case "$ID"
+	in
+	    debian)
+		if [ -z "$VERSION_ID" ] || [ "$VERSION_ID" -ge 11 ]; then
+		    echo "s/?{python-dev}, /python2-dev, /" >>$tmp.sed
+		else
+		    echo "s/?{python-dev}, /python-dev, /" >>$tmp.sed
+		fi
+		;;
+	    ubuntu)
+		VERSION_NO=$(echo "$VERSION_ID" | sed 's/[^0-9]//')
+		if [ "$VERSION_NO" -ge 2004 ]; then
+		    echo "s/?{python-dev}, /python2-dev, /" >>$tmp.sed
+		else
+		    echo "s/?{python-dev}, /python-dev, /" >>$tmp.sed
+		fi
+		;;
+	esac
+    )
 else
     echo "s/?{python-dev}, //" >>$tmp.sed
     echo "s/?{python-all}, //" >>$tmp.sed

--- a/qa/admin/check-vm
+++ b/qa/admin/check-vm
@@ -1234,27 +1234,27 @@ if which dpkg >/dev/null 2>&1
 then
     # Debian based
     #
-    # Borrowed from Makepkgs ... we don't use Python2 on some recent
-    # Ubuntu versions
+    # Borrowed from debian/fixcontrol.master ... we don't use Python2 on some recent
+    # Debian/Ubuntu versions
     #
     pkgs="python-all python-all-dev python3-all python3-all-dev"
-    if [ -f /etc/lsb-release ]
-    then
-	if grep -q 'DISTRIB_ID=Ubuntu' /etc/lsb-release
-	then
-	    eval `grep DISTRIB_RELEASE= /etc/lsb-release`
-	    XDISTRIB_RELEASE=`echo $DISTRIB_RELEASE | sed -e 's/[^0-9]//g' -e 's/\.//'`
-	    [ -z "$XDISTRIB_RELEASE" ] && XDISTRIB_RELEASE=0000
-	    if [ $XDISTRIB_RELEASE -ge 2004 ]
-	    then
-		# As of Ubuntu 20.04 the Python2 dependency packages have
-		# been renamed (at least python-dev -> python-dev-is-python2)
-		# so try building without Python2
-		#
-		pkgs=`echo "$pkgs" | sed -e 's/python-[^ ]*//g'`
-	    fi
-	fi
-    fi
+    (
+	. /etc/os-release
+	case "$ID"
+	in
+	    debian)
+		if [ -z "$VERSION_ID" ] || [ "$VERSION_ID" -ge 11 ]; then
+		    pkgs=`echo "$pkgs" | sed -e 's/python-[^ ]*//g'`
+		fi
+		;;
+	    ubuntu)
+		VERSION_NO=$(echo "$VERSION_ID" | sed 's/[^0-9]//')
+		if [ "$VERSION_NO" -ge 2004 ]; then
+		    pkgs=`echo "$pkgs" | sed -e 's/python-[^ ]*//g'`
+		fi
+		;;
+	esac
+    )
     dpkg -l >$tmp.tmp
     for pkg in $pkgs
     do

--- a/qa/admin/myconfigure
+++ b/qa/admin/myconfigure
@@ -83,23 +83,6 @@ then
 	echo "Botch: cannot get configopts from configure_paths in debian/rules"
 	exit 1
     fi
-    if [ -f /etc/lsb-release ]
-    then
-	if grep -q 'DISTRIB_ID=Ubuntu' /etc/lsb-release
-	then
-	    eval `grep DISTRIB_RELEASE= /etc/lsb-release`
-	    XDISTRIB_RELEASE=`echo $DISTRIB_RELEASE | sed -e 's/[^0-9]//g' -e 's/\.//'`
-	    [ -z "$XDISTRIB_RELEASE" ] && XDISTRIB_RELEASE=0000
-	    if [ $XDISTRIB_RELEASE -ge 2004 ]
-	    then
-		# As of Ubuntu 20.04 the Python2 dependency packages have
-		# been renamed (at least python-dev -> python-dev-is-python2)
-		# so try building without Python2
-		#
-		configopts="$configopts --without-python"
-	    fi
-	fi
-    fi
     # and optionally configure_tools from debian/rules also ...
     #
     configtools=`sed -n <debian/rules -e '/^configure_tools/s/^[^=]*= *//p'`

--- a/qa/admin/other-packages/manifest
+++ b/qa/admin/other-packages/manifest
@@ -1365,7 +1365,7 @@ brew?	libSoQt.so			[N/A (build optional)]
 #
 # python
 #
-dpkg?	/usr/include/python2.*/Python.h	[libpython-dev or python-dev]
+dpkg?	/usr/include/python2.*/Python.h	[libpython-dev or python-dev or python2-dev]
 dpkg?	/usr/include/python3.*/Python.h	[libpython3-dev]
 rpm?	/usr/include/python2.*/Python.h	[python-devel or python2-devel]
 rpm?	/usr/include/python3.*/Python.h	[python3-devel or python36-devel]


### PR DESCRIPTION
Debian bullseye removed the python-dev package. python2-dev also exists
on Debian buster, therefore use this instead of python-dev.