### PR TITLE
build: mark python3-bpfcc dependency as architecture specific

### DIFF
--- a/debian/fixcontrol
+++ b/debian/fixcontrol
@@ -81,7 +81,7 @@ fi
 
 if $PMDA_BCC
 then
-    echo "s/?{python3-bpfcc}, /python3-bpfcc | python3-bcc, /" >>$tmp.sed
+    echo "s/?{python3-bpfcc}, /python3-bpfcc [amd64 arm64 armhf ppc64el s390x ppc64], /" >>$tmp.sed
 else
     echo "s/?{python3-bpfcc}, //" >>$tmp.sed
 fi


### PR DESCRIPTION
See https://packages.debian.org/sid/libbpfcc for supported architectures
of libbpfcc