### PR TITLE
netcheck PMDA fixes

### DIFF
--- a/qa/1160.out
+++ b/qa/1160.out
@@ -18,13 +18,14 @@ Info: ping_loss
 Info: Module setup configurations read.
 Info: Initializing modules:
 Info: ping, cluster ID: 1804
-Info: ping: Module parameters: count: 1, timeout: 1.0.
+Info: ping: ['localhost']
+Info: ping: Module parameters: command: ping, cmdargs: , count: 1, timeout: 1.0.
 Info: ping: Initialized.
 Info: ping_latency, cluster ID: 248
-Info: ping_latency: Module parameters: count: 1, timeout: 2.0.
+Info: ping_latency: Module parameters: command: ping, cmdargs: , count: 1, timeout: 2.0.
 Info: ping_latency: Initialized.
 Info: ping_loss, cluster ID: 1339
-Info: ping_loss: Module parameters: count: 1, timeout: 2.0.
+Info: ping_loss: Module parameters: command: ping, cmdargs: , count: 1, timeout: 2.0.
 Info: ping_loss: Initialized.
 Info: Modules initialized.
 Info: Registering metrics:
@@ -49,13 +50,14 @@ Info: ping_loss
 Info: Module setup configurations read.
 Info: Initializing modules:
 Info: ping, cluster ID: 1804
-Info: ping: Module parameters: count: 1, timeout: 1.0.
+Info: ping: ['localhost']
+Info: ping: Module parameters: command: ping, cmdargs: , count: 1, timeout: 1.0.
 Info: ping: Initialized.
 Info: ping_latency, cluster ID: 248
-Info: ping_latency: Module parameters: count: 1, timeout: 2.0.
+Info: ping_latency: Module parameters: command: ping, cmdargs: , count: 1, timeout: 2.0.
 Info: ping_latency: Initialized.
 Info: ping_loss, cluster ID: 1339
-Info: ping_loss: Module parameters: count: 1, timeout: 2.0.
+Info: ping_loss: Module parameters: command: ping, cmdargs: , count: 1, timeout: 2.0.
 Info: ping_loss: Initialized.
 Info: Modules initialized.
 Info: Registering metrics:

--- a/src/pmdas/netcheck/modules/pcpnetcheck.python
+++ b/src/pmdas/netcheck/modules/pcpnetcheck.python
@@ -56,7 +56,6 @@ class PCPNetcheckModuleBase(object):
     """PCP Netcheck Module Base Class"""
     HOST_TMPL_STR = '%HOST'
     HOST_FAIL_STR = "<err>"
-    SIX_OPT = "SIX_OPT"
 
     def __init__(self, module, config, dbg, log, err, params):
         """Constructor"""
@@ -70,6 +69,10 @@ class PCPNetcheckModuleBase(object):
         self.check_hosts_parallel = params.check_hosts_parallel
         self.check_interval = params.check_interval
         self.align_interval = params.align_interval
+
+        self.errcnt = OrderedDict()
+        for host in self.hosts:
+            self.errcnt[host] = 0
 
         self.dgw = params.dgw
         self.dns = params.dns
@@ -214,20 +217,26 @@ class PCPNetcheckModuleBase(object):
                     self.hosts[host] = -1
 
     @staticmethod
-    def _generate_command(cmd_template, host, six_opt):
+    def _generate_command(cmd_template, host):
         """Generate command"""
         cmd = [item.replace(PCPNetcheckModuleBase.HOST_TMPL_STR, host) for item in cmd_template]
-        if six_opt and PCPNetcheckModuleBase.is_ipv6(host):
-            cmd = [item.replace(PCPNetcheckModuleBase.SIX_OPT, six_opt) for item in cmd]
-        else:
-            cmd.remove(PCPNetcheckModuleBase.SIX_OPT)
         return cmd
 
-    def _run_check_commands(self, cmd_template, six_opt, timed=False):
+    def _run_check_commands(self, cmd_template, timed=False):
         """Run check commands"""
         if self.check_hosts_parallel:
-            return self._run_check_commands_parallel(cmd_template, six_opt, timed)
-        return self._run_check_commands_sequential(cmd_template, six_opt, timed)
+            results = self._run_check_commands_parallel(cmd_template, timed)
+        else:
+            results = self._run_check_commands_sequential(cmd_template, timed)
+        # results[0]: output, results[1]: exit status, results[2]: timings
+        for host in self.hosts:
+            if results[1][host] != 0:
+                # command had non-zero exit status
+                self.errcnt[host] += 1
+                if self.errcnt[host] <= 3:
+                    # log first 3 such errors for each host
+                    self.log(host + ' failed, exit=' + str(results[1][host]) + ', output=' + str(list(results[0][host])))
+        return results
 
     @staticmethod
     def _collect_results(proc):
