### PR TITLE
libpcp_web coverity round2

### DIFF
--- a/src/libpcp_web/src/load.c
+++ b/src/libpcp_web/src/load.c
@@ -1341,12 +1341,14 @@ pmSeriesDiscoverInDom(pmDiscoverEvent *event, pmInResult *in, void *arg)
 	infofmt(msg, "%s: failed indom discovery (domain %u)",
 			"pmSeriesDiscoverInDom", pmInDom_domain(id));
 	moduleinfo(event->module, PMLOG_ERROR, msg, arg);
+	baton->error = -ENOMEM;
 	return;
     }
     if ((indom = pmwebapi_add_indom(context, domain, id)) == NULL) {
 	infofmt(msg, "%s: failed indom discovery (indom %s)",
 			"pmSeriesDiscoverInDom", pmInDomStr(id));
 	moduleinfo(event->module, PMLOG_ERROR, msg, arg);
+	baton->error = -ENOMEM;
 	return;
     }
     for (i = 0; i < in->numinst; i++) {
@@ -1356,6 +1358,8 @@ pmSeriesDiscoverInDom(pmDiscoverEvent *event, pmInResult *in, void *arg)
 			"pmSeriesDiscoverInDom", pmInDomStr(id),
 			in->instlist[i], in->namelist[i]);
 	moduleinfo(event->module, PMLOG_ERROR, msg, arg);
+	/* Coverity CID:328046 - resource leak from earlier pmwebapi_add_instance calls. */
+	baton->error = -ENOMEM;
 	return;
     }
 }

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -2216,8 +2216,10 @@ series_node_prepare_time(seriesQueryBaton *baton, series_set_t *query_series_set
     /* calloc nseries samples store space */
     if ((np->value_set.series_values =
     	(series_sample_set_t *)calloc(nseries, sizeof(series_sample_set_t))) == NULL) {
-	/* TODO: error report here */
 	baton->error = -ENOMEM;
+	sdsfree(start);
+	sdsfree(end);
+	return;
     }
 
     /*

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -4270,6 +4270,11 @@ series_solve(pmSeriesSettings *settings,
     seriesQueryBaton	*baton;
     unsigned int	i = 0;
 
+    if (root == NULL) {
+	/* Coverity CID366052 */
+    	return -ENOMEM;
+    }
+
     if ((baton = calloc(1, sizeof(seriesQueryBaton))) == NULL)
 	return -ENOMEM;
     initSeriesQueryBaton(baton, settings, arg);

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -4084,28 +4084,29 @@ series_redis_hash_expression(seriesQueryBaton *baton, char *hashbuf, int len_has
 	    baton->error = -EPROTO;
 	    continue;
 	}
