### PR TITLE
pmdabcc: netproc module + atop per-process network statistics

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,16 +3,18 @@ root = true
 
 [*]
 charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.c]
 # unfortunately editorconfig doesn't support the project style of mixed tabs
 # and spaces yet
 indent_style = tabs
 indent_size = 8
-end_of_line = lf
-insert_final_newline = true
 
-[*.py]
-indent_size = 4
+[*.{py,python,bpf}]
 indent_style = spaces
+indent_size = 4
 trim_trailing_whitespace = true
 
 [*.{yml,json,sh}]

--- a/qa/1286
+++ b/qa/1286
@@ -13,12 +13,14 @@ echo "QA output created by $seq"
 _pmdabcc_check
 _pmdabcc_require_kernel_version 4 6
 which curl >/dev/null 2>&1 || _notrun "No curl binary installed"
+which dig >/dev/null 2>&1 || _notrun "No dig binary installed"
 
 status=1       # failure is the default!
 signal=$PCP_BINADM_DIR/pmsignal
 $sudo rm -rf $tmp.* $seq.full
 
-target_ip=1.1.1.1
+target_http=http://1.1.1.1
+target_dns=1.1.1.1
 
 _value_filter()
 {
@@ -42,10 +44,16 @@ EOF
 _pmdabcc_wait_for_metric
 
 # Generate system activity for the BCC netproc module
-curl -s http://${target_ip} > /dev/null &
-curlpid=$!
-echo "curl pid: ${curlpid}" >> "$seq.full"
-wait ${curlpid}
+# TCP
+curl -s ${target_http} > /dev/null &
+pid_curl=$!
+echo "curl pid: ${pid_curl}" >> "$seq.full"
+wait ${pid_curl}
+
+# UDP
+# dig performs the DNS request from the first forked process
+pid_dig=$(strace -f -e 'trace=!all' dig @$target_dns -x $target_dns 2>&1 | awk '/Process .* attached/ { print $3; exit }')
+echo "dig pid: ${pid_dig}" >> "$seq.full"
 
 for metric in bcc.proc.io.net.perpid.tcp.in.packets \
               bcc.proc.io.net.perpid.tcp.in.bytes \
@@ -55,7 +63,18 @@ do
     echo "=== report metric values for $metric ==="
     pminfo -f $metric 2>&1 | tee -a $here/$seq.full \
     | tee -a $seq.full \
-    | _value_filter ${curlpid}
+    | _value_filter ${pid_curl}
+done
+
+for metric in bcc.proc.io.net.perpid.udp.in.packets \
+              bcc.proc.io.net.perpid.udp.in.bytes \
+              bcc.proc.io.net.perpid.udp.out.packets \
+              bcc.proc.io.net.perpid.udp.out.bytes
+do
+    echo "=== report metric values for $metric ==="
+    pminfo -f $metric 2>&1 | tee -a $here/$seq.full \
+    | tee -a $seq.full \
+    | _value_filter ${pid_dig}
 done
 
 _pmdabcc_remove

--- a/qa/1286
+++ b/qa/1286
@@ -1,0 +1,64 @@
+#!/bin/sh
+# PCP QA Test No. 1286
+# Exercise the BCC PMDA netproc hits module - install, remove and values.
+#
+# Copyright (c) 2020 Red Hat.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+. ./common.bcc
+
+_pmdabcc_check
+_pmdabcc_require_kernel_version 4 6
+which curl >/dev/null 2>&1 || _notrun "No curl binary installed"
+
+status=1       # failure is the default!
+signal=$PCP_BINADM_DIR/pmsignal
+$sudo rm -rf $tmp.* $seq.full
+
+target_ip=1.1.1.1
+
+_value_filter()
+{
+    awk '/"'"$1"'"/ && /value [1-9][0-9]*/ {print "OK"; exit}'
+}
+
+_prepare_pmda bcc
+trap "_pmdabcc_cleanup; exit \$status" 0 1 2 3 15
+_stop_auto_restart pmcd
+
+# real QA test starts here
+cat <<EOF | _pmdabcc_install
+[pmda]
+modules = netproc
+prefix = bcc.
+[netproc]
+module = netproc
+cluster = 40
+remove_stopped_processes = False
+EOF
+_pmdabcc_wait_for_metric
+
+# Generate system activity for the BCC netproc module
+curl -s http://${target_ip} > /dev/null &
+curlpid=$!
+echo "curl pid: ${curlpid}" >> "$seq.full"
+wait ${curlpid}
+
+for metric in bcc.proc.io.net.perpid.tcp.in.packets \
+              bcc.proc.io.net.perpid.tcp.in.bytes \
+              bcc.proc.io.net.perpid.tcp.out.packets \
+              bcc.proc.io.net.perpid.tcp.out.bytes
+do
+    echo "=== report metric values for $metric ==="
+    pminfo -f $metric 2>&1 | tee -a $here/$seq.full \
+    | tee -a $seq.full \
+    | _value_filter ${curlpid}
+done
+
+_pmdabcc_remove
+
+status=0
+exit

--- a/qa/1286
+++ b/qa/1286
@@ -40,6 +40,7 @@ prefix = bcc.
 [netproc]
 module = netproc
 cluster = 40
+pmda_indom_cache = False
 remove_stopped_processes = False
 EOF
 _pmdabcc_wait_for_metric
@@ -53,7 +54,7 @@ wait ${pid_curl}
 
 # UDP
 # dig performs the DNS request from the first forked process
-pid_dig=$(strace -f -e 'trace=!all' dig @$target_dns -x $target_dns 2>&1 | awk '/Process .* attached/ { print $3; exit }')
+pid_dig=`strace -f -e 'trace=!all' dig @$target_dns -x $target_dns 2>&1 | awk '/Process .* attached/ { print $3; exit }'`
 echo "dig pid: ${pid_dig}" >> "$seq.full"
 
 for metric in bcc.proc.io.net.perpid.tcp.in.packets \

--- a/qa/1286
+++ b/qa/1286
@@ -14,6 +14,7 @@ _pmdabcc_check
 _pmdabcc_require_kernel_version 4 6
 which curl >/dev/null 2>&1 || _notrun "No curl binary installed"
 which dig >/dev/null 2>&1 || _notrun "No dig binary installed"
+which strace >/dev/null 2>&1 || _notrun "No strace binary installed"
 
 status=1       # failure is the default!
 signal=$PCP_BINADM_DIR/pmsignal

--- a/qa/1286.out
+++ b/qa/1286.out
@@ -47,6 +47,14 @@ OK
 OK
 === report metric values for bcc.proc.io.net.perpid.tcp.out.bytes ===
 OK
+=== report metric values for bcc.proc.io.net.perpid.udp.in.packets ===
+OK
+=== report metric values for bcc.proc.io.net.perpid.udp.in.bytes ===
+OK
+=== report metric values for bcc.proc.io.net.perpid.udp.out.packets ===
+OK
+=== report metric values for bcc.proc.io.net.perpid.udp.out.bytes ===
+OK
 
 === remove bcc agent ===
 Culling the Performance Metrics Name Space ...

--- a/qa/1286.out
+++ b/qa/1286.out
@@ -1,0 +1,56 @@
+QA output created by 1286
+
+=== bcc agent installation ===
+Info: Initializing, currently in 'notready' state.
+Info: Enabled modules:
+Info: ['netproc']
+Info: Configuring modules:
+Info: netproc
+Info: Modules configured.
+Info: Initializing modules:
+Info: netproc
+Info: netproc: Initialized.
+Info: Modules initialized.
+Info: Registering metrics:
+Info: netproc
+Info: Metrics registered.
+Info: Registering helpers:
+Info: netproc
+Info: Helpers registered.
+Info: Initializing, currently in 'notready' state.
+Info: Enabled modules:
+Info: ['netproc']
+Info: Configuring modules:
+Info: netproc
+Info: Modules configured.
+Info: Initializing modules:
+Info: netproc
+Info: netproc: Initialized.
+Info: Modules initialized.
+Info: Registering metrics:
+Info: netproc
+Info: Metrics registered.
+Info: Registering helpers:
+Info: netproc
+Info: Helpers registered.
+Updating the Performance Metrics Name Space (PMNS) ...
+Terminate PMDA if already installed ...
+[...install files, make output...]
+Updating the PMCD control file, and notifying PMCD ...
+Check bcc metrics have appeared ... X metrics and X values
+
+=== report metric values for bcc.proc.io.net.perpid.tcp.in.packets ===
+OK
+=== report metric values for bcc.proc.io.net.perpid.tcp.in.bytes ===
+OK
+=== report metric values for bcc.proc.io.net.perpid.tcp.out.packets ===
+OK
+=== report metric values for bcc.proc.io.net.perpid.tcp.out.bytes ===
+OK
+
+=== remove bcc agent ===
+Culling the Performance Metrics Name Space ...
+bcc ... done
+Updating the PMCD control file, and notifying PMCD ...
+[...removing files...]
+Check bcc metrics have gone away ... OK

--- a/qa/group
+++ b/qa/group
@@ -1723,6 +1723,7 @@ x11
 1283 dbpmda local
 1284 pmrep pmda.linux local
 1285 pmlogsummary local
+1286 pmda.bcc local python
 1287 pmda.install pmda.openmetrics local python
 1289 pmval archive multi-archive decompress-xz local pmlogextract
 1294 libpcp_mmv labels local valgrind

--- a/src/pcp/atop/.gitignore
+++ b/src/pcp/atop/.gitignore
@@ -4,6 +4,7 @@ pcp-atopsar
 pmgenmap.sh
 hostmetrics.h
 procmetrics.h
+netprocmetrics.h
 acctmetrics.h
 systmetrics.h
 ifpropmetrics.h

--- a/src/pcp/atop/GNUmakefile
+++ b/src/pcp/atop/GNUmakefile
@@ -32,6 +32,7 @@ CFILES = \
 	ifprop.c \
 	parseable.c \
 	photoproc.c \
+	netproc.c \
 	photosyst.c \
 	procdbase.c \
 	showgeneric.c \
@@ -90,6 +91,9 @@ procmetrics.h:	pmgenmap.sh procmetrics.map
 acctmetrics.h:	pmgenmap.sh acctmetrics.map
 	$(PMGENMAP) acctmetrics.map > acctmetrics.h
 
+netprocmetrics.h:	pmgenmap.sh netprocmetrics.map
+	$(PMGENMAP) netprocmetrics.map > netprocmetrics.h
+
 systmetrics.h:	pmgenmap.sh systmetrics.map
 	$(PMGENMAP) systmetrics.map > systmetrics.h
 
@@ -100,6 +104,7 @@ hostmetrics.h:	pmgenmap.sh hostmetrics.map
 	$(PMGENMAP) hostmetrics.map > hostmetrics.h
 
 photoproc.o:	procmetrics.h
+netproc.o:	netprocmetrics.h
 photosyst.o:	systmetrics.h
 ifprop.o:	ifpropmetrics.h
 various.o:	hostmetrics.h

--- a/src/pcp/atop/atop.h
+++ b/src/pcp/atop/atop.h
@@ -239,6 +239,7 @@ unsigned int	netatop_exitstore(void);
 void		netatop_exiterase(void);
 void		netatop_exithash(char);
 void		netatop_exitfind(unsigned long, struct tstat *, struct tstat *);
+void		netproc_update_tasks(struct tstat **tasks, unsigned long taskslen);
 
 /*
 ** Optional process accounting module interfaces

--- a/src/pcp/atop/modules.c
+++ b/src/pcp/atop/modules.c
@@ -29,11 +29,6 @@ netatop_ipopen(void)
 }
 
 void
-netatop_probe(void)
-{
-}
-
-void
 netatop_signoff(void)
 {
 }

--- a/src/pcp/atop/netproc.c
+++ b/src/pcp/atop/netproc.c
@@ -1,0 +1,79 @@
+/*
+** Copyright (C) 2020 Red Hat.
+**
+** This program is free software; you can redistribute it and/or modify it
+** under the terms of the GNU General Public License as published by the
+** Free Software Foundation; either version 2, or (at your option) any
+** later version.
+**
+** This program is distributed in the hope that it will be useful, but
+** WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+** See the GNU General Public License for more details.
+*/
+
+#include <pcp/pmapi.h>
+#include "atop.h"
+#include "photoproc.h"
+#include "netprocmetrics.h"
+
+void
+netatop_probe(void)
+{
+	pmID	pmids[TASK_NET_NMETRICS];
+
+	int sts = pmLookupName(TASK_NET_NMETRICS, netprocmetrics, pmids);
+	if (sts == TASK_NET_NMETRICS)
+		supportflags |= NETATOP;
+	else
+		supportflags &= ~NETATOP;
+}
+
+static void
+netproc_update_task(struct tstat *task, int pid, pmResult *rp, pmDesc *dp)
+{
+	task->net.tcpsnd = extract_count_t_inst(rp, dp, TASK_NET_TCPSND, pid);
+	task->net.tcprcv = extract_count_t_inst(rp, dp, TASK_NET_TCPRCV, pid);
+	task->net.tcpssz = extract_count_t_inst(rp, dp, TASK_NET_TCPSSZ, pid);
+	task->net.tcprsz = extract_count_t_inst(rp, dp, TASK_NET_TCPRSZ, pid);
+
+	task->net.udpsnd = extract_count_t_inst(rp, dp, TASK_NET_UDPSND, pid);
+	task->net.udprcv = extract_count_t_inst(rp, dp, TASK_NET_UDPRCV, pid);
+	task->net.udpssz = extract_count_t_inst(rp, dp, TASK_NET_UDPSSZ, pid);
+	task->net.udprsz = extract_count_t_inst(rp, dp, TASK_NET_UDPRSZ, pid);
+}
+
+void
+netproc_update_tasks(struct tstat **tasks, unsigned long taskslen)
+{
+	static int 	setup;
+	static pmID	pmids[TASK_NET_NMETRICS];
+	static pmDesc	descs[TASK_NET_NMETRICS];
+	pmResult	*result;
+	char		**insts;
+	int		*pids;
+	int		netproc_insts_len, i, j;
+
+	if(!setup) {
+		setup_metrics(netprocmetrics, pmids, descs, TASK_NET_NMETRICS);
+		setup = 1;
+	}
+
+	fetch_metrics("task_netproc", TASK_NET_NMETRICS, pmids, &result);
+	netproc_insts_len = get_instances("task_netproc", TASK_NET_TCPSND, descs, &pids, &insts);
+
+	for (i=0; i < netproc_insts_len; i++)
+	{
+		if (pmDebugOptions.appl0)
+			fprintf(stderr, "%s: updating net info of process %d: %s\n",
+				pmGetProgname(), pids[i], insts[i]);
+
+		// for each instance of the netproc metrics, we need to find the index inside the tasks array
+		// TODO: better algorithm to avoid O(m*n) complexity?
+		for(j=0; j < taskslen; j++) {
+			if ((*tasks)[j].gen.pid == pids[i]) {
+				netproc_update_task(&(*tasks)[j], pids[i], result, descs);
+			}
+		}
+	}
+}

--- a/src/pcp/atop/netproc.c
+++ b/src/pcp/atop/netproc.c
@@ -54,7 +54,8 @@ netproc_update_tasks(struct tstat **tasks, unsigned long taskslen)
 	int		*pids;
 	int		netproc_insts_len, i, j;
 
-	if(!setup) {
+	if (!setup)
+	{
 		setup_metrics(netprocmetrics, pmids, descs, TASK_NET_NMETRICS);
 		setup = 1;
 	}
@@ -70,10 +71,16 @@ netproc_update_tasks(struct tstat **tasks, unsigned long taskslen)
 
 		// for each instance of the netproc metrics, we need to find the index inside the tasks array
 		// TODO: better algorithm to avoid O(m*n) complexity?
-		for(j=0; j < taskslen; j++) {
-			if ((*tasks)[j].gen.pid == pids[i]) {
+		for (j=0; j < taskslen; j++)
+		{
+			if ((*tasks)[j].gen.pid == pids[i])
 				netproc_update_task(&(*tasks)[j], pids[i], result, descs);
-			}
 		}
+	}
+
+	pmFreeResult(result);
+	if (netproc_insts_len > 0) {
+	    free(insts);
+	    free(pids);
 	}
 }

--- a/src/pcp/atop/netprocmetrics.map
+++ b/src/pcp/atop/netprocmetrics.map
@@ -1,5 +1,5 @@
 #
-# metric names and access macros for netatopif.c
+# metric names and access macros for netproc.c
 #
 netprocmetrics {
 	bcc.proc.io.net.perpid.tcp.out.packets	TASK_NET_TCPSND

--- a/src/pcp/atop/netprocmetrics.map
+++ b/src/pcp/atop/netprocmetrics.map
@@ -1,0 +1,17 @@
+#
+# metric names and access macros for netatopif.c
+#
+netprocmetrics {
+	bcc.proc.io.net.perpid.tcp.out.packets	TASK_NET_TCPSND
+	bcc.proc.io.net.perpid.tcp.out.bytes	TASK_NET_TCPSSZ
+	bcc.proc.io.net.perpid.tcp.in.packets	TASK_NET_TCPRCV
+	bcc.proc.io.net.perpid.tcp.in.bytes	TASK_NET_TCPRSZ
+
+	bcc.proc.io.net.perpid.udp.out.packets	TASK_NET_UDPSND
+	bcc.proc.io.net.perpid.udp.out.bytes	TASK_NET_UDPSSZ
+	bcc.proc.io.net.perpid.udp.in.packets	TASK_NET_UDPRCV
+	bcc.proc.io.net.perpid.udp.in.bytes	TASK_NET_UDPRSZ
+
+	# end marker - provides count
+	.					TASK_NET_NMETRICS
+}

--- a/src/pcp/atop/photoproc.c
+++ b/src/pcp/atop/photoproc.c
@@ -145,6 +145,9 @@ photoproc(struct tstat **tasks, unsigned int *taskslen)
 		setup = 1;
 	}
 
+	/* check if per-process network metrics are available */
+	netatop_probe();
+
 	if (!calcpss)
 		pmids[TASK_MEM_PMEM] = PM_ID_NULL;
 	else
@@ -172,6 +175,10 @@ photoproc(struct tstat **tasks, unsigned int *taskslen)
 				pmGetProgname(), pids[i], insts[i]);
 		update_task(&(*tasks)[i], pids[i], insts[i], result, descs);
 	}
