### PR TITLE
systemd: remove Wants=pmcd from pmlogger and pmie

### DIFF
--- a/src/pmie/pmie.service.in
+++ b/src/pmie/pmie.service.in
@@ -4,7 +4,6 @@ Documentation=man:pmie(1)
 After=network-online.target pmcd.service
 Before=pmie_check.timer pmie_daily.timer
 BindsTo=pmie_check.timer pmie_daily.timer
-Wants=pmcd.service
 
 [Service]
 Type=notify

--- a/src/pmlogger/pmlogger.service.in
+++ b/src/pmlogger/pmlogger.service.in
@@ -4,7 +4,6 @@ Documentation=man:pmlogger(1)
 After=network-online.target pmcd.service
 Before=pmlogger_check.timer pmlogger_daily.timer pmlogger_daily-poll.timer
 BindsTo=pmlogger_check.timer pmlogger_daily.timer pmlogger_daily-poll.timer
-Wants=pmcd.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
Rationale: pmlogger and pmie should not always start pmcd as a dependency,
because a local pmcd is not required if pmlogger or pmie is connecting to a
remote pmcd.

Resolves #1200