### PR TITLE
[docs] Text in table cells wrapped

### DIFF
--- a/docs/UAG/InstallingAndConfiguringPcp.rst
+++ b/docs/UAG/InstallingAndConfiguringPcp.rst
@@ -250,7 +250,7 @@ Pipe entries in the **pmcd.conf** file follow this syntax::
 The following rules apply to the pipe syntax:
 
 +------------------+-----------------------------------------------------------------------+
-| pipe             |    The entry type.                                                    |
+| **pipe**         | The entry type.                                                       |
 +------------------+-----------------------------------------------------------------------+
 | protocol         | Specifies whether a text-based or a binary PCP protocol should be used|
 |                  | over the pipes. Historically, this parameter was able to be “text” or |

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,11 @@
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,6 +109,12 @@ if not os.environ.get('READTHEDOCS') == 'True':
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in RTD theme
+        ],
+     }
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #


### PR DESCRIPTION
Currently, the text in table cells are not wrapped, due to which the tables are very wide with horizontal scroll bars. This PR resolves this issue by wrapping the text and spreading it over multiple lines.

![Screenshot from 2020-11-19 12-27-10](https://user-images.githubusercontent.com/17689823/99632496-502a2400-2a63-11eb-9597-c95b2814f6bf.png)
