### PR TITLE
rename netproc metrics and add pmlogconf rule

### DIFF
--- a/qa/1286
+++ b/qa/1286
@@ -49,8 +49,8 @@ esac
 _pid_filter()
 {
     sed \
-      -e "s/$1/SERVERPID/g" \
-      -e "s/$2/CLIENTPID/g" \
+      -e "s/0*$1/SERVERPID/g" \
+      -e "s/0*$2/CLIENTPID/g" \
       -e '/inst \[[0-9]/d' \
     #end
 }
@@ -91,14 +91,14 @@ wait ${server_pid}
 echo "server PID: ${server_pid}" >> "$seq.full"
 echo "client PID: ${client_pid}" >> "$seq.full"
 
-for metric in bcc.proc.io.net.perpid.tcp.send.calls \
-              bcc.proc.io.net.perpid.tcp.send.bytes \
-              bcc.proc.io.net.perpid.tcp.recv.calls \
-              bcc.proc.io.net.perpid.tcp.recv.bytes \
-              bcc.proc.io.net.perpid.udp.send.calls \
-              bcc.proc.io.net.perpid.udp.send.bytes \
-              bcc.proc.io.net.perpid.udp.recv.calls \
-              bcc.proc.io.net.perpid.udp.recv.bytes
+for metric in bcc.proc.net.tcp.send.calls \
+              bcc.proc.net.tcp.send.bytes \
+              bcc.proc.net.tcp.recv.calls \
+              bcc.proc.net.tcp.recv.bytes \
+              bcc.proc.net.udp.send.calls \
+              bcc.proc.net.udp.send.bytes \
+              bcc.proc.net.udp.recv.calls \
+              bcc.proc.net.udp.recv.bytes
 do
     echo && echo && echo "=== report metric values for $metric ==="
     pminfo -dfmtT $metric 2>&1 | tee -a $seq.full \

--- a/qa/1286.out
+++ b/qa/1286.out
@@ -41,18 +41,18 @@ Check bcc metrics have appeared ... X metrics and X values
 
 
 
-=== report metric values for bcc.proc.io.net.perpid.tcp.send.calls ===
+=== report metric values for bcc.proc.net.tcp.send.calls ===
 
     Data Type: 64-bit unsigned int  InDom: 149.40 0x25400028
     Semantics: counter  Units: count
     inst [CLIENTPID or "CLIENTPID"] value 1
     inst [SERVERPID or "SERVERPID"] value 1
 Help:
-bcc.proc.io.net.perpid.tcp.send.calls PMID: 149.40.0 [number of TCP send calls (tcp_sendmsg())]
+bcc.proc.net.tcp.send.calls PMID: 149.40.0 [number of TCP send calls (tcp_sendmsg())]
 number of TCP send calls (tcp_sendmsg())
 
 
-=== report metric values for bcc.proc.io.net.perpid.tcp.send.bytes ===
+=== report metric values for bcc.proc.net.tcp.send.bytes ===
 
     Data Type: 64-bit unsigned int  InDom: 149.40 0x25400028
     Semantics: counter  Units: byte
@@ -60,21 +60,21 @@ number of TCP send calls (tcp_sendmsg())
     inst [SERVERPID or "SERVERPID"] value 17
 Help:
 amount of bytes requested to be sent
-bcc.proc.io.net.perpid.tcp.send.bytes PMID: 149.40.1 [amount of bytes requested to be sent]
+bcc.proc.net.tcp.send.bytes PMID: 149.40.1 [amount of bytes requested to be sent]
 
 
-=== report metric values for bcc.proc.io.net.perpid.tcp.recv.calls ===
+=== report metric values for bcc.proc.net.tcp.recv.calls ===
 
     Data Type: 64-bit unsigned int  InDom: 149.40 0x25400028
     Semantics: counter  Units: count
     inst [CLIENTPID or "CLIENTPID"] value 1
     inst [SERVERPID or "SERVERPID"] value 1
 Help:
-bcc.proc.io.net.perpid.tcp.recv.calls PMID: 149.40.2 [number of TCP recv calls (tcp_recvmsg()/tcp_cleanup_rbuf())]
+bcc.proc.net.tcp.recv.calls PMID: 149.40.2 [number of TCP recv calls (tcp_recvmsg()/tcp_cleanup_rbuf())]
 number of TCP recv calls (tcp_recvmsg()/tcp_cleanup_rbuf())
 
 
