### PR TITLE
discovery: do not register callback twice for initial directories

### DIFF
--- a/src/libpcp_web/src/discover.c
+++ b/src/libpcp_web/src/discover.c
@@ -1531,6 +1531,7 @@ static void
 dir_callback(pmDiscover *p)
 {
     pmDiscoverMonitor(p->context.name, changed_callback);
+    p->flags &= ~PM_DISCOVER_FLAGS_NEW;
 }
 
 static void
@@ -1540,6 +1541,7 @@ archive_callback(pmDiscover *p)
 	if (pmDebugOptions.discovery)
 	    fprintf(stderr, "DISCOVERED ARCHIVE %s\n", p->context.name);
 	pmDiscoverMonitor(p->context.name, changed_callback);
+	p->flags &= ~PM_DISCOVER_FLAGS_NEW;
     }
 }
 


### PR DESCRIPTION
The initial directories and archive are registered twice:

pmDiscoverMonitor: added event for /var/log/pcp/pmlogger (flags: 0x0011 |new|directory|)
pmDiscoverMonitor: added event for /var/log/pcp/pmlogger/agerstmayr-thinkpad (flags: 0x0011 |new|directory|)
pmDiscoverMonitor: added event for /var/log/pcp/pmlogger/agerstmayr-thinkpad/20210421.14.42.meta (flags: 0x00a1 |new|datavol|metavol|)
fs_change_callBack: event on /var/log/pcp/pmlogger/agerstmayr-thinkpad - changed
pmDiscoverMonitor: added event for /var/log/pcp/pmlogger/agerstmayr-thinkpad/20210421.14.42.meta (flags: 0x00a1 |new|datavol|metavol|)
pmDiscoverMonitor: added event for /var/log/pcp/pmlogger (flags: 0x0011 |new|directory|)
pmDiscoverMonitor: added event for /var/log/pcp/pmlogger/agerstmayr-thinkpad (flags: 0x0011 |new|directory|)
fs_change_callBack: event on /var/log/pcp/pmlogger/agerstmayr-thinkpad - changed
fs_change_callBack: event on /var/log/pcp/pmlogger/agerstmayr-thinkpad - changed

resulting in the fs_change_callBack callback executed twice on every
change to the root pmlogger directory. This commit removes the
PM_DISCOVER_FLAGS_NEW flag upon first registration.