### PR TITLE
libpcp fix for recent interp.c changes

### DIFF
--- a/qa/1700
+++ b/qa/1700
@@ -45,7 +45,7 @@ EOF
 echo "=== start bpftrace script ==="
 ./src/store_and_fetch bpftrace.control.register "// name: testscript
 tracepoint:syscalls:sys_enter_openat { @ = count(); @scalar = 2; }" | pmjson | _filter_json
-_pmdabpftrace_wait_for_value bpftrace.scripts.testscript.probes 2
+_pmdabpftrace_wait_for_value bpftrace.scripts.testscript.probes 2 15
 
 echo "=== generating openat() syscall activity ==="
 _pmdabpftrace_generate_openat_syscall_activity &

--- a/qa/common.bpftrace
+++ b/qa/common.bpftrace
@@ -77,10 +77,14 @@ _pmdabpftrace_cleanup()
     _cleanup_pmda bpftrace
 }
 
+# Usage: _pmdabpftrace_wait_for_value [value_regex [timeout_sec]]
+#
 _pmdabpftrace_wait_for_value()
 {
     value_regex=${2:-".*"}
-    for i in `seq 1 20`
+    wait_sec=${3:-"10"}
+    wait_iter=`expr $wait_sec \* 2`
+    for i in `seq 1 $wait_iter`
     do
         if pminfo -f $1 2>/dev/null | grep -q "value $value_regex"; then
             echo "found metric $1 with matching value $value_regex"
@@ -89,7 +93,7 @@ _pmdabpftrace_wait_for_value()
         sleep 0.5
     done
 
-    echo "Timeout (10s) while waiting for metric $1 to match value $value_regex, script data:"
+    echo "Timeout (${wait_sec}s) while waiting for metric $1 to match value $value_regex, script data:"
     pminfo -f $(echo "$1" | sed -r 's/bpftrace\.scripts\.([^.]+)\..*/bpftrace.scripts.\1/')
     # error text above is sufficient to mark the test status as Failed
     # rather than Broken in CI => exit status of 0 is fine

--- a/scripts/pcp-refresh
+++ b/scripts/pcp-refresh
@@ -86,5 +86,5 @@ if [ -z "$ans" -o "$ans" = y ]
 then
     official_url=git://github.com/performancecopilot/pcp.git
     git fetch --tags --prune $official_url
-    git pull $official_url $branch
+    git pull --rebase $official_url $branch
 fi

--- a/src/libpcp/src/logutil.c
+++ b/src/libpcp/src/logutil.c
@@ -656,7 +656,7 @@ logFreeTrimInDom(__pmHashCtl *hcp)
 	    icp = &indomp->hashinst;
 	    /* loop over all instances for this indom */
 	    for (i = 0; i < icp->hsize; i++) {
-		for (ip = icp->hash[h], prior_ip = NULL; ip != NULL; ip = ip->next) {
+		for (ip = icp->hash[i], prior_ip = NULL; ip != NULL; ip = ip->next) {
 		    free((__pmLogTrimInst *)ip->data);
 		    if (prior_ip != NULL)
 			free(prior_ip);


### PR DESCRIPTION
Actually in logutil.c when an archive context is closed and the new "trim" indom data structures are freed.