-=== report metric values for bcc.proc.io.net.perpid.tcp.recv.bytes ===
+=== report metric values for bcc.proc.net.tcp.recv.bytes ===
 
     Data Type: 64-bit unsigned int  InDom: 149.40 0x25400028
     Semantics: counter  Units: byte
@@ -82,21 +82,21 @@ number of TCP recv calls (tcp_recvmsg()/tcp_cleanup_rbuf())
     inst [SERVERPID or "SERVERPID"] value 11
 Help:
 amount of bytes received
-bcc.proc.io.net.perpid.tcp.recv.bytes PMID: 149.40.3 [amount of bytes received]
+bcc.proc.net.tcp.recv.bytes PMID: 149.40.3 [amount of bytes received]
 
 
-=== report metric values for bcc.proc.io.net.perpid.udp.send.calls ===
+=== report metric values for bcc.proc.net.udp.send.calls ===
 
     Data Type: 64-bit unsigned int  InDom: 149.40 0x25400028
     Semantics: counter  Units: count
     inst [CLIENTPID or "CLIENTPID"] value 1
     inst [SERVERPID or "SERVERPID"] value 1
 Help:
-bcc.proc.io.net.perpid.udp.send.calls PMID: 149.40.4 [number of UDP send calls (udp_sendmsg())]
+bcc.proc.net.udp.send.calls PMID: 149.40.4 [number of UDP send calls (udp_sendmsg())]
 number of UDP send calls (udp_sendmsg())
 
 
-=== report metric values for bcc.proc.io.net.perpid.udp.send.bytes ===
+=== report metric values for bcc.proc.net.udp.send.bytes ===
 
     Data Type: 64-bit unsigned int  InDom: 149.40 0x25400028
     Semantics: counter  Units: byte
@@ -104,21 +104,21 @@ number of UDP send calls (udp_sendmsg())
     inst [SERVERPID or "SERVERPID"] value 22
 Help:
 amount of bytes requested to be sent
-bcc.proc.io.net.perpid.udp.send.bytes PMID: 149.40.5 [amount of bytes requested to be sent]
+bcc.proc.net.udp.send.bytes PMID: 149.40.5 [amount of bytes requested to be sent]
 
 
-=== report metric values for bcc.proc.io.net.perpid.udp.recv.calls ===
+=== report metric values for bcc.proc.net.udp.recv.calls ===
 
     Data Type: 64-bit unsigned int  InDom: 149.40 0x25400028
     Semantics: counter  Units: count
     inst [CLIENTPID or "CLIENTPID"] value 1
     inst [SERVERPID or "SERVERPID"] value 1
 Help:
-bcc.proc.io.net.perpid.udp.recv.calls PMID: 149.40.6 [number of UDP recv calls (udp_recvmsg()/skb_consume_udp())]
+bcc.proc.net.udp.recv.calls PMID: 149.40.6 [number of UDP recv calls (udp_recvmsg()/skb_consume_udp())]
 number of UDP recv calls (udp_recvmsg()/skb_consume_udp())
 
 
-=== report metric values for bcc.proc.io.net.perpid.udp.recv.bytes ===
+=== report metric values for bcc.proc.net.udp.recv.bytes ===
 
     Data Type: 64-bit unsigned int  InDom: 149.40 0x25400028
     Semantics: counter  Units: byte
@@ -126,7 +126,7 @@ number of UDP recv calls (udp_recvmsg()/skb_consume_udp())
     inst [SERVERPID or "SERVERPID"] value 16
 Help:
 amount of bytes received
-bcc.proc.io.net.perpid.udp.recv.bytes PMID: 149.40.7 [amount of bytes received]
+bcc.proc.net.udp.recv.bytes PMID: 149.40.7 [amount of bytes received]
 
 === remove bcc agent ===
 Culling the Performance Metrics Name Space ...

--- a/src/derived/proc.conf
+++ b/src/derived/proc.conf
@@ -30,7 +30,7 @@ proc.hog.disk(helptext) = '\
 average I/O rate (reads and writes less cancelled writes) of each process
 since it was started.'
 