@@ -236,14 +245,14 @@ class PCPNetcheckModuleBase(object):
         return_code = -2 if proc.returncode == -15 else proc.returncode
         return output, return_code
 
-    def _run_check_commands_sequential(self, cmd_template, six_opt, timed):
+    def _run_check_commands_sequential(self, cmd_template, timed):
         """Run check commands sequentially"""
         procs = OrderedDict()
         outputs = OrderedDict()
         return_codes = OrderedDict()
         timings = OrderedDict() if timed else {}
         for host in self.hosts:
-            cmd = self._generate_command(cmd_template, host, six_opt)
+            cmd = self._generate_command(cmd_template, host)
             if timed:
                 timings[host] = time()
             procs[host] = Popen(cmd, stdout=PIPE, stderr=PIPE)
@@ -252,14 +261,14 @@ class PCPNetcheckModuleBase(object):
             del procs[host]
         return outputs, return_codes, timings
 
-    def _run_check_commands_parallel(self, cmd_template, six_opt, timed):
+    def _run_check_commands_parallel(self, cmd_template, timed):
         """Run check commands in parallel"""
         procs = OrderedDict()
         outputs = OrderedDict()
         return_codes = OrderedDict()
         timings = OrderedDict() if timed else {}
         for host in self.hosts:
-            cmd = self._generate_command(cmd_template, host, six_opt)
+            cmd = self._generate_command(cmd_template, host)
             if timed:
                 timings[host] = time()
             procs[host] = Popen(cmd, stdout=PIPE, stderr=PIPE)

--- a/src/pmdas/netcheck/modules/pcpnetcheck.python
+++ b/src/pmdas/netcheck/modules/pcpnetcheck.python
@@ -235,7 +235,8 @@ class PCPNetcheckModuleBase(object):
                 self.errcnt[host] += 1
                 if self.errcnt[host] <= 3:
                     # log first 3 such errors for each host
-                    self.log(host + ' failed, exit=' + str(results[1][host]) + ', output=' + str(list(results[0][host])))
+                    self.log(host + ' failed, exit=' + str(results[1][host]) +
+                             ', output=' + str(list(results[0][host])))
         return results
 
     @staticmethod

--- a/src/pmdas/netcheck/modules/ping.python
+++ b/src/pmdas/netcheck/modules/ping.python
@@ -37,33 +37,43 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
         """Constructor"""
         PCPNetcheckModuleBase.__init__(self, MODULE, config, dbg, log, err, params)
 
+        self.command = 'ping'
+        self.cmdargs = ''
         self.count = 1
 
-        self.prereq_check()
+        self.onetrip = 1
+
+        self.log(str(list(self.hosts)))
+
+        self.prereq_check(self)
 
         for opt in self.config.options(MODULE):
-            if opt == 'count':
+            if opt == 'command':
+                self.command = self.config.get(MODULE, opt)
+            elif opt == 'cmdargs':
+                self.cmdargs = self.config.get(MODULE, opt)
+            elif opt == 'count':
                 self.count = int(self.config.get(MODULE, opt))
                 self.assert_positive(opt, self.count)
             elif opt not in self.common_opts:
                 self.err("Invalid directive '%s' in %s, aborting." % (opt, MODULE))
                 sys.exit(1)
 
-        self.log("Module parameters: count: %s, timeout: %s." % (self.count, self.timeout))
+        self.log("Module parameters: command: %s, cmdargs: %s, count: %s, timeout: %s." % (self.command, self.cmdargs, self.count, self.timeout))
 
         self.log("Initialized.")
 
     @staticmethod
-    def prereq_check():
+    def prereq_check(self):
         """Check module prerequisities"""
         try:
-            cmd = ['ping', '-c', '1', '-W', '1', 'localhost']
+            cmd = [self.command, '-c', '1', '-W', '1', 'localhost']
             proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
             proc.communicate()
             if proc.returncode:
                 raise RuntimeError("Can't ping the loopback interface!")
         except OSError:  # pylint: disable=broad-except