+
+	if (supportflags & NETATOP)
+		netproc_update_tasks(tasks, count);
+
 	if (pmDebugOptions.appl0)
 		fprintf(stderr, "%s: done %lu processes\n", pmGetProgname(), count);
 

--- a/src/pcp/atop/showgeneric.c
+++ b/src/pcp/atop/showgeneric.c
@@ -960,20 +960,15 @@ generic_samp(double sampletime, double nsecs,
 			   ** sort in network-activity order
 			   */
 			   case MSORTNET:
-#if 1
-				statmsg = "Not yet supported in this atop!";
-				beep();
-#else
 				if ( !(supportflags & NETATOP) )
 				{
-					statmsg = "Kernel module 'netatop' not "
-					          "active or no root privs; "
+					statmsg = "BCC PMDA not active or "
+					          "'netproc' module not enabled; "
 					          "request ignored!";
 					break;
 				}
 				showorder = MSORTNET;
 				firstproc = 0;
-#endif
 				break;
 
 			   /*
@@ -1037,14 +1032,10 @@ generic_samp(double sampletime, double nsecs,
 			   ** network-specific figures per process
 			   */
 			   case MPROCNET:
-#if 1
-				statmsg = "Not yet supported in this atop!";
-				beep();
-#else
 				if ( !(supportflags & NETATOP) )
 				{
-					statmsg = "Kernel module 'netatop' not "
-					          "active or no root privs; "
+					statmsg = "BCC PMDA not active or "
+					          "'netproc' module not enabled; "
 					          "request ignored!";
 					break;
 				}
@@ -1055,7 +1046,6 @@ generic_samp(double sampletime, double nsecs,
 					showorder = MSORTNET;
 
 				firstproc = 0;
-#endif
 				break;
 
 			   /*
@@ -2512,8 +2502,9 @@ generic_init(void)
 		   case MPROCNET:
 			if ( !(supportflags & NETATOP) )
 			{
-				fprintf(stderr, "Kernel module 'netatop' not "
-					          "active; request ignored!");
+				fprintf(stderr, "BCC PMDA not active or "
+					        "'netproc' module not enabled; "
+					        "request ignored!");
 				sleep(3);
 				break;
 			}

--- a/src/pmdas/bcc/bcc.conf
+++ b/src/pmdas/bcc/bcc.conf
@@ -247,9 +247,15 @@ cluster = 31
 #
 
 # This module provides per-process TCP and UDP statistics (number of packets and bytes sent and received)
+#
+# Configuration options:
+# Name                     - type    - default
+#
+# remove_stopped_processes - boolean - True : show active processes only
 [netproc]
 module = netproc
 cluster = 40
+#remove_stopped_processes = True
 
 
 #

--- a/src/pmdas/bcc/bcc.conf
+++ b/src/pmdas/bcc/bcc.conf
@@ -255,8 +255,8 @@ cluster = 31
 [netproc]
 module = netproc
 cluster = 40
-#remove_stopped_processes = True
 pmda_indom_cache = False
+#remove_stopped_processes = True
 
 
 #

--- a/src/pmdas/bcc/bcc.conf
+++ b/src/pmdas/bcc/bcc.conf
@@ -256,6 +256,7 @@ cluster = 31
 module = netproc
 cluster = 40
 #remove_stopped_processes = True
+pmda_indom_cache = False
 
 
 #

--- a/src/pmdas/bcc/bcc.conf
+++ b/src/pmdas/bcc/bcc.conf
@@ -243,6 +243,16 @@ cluster = 31
 
 
 #
+# Network modules
+#
+
+# This module provides per-process TCP and UDP statistics (number of packets and bytes sent and received)
+[netproc]
+module = netproc
+cluster = 40
+
+
+#
 # TCP related modules
 #
 

--- a/src/pmdas/bcc/modules/netproc.bpf
+++ b/src/pmdas/bcc/modules/netproc.bpf
@@ -1,0 +1,53 @@
+// Based on the tcptop BCC tool by Brendan Gregg:
+// https://github.com/iovisor/bcc/blob/master/tools/tcptop.py
+#include <uapi/linux/ptrace.h>
+#include <net/sock.h>
+
+struct netstats {
+    u64 tcp_send_packets;
+    u64 tcp_send_bytes;
+    u64 tcp_recv_packets;
+    u64 tcp_recv_bytes;
+
+    u64 udp_send_packets;
+    u64 udp_send_bytes;
+    u64 udp_recv_packets;
+    u64 udp_recv_bytes;
+};
+BPF_HASH(netstats_per_pid, u32, struct netstats);
+
+int kprobe__tcp_sendmsg(struct pt_regs *ctx, struct sock *sk,
+    struct msghdr *msg, size_t size)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+
+    struct netstats *statp, zero = {};
+    statp = netstats_per_pid.lookup_or_try_init(&pid, &zero);
+    if (statp) {
+        statp->tcp_send_bytes += size;
+    }
+
+    return 0;
+}
+
+/*
+ * tcp_recvmsg() would be obvious to trace, but is less suitable because:
+ * - we'd need to trace both entry and return, to have both sock and size
+ * - misses tcp_read_sock() traffic
+ * we'd much prefer tracepoints once they are available.
+ */
+int kprobe__tcp_cleanup_rbuf(struct pt_regs *ctx, struct sock *sk, int copied)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+
+    if (copied <= 0)
+        return 0;
+
+    struct netstats *statp, zero = {};
+    statp = netstats_per_pid.lookup_or_try_init(&pid, &zero);
+    if (statp) {
+        statp->tcp_recv_bytes += copied;
+    }
+
+    return 0;
+}

--- a/src/pmdas/bcc/modules/netproc.bpf
+++ b/src/pmdas/bcc/modules/netproc.bpf
@@ -15,7 +15,7 @@ struct netstats {
     u64 udp_recv_bytes;
 };
 
-// TODO: limit size of map, FIFO?
+// TODO: limit size of map, FIFO? approx max map size: PID_MAX * 8 * 8 bytes
 BPF_HASH(netstats_per_pid, u32, struct netstats);
 
 int kprobe__tcp_sendmsg(struct pt_regs *ctx, struct sock *sk,
@@ -51,6 +51,36 @@ int kprobe__tcp_cleanup_rbuf(struct pt_regs *ctx, struct sock *sk, int copied)
     if (statp) {
         statp->tcp_recv_packets++; // TODO
         statp->tcp_recv_bytes += copied;
+    }
+
+    return 0;
+}
+
+int kprobe__udp_sendmsg(struct pt_regs *ctx, struct sock *sk,
+    struct msghdr *msg, size_t len)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+
+    struct netstats *statp, zero = {};
+    statp = netstats_per_pid.lookup_or_try_init(&pid, &zero);
+    if (statp) {
+        statp->udp_send_packets++; // TODO
+        statp->udp_send_bytes += len;
+    }
+
+    return 0;
+}
+
+int kprobe__udp_recvmsg(struct pt_regs *ctx, struct sock *sk,
+    struct msghdr *msg, size_t len, int noblock, int flags, int *addr_len)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+
+    struct netstats *statp, zero = {};
+    statp = netstats_per_pid.lookup_or_try_init(&pid, &zero);
+    if (statp) {
+        statp->udp_recv_packets++; // TODO
+        statp->udp_recv_bytes += len;
     }
 
     return 0;