-proc.hog.net = rate(bcc.proc.io.net.perpid.tcp.recv.bytes) + rate(bcc.proc.io.net.perpid.tcp.send.bytes) + rate(bcc.proc.io.net.perpid.udp.recv.bytes) + rate(bcc.proc.io.net.perpid.udp.send.bytes)
+proc.hog.net = rate(bcc.proc.net.tcp.recv.bytes) + rate(bcc.proc.net.tcp.send.bytes) + rate(bcc.proc.net.udp.recv.bytes) + rate(bcc.proc.net.udp.send.bytes)
 proc.hog.net(oneline) = sum of network usage by the process
 proc.hog.net(helptext) = '\
 sum of network usage (TCP/UDP recv/send) by each process.'

--- a/src/pcp/atop/netprocmetrics.map
+++ b/src/pcp/atop/netprocmetrics.map
@@ -2,15 +2,15 @@
 # metric names and access macros for netproc.c
 #
 netprocmetrics {
-	bcc.proc.io.net.perpid.tcp.send.calls	TASK_NET_TCPSND
-	bcc.proc.io.net.perpid.tcp.send.bytes	TASK_NET_TCPSSZ
-	bcc.proc.io.net.perpid.tcp.recv.calls	TASK_NET_TCPRCV
-	bcc.proc.io.net.perpid.tcp.recv.bytes	TASK_NET_TCPRSZ
+	bcc.proc.net.tcp.send.calls	TASK_NET_TCPSND
+	bcc.proc.net.tcp.send.bytes	TASK_NET_TCPSSZ
+	bcc.proc.net.tcp.recv.calls	TASK_NET_TCPRCV
+	bcc.proc.net.tcp.recv.bytes	TASK_NET_TCPRSZ
 
-	bcc.proc.io.net.perpid.udp.send.calls	TASK_NET_UDPSND
-	bcc.proc.io.net.perpid.udp.send.bytes	TASK_NET_UDPSSZ
-	bcc.proc.io.net.perpid.udp.recv.calls	TASK_NET_UDPRCV
-	bcc.proc.io.net.perpid.udp.recv.bytes	TASK_NET_UDPRSZ
+	bcc.proc.net.udp.send.calls	TASK_NET_UDPSND
+	bcc.proc.net.udp.send.bytes	TASK_NET_UDPSSZ
+	bcc.proc.net.udp.recv.calls	TASK_NET_UDPRCV
+	bcc.proc.net.udp.recv.bytes	TASK_NET_UDPRSZ
 
 	# end marker - provides count
 	.					TASK_NET_NMETRICS

--- a/src/pmdas/bcc/GNUmakefile
+++ b/src/pmdas/bcc/GNUmakefile
@@ -27,6 +27,9 @@ PMDAADMDIR = $(PCP_PMDASADM_DIR)/$(IAM)
 PMDACONFIG = $(PCP_SYSCONF_DIR)/$(IAM)
 PMDATMPDIR = $(PCP_PMDAS_DIR)/$(IAM)
 
+REWRITEDIR = $(PCP_SYSCONF_DIR)/pmlogrewrite
+REWRITEVARDIR = $(PCP_VAR_DIR)/config/pmlogrewrite
+
 MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
@@ -45,6 +48,7 @@ install_pcp install ::	default
 	$(INSTALL) -m 644 -t $(PMDATMPDIR) pmdautil.python README.md $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDACONFIG)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR) $(CONFIGS) $(PMDACONFIG)
+	$(INSTALL) -m 644 -t $(REWRITEVARDIR)/bcc_migrate.conf migrate.conf $(REWRITEDIR)/bcc_migrate.conf
 	@$(INSTALL_MAN)
 
 default_pcp default ::	$(SUBDIRS)

