### PR TITLE
zeroconf: remove duplicate metrics from 30-second sampling setting.

### DIFF
--- a/src/pmlogconf/tools/sar
+++ b/src/pmlogconf/tools/sar
@@ -71,6 +71,7 @@ probe	kernel.uname.sysname ~ Linux ? include : exclude
 	kernel.all.cpu.sys
 	kernel.all.cpu.user
 	kernel.all.cpu.wait.total
+	kernel.all.cpu.vuser
 	kernel.all.intr
 	kernel.all.load
 	kernel.all.pswitch

--- a/src/pmlogconf/zeroconf/pidstat
+++ b/src/pmlogconf/zeroconf/pidstat
@@ -21,11 +21,3 @@ delta	30 seconds
 	proc.id.uid
 	proc.id.uid_nm
 	proc.psinfo.psargs
-
-	kernel.all.cpu.user
-	kernel.all.cpu.vuser
-	kernel.all.cpu.sys
-	kernel.all.cpu.guest
-	kernel.all.cpu.nice
-	kernel.all.cpu.idle
-


### PR DESCRIPTION
There are two intervals (10 sec, 30 sec) to collect kernel.all.cpu.*
metrics if zeroconf is enabled.

In this case, the metrics can be collected twice in a very short period
of time. Due to the short sampling interval, large error values may be
output in rate calculation.

To resolve the issue, remove the metrics from 30-second sampling setting.
At the same time, we'll add kernel.all.cpu.vuser to tools/sar to make
sure we don't lose the metric.

modified: src/pmlogconf/zeroconf/pidstat
modified: src/pmlogconf/tools/sar