### PR TITLE
pmns/Make: drop duplicate if/else

### DIFF
--- a/src/pmns/Make.stdpmid
+++ b/src/pmns/Make.stdpmid
@@ -16,15 +16,7 @@
 # source the PCP configuration environment variables
 . $PCP_DIR/etc/pcp.env
 
-if [ -d "$PCP_TMPFILE_DIR" ]
-then
-    tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmns_stdpmid.XXXXXXXXX"` || exit 1
-else
-    # if configure --prefix is used in a the build, then $PCP_TMPFILE_DIR
-    # may not yet exist ... /tmp is a safe bet
-    #
-    tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmns_stdpmid.XXXXXXXXX"` || exit 1
-fi
+tmp=`mktemp -d "$PCP_TMPFILE_DIR/pmns_stdpmid.XXXXXXXXX"` || exit 1
 status=1
 trap "rm -rf $tmp; exit \$status" 0 1 2 3 15
 


### PR DESCRIPTION
As of 029add427a42344ea7129452c9e0fb286d3cf881, both the if and else
branches here match. Restoration of the previous build-time logic is
tracked via https://github.com/performancecopilot/pcp/issues/1140 and
will affect more scripts than just this one.

Signed-off-by: David Disseldorp <ddiss@suse.de>