### PR TITLE
libpcp: complete remaining libpcp.h internal struct renaming

### DIFF
--- a/qa/src/parsehostattrs.c
+++ b/qa/src/parsehostattrs.c
@@ -22,7 +22,7 @@ main(int argc, char **argv)
     char		*msg;
     char		buffer[512];
     __pmHashCtl		attrs;
-    pmHostSpec		*hosts;
+    __pmHostSpec	*hosts;
     int			count, sts, i, j;
 
     if (argc != 2) {

--- a/qa/src/parsehostspec.c
+++ b/qa/src/parsehostspec.c
@@ -6,7 +6,7 @@ int
 main(int argc, char **argv)
 {
     char		*msg, buffer[512];
-    pmHostSpec		*hosts;
+    __pmHostSpec	*hosts;
     int			count, sts, i, j;
 
     if (argc != 2) {

--- a/src/include/pcp/libpcp.h
+++ b/src/include/pcp/libpcp.h
@@ -24,13 +24,6 @@
 #ifndef PCP_LIBPCP_H
 #define PCP_LIBPCP_H
 
-/*
- * TODO
- * demote names from pm... to __pm... for
- * - pmHostSpec
- * - pmTimeZone
- */
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -521,9 +514,9 @@ typedef struct {
     char	*name;			/* hostname (always valid) */
     int		*ports;			/* array of host port numbers */
     int		nports;			/* number of ports in host port array */
-} pmHostSpec;
-PCP_CALL extern int __pmParseHostSpec(const char *, pmHostSpec **, int *, char **);
-PCP_CALL extern int __pmUnparseHostSpec(pmHostSpec *, int, char *, size_t);
+} __pmHostSpec;
+PCP_CALL extern int __pmParseHostSpec(const char *, __pmHostSpec **, int *, char **);
+PCP_CALL extern int __pmUnparseHostSpec(__pmHostSpec *, int, char *, size_t);
 
 /*
  * unfortunately, in this version, PCP archives are limited to no
@@ -600,8 +593,8 @@ PCP_CALL extern int __pmCompressedFileIndex(char *, size_t);
 typedef struct {
     int			pc_fd;		/* socket for comm with pmcd */
 					/* ... -1 means no connection */
-    pmHostSpec		*pc_hosts;	/* pmcd and proxy host specifications */
-    int			pc_nhosts;	/* number of pmHostSpec entries */
+    __pmHostSpec	*pc_hosts;	/* pmcd and proxy host specifications */
+    int			pc_nhosts;	/* number of hostspec entries */
     int			pc_timeout;	/* set if connect times out */
     int			pc_tout_sec;	/* timeout for __pmGetPDU */
     time_t		pc_again;	/* time to try again */
@@ -1220,13 +1213,6 @@ PCP_CALL extern void __pmSetLocalContextFlag(pmOptions *);
 PCP_CALL extern void __pmSetLocalContextTable(pmOptions *, char *);
 PCP_CALL extern void __pmEndOptions(pmOptions *);
 
-/* real pmTimeZone declaration */
-typedef struct {
-    char		*label;		/* label to name tz */
-    char		*tz;		/* env $TZ */
-    int			handle;		/* handle from pmNewZone() */
-} pmTimeZone;
-
 /* work out local timezone */
 PCP_CALL extern char *__pmTimezone(void);		/* NOT thread-safe */
 PCP_CALL extern char *__pmTimezone_r(char *, int);
@@ -1312,9 +1298,9 @@ typedef enum {
 } __pmAttrKey;
 PCP_CALL extern __pmAttrKey __pmLookupAttrKey(const char *, size_t);
 PCP_CALL extern int __pmParseHostAttrsSpec(
-    const char *, pmHostSpec **, int *, __pmHashCtl *, char **);
+    const char *, __pmHostSpec **, int *, __pmHashCtl *, char **);
 PCP_CALL extern int __pmUnparseHostAttrsSpec(
-    pmHostSpec *, int, __pmHashCtl *, char *, size_t);
+    __pmHostSpec *, int, __pmHashCtl *, char *, size_t);
 
 /* SSL/TLS/IPv6 support via NSS/NSPR */
 PCP_CALL extern int __pmSecureServerCertificateSetup(const char *, const char *, const char *);
@@ -1333,8 +1319,8 @@ PCP_CALL extern int __pmInProfile(pmInDom, const pmProfile *, int);
 
 /* free malloc'd data structures */
 PCP_CALL extern void __pmFreeAttrsSpec(__pmHashCtl *);
-PCP_CALL extern void __pmFreeHostAttrsSpec(pmHostSpec *, int, __pmHashCtl *);
-PCP_CALL extern void __pmFreeHostSpec(pmHostSpec *, int);
+PCP_CALL extern void __pmFreeHostAttrsSpec(__pmHostSpec *, int, __pmHashCtl *);
+PCP_CALL extern void __pmFreeHostSpec(__pmHostSpec *, int);
 PCP_CALL extern void __pmFreeInResult(pmInResult *);
 PCP_CALL extern void __pmFreePMNS(__pmnsTree *);
 PCP_CALL extern void __pmFreeProfile(pmProfile *);

