### PR TITLE
pcp-atop: add support for process accounting

### DIFF
--- a/src/pcp/atop/.gitignore
+++ b/src/pcp/atop/.gitignore
@@ -4,6 +4,7 @@ pcp-atopsar
 pmgenmap.sh
 hostmetrics.h
 procmetrics.h
+acctmetrics.h
 systmetrics.h
 ifpropmetrics.h
 pcp-atop.1.*

--- a/src/pcp/atop/GNUmakefile
+++ b/src/pcp/atop/GNUmakefile
@@ -87,6 +87,9 @@ pmgenmap.sh:
 procmetrics.h:	pmgenmap.sh procmetrics.map
 	$(PMGENMAP) procmetrics.map > procmetrics.h
 
+acctmetrics.h:	pmgenmap.sh acctmetrics.map
+	$(PMGENMAP) acctmetrics.map > acctmetrics.h
+
 systmetrics.h:	pmgenmap.sh systmetrics.map
 	$(PMGENMAP) systmetrics.map > systmetrics.h
 
@@ -100,6 +103,7 @@ photoproc.o:	procmetrics.h
 photosyst.o:	systmetrics.h
 ifprop.o:	ifpropmetrics.h
 various.o:	hostmetrics.h
+modules.o:	acctmetrics.h
 
 atop.o atopsar.o various.o:	$(TOPDIR)/src/include/pcp/libpcp.h
 

--- a/src/pcp/atop/acctmetrics.map
+++ b/src/pcp/atop/acctmetrics.map
@@ -1,0 +1,21 @@
+#
+# metric names and access macros for acctmetrics.h and modules.c
+# use the acct variants here, and at runtime we
+# switch metrics (acct.*) via pointer
+# manipulation.
+#
+acctmetrics {
+	acct.psinfo.exitcode	ACCT_GEN_EXCODE
+	acct.id.uid		ACCT_GEN_UID
+	acct.id.gid		ACCT_GEN_GID
+	acct.psinfo.ppid	ACCT_GEN_PPID
+	acct.psinfo.btime	ACCT_GEN_BTIME
+	acct.psinfo.etime	ACCT_GEN_ETIME
+	acct.psinfo.utime	ACCT_CPU_UTIME
+	acct.psinfo.stime	ACCT_CPU_STIME
+	acct.psinfo.rw		ACCT_DSK_RIO
+	acct.psinfo.minflt	ACCT_MEM_MINFLT
+	acct.psinfo.majflt	ACCT_MEM_MAJFLT
+	# end marker - provides count
+	.			ACCT_NMETRICS
+}

--- a/src/pcp/atop/atop.c
+++ b/src/pcp/atop/atop.c
@@ -507,7 +507,8 @@ engine(void)
 	*/
 	static struct tstat	*curtpres;	/* current present list      */
 	static unsigned int	curtlen;	/* size of present list      */
-	struct tstat		*curpexit;	/* exited process list	     */
+	static struct tstat	*curpexit;	/* exited process list	     */
+	static unsigned int	curtexitlen;	/* size of exited proc list  */
 
 	static struct devtstat	devtstat;	/* deviation info	     */
 
@@ -604,6 +605,10 @@ engine(void)
 		memset(curtpres, 0, curtlen * sizeof(struct tstat));
 		ntaskpres = photoproc(&curtpres, &curtlen);
 
+		memset(curpexit, 0, curtexitlen * sizeof(struct tstat));
+		nprocexit = acctphotoproc(&curpexit, &curtexitlen, pmtimevalToReal(&cursstat->stamp),
+								   pmtimevalSub(&cursstat->stamp, &interval));
+
 		/*
 		** register processes that exited during last sample;
 		** first determine how many processes exited
@@ -611,8 +616,6 @@ engine(void)
 		** the number of exited processes is limited to avoid
 		** that atop explodes in memory and introduces OOM killing
 		*/
-		nprocexit = acctprocnt();	/* number of exited processes */
-
 		if (nprocexit > MAXACCTPROCS)
 		{
 			noverflow = nprocexit - MAXACCTPROCS;
@@ -630,32 +633,6 @@ engine(void)
 			nprocexitnet = netatop_exitstore();
 		else
 			nprocexitnet = 0;
-
-		/*
-		** reserve space for the exited processes and read them
-		*/
-		if (nprocexit > 0)
-		{
-			curpexit = calloc(nprocexit, sizeof(struct tstat));
-
-			ptrverify(curpexit,
-			          "Malloc failed for %lu exited processes\n",
-			          nprocexit);
-
-			nprocexit = acctphotoproc(curpexit, nprocexit);
-
-			/*
- 			** reposition offset in accounting file when not
-			** all exited processes have been read (i.e. skip
-			** those processes)
-			*/
-			if (noverflow)
-				acctrepos(noverflow);
-		}
-		else
-		{
-			curpexit    = NULL;
-		}
 
 		/*
 		** calculate the deviations (i.e. calculate the activity
@@ -702,11 +679,6 @@ engine(void)
                 */
                 (*vis.prep)();
 
-		/*
-		** release dynamically allocated memory
-		*/
-		if (nprocexit > 0)
-			free(curpexit);
 
 		if (nprocexitnet > 0)
 			netatop_exiterase();
@@ -736,6 +708,12 @@ reset:
 
 		sampflags = 0;
 	} /* end of main-loop */