-            raise RuntimeError("Can't run the ping(1) command!")
+            raise RuntimeError("Can't run the " + self.command + "(1) command!")
 
     def metrics(self):
         """Get metric definitions"""
@@ -76,6 +86,13 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
 
     def do_check(self):
         """Do net check"""
-        cmd_template = ['ping', '-c', str(self.count), '-W', str(self.timeout),
-                        self.SIX_OPT, self.HOST_TMPL_STR]
-        self.hosts = self._run_check_commands(cmd_template, '-6')[1]
+        cmd_template = [self.command, '-c', str(self.count), '-W', str(self.timeout)]
+        if self.cmdargs != '': cmd_template.append(self.cmdargs)
+        cmd_template.append(self.HOST_TMPL_STR)
+        if self.onetrip == 1:
+            # log real shell command
+            msg = 'shell command:'
+            for arg in cmd_template: msg = msg + ' ' + arg
+            self.log(msg)
+            self.onetrip = 0
+        self.hosts = self._run_check_commands(cmd_template)[1]

--- a/src/pmdas/netcheck/modules/ping.python
+++ b/src/pmdas/netcheck/modules/ping.python
@@ -45,7 +45,7 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
 
         self.log(str(list(self.hosts)))
 
-        self.prereq_check(self)
+        self.prereq_check(self.command)
 
         for opt in self.config.options(MODULE):
             if opt == 'command':
@@ -59,21 +59,22 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
                 self.err("Invalid directive '%s' in %s, aborting." % (opt, MODULE))
                 sys.exit(1)
 
-        self.log("Module parameters: command: %s, cmdargs: %s, count: %s, timeout: %s." % (self.command, self.cmdargs, self.count, self.timeout))
+        self.log("Module parameters: command: %s, cmdargs: %s, count: %s, timeout: %s." %
+                 (self.command, self.cmdargs, self.count, self.timeout))
 
         self.log("Initialized.")
 
     @staticmethod
-    def prereq_check(self):
+    def prereq_check(command):
         """Check module prerequisities"""
         try:
-            cmd = [self.command, '-c', '1', '-W', '1', 'localhost']
+            cmd = [command, '-c', '1', '-W', '1', 'localhost']
             proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
             proc.communicate()
             if proc.returncode:
                 raise RuntimeError("Can't ping the loopback interface!")
         except OSError:  # pylint: disable=broad-except
-            raise RuntimeError("Can't run the " + self.command + "(1) command!")
+            raise RuntimeError("Can't run the " + command + "(1) command!")
 
     def metrics(self):
         """Get metric definitions"""
@@ -87,12 +88,14 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
     def do_check(self):
         """Do net check"""
         cmd_template = [self.command, '-c', str(self.count), '-W', str(self.timeout)]
-        if self.cmdargs != '': cmd_template.append(self.cmdargs)
+        if self.cmdargs != '':
+            cmd_template.append(self.cmdargs)
         cmd_template.append(self.HOST_TMPL_STR)
         if self.onetrip == 1:
             # log real shell command
             msg = 'shell command:'
-            for arg in cmd_template: msg = msg + ' ' + arg
+            for arg in cmd_template:
+                msg = msg + ' ' + arg
             self.log(msg)
             self.onetrip = 0
         self.hosts = self._run_check_commands(cmd_template)[1]

--- a/src/pmdas/netcheck/modules/ping_latency.python
+++ b/src/pmdas/netcheck/modules/ping_latency.python
@@ -37,34 +37,42 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
         """Constructor"""
         PCPNetcheckModuleBase.__init__(self, MODULE, config, dbg, log, err, params)
 
+        self.command = 'ping'
+        self.cmdargs = ''
         self.count = 2
         self.timeout = 2.0
 
-        self.prereq_check()
+        self.onetrip = 1
+
+        self.prereq_check(self)
 
         for opt in self.config.options(MODULE):
-            if opt == 'count':
+            if opt == 'command':
+                self.command = self.config.get(MODULE, opt)
+            elif opt == 'cmdargs':
+                self.cmdargs = self.config.get(MODULE, opt)
+            elif opt == 'count':
                 self.count = int(self.config.get(MODULE, opt))
                 self.assert_positive(opt, self.count)
             elif opt not in self.common_opts:
                 self.err("Invalid directive '%s' in %s, aborting." % (opt, MODULE))
                 sys.exit(1)
 
