### PR TITLE
pmlogger: fix FD leak on reexec, plus QA

### DIFF
--- a/qa/1901
+++ b/qa/1901
@@ -1,0 +1,45 @@
+#!/bin/sh
+# PCP QA Test No. 1901
+# test pmlogger FD leak on SIGUSR1 reexec
+#
+# Copyright (c) 2021 Red Hat.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+. ./common.secure
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+mkdir -p $tmp
+PMLOGGER=$PCP_BIN_DIR/pmlogger
+spec=qa-$seq-%Y%m%d.%H.%M
+
+echo "== checking SIGUSR2 reexec does not leak FDs" | tee -a $seq.full
+$PMLOGGER -U$username -s10 -t 1s -c config.default -l $tmp/pmlogger.log $tmp/$spec 2>$tmp/$seq.err &
+pid=$!; sleep 5; 
+before=`$sudo pminfo -f proc.fd.count | awk '$2 ~ "'$pid'" {print $NF}'`
+$sudo -u $username kill -USR2 $pid; sleep 5
+after=`$sudo pminfo -f proc.fd.count | awk '$2 ~ "'$pid'" {print $NF}'`
+echo === log === >>$seq.full; cat $tmp/pmlogger.log >>$seq.full
+echo === err === >>$seq.full; cat $tmp/$seq.err >>$seq.full
+if [ "$before" -ne "$after" ]
+then
+    echo "FAILED $before not equal to $after"
+    status=1
+else
+    status=0
+fi
+exit

--- a/qa/1901.out
+++ b/qa/1901.out
@@ -1,0 +1,2 @@
+QA output created by 1901
+== checking SIGUSR2 reexec does not leak FDs

--- a/qa/group
+++ b/qa/group
@@ -1922,6 +1922,7 @@ x11
 1896 pmlogger logutil pmlc local
 1897 pmda.hacluster local valgrind
 1899 fetch local
+1901 pmlogger local
 1902 help local
 1937 pmlogrewrite pmda.xfs local
 1955 libpcp pmda pmda.pmcd local

--- a/src/pmlogger/src/ports.c
+++ b/src/pmlogger/src/ports.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2015,2018 Red Hat.
+ * Copyright (c) 2012-2015,2018,2021 Red Hat.
  * Copyright (c) 1995-2001,2004 Silicon Graphics, Inc.  All Rights Reserved.
  * 
  * This program is free software; you can redistribute it and/or modify it
@@ -250,6 +250,7 @@ GetPorts(char *file)
     int			address = INADDR_ANY;
     int			ctlix;
     int			sts;
+    int			fdFlags;
     char		*env_str;
     __pmSockAddr	*myAddr;
 #if defined(HAVE_STRUCT_SOCKADDR_UN)
@@ -424,6 +425,10 @@ GetPorts(char *file)
 	    }
 	    __pmSockAddrFree(myAddr);
 	}
+
+	/* Set close on exec for daily reexec log-roll */
+	if ((fdFlags = __pmGetFileDescriptorFlags(fd)) >= 0)
+	    __pmSetFileDescriptorFlags(fd, fdFlags | FD_CLOEXEC);
 
 	/* Now listen on the new socket. */
 	if (sts >= 0) {


### PR DESCRIPTION
Set FD_CLOEXEC flag on the pmlogger control sockets so they are
closed when pmlogger reexecs. Add new test qa/1901 to verify.