### PR TITLE
pcp-htop: fix ZramMeter, Handle missing condition

### DIFF
--- a/src/pcp/htop/pcp/Platform.c
+++ b/src/pcp/htop/pcp/Platform.c
@@ -590,6 +590,9 @@ void Platform_setZramValues(Meter* this) {
    (void)this;
 
    int i, count = Metric_instanceCount(PCP_ZRAM_CAPACITY);
+   if(!count)
+      return;
+
    pmAtomValue *values = xCalloc(count, sizeof(pmAtomValue));
    ZramStats stats = {0};
 


### PR DESCRIPTION
If ZramMeter does not exist in the machine for any reason, pcp-htop will
panic. This condition prevents this case.