### PR TITLE
qa: remove valgrind requirements from statsd tests that don't actually use it

### DIFF
--- a/qa/1599
+++ b/qa/1599
@@ -13,8 +13,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here

--- a/qa/1708
+++ b/qa/1708
@@ -13,8 +13,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here

--- a/qa/1709
+++ b/qa/1709
@@ -13,8 +13,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here

--- a/qa/1710
+++ b/qa/1710
@@ -21,8 +21,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here

--- a/qa/1711
+++ b/qa/1711
@@ -13,8 +13,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here

--- a/qa/1712
+++ b/qa/1712
@@ -13,8 +13,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here

--- a/qa/1713
+++ b/qa/1713
@@ -13,8 +13,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here

--- a/qa/1714
+++ b/qa/1714
@@ -13,8 +13,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here

--- a/qa/1715
+++ b/qa/1715
@@ -16,8 +16,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here

--- a/qa/1716
+++ b/qa/1716
@@ -13,8 +13,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here

--- a/qa/1717
+++ b/qa/1717
@@ -13,8 +13,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here

--- a/qa/1718
+++ b/qa/1718
@@ -14,8 +14,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here

--- a/qa/1719
+++ b/qa/1719
@@ -13,8 +13,6 @@ echo "QA output created by $seq"
 
 test -e $PCP_PMDAS_DIR/statsd/pmdastatsd || _notrun "statsd PMDA not installed"
 
-_check_valgrind
-
 _cleanup()
 {
     cd $here


### PR DESCRIPTION
See title, was trying to run tests on a clean system, that's how I found out.