### PR TITLE
selinux: use new logging_watch_all_log_dirs_path macro

### DIFF
--- a/configure
+++ b/configure
@@ -713,6 +713,7 @@ fmt_uint64
 fmt_int64
 fmt_pid
 rdynamic_flag
+pcp_selinux_logging_watch_all_log_dirs_path
 pcp_selinux_files_mmap_all_files
 pcp_selinux_netlink_tcpdiag_socket_class
 pcp_selinux_netlink_generic_socket_class
@@ -11977,9 +11978,10 @@ fi
 
 
 pcp_selinux_files_mmap_all_files=false
+pcp_selinux_logging_watch_all_log_dirs_path=false
 if test "x$enable_selinux" != "xfalse"
 then
-            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for selinux files_mmap_all_files() macro" >&5
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for selinux files_mmap_all_files() macro" >&5
 $as_echo_n "checking for selinux files_mmap_all_files() macro... " >&6; }
     cat <<End-of-File >conftest.te
 module conftest 1.0;
@@ -12000,7 +12002,30 @@ $as_echo "yes" >&6; }
 $as_echo "no" >&6; }
     fi
         rm -f tmp/all_interfaces.conf tmp/conftest.* tmp/iferror.m4
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for selinux logging_watch_all_log_dirs_path() macro" >&5
+$as_echo_n "checking for selinux logging_watch_all_log_dirs_path() macro... " >&6; }
+    cat <<End-of-File >conftest.te
+module conftest 1.0;
+require {
+	attribute logfile;
+	attribute pcp_domain;
+	class dir { getattr search open watch };
+}
+logging_watch_all_log_dirs_path(pcp_domain);
+End-of-File
+    if make -f /usr/share/selinux/devel/Makefile conftest.pp >/dev/null 2>&1
+    then
+	pcp_selinux_logging_watch_all_log_dirs_path=true
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+    else
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+    fi
+        rm -f tmp/all_interfaces.conf tmp/conftest.* tmp/iferror.m4
 fi
+
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking return type of signal handlers" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -2220,11 +2220,11 @@ AC_SUBST(pcp_selinux_rawip_socket_class)
 AC_SUBST(pcp_selinux_netlink_generic_socket_class)
 AC_SUBST(pcp_selinux_netlink_tcpdiag_socket_class)
 
+dnl more work to do, these selinux macro are not always supported
 pcp_selinux_files_mmap_all_files=false
+pcp_selinux_logging_watch_all_log_dirs_path=false
 if test "x$enable_selinux" != "xfalse"
 then
-    dnl more work to do, files_mmap_all_files() macro is not always
-    dnl supported
     AC_MSG_CHECKING([for selinux files_mmap_all_files() macro])
     cat <<End-of-File >conftest.te
 module conftest 1.0;
@@ -2244,8 +2244,29 @@ End-of-File
     fi
     dnl cleanup turds from selinux Makefile
     rm -f tmp/all_interfaces.conf tmp/conftest.* tmp/iferror.m4
+
+    AC_MSG_CHECKING([for selinux logging_watch_all_log_dirs_path() macro])
+    cat <<End-of-File >conftest.te
+module conftest 1.0;
+require {
+	attribute logfile;
+	attribute pcp_domain;
+	class dir { getattr search open watch };
+}
+logging_watch_all_log_dirs_path(pcp_domain);
+End-of-File
+    if make -f /usr/share/selinux/devel/Makefile conftest.pp >/dev/null 2>&1
+    then
+	pcp_selinux_logging_watch_all_log_dirs_path=true
+	AC_MSG_RESULT(yes)
+    else
+	AC_MSG_RESULT(no)
+    fi
+    dnl cleanup turds from selinux Makefile
+    rm -f tmp/all_interfaces.conf tmp/conftest.* tmp/iferror.m4
 fi
 AC_SUBST(pcp_selinux_files_mmap_all_files)
+AC_SUBST(pcp_selinux_logging_watch_all_log_dirs_path)
 
 dnl Checks for library functions.
 AC_TYPE_SIGNAL