+
+	/*
+	** release dynamically allocated memory
+	*/
+	if (curtexitlen > 0)
+		free(curpexit);
 }
 
 /*

--- a/src/pcp/atop/atop.h
+++ b/src/pcp/atop/atop.h
@@ -247,6 +247,6 @@ void		netatop_exitfind(unsigned long, struct tstat *, struct tstat *);
 int 		acctswon(void);
 void		acctswoff(void);
 unsigned long 	acctprocnt(void);
-int 		acctphotoproc(struct tstat *, int);
+int		acctphotoproc(struct tstat **, unsigned int *, double, double);
 void 		acctrepos(unsigned int);
 void		do_pacctdir(char *, char *);

--- a/src/pcp/atop/modules.c
+++ b/src/pcp/atop/modules.c
@@ -14,6 +14,8 @@
 
 #include <pcp/pmapi.h>
 #include "atop.h"
+#include "photoproc.h"
+#include "acctmetrics.h"
 
 /*
 ** Stub functions, disabling functionality that we're not supporting from
@@ -90,11 +92,87 @@ acctprocnt(void)
 }
 
 int
-acctphotoproc(struct tstat *tstat, int isproc)
+acctphotoproc(struct tstat **accproc, unsigned int *taskslen, double cur_time, double prev_time)
 {
-	(void)tstat;
-	(void)isproc;
-	return 0;
+	static int setup;
+	static pmID	pmids[ACCT_NMETRICS];
+	static pmDesc	descs[ACCT_NMETRICS];
+	pmResult	*result;
+	char		**insts;
+	int		*pids;
+	unsigned long	count, i;
+
+	int nrexit = 0;
+	struct tstat *api;
+	int pid;
+
+	if (!setup)
+	{
+		setup = 1;
+		setup_metrics(acctmetrics, pmids, descs, ACCT_NMETRICS);
+		for (i = 0; i < ACCT_NMETRICS; i++)
+		{
+			if (descs[i].pmid == PM_ID_NULL)
+				return 0;
+		}
+	}
+	else if (!(supportflags & ACCTACTIVE))
+		return 0;
+
+	fetch_metrics("acct", ACCT_NMETRICS, pmids, &result);
+	count = get_instances("acct", ACCT_GEN_ETIME, descs, &pids, &insts);
+	if (count > *taskslen)
+	{
+		size_t	size = count * sizeof(struct tstat);
+
+		*accproc = (struct tstat *)realloc(*accproc, size);
+		ptrverify(*accproc, "Malloc failed for %lu exited processes\n", count);
+		*taskslen = count;
+	}
+
+	supportflags |= ACCTACTIVE;
+
+	for  (i=0; i < count; i++)
+	{
+		/*
+		** fill process info from accounting-record
+		*/
+		pid = pids[i];
+		time_t acct_btime = extract_count_t_inst(result, descs, ACCT_GEN_BTIME, pid);
+		float  acct_etime = extract_float_inst(result, descs, ACCT_GEN_ETIME, pid);
+		double pexit_time = (double)acct_btime + acct_etime;
+		if (pexit_time <= prev_time || cur_time < pexit_time)
+			continue;
+
+		api = &(*accproc)[nrexit++];
+		api->gen.state  = 'E';
+		api->gen.pid    = pid;
+		api->gen.tgid   = pid;
+		api->gen.ppid   = extract_integer_inst(result, descs, ACCT_GEN_PPID, pid);
+		api->gen.nthr   = 1;
+		api->gen.isproc = 1;
+		api->gen.excode = extract_integer_inst(result, descs, ACCT_GEN_EXCODE, pid);
+		api->gen.ruid   = extract_integer_inst(result, descs, ACCT_GEN_UID, pid);
+		api->gen.rgid   = extract_integer_inst(result, descs, ACCT_GEN_GID, pid);
+		api->gen.btime  = (acct_btime - system_boottime) * 1000;
+		api->gen.elaps  = acct_etime;
+		api->cpu.stime  = extract_float_inst(result, descs, ACCT_CPU_STIME, pid) * 1000;
+		api->cpu.utime  = extract_float_inst(result, descs, ACCT_CPU_UTIME, pid) * 1000;
+		api->mem.minflt = extract_count_t_inst(result, descs, ACCT_MEM_MINFLT, pid);
+		api->mem.majflt = extract_count_t_inst(result, descs, ACCT_MEM_MAJFLT, pid);
+		api->dsk.rio    = extract_count_t_inst(result, descs, ACCT_DSK_RIO, pid);
+
+		strcpy(api->gen.name, insts[i]);
+	}
+
+	pmFreeResult(result);
+	if (count > 0)
+	{
+		free(insts);
+		free(pids);
+	}
+
+	return nrexit;
 }
 
 void


### PR DESCRIPTION
Resolves: https://github.com/performancecopilot/pcp/issues/922

Note that process accounting is available if psacct service is running or acct.control.enable_acct is set to non-zero.
