### PR TITLE
pcp-atop: restore an original state of process accounting when pcp-atop exits

### DIFF
--- a/src/pcp/atop/modules.c
+++ b/src/pcp/atop/modules.c
@@ -71,19 +71,49 @@ netatop_exitfind(unsigned long x, struct tstat *a, struct tstat *b)
 	(void)b;
 }
 
+static int
+get_current_enable_acct(void)
+{
+	int ret = 0;
+	pmID	pmid = pmID_build(3, 70, 28);
+	pmResult	*result;
+	int		sts;
+
+	sts = pmFetch(1, &pmid, &result);
+	if (sts < 0)
+	{
+		if (pmDebugOptions.appl0)
+			fprintf(stderr, "%s: %s pmFetch failed: %s\n",
+				pmGetProgname(), "acctsw", pmErrStr(sts));
+		return -1;
+	}
+	ret = result->vset[0]->numval == 1 ? result->vset[0]->vlist[0].value.lval : -1;
+	pmFreeResult(result);
+	return ret;
+}
+
 /* set acct.control.enable_acct to unsigned integer value */
 static int
 acctsw(unsigned int enable)
 {
-	pmResult	*result = calloc(1, sizeof(pmResult));
-	pmValueSet	*vset = calloc(1, sizeof(pmValueSet));
+	int prev_val;
+	pmResult	*result;
+	pmValueSet	*vset;
 	int		sts;
+
+	prev_val = get_current_enable_acct();
+	if (prev_val < 0) {
+		return 1;
+	}
+
+	result = calloc(1, sizeof(pmResult));
+	vset = calloc(1, sizeof(pmValueSet));
 
 	ptrverify(vset, "Malloc vset failed for %s enabling\n", "acct");
 	ptrverify(result, "Malloc result failed for %s enabling\n", "acct");
 
 	vset->vlist[0].inst = PM_IN_NULL;
-	vset->vlist[0].value.lval = enable;
+	vset->vlist[0].value.lval = enable ? (prev_val + 1) : (prev_val > 0 ? (prev_val - 1) : 0);
 	vset->valfmt = PM_VAL_INSITU;
 	vset->numval = 1;
 	vset->pmid = pmID_build(3, 70, 28);

--- a/src/pmdas/linux_proc/acct.c
+++ b/src/pmdas/linux_proc/acct.c
@@ -671,8 +671,12 @@ acct_store(pmResult *result, pmdaExt *pmda, pmValueSet *vsp)
     case CONTROL_ACCT_ENABLE: /* acct.control.enable_acct */
 	if ((sts = pmExtractValue(vsp->valfmt, &vsp->vlist[0],
 			PM_TYPE_U32, &av, PM_TYPE_U32)) >= 0) {
-	    acct_enable_private_acct = av.ul ? 1 : 0;
-	    reopen_pacct_file();
+	    int state_changed = !acct_enable_private_acct != !av.ul;
+	    if (pmDebugOptions.libpmda && pmDebugOptions.desperate)
+		pmNotifyErr(LOG_DEBUG, "acct: store enable_acct old=%d new=%d\n", acct_enable_private_acct, av.ul);
+	    acct_enable_private_acct = av.ul;
+	    if (state_changed)
+		reopen_pacct_file();
 	}
 	break;
     default:


### PR DESCRIPTION
Previously pcp-atop force pmdaproc to disable process accounting state
when it exits regardless of what the original state was.
pcp-atop will control the state regarding acct.control.enable_acct as
a reference count to make sure to restore the original state after
all pcp-atop instances exit.