### PR TITLE
pmrep: add RHEL8 compatible sar metricsets to default pmrep conf directory

### DIFF
--- a/src/pmrep/conf/sar_v11.conf
+++ b/src/pmrep/conf/sar_v11.conf
@@ -1,0 +1,78 @@
+#
+# pmrep(1) configuration file - see pmrep.conf(5)
+#
+
+
+# Compact metric specifications are of form (see pmrep(1)):
+#pcp.metric.name = label,instances,unit/scale,type,width,precision,limit
+
+
+#
+# Mimic assorted sar(1) reports - sysstat-11.7
+#
+[sar_v11-b]
+header = yes
+unitinfo = no
+globals = no
+timestamp = yes
+width = 9
+precision = 2
+delimiter = " "
+disk.all.total    = tps,,,,12
+disk.all.read     = rtps,,,,
+disk.all.write    = wtps,,,,
+disk.all.blkread  = bread/s,,,,
+disk.all.blkwrite = bwrtn/s,,,,
+
+[sar_v11-d-dev]
+header = yes
+unitinfo = no
+globals = no
+timestamp = yes
+width = 9
+precision = 2
+delimiter = " "
+colxrow = "         DEV"
+disk.dev.total       = tps,,,,
+disk.dev.read_bytes  = rkB/s,,kB,,
+disk.dev.write_bytes = wkB/s,,kB,,
+disk.dev.avg_rqsz    = areq-sz,,,,
+disk.dev.avg_qlen    = aqu_sz,,,,
+disk.dev.await       = await,,,,,
+svctm                = svctm,,,,
+svctm.formula        = 1000 * rate(disk.dev.avactive) / rate(disk.dev.total)
+disk.dev.util        = %%util
+
+[sar_v11-d-dm]
+header = yes
+unitinfo = no
+globals = no
+timestamp = yes
+width = 9
+precision = 2
+delimiter = " "
+colxrow = "         DEV"
+disk.dm.total       = tps,,,,
+disk.dm.read_bytes  = rkB/s,,KB,,
+disk.dm.write_bytes = wkB/s,,KB,,
+disk.dm.avg_rqsz    = avgrq-sz_kb,,,,
+disk.dm.avg_qlen    = avgqu-sz,,,,
+disk.dm.await       = await,,,,
+svctm               = svctm,,,,
+svctm.formula       = 1000 * rate(disk.dm.avactive) / rate(disk.dm.total)
+disk.dm.util        = %%util,,,,
+
+[sar_v11-H]
+header = yes
+unitinfo = no
+globals = no
+timestamp = yes
+width = 9
+precision = 2
+delimiter = " "
+mem.util.hugepagesFreeBytes = kbhugfree,,kB,,12,0
+mem.util.hugepagesRsvdBytes = kbhugused,,kB,,,0
+hugusedp                    = mem.util.hugepagesRsvd_pct
+hugusedp.label              = %%hugused
+hugusedp.formula            = 100 * ((mem.util.hugepagesTotalBytes - mem.util.hugepagesFreeBytes) / mem.util.hugepagesTotalBytes)
+


### PR DESCRIPTION
The output format of some metricsets has been changed to
follow the changes in sysstat v12. Leave the old sar-v11 output
format as well for RHEL8 users.