### PR TITLE
pmproxy: add pmproxy.mem.rss and pmproxy.mem.vsz metrics

### DIFF
--- a/src/pmproxy/src/server.h
+++ b/src/pmproxy/src/server.h
@@ -45,6 +45,8 @@ typedef enum proxy_registry {
 
 typedef enum server_metric {
     SERVER_PID,
+    SERVER_MEM_VSZ,
+    SERVER_MEM_RSS,
     NUM_SERVER_METRIC
 } server_metric;
 
@@ -166,6 +168,7 @@ typedef struct proxy {
     struct dict		*config;	/* configuration dictionary */
     uv_loop_t		*events;	/* global, async event loop */
     uv_callback_t	write_callbacks;
+    void		*metrics_handle;
 } proxy;
 
 extern void proxylog(pmLogLevel, sds, void *);

--- a/src/pmrep/conf/pmproxy.conf
+++ b/src/pmrep/conf/pmproxy.conf
@@ -13,6 +13,8 @@
 [pmproxy]
 timestamp = yes
 repeat_header = auto
+pmproxy.mem.vsz = vsz,,,,7
+pmproxy.mem.rss = rss,,,,7
 pmproxy.redis.requests.inflight.bytes = backlog,,,,8
 pmproxy.redis.requests.inflight.total = inflight,,,,8
 pmproxy.redis.requests.total = reqs/s,,,,8,1


### PR DESCRIPTION
Adds pmproxy metrics for virtual size and resident set size.
This will be useful for correlating pmproxy memory growth
with other metrics.

Also updates pmrep config for ':pmproxy' to include these in
the first two columns.

QA is still todo (would just verify against ps listing).

Related: https://github.com/performancecopilot/pcp/issues/1318