### PR TITLE
libpcp_web coverity fixes

### DIFF
--- a/src/libpcp_web/src/load.c
+++ b/src/libpcp_web/src/load.c
@@ -1303,6 +1303,12 @@ pmSeriesDiscoverValues(pmDiscoverEvent *event, pmResult *result, void *arg)
     if (pmDebugOptions.discovery)
 	fprintf(stderr, "%s: result numpmids=%d\n", "pmSeriesDiscoverValues", result->numpmid);
 
+    if (data == NULL) {
+	/* calloc failed in getDiscoverModuleData() */
+    	baton->error = -ENOMEM;
+	return;
+    }
+
     if (baton == NULL || baton->slots == NULL || baton->slots->setup == 0)
 	return;
 

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -4951,6 +4951,7 @@ series_instances_reply(seriesQueryBaton *baton,
 
 	if (extract_sha1(baton, series, elements[i], &sid->name, "series") < 0) {
 	    /* TODO: report error */
+	    freeSeriesGetSID(sid); /* Coverity CID308764 */
 	    continue;
 	}
 	seriesBatonReference(sid, "series_instances_reply");

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -4078,8 +4078,25 @@ series_redis_hash_expression(seriesQueryBaton *baton, char *hashbuf, int len_has
 	    if (!np->value_set.series_values[j].compatibility || i == j)
 	    	continue;
 
-	    pmParseUnitsStr(np->value_set.series_values[i].series_desc.units, &units0, &mult, &errmsg);
-	    pmParseUnitsStr(np->value_set.series_values[j].series_desc.units, &units1, &mult, &errmsg);
+	    if (pmParseUnitsStr(np->value_set.series_values[i].series_desc.units,
+	    	&units0, &mult, &errmsg) != 0) {
+		np->value_set.series_values[i].compatibility = 0;
+		infofmt(msg, "Invalid units string\n");
+		batoninfo(baton, PMLOG_ERROR, msg);
+		baton->error = -EPROTO;
+		free(errmsg);
+		break;
+	    }
+
+	    if (pmParseUnitsStr(np->value_set.series_values[j].series_desc.units,
+	    	&units1, &mult, &errmsg) != 0) {
+		np->value_set.series_values[i].compatibility = 0;
+		infofmt(msg, "Invalid units string\n");
+		batoninfo(baton, PMLOG_ERROR, msg);
+		baton->error = -EPROTO;
+		free(errmsg);
+		break;
+	    }
 
 	    if (check_compatibility(&units0, &units1) != 0) {
 		np->value_set.series_values[j].compatibility = 0;

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -201,6 +201,11 @@ initSeriesQueryBaton(seriesQueryBaton *baton,
 {
     seriesModuleData	*data = getSeriesModuleData(&settings->module);
 
+    if (data == NULL) {
+	/* calloc failed in getSeriesModuleData */
+    	baton->error = -ENOMEM;
+	return;
+    }
     initSeriesBatonMagic(baton, MAGIC_QUERY);
     baton->callbacks = &settings->callbacks;
     baton->info = settings->module.on_info;

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -4078,20 +4078,26 @@ series_redis_hash_expression(seriesQueryBaton *baton, char *hashbuf, int len_has
 	    if (!np->value_set.series_values[j].compatibility || i == j)
 	    	continue;
 
-	    if (pmParseUnitsStr(np->value_set.series_values[i].series_desc.units,
+	    if (strncmp(np->value_set.series_values[i].series_desc.units, "none", 4) == 0)
+		memset(&units0, 0, sizeof(units0));
+	    else if (pmParseUnitsStr(np->value_set.series_values[i].series_desc.units,
 	    	&units0, &mult, &errmsg) != 0) {
 		np->value_set.series_values[i].compatibility = 0;
-		infofmt(msg, "Invalid units string\n");
+		infofmt(msg, "Invalid units string: %s\n",
+			np->value_set.series_values[i].series_desc.units);
 		batoninfo(baton, PMLOG_ERROR, msg);
 		baton->error = -EPROTO;
 		free(errmsg);
 		break;
 	    }
 
-	    if (pmParseUnitsStr(np->value_set.series_values[j].series_desc.units,
+	    if (strncmp(np->value_set.series_values[j].series_desc.units, "none", 4) == 0)
+		memset(&units1, 0, sizeof(units1));
+	    else if (pmParseUnitsStr(np->value_set.series_values[j].series_desc.units,
 	    	&units1, &mult, &errmsg) != 0) {
 		np->value_set.series_values[i].compatibility = 0;
-		infofmt(msg, "Invalid units string\n");
+		infofmt(msg, "Invalid units string: %s\n",
+			np->value_set.series_values[j].series_desc.units);
 		batoninfo(baton, PMLOG_ERROR, msg);
 		baton->error = -EPROTO;
 		free(errmsg);

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -1655,7 +1655,7 @@ series_expr_query_desc(seriesQueryBaton *baton, series_set_t *query_series_set, 
 	return;
     }
     for (i = 0; i < nseries; i++, series += SHA1SZ) {
-	if ((sid = calloc(1, sizeof(seriesGetSID)) == NULL) {
+	if ((sid = (seriesGetSID *)calloc(1, sizeof(seriesGetSID))) == NULL) {
 	    baton->error = -ENOMEM;
 	    return;
 	}

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -4554,6 +4554,8 @@ series_label_reply(seriesQueryBaton *baton, sds series,
 		infofmt(msg, "%s - label value lookup OOM", series);
 		batoninfo(baton, PMLOG_ERROR, msg);
 		sts = -ENOMEM;
+		if (vmap) /* Coverity CID308763 */
+		    redisMapRelease(vmap);
 		continue;
 	    }
 	    initSeriesGetLabelMap(labelmap, series, name, vmap, vmapID, vkey, baton);

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -995,6 +995,7 @@ node_pattern_reply(seriesQueryBaton *baton, node_t *np, const char *name, int ne
 	    infofmt(msg, "out of memory (%s, %" FMT_INT64 " bytes)",
 			"pattern reply", (__int64_t)bytes);
 	    batoninfo(baton, PMLOG_REQUEST, msg);
+	    sdsfree(key); /* Coverity CID328038 */
 	    return -ENOMEM;
 	}
 	matches[np->nmatches++] = key;

--- a/src/libpcp_web/src/query.c.orig
+++ b/src/libpcp_web/src/query.c.orig
@@ -1651,14 +1651,11 @@ series_expr_query_desc(seriesQueryBaton *baton, series_set_t *query_series_set, 
 
     /* calloc nseries samples store space */
     if ((np->value_set.series_values = (series_sample_set_t *)calloc(nseries, sizeof(series_sample_set_t))) == NULL) {
+	/* TODO: error report here */
 	baton->error = -ENOMEM;
-	return;
     }
     for (i = 0; i < nseries; i++, series += SHA1SZ) {
-	if ((sid = calloc(1, sizeof(seriesGetSID)) == NULL) {
-	    baton->error = -ENOMEM;
-	    return;
-	}
+	sid = calloc(1, sizeof(seriesGetSID));
 	pmwebapi_hash_str(series, hashbuf, sizeof(hashbuf));
 	initSeriesGetSID(sid, hashbuf, 1, baton);
 	np->value_set.series_values[i].baton = baton;

--- a/src/libpcp_web/src/util.c
+++ b/src/libpcp_web/src/util.c
@@ -270,15 +270,15 @@ metric_labelsets(metric_t *metric, char *buffer, int length,
     indom_t	*indom = metric->indom;
     int		nsets = 0;
 
-    if (context->labelset)
+    if (context && context->labelset)
 	sets[nsets++] = context->labelset;
-    if (domain->labelset)
+    if (domain && domain->labelset)
 	sets[nsets++] = domain->labelset;
     if (indom && indom->labelset)
 	sets[nsets++] = indom->labelset;
-    if (cluster->labelset)
+    if (cluster && cluster->labelset)
 	sets[nsets++] = cluster->labelset;
-    if (metric->labelset)
+    if (metric && metric->labelset)
 	sets[nsets++] = metric->labelset;
 
     return pmMergeLabelSets(sets, nsets, buffer, length, filter, arg);


### PR DESCRIPTION
```
fdd2eda72 libpcp_web: fix compilation error in series_node_prepare_time
ad75163ca libpcp_web: err handling in series_expr_query_desc(), CID366098
938607ee6 libpcp_web: fix err handling in initSeriesQueryBaton(), Coverity CID341677
9bee6e9b6 libpcp_web: fix null check in pmSeriesDiscoverValues, Coverity CID353645
9a0eec3dd libpcp_web: fix null check, Coverity CID353502.
1cb3fe3c7 libpcp_web: check err in query functions. Coverity CID366058,366064,366088
057ffc30d libpcp_web: check ret value from pmParseUnitsStr in series_redis_hash_expression
6c6aebf0f libpcp_web: fix resource leak in redisSlotsInit CID370634
c0f3ad57f libpcp_web: fix resource leak in series_redis_hash_expression CID366094
bb71b0943 libpcp_web: fix resource leak in node_pattern_reply Coverity CID328038
```

Have checked QA groups -g pmproxy -g libpcp_web -g pmseries