--- a/src/pmdas/bcc/migrate.conf
+++ b/src/pmdas/bcc/migrate.conf
@@ -1,0 +1,15 @@
+#
+# Copyright 2021 Red Hat.
+#
+# pmlogrewrite configuration for migrating archives containing netproc metrics
+# before the metric rename
+#
+
+metric bcc.proc.io.net.perpid.tcp.send.calls { name -> bcc.proc.net.tcp.send.calls }
+metric bcc.proc.io.net.perpid.tcp.send.bytes { name -> bcc.proc.net.tcp.send.bytes }
+metric bcc.proc.io.net.perpid.tcp.recv.calls { name -> bcc.proc.net.tcp.recv.calls }
+metric bcc.proc.io.net.perpid.tcp.recv.bytes { name -> bcc.proc.net.tcp.recv.bytes }
+metric bcc.proc.io.net.perpid.udp.send.calls { name -> bcc.proc.net.udp.send.calls }
+metric bcc.proc.io.net.perpid.udp.send.bytes { name -> bcc.proc.net.udp.send.bytes }
+metric bcc.proc.io.net.perpid.udp.recv.calls { name -> bcc.proc.net.udp.recv.calls }
+metric bcc.proc.io.net.perpid.udp.recv.bytes { name -> bcc.proc.net.udp.recv.bytes }

--- a/src/pmdas/bcc/modules/netproc.python
+++ b/src/pmdas/bcc/modules/netproc.python
@@ -38,7 +38,7 @@ bpf_src = "modules/netproc.bpf"
 # PCP BCC PMDA constants
 #
 MODULE = "netproc"
-BASENS = "proc.io.net.perpid."
+BASENS = "proc.net."
 units_bytes = pmUnits(1, 0, 0, PM_SPACE_BYTE, 0, 0)
 units_count = pmUnits(0, 0, 1, 0, 0, PM_COUNT_ONE)
 units_none = pmUnits(0, 0, 0, 0, 0, 0)

--- a/src/pmlogconf/networking/localdefs
+++ b/src/pmlogconf/networking/localdefs
@@ -1,1 +1,1 @@
-FILES = nfs2-client nfs2-server nfs3-client nfs3-server nfs4-client nfs4-server rpc interface-summary interface-all socket-linux mbufs multicast streams tcp-all udp-all tcp-activity-linux udp-packets-linux other-protocols softnet icmp6 ip6 udp6 persocket-linux
+FILES = nfs2-client nfs2-server nfs3-client nfs3-server nfs4-client nfs4-server rpc interface-summary interface-all socket-linux mbufs multicast streams tcp-all udp-all tcp-activity-linux udp-packets-linux other-protocols softnet icmp6 ip6 udp6 persocket-linux perprocess-linux

--- a/src/pmlogconf/networking/perprocess-linux
+++ b/src/pmlogconf/networking/perprocess-linux
@@ -1,0 +1,4 @@
+#pmlogconf-setup 2.0
+ident	per-process network statistics [Linux]
+probe	bcc.proc.net.tcp.recv.bytes values ? include : exclude
+	bcc.proc.net

--- a/src/pmrep/pmrep.conf
+++ b/src/pmrep/pmrep.conf
@@ -168,16 +168,16 @@ proc.psinfo.delayacct_blkio_time = ,,
 #bcc.proc.io.total                = ,,kb/s
 
 [proc-net]
-bcc.proc.io.net.perpid.tcp.recv.bytes = ,,
-bcc.proc.io.net.perpid.tcp.send.bytes = ,,
-bcc.proc.io.net.perpid.udp.recv.bytes = ,,
-bcc.proc.io.net.perpid.udp.send.bytes = ,,
+bcc.proc.net.tcp.recv.bytes = ,,
+bcc.proc.net.tcp.send.bytes = ,,
+bcc.proc.net.udp.recv.bytes = ,,
+bcc.proc.net.udp.send.bytes = ,,
 
 [proc-net-ext]
-bcc.proc.io.net.perpid.tcp.recv.calls = ,,
-bcc.proc.io.net.perpid.tcp.send.calls = ,,
-bcc.proc.io.net.perpid.udp.recv.calls = ,,
-bcc.proc.io.net.perpid.udp.send.calls = ,,
+bcc.proc.net.tcp.recv.calls = ,,
+bcc.proc.net.tcp.send.calls = ,,
+bcc.proc.net.udp.recv.calls = ,,
+bcc.proc.net.udp.send.calls = ,,
 
 [proc-children]
 proc.psinfo.cmin_flt = ,,


### PR DESCRIPTION
afaics I've covered all usages of the netproc PMDA and renamed the metric in all places. Can you please double-check?

I've also added a pmlogconf rule to log the metric if it's available (note: the BCC PMDA is *not* installed by default).