--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -280,6 +280,7 @@ PCP_SELINUX_VIRT_VAR_RUN = @pcp_selinux_virt_var_run@
 PCP_SELINUX_PROC_SECURITY = @pcp_selinux_proc_security@
 PCP_SELINUX_SBD_EXEC = @pcp_selinux_sbd_exec@
 PCP_SELINUX_FILES_MMAP_ALL_FILES = @pcp_selinux_files_mmap_all_files@
+PCP_SELINUX_LOGGING_WATCH_ALL_LOG_DIRS_PATH = @pcp_selinux_logging_watch_all_log_dirs_path@
 PCP_SELINUX_CAPABILITY2_SYSLOG = @pcp_selinux_capability2_syslog@
 PCP_SELINUX_CAPABILITY2_BPF = @pcp_selinux_capability2_bpf@
 PCP_SELINUX_ICMP_SOCKET_CLASS = @pcp_selinux_icmp_socket_class@

--- a/src/selinux/GNUlocaldefs
+++ b/src/selinux/GNUlocaldefs
@@ -50,6 +50,11 @@ ifeq "$(PCP_SELINUX_FILES_MMAP_ALL_FILES)" "true"
 PCP_MMAP_ALL="files_mmap_all_files(pcp_domain);"
 endif
 
+ifeq "$(PCP_SELINUX_LOGGING_WATCH_ALL_LOG_DIRS_PATH)" "true"
+PCP_WATCH_ALL="logging_watch_all_log_dirs_path(pcp_domain);"
+PCP_WATCH_JOURNAL="logging_watch_journal_dir(pcp_domain);"
+endif
+
 ifeq "$(PCP_SELINUX_UNCONFINED)" "true"
 PCP_UNCONFINED_SERVICE="type unconfined_service_t;"
 PCP_PMLOGGER_UNCONFINED_SERVICE_RULE="allow pcp_pmlogger_t unconfined_service_t:process signal;"

--- a/src/selinux/GNUmakefile
+++ b/src/selinux/GNUmakefile
@@ -62,6 +62,8 @@ $(IAM).te: $(IAM).te.in
 		-e 's+@PCP_NUMAD_RULE@+'$(PCP_NUMAD_RULE)'+' \
 		-e 's+@PCP_FSADM_EXEC_MAP@+'$(PCP_FSADM_EXEC_MAP)'+' \
 		-e 's+@PCP_MMAP_ALL@+'$(PCP_MMAP_ALL)'+' \
+		-e 's+@PCP_WATCH_ALL@+'$(PCP_WATCH_ALL)'+' \
+		-e 's+@PCP_WATCH_JOURNAL@+'$(PCP_WATCH_JOURNAL)'+' \
 		-e 's+@PCP_BPF_CLASS@+'$(PCP_BPF_CLASS)'+' \
 		-e 's+@PCP_BPF_RULE@+'$(PCP_BPF_RULE)'+' \
 		-e 's+@PCP_RPM_VAR_LIB_T@+'$(PCP_RPM_VAR_LIB_T)'+' \

--- a/src/selinux/pcpupstream.te.in
+++ b/src/selinux/pcpupstream.te.in
@@ -1,4 +1,4 @@
-module pcpupstream @PACKAGE_VERSION@;
+policy_module(pcpupstream,@PACKAGE_VERSION@);
 
 require {
         attribute domain;
@@ -434,6 +434,10 @@ corenet_tcp_connect_all_ports(pcp_domain)
 
 # all pcp_domain read access to all maps
 @PCP_MMAP_ALL@
+
+# all pcp_domain watch access to all log files
+@PCP_WATCH_ALL@
+@PCP_WATCH_JOURNAL@
 
 #=========== pmda-hacluster ============
 # pmda-hacluster requirements for checking crm_mon, cibadmin, corosync-quorumtool, corosync-cfgtool


### PR DESCRIPTION
Allow PMDAs that access log files to do so when latest versions
of the kernel and selinux-policy is installed.

This resolves a new qa/652 (pmdasystemd) failure amongst others.