-        self.log("Module parameters: count: %s, timeout: %s." % (self.count, self.timeout))
+        self.log("Module parameters: command: %s, cmdargs: %s, count: %s, timeout: %s." % (self.command, self.cmdargs, self.count, self.timeout))
 
         self.log("Initialized.")
 
     @staticmethod
-    def prereq_check():
+    def prereq_check(self):
         """Check module prerequisities"""
         try:
-            cmd = ['ping', '-c', '1', '-W', '1', 'localhost']
+            cmd = [self.command, '-c', '1', '-W', '1', 'localhost']
             proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
             proc.communicate()
             if proc.returncode:
                 raise RuntimeError("Can't ping the loopback interface!")
         except OSError:
-            raise RuntimeError("Can't run the ping(1) command!")
+            raise RuntimeError("Can't run the " + self.command + "(1) command!")
 
     def metrics(self):
         """Get metric definitions"""
@@ -77,9 +85,16 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
 
     def do_check(self):
         """Do net check"""
-        cmd_template = ['ping', '-c', str(self.count), '-W', str(self.timeout),
-                        self.SIX_OPT, self.HOST_TMPL_STR]
-        outputs = self._run_check_commands(cmd_template, '-6')[0]
+        cmd_template = [self.command, '-c', str(self.count), '-W', str(self.timeout)]
+        if self.cmdargs != '': cmd_template.append(self.cmdargs)
+        cmd_template.append(self.HOST_TMPL_STR)
+        if self.onetrip == 1:
+            # log real shell command
+            msg = 'shell command:'
+            for arg in cmd_template: msg = msg + ' ' + arg
+            self.log(msg)
+            self.onetrip = 0
+        outputs = self._run_check_commands(cmd_template)[0]
         for host in self.hosts:
             try:
                 self.hosts[host] = \

--- a/src/pmdas/netcheck/modules/ping_latency.python
+++ b/src/pmdas/netcheck/modules/ping_latency.python
@@ -44,7 +44,7 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
 
         self.onetrip = 1
 
-        self.prereq_check(self)
+        self.prereq_check(self.command)
 
         for opt in self.config.options(MODULE):
             if opt == 'command':
@@ -58,21 +58,22 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
                 self.err("Invalid directive '%s' in %s, aborting." % (opt, MODULE))
                 sys.exit(1)
 
-        self.log("Module parameters: command: %s, cmdargs: %s, count: %s, timeout: %s." % (self.command, self.cmdargs, self.count, self.timeout))
+        self.log("Module parameters: command: %s, cmdargs: %s, count: %s, timeout: %s." %
+                 (self.command, self.cmdargs, self.count, self.timeout))
 
         self.log("Initialized.")
 
     @staticmethod
-    def prereq_check(self):
+    def prereq_check(command):
         """Check module prerequisities"""
         try:
-            cmd = [self.command, '-c', '1', '-W', '1', 'localhost']
+            cmd = [command, '-c', '1', '-W', '1', 'localhost']
             proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
             proc.communicate()
             if proc.returncode:
                 raise RuntimeError("Can't ping the loopback interface!")
         except OSError:
-            raise RuntimeError("Can't run the " + self.command + "(1) command!")
+            raise RuntimeError("Can't run the " + command + "(1) command!")
 
     def metrics(self):
         """Get metric definitions"""
@@ -86,12 +87,14 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
     def do_check(self):
         """Do net check"""
         cmd_template = [self.command, '-c', str(self.count), '-W', str(self.timeout)]
-        if self.cmdargs != '': cmd_template.append(self.cmdargs)
+        if self.cmdargs != '':
+            cmd_template.append(self.cmdargs)
         cmd_template.append(self.HOST_TMPL_STR)
         if self.onetrip == 1:
             # log real shell command
             msg = 'shell command:'
-            for arg in cmd_template: msg = msg + ' ' + arg
+            for arg in cmd_template:
+                msg = msg + ' ' + arg
             self.log(msg)
             self.onetrip = 0
         outputs = self._run_check_commands(cmd_template)[0]

--- a/src/pmdas/netcheck/modules/ping_loss.python
+++ b/src/pmdas/netcheck/modules/ping_loss.python
@@ -38,34 +38,42 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
         """Constructor"""
         PCPNetcheckModuleBase.__init__(self, MODULE, config, dbg, log, err, params)
 
+        self.command = 'ping'
+        self.cmdargs = ''
         self.count = 5
         self.timeout = 2.0
 
-        self.prereq_check()
+        self.onetrip = 1
+
+        self.prereq_check(self)
 
         for opt in self.config.options(MODULE):
