### PR TITLE
Automatic cpu core detection for pmda-denki

### DIFF
--- a/qa/1653
+++ b/qa/1653
@@ -47,7 +47,7 @@ echo -e "\n### Installing test dataset 1...\n"
 cd $PCP_PMDAS_DIR/denki
 ROOTPATH="$here/denki/Thinkpad_L480_bat_busy"
 $sudo sed -ie \
-	"s,^args.*,args=\"-U root -c 4 -r ${ROOTPATH}\","  \
+	"s,^args.*,args=\"-U root -r ${ROOTPATH}\","  \
 	Install
 $sudo ./Install 2>&1
 pminfo -fF denki
@@ -55,7 +55,7 @@ pminfo -fF denki
 echo -e "\n### Installing test dataset 2...\n"
 ROOTPATH="$here/denki/bigsystem"
 $sudo sed -ie \
-	"s,^args.*,args=\"-U root -c 32 -r ${ROOTPATH}\","  \
+	"s,^args.*,args=\"-U root -r ${ROOTPATH}\","  \
 	Install
 $sudo ./Install 2>&1
 pminfo -fF denki

--- a/src/pmdas/denki/Install
+++ b/src/pmdas/denki/Install
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # Copyright (c) 2013 Red Hat.
 # Copyright (c) 1997 Silicon Graphics, Inc.  All Rights Reserved.
@@ -26,8 +26,7 @@ dso_opt=false
 socket_opt=false
 pmns_source=root_denki
 
-# args="-U root -r $PCP_PMDAS_DIR/denki/data/Thinkpad_T460s_AC"
-# args="-U root -r $PCP_PMDAS_DIR/denki/data/Thinkpad_T460s_bat_idle"
+# args="-U root -r <directory>"
 args="-U root"
 
 # Set up the denki PMDA (domain 156) InDom cache

--- a/src/pmdas/denki/Install
+++ b/src/pmdas/denki/Install
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 #
 # Copyright (c) 2013 Red Hat.
 # Copyright (c) 1997 Silicon Graphics, Inc.  All Rights Reserved.

--- a/src/pmdas/denki/denki.c
+++ b/src/pmdas/denki/denki.c
@@ -28,7 +28,7 @@
 
 #define NUM_RAPL_DOMAINS	10
 #define MAX_PACKAGES		16
-#define MAX_CPUS		4096
+#define MAX_CPUS		2147483648
 
 static int has_rapl, has_bat;				/* Has the system rapl or battery? */
 
@@ -66,8 +66,8 @@ static int detect_rapl_packages(void) {
 		printf("\tcore %d (package %d)\n",i,package);
 		fclose(fff);
 
-		if (package >= MAX_PACKAGES) {
-			pmNotifyErr(LOG_ERR, "package number %d too big, max %u", package, MAX_PACKAGES);
+		if (package < 0 || package >= MAX_PACKAGES) {
+			pmNotifyErr(LOG_ERR, "package number %d invalid, range 0-%u", package, MAX_PACKAGES);
 			continue;
 		}
 
@@ -618,7 +618,7 @@ main(int argc, char **argv)
     else {
 	has_rapl=1;
     	detect_rapl_packages();
-    	pmNotifyErr(LOG_DEBUG, "detected RAPL, with %d cpu-cores and %d rapl-packages.", total_cores, total_packages);
+    	pmNotifyErr(LOG_DEBUG, "RAPL detected, with %d cpu-cores and %d rapl-packages.", total_cores, total_packages);
     	detect_rapl_domains();
     	denki_rapl_check();	// now we register the found rapl indoms
     }


### PR DESCRIPTION
- remove command line option for cpus
- autodetect for up to 4096 cores, current linux kernel limit
- "intel rapl" -> "rapl", as also newer AMD cpus support it