### PR TITLE
Libpcp web coverity round3

### DIFF
--- a/src/libpcp_web/src/load.c
+++ b/src/libpcp_web/src/load.c
@@ -924,14 +924,24 @@ connect_redis_source_service(seriesLoadBaton *baton)
 }
 
 static void
-setup_source_services(void *arg)
+setup_pmapi_source_service(void *arg)
 {
     seriesLoadBaton	*baton = (seriesLoadBaton *)arg;
 
-    seriesBatonCheckMagic(baton, MAGIC_LOAD, "setup_source_services");
-    seriesBatonReferences(baton, 2, "setup_source_services");
+    seriesBatonCheckMagic(baton, MAGIC_LOAD, "setup_pmapi_source_service");
+    seriesBatonReferences(baton, 1, "setup_pmapi_source_service");
 
     connect_pmapi_source_service(baton);
+}
+
+static void
+setup_redis_source_service(void *arg)
+{
+    seriesLoadBaton	*baton = (seriesLoadBaton *)arg;
+
+    seriesBatonCheckMagic(baton, MAGIC_LOAD, "setup_redis_source_service");
+    seriesBatonReferences(baton, 1, "setup_redis_source_service");
+
     connect_redis_source_service(baton);
 }
 
@@ -1014,7 +1024,9 @@ series_load(pmSeriesSettings *settings,
     /* ordering of async operations */
     i = 0;
     baton->current = &baton->phases[i];
-    baton->phases[i++].func = setup_source_services;
+    /* Coverity CID341699 - split pmapi and redis setup to avoid use after free */
+    baton->phases[i++].func = setup_pmapi_source_service;
+    baton->phases[i++].func = setup_redis_source_service;
     /* assign source/host string map (series_source_mapping) */
     baton->phases[i++].func = series_source_mapping;
     /* write source info into schema (series_cache_source) */

--- a/src/libpcp_web/src/query_parser.y
+++ b/src/libpcp_web/src/query_parser.y
@@ -1416,7 +1416,7 @@ series_lex(YYSTYPE *lvalp, PARSER *lp)
 	else if (p >= &lp->yy_tokbuf[lp->yy_tokbuflen]) {
 	    len = p - lp->yy_tokbuf;
 	    lp->yy_tokbuflen *= 2;
-	    if (!(p = (char *)realloc(lp->yy_tokbuf, lp->yy_tokbuflen))) {
+	    if (!(p = (char *)realloc(lp->yy_tokbuf, lp->yy_tokbuflen+1))) { /* CID287946 */
 		lp->yy_errstr = sdscatfmt(sdsempty(),
 				"cannot reallocate token buffer (length=%lld)",
 				(long long)lp->yy_tokbuflen);

--- a/src/libpcp_web/src/schema.h
+++ b/src/libpcp_web/src/schema.h
@@ -118,7 +118,7 @@ extern void redis_series_metric(redisSlots *, metric_t *, sds, int, int, void *)
 /*
  * Asynchronous schema load baton structures
  */
-#define LOAD_PHASES	5
+#define LOAD_PHASES	6
 
 typedef struct seriesGetContext {
     seriesBatonMagic	header;		/* MAGIC_CONTEXT */


### PR DESCRIPTION
Should be all done for libpcp_web now.

```
8c7680feb libpcp_web: split pmapi and redis setup into separate phases, CID341699
eb3d17c7a libpcp_web: fix another read overrun in series_lex, CID287946

```