### PR TITLE
fix no longer working link

### DIFF
--- a/src/pmdas/openmetrics/pmdaopenmetrics.1
+++ b/src/pmdas/openmetrics/pmdaopenmetrics.1
@@ -385,7 +385,7 @@ In the case of CPU counters, the metric type definition should be
 not
 .BR gauge .
 For full details of the openmetrics exposition formats, see
-.IR https://prometheus.io/docs/concepts/metric_types/ .
+.IR https://github.com/OpenObservability/OpenMetrics/blob/master/specification/OpenMetrics.md .
 .SH "METRIC NAMING"
 All metrics from a file named
 .IR JOB .*

--- a/src/pmdas/openmetrics/pmdaopenmetrics.1
+++ b/src/pmdas/openmetrics/pmdaopenmetrics.1
@@ -385,7 +385,7 @@ In the case of CPU counters, the metric type definition should be
 not
 .BR gauge .
 For full details of the openmetrics exposition formats, see
-.IR https://openmetrics.io/docs/instrumenting/exposition_formats .
+.IR https://prometheus.io/docs/concepts/metric_types/ .
 .SH "METRIC NAMING"
 All metrics from a file named
 .IR JOB .*


### PR DESCRIPTION
https://prometheus.io/docs/concepts/metric_types/ seems to make most sense.
https://github.com/OpenObservability/OpenMetrics/blob/master/specification/OpenMetrics.md looks like a more upstream definition, but it refers to types which openmetrics seems to not support currently.