-            if opt == 'count':
+            if opt == 'command':
+                self.command = self.config.get(MODULE, opt)
+            elif opt == 'cmdargs':
+                self.cmdargs = self.config.get(MODULE, opt)
+            elif opt == 'count':
                 self.count = int(self.config.get(MODULE, opt))
                 self.assert_positive(opt, self.count)
             elif opt not in self.common_opts:
                 self.err("Invalid directive '%s' in %s, aborting." % (opt, MODULE))
                 sys.exit(1)
 
-        self.log("Module parameters: count: %s, timeout: %s." % (self.count, self.timeout))
+        self.log("Module parameters: command: %s, cmdargs: %s, count: %s, timeout: %s." % (self.command, self.cmdargs, self.count, self.timeout))
 
         self.log("Initialized.")
 
     @staticmethod
-    def prereq_check():
+    def prereq_check(self):
         """Check module prerequisities"""
         try:
-            cmd = ['ping', '-c', '1', '-W', '1', 'localhost']
+            cmd = [self.command, '-c', '1', '-W', '1', 'localhost']
             proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
             proc.communicate()
             if proc.returncode:
                 raise RuntimeError("Can't ping the loopback interface!")
         except OSError:  # pylint: disable=broad-except
-            raise RuntimeError("Can't run the ping(1) command!")
+            raise RuntimeError("Can't run the " + self.command + "(1) command!")
 
     def metrics(self):
         """Get metric definitions"""
@@ -78,9 +86,16 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
 
     def do_check(self):
         """Do net check"""
-        cmd_template = ['ping', '-c', str(self.count), '-W', str(self.timeout),
-                        self.SIX_OPT, self.HOST_TMPL_STR]
-        outputs = self._run_check_commands(cmd_template, '-6')[0]
+        cmd_template = [self.command, '-c', str(self.count), '-W', str(self.timeout)]
+        if self.cmdargs != '': cmd_template.append(self.cmdargs)
+        cmd_template.append(self.HOST_TMPL_STR)
+        if self.onetrip == 1:
+            # log real shell command
+            msg = 'shell command:'
+            for arg in cmd_template: msg = msg + ' ' + arg
+            self.log(msg)
+            self.onetrip = 0
+        outputs = self._run_check_commands(cmd_template)[0]
         for host in self.hosts:
             try:
                 self.hosts[host] = \

--- a/src/pmdas/netcheck/modules/ping_loss.python
+++ b/src/pmdas/netcheck/modules/ping_loss.python
@@ -45,7 +45,7 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
 
         self.onetrip = 1
 
-        self.prereq_check(self)
+        self.prereq_check(self.command)
 
         for opt in self.config.options(MODULE):
             if opt == 'command':
@@ -59,21 +59,22 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
                 self.err("Invalid directive '%s' in %s, aborting." % (opt, MODULE))
                 sys.exit(1)
 
-        self.log("Module parameters: command: %s, cmdargs: %s, count: %s, timeout: %s." % (self.command, self.cmdargs, self.count, self.timeout))
+        self.log("Module parameters: command: %s, cmdargs: %s, count: %s, timeout: %s." %
+                 (self.command, self.cmdargs, self.count, self.timeout))
 
         self.log("Initialized.")
 
     @staticmethod
-    def prereq_check(self):
+    def prereq_check(command):
         """Check module prerequisities"""
         try:
-            cmd = [self.command, '-c', '1', '-W', '1', 'localhost']
+            cmd = [command, '-c', '1', '-W', '1', 'localhost']
             proc = Popen(cmd, stdout=PIPE, stderr=PIPE)
             proc.communicate()
             if proc.returncode:
                 raise RuntimeError("Can't ping the loopback interface!")
         except OSError:  # pylint: disable=broad-except
-            raise RuntimeError("Can't run the " + self.command + "(1) command!")
+            raise RuntimeError("Can't run the " + command + "(1) command!")
 
     def metrics(self):
         """Get metric definitions"""
@@ -87,12 +88,14 @@ class PCPNetcheckModule(PCPNetcheckModuleBase):
     def do_check(self):
         """Do net check"""
         cmd_template = [self.command, '-c', str(self.count), '-W', str(self.timeout)]
-        if self.cmdargs != '': cmd_template.append(self.cmdargs)
+        if self.cmdargs != '':
+            cmd_template.append(self.cmdargs)
         cmd_template.append(self.HOST_TMPL_STR)
         if self.onetrip == 1:
             # log real shell command
             msg = 'shell command:'
