### PR TITLE
pmdabcc: free BPF memory after module setup completes

### DIFF
--- a/src/pmdas/bcc/modules/pcpbcc.python
+++ b/src/pmdas/bcc/modules/pcpbcc.python
@@ -91,6 +91,11 @@ class PCPBCCBase(object):
         """ Store callback """
         return PM_ERR_BADSTORE
 
+    def free_memory(self):
+        if self.bpf is not None:
+            self.bpf.free_bcc_memory()
+            self.log("BPF freed")
+
     def cleanup(self):
         """ Clean up at exit """
         if self.bpf is not None:


### PR DESCRIPTION
reduces RSS footprint slightly (180 -> 140MB) for ~40MB savings on pmdabcc after load