### PR TITLE
pmproxy: start pmproxy after Redis (if available)

### DIFF
--- a/src/pmproxy/pmproxy.service.in
+++ b/src/pmproxy/pmproxy.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Proxy for Performance Metrics Collector Daemon
 Documentation=man:pmproxy(1)
-After=network-online.target pmcd.service
+After=network-online.target pmcd.service redis.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
If pmproxy starts before Redis, it will disable time-series
functionality. This update makes sure that pmproxy starts after Redis
(only if Redis is available, otherwise there is no change in behavior).

Related: #1296