-            for arg in cmd_template: msg = msg + ' ' + arg
+            for arg in cmd_template:
+                msg = msg + ' ' + arg
             self.log(msg)
             self.onetrip = 0
         outputs = self._run_check_commands(cmd_template)[0]

--- a/src/pmdas/netcheck/netcheck.conf
+++ b/src/pmdas/netcheck/netcheck.conf
@@ -68,14 +68,18 @@ family = both
 [dns_reverse]
 timeout = 1
 
-# This module pings the hosts (using ping(1))
+# This module pings the hosts (using ping(1) or similar)
 #
 # Configuration options:
 # Name    - type - default - description
 #
+# command - str  - ping    : the ping command ... usually ping or ping6
+# cmdargs - str  -         : optional arguments for the ping command
 # timeout - int  - 1       : seconds
 # count   - int  - 1       : ping count
 [ping]
+command = ping
+cmdargs =
 timeout = 1
 count = 1
 
@@ -84,9 +88,13 @@ count = 1
 # Configuration options:
 # Name    - type - default - description
 #
-# timeout - int   - 2      : seconds
-# count   - int   - 2      : ping count
+# command - str  - ping    : the ping command ... usually ping or ping6
+# cmdargs - str  -         : optional arguments for the ping command
+# timeout - int  - 2       : seconds
+# count   - int  - 2       : ping count
 [ping_latency]
+command = ping
+cmdargs =
 timeout = 2
 count = 2
 
@@ -95,9 +103,13 @@ count = 2
 # Configuration options:
 # Name    - type - default - description
 #
-# timeout - int   - 2      : seconds
-# count   - int   - 5      : ping count
+# command - str  - ping    : the ping command ... usually ping or ping6
+# cmdargs - str  -         : optional arguments for the ping command
+# timeout - int  - 2       : seconds
+# count   - int  - 5       : ping count
 [ping_loss]
+command = ping
+cmdargs =
 timeout = 2
 count = 5
 


### PR DESCRIPTION
Changes committed to git@github.com:kmcdonell/pcp.git 20201020

Ken McDonell (1):
      src/pmdas/netcheck: rework to accommodate some QA failures

 qa/1160.out                                    |   14 +++++-----
 src/pmdas/netcheck/modules/pcpnetcheck.python  |   35 +++++++++++++++----------
 src/pmdas/netcheck/modules/ping.python         |   35 ++++++++++++++++++-------
 src/pmdas/netcheck/modules/ping_latency.python |   33 +++++++++++++++++------
 src/pmdas/netcheck/modules/ping_loss.python    |   33 +++++++++++++++++------
 src/pmdas/netcheck/netcheck.conf               |   22 ++++++++++++---
 6 files changed, 121 insertions(+), 51 deletions(-)

Details ...

commit 4986a0c3ea45240b3202de4674a61451c879c347
Author: Ken McDonell <kenj@kenj.id.au>
Date:   Tue Oct 20 07:11:49 2020 +1100

    src/pmdas/netcheck: rework to accommodate some QA failures
    
    Finally had time to understand why test is failing sometimes.
    
    The following situations were all problematic for the "ping"
    modules (ping, ping_latency and ping_loss):
    - ping(1) command has no -6 option, even when IPv6 is enabled
    - ping6(1) is required to do IPv6 ping
    - IPv6 is enabled on the local host but the local gateway does not
      support IPv6
    
    This comment includes the following changes:
    - default to using IPv4 for "ping" modules
    - add "command" (default "ping") and "cmdargs" (default empty) configuration
      options in the .conf file for the "ping" modules ... the previous defaults
      could be activated with:
            command = ping6
      or:
            cmdargs = -6
      depending on the platform.
    - remove all references to SIX_OPT and six_opt in the code base
    - remove all use of the literal 'ping' when constructing the "ping" command
      ... use the "command" configuration option
    - add "cmdargs" to the "ping" command after all other arguments and before
      the hostname
    - after the "ping" command has been constructed, log the full shell command
      so we can see what is really being run
    - log the list of hosts to be pinged for the ping module
    - add per host error counters, incremented when the "ping" command returns
      non-zero status ... and if this happens and the error count is <= 3 log
      the event and the output from the "ping" command to aid triage
    
    Some of these changes are in the common pcpnetcheck code, but some of
    them are replicated across each of the ping, ping_latency and ping_loss
    modules.