### PR TITLE
libpcp_web: disable Redis connection if version check fails

### DIFF
--- a/src/libpcp_web/src/schema.c
+++ b/src/libpcp_web/src/schema.c
@@ -1303,6 +1303,7 @@ redis_load_version_callback(
 		    infofmt(msg, "unsupported redis server (got v%u, expected v%u or above)", 
 				server_version, SERVER_VERSION);
 	    	    batoninfo(baton, PMLOG_ERROR, msg);
+		    baton->slots->setup = 0;
 	    	}
 	    	break;
 	    }


### PR DESCRIPTION
Set slots->setup to zero if the Redis version check fails,
indicating Redis is too old (< V5) on this platform.

If the Redis version check fails, "redis-cli monitor" shows
the version request but no further activity.  qa/1543 passes
as do QA groups pmproxy, libpcp_web, redis and pmseries.