--- a/src/libpcp/src/connect.c
+++ b/src/libpcp/src/connect.c
@@ -332,7 +332,7 @@ load_pmcd_ports(void)
 }
 
 static void
-load_proxy_hostspec(pmHostSpec *proxy)
+load_proxy_hostspec(__pmHostSpec *proxy)
 {
     char	errmsg[PM_MAXERRMSGLEN];
     char	*envstr;
@@ -362,7 +362,7 @@ load_proxy_hostspec(pmHostSpec *proxy)
 }
 
 void
-__pmConnectGetPorts(pmHostSpec *host)
+__pmConnectGetPorts(__pmHostSpec *host)
 {
     PM_INIT_LOCKS();
     PM_LOCK(connect_lock);
@@ -378,7 +378,7 @@ __pmConnectGetPorts(pmHostSpec *host)
 }
 
 int
-__pmConnectPMCD(pmHostSpec *hosts, int nhosts, int ctxflags, __pmHashCtl *attrs)
+__pmConnectPMCD(__pmHostSpec *hosts, int nhosts, int ctxflags, __pmHashCtl *attrs)
 {
     int		sts = -1;
     int		fd = -1;	/* Fd for socket connection to pmcd */
@@ -387,10 +387,10 @@ __pmConnectPMCD(pmHostSpec *hosts, int nhosts, int ctxflags, __pmHashCtl *attrs)
     int		portIx;
     int		version = -1;
     int		proxyport;
-    pmHostSpec	*proxyhost;
+    __pmHostSpec *proxyhost;
 
     static int first_time = 1;
-    static pmHostSpec proxy;
+    static __pmHostSpec proxy;
 
     PM_INIT_LOCKS();
     PM_LOCK(connect_lock);

--- a/src/libpcp/src/context.c
+++ b/src/libpcp/src/context.c
@@ -1114,7 +1114,7 @@ INIT_CONTEXT:
 
     if (new->c_type == PM_CONTEXT_HOST) {
 	__pmHashCtl	*attrs = &new->c_attrs;
-	pmHostSpec	*hosts = NULL;
+	__pmHostSpec	*hosts = NULL;
 	int		nhosts;
 	char		*errmsg;
 

--- a/src/libpcp/src/internal.h
+++ b/src/libpcp/src/internal.h
@@ -390,14 +390,14 @@ extern void	     __pmSockAddrSetScope(__pmSockAddr *, int) _PCP_HIDDEN;
 extern __pmSockAddr *__pmSockAddrFirstSubnetAddr(const __pmSockAddr *, int) _PCP_HIDDEN;
 extern __pmSockAddr *__pmSockAddrNextSubnetAddr(__pmSockAddr *, int) _PCP_HIDDEN;
 
-extern int __pmConnectPMCD(pmHostSpec *, int, int, __pmHashCtl *) _PCP_HIDDEN;
+extern int __pmConnectPMCD(__pmHostSpec *, int, int, __pmHashCtl *) _PCP_HIDDEN;
 
 extern int __pmConnectLocal(__pmHashCtl *) _PCP_HIDDEN;
 extern int __pmAuxConnectPMCD(const char *) _PCP_HIDDEN;
 extern int __pmAuxConnectPMCDUnixSocket(const char *) _PCP_HIDDEN;
-extern int __pmAddHostPorts(pmHostSpec *, int *, int) _PCP_HIDDEN;
-extern void __pmDropHostPort(pmHostSpec *) _PCP_HIDDEN;
-extern void __pmConnectGetPorts(pmHostSpec *) _PCP_HIDDEN;
+extern int __pmAddHostPorts(__pmHostSpec *, int *, int) _PCP_HIDDEN;
+extern void __pmDropHostPort(__pmHostSpec *) _PCP_HIDDEN;
+extern void __pmConnectGetPorts(__pmHostSpec *) _PCP_HIDDEN;
 
 extern int __pmLogOpen(const char *, __pmContext *) _PCP_HIDDEN;
 extern int __pmLogReopen(const char *, __pmContext *) _PCP_HIDDEN;

--- a/src/libpcp/src/spec.c
+++ b/src/libpcp/src/spec.c
@@ -343,14 +343,14 @@ hostStrndup(const char *name, int namelen)
     return s;
 }
 
-static pmHostSpec *
-hostAdd(pmHostSpec *specp, int *count, const char *name, int namelen)
+static __pmHostSpec *
+hostAdd(__pmHostSpec *specp, int *count, const char *name, int namelen)
 {
     int n = *count;
     char *host;
 
     host = hostStrndup(name, namelen);
-    if (!host || (specp = realloc(specp, sizeof(pmHostSpec) * (n+1))) == NULL) {
+    if (!host || (specp = realloc(specp, sizeof(__pmHostSpec) * (n+1))) == NULL) {
 	if (host != NULL)
 	    free(host);
 	*count = 0;
@@ -365,7 +365,7 @@ hostAdd(pmHostSpec *specp, int *count, const char *name, int namelen)
 }
 
 int
-__pmAddHostPorts(pmHostSpec *specp, int *ports, int nports)
+__pmAddHostPorts(__pmHostSpec *specp, int *ports, int nports)
 {
     int *portlist;
 
@@ -382,7 +382,7 @@ __pmAddHostPorts(pmHostSpec *specp, int *ports, int nports)
 }
 
 void
-__pmDropHostPort(pmHostSpec *specp)
+__pmDropHostPort(__pmHostSpec *specp)
 {
     specp->nports--;
     memmove(&specp->ports[0], &specp->ports[1], specp->nports*sizeof(int));
@@ -421,11 +421,11 @@ static int      /* 0 -> ok, PM_ERR_GENERIC -> error message is set */
 parseHostSpec(
     const char *spec,
     char **position,            /* parse this string, return end char */
-    pmHostSpec **rslt,          /* result allocated and returned here */
+    __pmHostSpec **rslt,          /* result allocated and returned here */
     int *count,
     char **errmsg)              /* error message */
 {
-    pmHostSpec *hsp = NULL;
+    __pmHostSpec *hsp = NULL;
     const char *s, *start, *next;
     int nhosts = 0, sts = 0;
 
@@ -511,9 +511,9 @@ static int      /* 0 -> ok, PM_ERR_GENERIC -> error message is set */
 parseSocketPath(
     const char *spec,
     char **position,            /* parse this string, return end char */
-    pmHostSpec **rslt)          /* result allocated and returned here */
+    __pmHostSpec **rslt)          /* result allocated and returned here */
 {
-    pmHostSpec *hsp = NULL;
+    __pmHostSpec *hsp = NULL;
     const char *s, *start, *path;
     char absolute_path[MAXPATHLEN];
     size_t len;
@@ -570,7 +570,7 @@ parseSocketPath(
 int
 __pmParseHostSpec(
     const char *spec,           /* parse this string */
-    pmHostSpec **rslt,          /* result allocated and returned here */
+    __pmHostSpec **rslt,          /* result allocated and returned here */
     int *count,			/* number of host specs returned here */
     char **errmsg)              /* error message */
 {
@@ -591,7 +591,7 @@ __pmParseHostSpec(
 }
 
 static int
-unparseHostSpec(pmHostSpec *hostp, int count, char *string, size_t size, int prefix)
+unparseHostSpec(__pmHostSpec *hostp, int count, char *string, size_t size, int prefix)
 {
     int off = 0, len = size;	/* offset in string and space remaining */
     int i, j, sts;
@@ -656,13 +656,13 @@ done:
 }
 
 int
-__pmUnparseHostSpec(pmHostSpec *hostp, int count, char *string, size_t size)
+__pmUnparseHostSpec(__pmHostSpec *hostp, int count, char *string, size_t size)
 {
     return unparseHostSpec(hostp, count, string, size, 1);
 }
 
 void
-__pmFreeHostSpec(pmHostSpec *specp, int count)
+__pmFreeHostSpec(__pmHostSpec *specp, int count)
 {
     int i;
 
@@ -694,7 +694,7 @@ __pmFreeAttrsSpec(__pmHashCtl *attrs)
 }
 
 void
-__pmFreeHostAttrsSpec(pmHostSpec *hosts, int count, __pmHashCtl *attrs)
+__pmFreeHostAttrsSpec(__pmHostSpec *hosts, int count, __pmHashCtl *attrs)
 {
     __pmFreeHostSpec(hosts, count);
     __pmFreeAttrsSpec(attrs);
@@ -903,7 +903,7 @@ fail:
 int
 __pmParseHostAttrsSpec(
     const char *spec,           /* the original, complete string to parse */
-    pmHostSpec **host,          /* hosts result allocated and returned here */
+    __pmHostSpec **host,          /* hosts result allocated and returned here */
     int *count,
     __pmHashCtl *attributes,
     char **errmsg)              /* error message */
@@ -1043,7 +1043,7 @@ __pmAttrStr_r(__pmAttrKey key, const char *data, char *string, size_t size)
 
 int
 __pmUnparseHostAttrsSpec(
-    pmHostSpec *hosts,
+    __pmHostSpec *hosts,
     int count,
     __pmHashCtl *attrs,
     char *string,

--- a/src/libpcp_web/src/webgroup.c
+++ b/src/libpcp_web/src/webgroup.c
@@ -127,7 +127,7 @@ webgroup_access(struct context *cp, sds hostspec, dict *params,
 {
     __pmHashNode	*node;
     __pmHashCtl		attrs;
-    pmHostSpec		*hosts = NULL;
+    __pmHostSpec	*hosts = NULL;
     char		*msg, buf[512];
     int			sts, bytes, numhosts = 0;
     sds			value;


### PR DESCRIPTION
Resolve the two remaining "pm" vs "__pm" structure names that
were called out in the TODO near the head of libpcp.h.  After
auditing code, pmTimeZone is unused so just drop it.  Renamed
pmHostSpec to __pmHostSpec - used in libraries and QA only.