+
+	if (strncmp(np->value_set.series_values[i].series_desc.units, "none", 4) == 0)
+	    memset(&units0, 0, sizeof(units0));
+	else if (pmParseUnitsStr(np->value_set.series_values[i].series_desc.units,
+	    &units0, &mult, &errmsg) != 0) {
+	    np->value_set.series_values[i].compatibility = 0;
+	    infofmt(msg, "Invalid units string: %s\n",
+		    np->value_set.series_values[i].series_desc.units);
+	    batoninfo(baton, PMLOG_ERROR, msg);
+	    baton->error = -EPROTO;
+	    free(errmsg);
+	    break;
+	}
+
 	for (j = 0; j < num_series; j++) {
 	    if (!np->value_set.series_values[j].compatibility || i == j)
 	    	continue;
-
-	    if (strncmp(np->value_set.series_values[i].series_desc.units, "none", 4) == 0)
-		memset(&units0, 0, sizeof(units0));
-	    else if (pmParseUnitsStr(np->value_set.series_values[i].series_desc.units,
-	    	&units0, &mult, &errmsg) != 0) {
-		np->value_set.series_values[i].compatibility = 0;
-		infofmt(msg, "Invalid units string: %s\n",
-			np->value_set.series_values[i].series_desc.units);
-		batoninfo(baton, PMLOG_ERROR, msg);
-		baton->error = -EPROTO;
-		free(errmsg);
-		break;
-	    }
 
 	    if (strncmp(np->value_set.series_values[j].series_desc.units, "none", 4) == 0)
 		memset(&units1, 0, sizeof(units1));
 	    else if (pmParseUnitsStr(np->value_set.series_values[j].series_desc.units,
 	    	&units1, &mult, &errmsg) != 0) {
-		np->value_set.series_values[i].compatibility = 0;
+		np->value_set.series_values[j].compatibility = 0;
 		infofmt(msg, "Invalid units string: %s\n",
 			np->value_set.series_values[j].series_desc.units);
 		batoninfo(baton, PMLOG_ERROR, msg);

--- a/src/libpcp_web/src/query_parser.y
+++ b/src/libpcp_web/src/query_parser.y
@@ -1403,7 +1403,7 @@ series_lex(YYSTYPE *lvalp, PARSER *lp)
 	}
 	if (p == NULL) {
 	    lp->yy_tokbuflen = 128;
-	    if ((p = (char *)malloc(lp->yy_tokbuflen)) == NULL) {
+	    if ((p = (char *)malloc(lp->yy_tokbuflen+1)) == NULL) { /* CID287946 */
 		lp->yy_errstr = sdscatfmt(sdsempty(),
 				"cannot allocate token buffer (length=%lld)",
 				(long long)lp->yy_tokbuflen);

--- a/src/libpcp_web/src/search.c
+++ b/src/libpcp_web/src/search.c
@@ -122,6 +122,11 @@ redis_search_text_prep(sds s, int min_length, char *prefix, char *suffix)
     }
     sdstrim(result, " ");
     tokens = sdssplitlen(result, sdslen(result), " ", 1, &token_count);
+    if (tokens == NULL) {
+	/* Coverity: CID370640 */
+    	sdsfree(result);
+	return NULL;
+    }
     formatted_result = sdsempty();
     for (i = 0; i < token_count; i++) {
 	size_t token_len = sdslen(tokens[i]);

--- a/src/libpcp_web/src/slots.c
+++ b/src/libpcp_web/src/slots.c
@@ -149,8 +149,14 @@ redisSlotsInit(dict *config, void *events)
     if (servers == NULL)
         servers = def_servers = sdsnew(default_server);
 
-    slots->acc = redisClusterAsyncContextInit();
-    if (slots->acc && slots->acc->err) {
+    if ((slots->acc = redisClusterAsyncContextInit()) == NULL) {
+	/* Coverity CID370635 */
+	pmNotifyErr(LOG_ERR, "redisSlotsInit: redisClusterAsyncContextInit failed\n");
+	sdsfree(def_servers);
+        return slots;
+    }
+
+    if (slots->acc->err) {
         pmNotifyErr(LOG_ERR, "redisSlotsInit: %s\n", slots->acc->errstr);
 	sdsfree(def_servers);
         return slots;

--- a/src/libpcp_web/src/util.c
+++ b/src/libpcp_web/src/util.c
@@ -256,6 +256,8 @@ default_labelset(context_t *c, pmLabelSet **sets)
 	*sets = lp;
 	return 0;
     }
+    if (lp)
+	free(lp); /* Coverity CID340558 */
     return sts;
 }
 


### PR DESCRIPTION
Still have CID 341699 Use-after-free in libpcp_web/src/load.c when connect_pmapi_source_service() fails., which is giving me trouble with qa/1211 hanging. And probably a new resource leak due to changed error handling in an ENOMEM path (this will need to be ignored if it occurs).

```
6b6f36b49 libpcp_web: fix resource leak when default_labelset fails, CID340558
3f2b486fe libpcp_web: improve err handling in pmSeriesDiscoverInDom, CID328046
b824f69f6 libpcp_web: fix read overrun in series_lex, CID287946
8ea559f3d libpcp_web: add null check in series_solve, CID366052
a09855144 libpcp_web: check sdssplitlen in redis_search_text_prep, CID370640
84fd38401 libpcp_web: check async context init in redisSlotsInit, CID370635
b6c2c914b libpcp_web: imrpove ENOMEM err handling, CID366063
21642c00f libpcp_web: copy-paste err in series_redis_hash_expression CID372009
```