--- a/src/pmdas/bcc/modules/netproc.bpf
+++ b/src/pmdas/bcc/modules/netproc.bpf
@@ -14,6 +14,8 @@ struct netstats {
     u64 udp_recv_packets;
     u64 udp_recv_bytes;
 };
+
+// TODO: limit size of map, FIFO?
 BPF_HASH(netstats_per_pid, u32, struct netstats);
 
 int kprobe__tcp_sendmsg(struct pt_regs *ctx, struct sock *sk,
@@ -24,6 +26,7 @@ int kprobe__tcp_sendmsg(struct pt_regs *ctx, struct sock *sk,
     struct netstats *statp, zero = {};
     statp = netstats_per_pid.lookup_or_try_init(&pid, &zero);
     if (statp) {
+        statp->tcp_send_packets++; // TODO
         statp->tcp_send_bytes += size;
     }
 
@@ -46,6 +49,7 @@ int kprobe__tcp_cleanup_rbuf(struct pt_regs *ctx, struct sock *sk, int copied)
     struct netstats *statp, zero = {};
     statp = netstats_per_pid.lookup_or_try_init(&pid, &zero);
     if (statp) {
+        statp->tcp_recv_packets++; // TODO
         statp->tcp_recv_bytes += copied;
     }
 

--- a/src/pmdas/bcc/modules/netproc.python
+++ b/src/pmdas/bcc/modules/netproc.python
@@ -1,7 +1,5 @@
 #
 # Copyright (C) 2020 Red Hat.
-# Based on the tcptop BCC tool by Brendan Gregg:
-# https://github.com/iovisor/bcc/blob/master/tools/tcptop.py
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,7 +21,13 @@ import os
 from bcc import BPF
 
 from pcp.pmapi import pmUnits
-from cpmapi import PM_TYPE_U32, PM_TYPE_U64, PM_TYPE_STRING, PM_COUNT_ONE, PM_SEM_COUNTER
+from cpmapi import (
+    PM_TYPE_U32,
+    PM_TYPE_U64,
+    PM_TYPE_STRING,
+    PM_COUNT_ONE,
+    PM_SEM_COUNTER,
+)
 from cpmapi import PM_SEM_INSTANT, PM_SPACE_BYTE, PM_TIME_USEC
 from cpmda import PMDA_FETCH_NOVALUES
 
@@ -37,25 +41,43 @@ bpf_src = "modules/netproc.bpf"
 #
 # PCP BCC PMDA constants
 #
-MODULE = 'netproc'
-BASENS = 'proc.io.net.perpid.'
+MODULE = "netproc"
+BASENS = "proc.io.net.perpid."
 units_bytes = pmUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0)
 units_count = pmUnits(0, 0, 1, 0, 0, PM_COUNT_ONE)
 units_none = pmUnits(0, 0, 0, 0, 0, 0)
 
 # use tuple here instead of a dict or class to access the fields by index in the bpfdata method
-Netstats = namedtuple('Netstats', ['tcp_send_packets', 'tcp_send_bytes', 'tcp_recv_packets', 'tcp_recv_bytes', 'udp_send_packets', 'udp_send_bytes', 'udp_recv_packets', 'udp_recv_bytes'])
+Netstats = namedtuple(
+    "Netstats",
+    [
+        "tcp_send_packets",
+        "tcp_send_bytes",
+        "tcp_recv_packets",
+        "tcp_recv_bytes",
+        "udp_send_packets",
+        "udp_send_bytes",
+        "udp_recv_packets",
+        "udp_recv_bytes",
+    ],
+)
 
 #
 # PCP BCC Module
 #
 class PCPBCCModule(PCPBCCBase):
     """ PCP BCC netproc module """
+
     def __init__(self, config, log, err):
         """ Constructor """
         PCPBCCBase.__init__(self, MODULE, config, log, err)
 
-        self.cache = defaultdict(lambda: Netstats(0,0,0,0,0,0,0,0))
+        self.remove_stopped_processes = True
+        for opt in self.config.options(MODULE):
+            if opt == "remove_stopped_processes":
+                self.remove_stopped_processes = self.config.getboolean(MODULE, opt)
+
+        self.cache = defaultdict(lambda: Netstats(0, 0, 0, 0, 0, 0, 0, 0))
         self.insts = {}
 
         self.log("Initialized.")
@@ -66,14 +88,70 @@ class PCPBCCModule(PCPBCCBase):
         self.items = (
             # Name - reserved - type - semantics - units - help
             # note: ordering of these metrics must match ordering of the Netstats named tuple
-            (name + 'tcp.out.packets', None, PM_TYPE_U64, PM_SEM_COUNTER, units_count, 'packets sent'),
-            (name + 'tcp.out.bytes', None, PM_TYPE_U64, PM_SEM_COUNTER, units_bytes, 'bytes sent'),
-            (name + 'tcp.in.packets', None, PM_TYPE_U64, PM_SEM_COUNTER, units_count, 'packets received'),
-            (name + 'tcp.in.bytes', None, PM_TYPE_U64, PM_SEM_COUNTER, units_bytes, 'bytes received'),
-            (name + 'udp.out.packets', None, PM_TYPE_U64, PM_SEM_COUNTER, units_count, 'packets sent'),
-            (name + 'udp.out.bytes', None, PM_TYPE_U64, PM_SEM_COUNTER, units_bytes, 'bytes sent'),
-            (name + 'udp.in.packets', None, PM_TYPE_U64, PM_SEM_COUNTER, units_count, 'packets received'),
-            (name + 'udp.in.bytes', None, PM_TYPE_U64, PM_SEM_COUNTER, units_bytes, 'bytes received'),
+            (
+                name + "tcp.out.packets",
+                None,
+                PM_TYPE_U64,
+                PM_SEM_COUNTER,
+                units_count,
+                "packets sent",
+            ),
+            (
+                name + "tcp.out.bytes",
+                None,
+                PM_TYPE_U64,
+                PM_SEM_COUNTER,
+                units_bytes,
+                "bytes sent",
+            ),
+            (
+                name + "tcp.in.packets",
+                None,
+                PM_TYPE_U64,
+                PM_SEM_COUNTER,
+                units_count,
+                "packets received",
+            ),
+            (
+                name + "tcp.in.bytes",
+                None,
+                PM_TYPE_U64,
+                PM_SEM_COUNTER,
+                units_bytes,
+                "bytes received",
+            ),
+            (
+                name + "udp.out.packets",
+                None,
+                PM_TYPE_U64,
+                PM_SEM_COUNTER,
+                units_count,
+                "packets sent",
+            ),
+            (
+                name + "udp.out.bytes",
+                None,
+                PM_TYPE_U64,
+                PM_SEM_COUNTER,
+                units_bytes,
+                "bytes sent",
+            ),
+            (
+                name + "udp.in.packets",
+                None,
+                PM_TYPE_U64,
+                PM_SEM_COUNTER,
+                units_count,
+                "packets received",
+            ),
+            (
+                name + "udp.in.bytes",
+                None,
+                PM_TYPE_U64,
+                PM_SEM_COUNTER,
+                units_bytes,
+                "bytes received",
+            ),
         )
         return True, self.items
 
@@ -82,7 +160,7 @@ class PCPBCCModule(PCPBCCBase):
         try:
             self.bpf = BPF(src_file=bpf_src)
             self.log("Compiled.")
-        except Exception as error: # pylint: disable=broad-except
+        except Exception as error:  # pylint: disable=broad-except
             self.bpf = None
             self.err(str(error))
             self.err("Module NOT active!")
@@ -93,30 +171,35 @@ class PCPBCCModule(PCPBCCBase):
         if self.bpf is None:
             return None
 
-        netstats_per_pid = self.bpf['netstats_per_pid']
+        netstats_per_pid = self.bpf["netstats_per_pid"]
         for pid_ct, cur_netstat in netstats_per_pid.items():
             pid = pid_ct.value
             prev_netstat = self.cache[pid]
             self.cache[pid] = Netstats(
-                tcp_send_packets=prev_netstat.tcp_send_packets + cur_netstat.tcp_send_packets,
+                tcp_send_packets=prev_netstat.tcp_send_packets
+                + cur_netstat.tcp_send_packets,
                 tcp_send_bytes=prev_netstat.tcp_send_bytes + cur_netstat.tcp_send_bytes,
-                tcp_recv_packets=prev_netstat.tcp_recv_packets + cur_netstat.tcp_recv_packets,
+                tcp_recv_packets=prev_netstat.tcp_recv_packets
+                + cur_netstat.tcp_recv_packets,
                 tcp_recv_bytes=prev_netstat.tcp_recv_bytes + cur_netstat.tcp_recv_bytes,
-                udp_send_packets=prev_netstat.udp_send_packets + cur_netstat.udp_send_packets,
+                udp_send_packets=prev_netstat.udp_send_packets
+                + cur_netstat.udp_send_packets,
                 udp_send_bytes=prev_netstat.udp_send_bytes + cur_netstat.udp_send_bytes,
-                udp_recv_packets=prev_netstat.udp_recv_packets + cur_netstat.udp_recv_packets,
+                udp_recv_packets=prev_netstat.udp_recv_packets
+                + cur_netstat.udp_recv_packets,
                 udp_recv_bytes=prev_netstat.udp_recv_bytes + cur_netstat.udp_recv_bytes,
             )
             self.insts[str(pid)] = ct.c_int(1)
         netstats_per_pid.clear()
 
         # remove stopped processes
-        current_pids = frozenset(os.listdir("/proc"))
-        cached_pids = frozenset(self.insts.keys())
-        stopped_pids = cached_pids - current_pids
-        for pid in stopped_pids:
-            del self.cache[int(pid)]
-            del self.insts[pid]
+        if self.remove_stopped_processes:
+            current_pids = frozenset(os.listdir("/proc"))
+            cached_pids = frozenset(self.insts.keys())
+            stopped_pids = cached_pids - current_pids
+            for pid in stopped_pids:
+                del self.cache[int(pid)]
+                del self.insts[pid]
 
         return self.insts
 
@@ -126,5 +209,5 @@ class PCPBCCModule(PCPBCCBase):
             key = int(self.pmdaIndom.inst_name_lookup(inst))
             value = self.cache[key][item]
             return [value, 1]
-        except Exception: # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             return [PMDA_FETCH_NOVALUES, 0]

--- a/src/pmdas/bcc/modules/netproc.python
+++ b/src/pmdas/bcc/modules/netproc.python
@@ -16,7 +16,7 @@
 import ctypes as ct
 from threading import Lock, Thread
 from time import sleep
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 import os
 from bcc import BPF
 
@@ -77,7 +77,7 @@ class PCPBCCModule(PCPBCCBase):
             if opt == "remove_stopped_processes":
                 self.remove_stopped_processes = self.config.getboolean(MODULE, opt)
 
-        self.cache = defaultdict(lambda: Netstats(0, 0, 0, 0, 0, 0, 0, 0))
+        self.cache = {}
         self.insts = {}
 
         self.log("Initialized.")
@@ -174,7 +174,7 @@ class PCPBCCModule(PCPBCCBase):
         netstats_per_pid = self.bpf["netstats_per_pid"]
         for pid_ct, cur_netstat in netstats_per_pid.items():
             pid = pid_ct.value
-            prev_netstat = self.cache[pid]
+            prev_netstat = self.cache.get(pid, Netstats(0, 0, 0, 0, 0, 0, 0, 0))
             self.cache[pid] = Netstats(
                 tcp_send_packets=prev_netstat.tcp_send_packets
                 + cur_netstat.tcp_send_packets,

--- a/src/pmdas/bcc/modules/netproc.python
+++ b/src/pmdas/bcc/modules/netproc.python
@@ -189,7 +189,7 @@ class PCPBCCModule(PCPBCCBase):
                 + cur_netstat.udp_recv_packets,
                 udp_recv_bytes=prev_netstat.udp_recv_bytes + cur_netstat.udp_recv_bytes,
             )
-            self.insts[str(pid)] = ct.c_int(1)
+            self.insts[str(pid)] = ct.c_int(pid)
         netstats_per_pid.clear()
 
         # remove stopped processes
@@ -206,8 +206,7 @@ class PCPBCCModule(PCPBCCBase):
     def bpfdata(self, item, inst):
         """ Return BPF data as PCP metric value """
         try:
-            key = int(self.pmdaIndom.inst_name_lookup(inst))
-            value = self.cache[key][item]
+            value = self.cache[inst][item]
             return [value, 1]
         except Exception:  # pylint: disable=broad-except
             return [PMDA_FETCH_NOVALUES, 0]

--- a/src/pmdas/bcc/modules/netproc.python
+++ b/src/pmdas/bcc/modules/netproc.python
@@ -1,0 +1,130 @@
+#
+# Copyright (C) 2020 Red Hat.
+# Based on the tcptop BCC tool by Brendan Gregg:
+# https://github.com/iovisor/bcc/blob/master/tools/tcptop.py
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+""" PCP BCC PMDA netproc module """
+
+import ctypes as ct
+from threading import Lock, Thread
+from time import sleep
+from collections import defaultdict, namedtuple
+import os
+from bcc import BPF
+
+from pcp.pmapi import pmUnits
+from cpmapi import PM_TYPE_U32, PM_TYPE_U64, PM_TYPE_STRING, PM_COUNT_ONE, PM_SEM_COUNTER
+from cpmapi import PM_SEM_INSTANT, PM_SPACE_BYTE, PM_TIME_USEC
+from cpmda import PMDA_FETCH_NOVALUES
+
+from modules.pcpbcc import PCPBCCBase
+
+#
+# BPF program
+#
+bpf_src = "modules/netproc.bpf"
+
+#
+# PCP BCC PMDA constants
+#
+MODULE = 'netproc'
+BASENS = 'proc.io.net.perpid.'
+units_bytes = pmUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0)
+units_count = pmUnits(0, 0, 1, 0, 0, PM_COUNT_ONE)
+units_none = pmUnits(0, 0, 0, 0, 0, 0)
+
+# use tuple here instead of a dict or class to access the fields by index in the bpfdata method
+Netstats = namedtuple('Netstats', ['tcp_send_packets', 'tcp_send_bytes', 'tcp_recv_packets', 'tcp_recv_bytes', 'udp_send_packets', 'udp_send_bytes', 'udp_recv_packets', 'udp_recv_bytes'])
+
+#
+# PCP BCC Module
+#
+class PCPBCCModule(PCPBCCBase):
+    """ PCP BCC netproc module """
+    def __init__(self, config, log, err):
+        """ Constructor """
+        PCPBCCBase.__init__(self, MODULE, config, log, err)
+
+        self.cache = defaultdict(lambda: Netstats(0,0,0,0,0,0,0,0))
+        self.insts = {}
+
+        self.log("Initialized.")
+
+    def metrics(self):
+        """ Get metric definitions """
+        name = BASENS
+        self.items = (
+            # Name - reserved - type - semantics - units - help
+            # note: ordering of these metrics must match ordering of the Netstats named tuple
+            (name + 'tcp.out.packets', None, PM_TYPE_U64, PM_SEM_COUNTER, units_count, 'packets sent'),
+            (name + 'tcp.out.bytes', None, PM_TYPE_U64, PM_SEM_COUNTER, units_bytes, 'bytes sent'),
+            (name + 'tcp.in.packets', None, PM_TYPE_U64, PM_SEM_COUNTER, units_count, 'packets received'),
+            (name + 'tcp.in.bytes', None, PM_TYPE_U64, PM_SEM_COUNTER, units_bytes, 'bytes received'),
+            (name + 'udp.out.packets', None, PM_TYPE_U64, PM_SEM_COUNTER, units_count, 'packets sent'),
+            (name + 'udp.out.bytes', None, PM_TYPE_U64, PM_SEM_COUNTER, units_bytes, 'bytes sent'),
+            (name + 'udp.in.packets', None, PM_TYPE_U64, PM_SEM_COUNTER, units_count, 'packets received'),
+            (name + 'udp.in.bytes', None, PM_TYPE_U64, PM_SEM_COUNTER, units_bytes, 'bytes received'),
+        )
+        return True, self.items
+
+    def compile(self):
+        """ Compile BPF """
+        try:
+            self.bpf = BPF(src_file=bpf_src)
+            self.log("Compiled.")
+        except Exception as error: # pylint: disable=broad-except
+            self.bpf = None
+            self.err(str(error))
+            self.err("Module NOT active!")
+            raise
+
+    def refresh(self):
+        """ Refresh BPF data """
+        if self.bpf is None:
+            return None
+
+        netstats_per_pid = self.bpf['netstats_per_pid']
+        for pid_ct, cur_netstat in netstats_per_pid.items():
+            pid = pid_ct.value
+            prev_netstat = self.cache[pid]
+            self.cache[pid] = Netstats(
+                tcp_send_packets=prev_netstat.tcp_send_packets + cur_netstat.tcp_send_packets,
+                tcp_send_bytes=prev_netstat.tcp_send_bytes + cur_netstat.tcp_send_bytes,
+                tcp_recv_packets=prev_netstat.tcp_recv_packets + cur_netstat.tcp_recv_packets,
+                tcp_recv_bytes=prev_netstat.tcp_recv_bytes + cur_netstat.tcp_recv_bytes,
+                udp_send_packets=prev_netstat.udp_send_packets + cur_netstat.udp_send_packets,
+                udp_send_bytes=prev_netstat.udp_send_bytes + cur_netstat.udp_send_bytes,
+                udp_recv_packets=prev_netstat.udp_recv_packets + cur_netstat.udp_recv_packets,
+                udp_recv_bytes=prev_netstat.udp_recv_bytes + cur_netstat.udp_recv_bytes,
+            )
+            self.insts[str(pid)] = ct.c_int(1)
+        netstats_per_pid.clear()
+
+        # remove stopped processes
+        current_pids = frozenset(os.listdir("/proc"))
+        cached_pids = frozenset(self.insts.keys())
+        stopped_pids = cached_pids - current_pids
+        for pid in stopped_pids:
+            del self.cache[int(pid)]
+            del self.insts[pid]
+
+        return self.insts
+
+    def bpfdata(self, item, inst):
+        """ Return BPF data as PCP metric value """
+        try:
+            key = int(self.pmdaIndom.inst_name_lookup(inst))
+            value = self.cache[key][item]
+            return [value, 1]
+        except Exception: # pylint: disable=broad-except
+            return [PMDA_FETCH_NOVALUES, 0]


### PR DESCRIPTION
first version of the BCC netproc module, which provides data for the pcp atop per-process bandwidth statistics

I'm open to changes of the name (`netproc` was the best I could come up with) and metric names

```
bcc.proc.io.net.perpid.tcp.in.packets
bcc.proc.io.net.perpid.tcp.in.bytes
bcc.proc.io.net.perpid.tcp.out.packets
bcc.proc.io.net.perpid.tcp.out.bytes
bcc.proc.io.net.perpid.udp.in.packets
bcc.proc.io.net.perpid.udp.in.bytes
bcc.proc.io.net.perpid.udp.out.packets
bcc.proc.io.net.perpid.udp.out.bytes
```

(`bcc.proc.io.net.tcp.*` is already in use by the `tcplife` BCC module)