### PR TITLE
pmproxy/libpcp_web: add generic timer API, add generic server metrics

### DIFF
--- a/debian/libpcp3-dev.install
+++ b/debian/libpcp3-dev.install
@@ -279,6 +279,9 @@ usr/share/man/man3/pmUsageMessage.3.gz
 usr/share/man/man3/pmUseContext.3.gz
 usr/share/man/man3/pmUseZone.3.gz
 usr/share/man/man3/PMWEBAPI.3.gz
+usr/share/man/man3/pmWebTimerRegister.3.gz
+usr/share/man/man3/pmWebTimerRelease.3.gz
+usr/share/man/man3/pmWebTimerSetMetricRegistry.3.gz
 usr/share/man/man3/pmWhichContext.3.gz
 usr/share/man/man3/pmWhichZone.3.gz
 usr/share/man/man3/QMC.3.gz

--- a/man/man3/pmwebtimerregister.3
+++ b/man/man3/pmwebtimerregister.3
@@ -1,0 +1,103 @@
+'\"macro stdmacro
+.\"
+.\" Copyright (c) 2021 Red Hat.
+.\"
+.\" This program is free software; you can redistribute it and/or modify it
+.\" under the terms of the GNU General Public License as published by the
+.\" Free Software Foundation; either version 2 of the License, or (at your
+.\" option) any later version.
+.\"
+.\" This program is distributed in the hope that it will be useful, but
+.\" WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+.\" or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+.\" for more details.
+.\"
+.\"
+.TH PMWEBTIMERREGISTER 3 "PCP" "Performance Co-Pilot"
+.SH NAME
+\f3pmWebTimerRegister\f1,
+\f3pmWebTimerRelease\f1,
+\f3pmWebTimerSetMetricRegistry\f1 \- thread-safe timer list management
+.SH "C SYNOPSIS"
+.ft 3
+#include <pcp/pmwebapi.h>
+.sp
+.ad l
+.hy 0
+.in +8n
+.ti -8n
+typedef void (*pmWebTimerCallBack)(void *\fIdata\fP);
+.ti -8n
+int pmWebTimerRegister(pmWebTimerCallBack \fIcallback\fP, void *\fIdata\fP);
+.sp
+.ti -8n
+int pmWebTimerRelease(int \fIseq\fP);
+.br
+.ti -8n
+int pmWebTimerSetMetricRegistry(struct mmv_registry *\fIregistry\fP);
+.in
+.hy
+.ad
+cc ... \-lpcp_web
+.ft 1
+.SH DESCRIPTION
+The
+.B pmWebTimerRegister
+and related API functions provide a convenient thread-safe API for
+applications to manage a list of timer driven callbacks.
+On the first call to
+.B pmWebTimerRegister
+or
+.BR pmWebTimerSetMetricRegistry ,
+an internal timer is set up and initialized to fire every 1.0 seconds.
+Each time the timer fires, all currently registered \fIcallback\fP functions
+will be called serially with the opaque \fIdata\fP pointer that was supplied
+when each function was registered.
+The \fIpmWebTimerCallBack\fP typedef provides a suitable callback function prototype.
+.PP
+All registered \fIcallback\fP functions should be non-blocking
+and execute quickly and synchronously.
+Typical \fIcallback\fP functions include refreshing instrumentation,
+calculating and updating performance metric values, periodic garbage
+collection and any other local function that requires regular execution.
+.PP
+The
+.B pmWebTimerSetMetricRegistry
+function provides a convenient way for an application to pass in a pointer to an
+.BR libpcp_mmv (3)
+\fIregistry\fP that has been suitably initialized by the calling application.
+This \fIregistry\fP will be used to dynamically create six server resource metrics named
+\fINAME\fP\fB.mem.datasz\fP, \fINAME\fP\fB.mem.maxrss\fP, \fINAME\fP\fB.cpu.total\fP,
+\fINAME\fP\fB.cpu.sys\fP, \fINAME\fP\fB.cpu.user\fP and \fINAME\fP\fB.pid\fP,
+where
+.I NAME
+is the root PCP
+.BR PMNS(5)
+name set up by the calling application.
+These metrics should be reasonably self explanatory; they provide resource usage metrics
+from the calling application / server and use
+.BR getrusage (2),
+.BR times (2)
+and
+.BR getpid(2).
+.SH RETURN VALUE
+The
+.B pmWebTimerRegister
+function returns a positive integer handle that may be subsequently used
+in a call to
+.B pmWebTimerRelease
+to remove a timer from the internal timer list.
+When a timer is removed with a call to
+.BR pmWebTimerRelease ,
+the internal data structures are freed.
+The caller however, is responsible for freeing the associated
+.B data
+(since it may or may not be dynamically allocated).
+.SH DIAGNOSTICS
+On failure a negative PMAPI error code is returned in all cases.
+.SH SEE ALSO
+.BR pmproxy (1),
+.BR mmv_stats_registry (3),
+.BR PMAPI (3)
+and
+.BR PMWEBAPI (3).

--- a/qa/1626
+++ b/qa/1626
@@ -1,68 +1,128 @@
 #!/bin/sh
 # PCP QA Test No. 1626
-# [what am I here for?]
+# pmproxy metrics
 #
-# Copyright (c) 2021 [who are you?].  All Rights Reserved.
+# Copyright (c) 2021 Red Hat.
 #
 
-if [ $# -eq 0 ]
-then
-    seq=`basename $0`
-    echo "QA output created by $seq"
-else
-    # use $seq from caller, unless not set
-    [ -n "$seq" ] || seq=`basename $0`
-    echo "QA output created by `basename $0` $*"
-fi
+seq=`basename $0`
+echo "QA output created by $seq"
 
 # get standard environment, filters and checks
 . ./common.product
 . ./common.filter
 . ./common.check
 
-do_valgrind=false
-if [ "$1" = "--valgrind" ]
-then
-    _check_valgrind
-    do_valgrind=true
-fi
-
-# test for-some-thing || _notrun No support for some-thing
+_check_redis_server
+which curl >/dev/null 2>&1 || _notrun needs curl
 
 _cleanup()
 {
     cd $here
+    if $pmproxy_was_running
+    then
+	echo "Restart pmproxy ..." >>$here/$seq.full
+	_service pmproxy restart >>$here/$seq.full 2>&1
+	_wait_for_pmproxy
+    else
+	echo "Stopping pmproxy ..." >>$here/$seq.full
+	_service pmproxy stop >>$here/$seq.full 2>&1
+	_wait_pmproxy_end
+    fi
     $sudo rm -rf $tmp $tmp.*
 }
 
-status=0	# success is the default!
+_pmproxy_mainpid()
+{
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | \
+    $PCP_AWK_PROG '$8 ~ "'$PCP_BINADM_DIR'/pmproxy" {print $2}'
+}
+
+_probe_val()
+{
+    pmprobe -v $1 | awk '{print $NF}'
+}
+
+status=1	# failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 trap "_cleanup; exit \$status" 0 1 2 3 15
 
-_filter()
-{
-    sed \
-	-e 's/<something>/<else>/' \
-    # end
-}
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
 
 # real QA test starts here
+status=0
 
-if $do_valgrind
-then
-    _run_valgrind ...your test goes here...
-else
-    ...your test goes here... 2>&1
-fi \
-| _filter
+# need a fresh pmproxy service
+_service pmproxy stop >/dev/null 2>&1
+_wait_pmproxy_end
+_service pmproxy start 2>&1 | _filter_pmproxy_start
+_wait_for_pmproxy
+sleep 1
 
-# if really bad error
-status=1
-exit
+echo === check pmproxy.pid
+val=`_probe_val pmproxy.pid`
+pid=`_pmproxy_mainpid`
+[ "$pid" -ne "$val" ] && echo FAIL && status=1
 
-# optional stuff if your test has verbose output to help resolve problems
-#echo
-#echo "If failure, check $seq.full"
+echo === check initial pmproxy.webgroup metrics
+for m in instmap labelsmap namesmap contextmap; do
+    [ `_probe_val pmproxy.webgroup.$m.size` -eq 0 ] && continue
+    echo FAILED pmproxy.webgroup.$m.size expected to be zero
+    status=1
+done
 
-# success, all done
+echo "=== start the metrics timer with a /metrics RESTAPI call"
+val=`curl -Gs 'http://localhost:44322/metrics?names=pmproxy.pid' |\
+     $PCP_AWK_PROG '/^pmproxy_pid/ {print $NF}'`
+[ "$pid" -ne "$val" ] && echo FAIL RESTAPI fetch for pmproxy.pid && status=1
+
+echo "=== wait for the maps to be updated"
+count=0
+while true; do
+    sz=`_probe_val pmproxy.webgroup.namesmap.size`
+    [ "$sz" -gt 0 ] && break
+    count=`expr $count + 1`
+    [ $count -gt 10 ] && echo FAILED after $count iterations && status=1 && break
+    sleep 2
+done
+
+echo === pmproxy.webgroup map size metrics should now be nonzero
+for m in instmap labelsmap namesmap contextmap; do
+    [ `_probe_val pmproxy.webgroup.$m.size` -gt 0 ] && continue
+    echo FAILED pmproxy.webgroup.$m.size expected to be non-zero
+    echo pmproxy.webgroup.$m.size = `_probe_val pmproxy.webgroup.$m.size`
+    status=1
+done
+
+echo === check pmproxy cpu counters
+total=`_probe_val pmproxy.cpu.total`
+user=`_probe_val pmproxy.cpu.user`
+sys=`_probe_val pmproxy.cpu.sys`
+[ "$total" -eq 0 ] && echo FAIL pmproxy.cpu.total is zero && status=1
+sum=`expr $user + $sys`
+[ "$total" -ne "$sum" ] && echo FAIL $total not equal $user + $sys && status=1
+
+echo === check for discovery partial metadata reads
+partial=`_probe_val pmproxy.discover.metadata.partial_reads`
+[ "$partial" -ne 0 ] && echo FAIL $partial partial reads, should be zero && status=1
+
+echo === check maxrss and datasz values
+for m in maxrss datasz; do
+    val=`_probe_val pmproxy.mem.$m`
+    [ "$val" -eq 0 ] && echo FAIL pmproxy.mem.$m should be non-zero && status=1
+done
+
+echo === check maxrss doesnt grow after 100 basic restapi requests
+start_maxrss=`_probe_val pmproxy.mem.maxrss`
+for n in `seq 1 100`; do
+    curl -Gs 'http://localhost:44322/metrics?names=kernel.all.load' >/dev/null 2>&1
+done
+finish_maxrss=`_probe_val pmproxy.mem.maxrss`
+growth=`expr $finish_maxrss - $start_maxrss`
+_within_tolerance "maxrss growth after 100 /metrics calls" "$growth" 0 %10 -v
+
+# sleep to avoid systemd StartLimitIntervalSec limits
+sleep 4
 exit

--- a/qa/1626.out
+++ b/qa/1626.out
@@ -1,2 +1,11 @@
 QA output created by 1626
-[skeleton from qa/new, replace me]
+=== check pmproxy.pid
+=== check initial pmproxy.webgroup metrics
+=== start the metrics timer with a /metrics RESTAPI call
+=== wait for the maps to be updated
+=== pmproxy.webgroup map size metrics should now be nonzero
+=== check pmproxy cpu counters
+=== check for discovery partial metadata reads
+=== check maxrss and datasz values
+=== check maxrss doesnt grow after 100 basic restapi requests
+maxrss growth after 100 /metrics calls is in range

--- a/qa/1689
+++ b/qa/1689
@@ -1,6 +1,6 @@
 #!/bin/sh
 # PCP QA Test No. 1689
-# Exercise and check pmproxy / libpcp_web metrics
+# Exercise and check pmproxy metrics metadata and help text
 #
 # Copyright (c) 2021 Red Hat.  All Rights Reserved.
 #
@@ -32,8 +32,6 @@ _cleanup()
 # basic namespace and metadata check
 names=`pminfo pmproxy | LC_COLLATE=POSIX sort`
 pminfo -mdtT $names
-
-# TODO check metric values after various operations
 
 # success, all done
 exit

--- a/qa/1689.out
+++ b/qa/1689.out
@@ -19,23 +19,23 @@ Help:
 Writing anything other then 0 to this metric will result in
 re-reading directory and re-mapping files.
 
-pmproxy.cpu.sys PMID: 4.1.2 [server system CPU]
+pmproxy.cpu.sys PMID: 4.1.2 [system CPU time]
     Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: millisec
 Help:
-server process system CPU time counter
+process system CPU time counter
 
-pmproxy.cpu.total PMID: 4.1.3 [server system + user CPU]
+pmproxy.cpu.total PMID: 4.1.3 [system + user CPU time]
     Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: millisec
 Help:
-server process system + user CPU time
+process system + user CPU time
 
-pmproxy.cpu.user PMID: 4.1.1 [server user CPU]
+pmproxy.cpu.user PMID: 4.1.1 [user CPU time]
     Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: millisec
 Help:
-server process user CPU time counter
+process user CPU time counter
 
 pmproxy.discover.changed_callbacks PMID: 4.5.17 [filesystem changed callbacks]
     Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
@@ -159,23 +159,23 @@ pmproxy.discover.throttled_changed_callbacks PMID: 4.5.18 [filesystem changed ca
 Help:
 number of throttled filesystem change callbacks
 
-pmproxy.mem.datasz PMID: 4.1.5 [server virtual data size]
+pmproxy.mem.datasz PMID: 4.1.5 [virtual data size]
     Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: instant  Units: Kbyte
 Help:
-server process data memory size, returned from sbrk(2)
+process data memory size, returned from sbrk(2)
 
-pmproxy.mem.maxrss PMID: 4.1.4 [server maximum RSS]
+pmproxy.mem.maxrss PMID: 4.1.4 [maximum RSS]
     Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: instant  Units: Kbyte
 Help:
-server process maximum resident set memory size
+process maximum resident set memory size
 
-pmproxy.pid PMID: 4.1.0 [server PID]
+pmproxy.pid PMID: 4.1.0 [Identifier]
     Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: discrete  Units: none
 Help:
-PID for the current server invocation
+Identifier for the current process
 
 pmproxy.redis.requests.error PMID: 4.2.2 [number of request errors]
     Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff

--- a/qa/1689.out
+++ b/qa/1689.out
@@ -19,6 +19,24 @@ Help:
 Writing anything other then 0 to this metric will result in
 re-reading directory and re-mapping files.
 
+pmproxy.cpu.sys PMID: 4.1.2 [server system CPU]
+    Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: millisec
+Help:
+server process system CPU time counter
+
+pmproxy.cpu.total PMID: 4.1.3 [server system + user CPU]
+    Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: millisec
+Help:
+server process system + user CPU time
+
+pmproxy.cpu.user PMID: 4.1.1 [server user CPU]
+    Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: millisec
+Help:
+server process user CPU time counter
+
 pmproxy.discover.changed_callbacks PMID: 4.5.17 [filesystem changed callbacks]
     Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: count
@@ -141,11 +159,23 @@ pmproxy.discover.throttled_changed_callbacks PMID: 4.5.18 [filesystem changed ca
 Help:
 number of throttled filesystem change callbacks
 
-pmproxy.pid PMID: 4.1.0 [pmproxy PID]
+pmproxy.mem.datasz PMID: 4.1.5 [server virtual data size]
+    Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: instant  Units: Kbyte
+Help:
+server process data memory size, returned from sbrk(2)
+
+pmproxy.mem.maxrss PMID: 4.1.4 [server maximum RSS]
+    Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: instant  Units: Kbyte
+Help:
+server process maximum resident set memory size
+
+pmproxy.pid PMID: 4.1.0 [server PID]
     Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: discrete  Units: none
 Help:
-PID for the current pmproxy invocation
+PID for the current server invocation
 
 pmproxy.redis.requests.error PMID: 4.2.2 [number of request errors]
     Data Type: 64-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff

--- a/qa/group
+++ b/qa/group
@@ -1852,7 +1852,7 @@ x11
 1613 pmda.linux kernel local
 1622 selinux local
 1623 libpcp_import collectl local
-1626:reserved pmproxy libpcp_web local
+1626 pmproxy libpcp_web local
 1627 libpcp_import local
 1628 libpcp_import valgrind local
 1633 python pmda.sockets local

--- a/src/include/pcp/pmwebapi.h
+++ b/src/include/pcp/pmwebapi.h
@@ -170,11 +170,11 @@ extern int pmSeriesQuery(pmSeriesSettings *, sds, pmSeriesFlags, void *);
 extern int pmSeriesLoad(pmSeriesSettings *, sds, pmSeriesFlags, void *);
 
 /* libpcp_web timer list interface - global, thread-safe */
-typedef void (*pmServerTimerCallBack)(void *);
-extern int pmServerSetMetricRegistry(struct mmv_registry *); /* for generic server metrics */
-extern int pmServerRegisterTimer(pmServerTimerCallBack, void *);
-extern int pmServerReleaseTimer(void *); /* deregister one timer */
-extern void pmServerReleaseAllTimers(void); /* stop and free all registered timers */
+typedef void (*pmWebTimerCallBack)(void *);
+extern int pmWebTimerSetMetricRegistry(struct mmv_registry *); /* for generic server metrics */
+extern int pmWebTimerRegister(pmWebTimerCallBack, void *);
+extern int pmWebTimerRelease(int); /* deregister one timer */
+extern void pmWebTimerReleaseAll(void); /* stop and free all registered timers */
 
 /*
  * Asynchronous archive location and contents discovery services

--- a/src/include/pcp/pmwebapi.h
+++ b/src/include/pcp/pmwebapi.h
@@ -174,7 +174,6 @@ typedef void (*pmWebTimerCallBack)(void *);
 extern int pmWebTimerSetMetricRegistry(struct mmv_registry *); /* for generic server metrics */
 extern int pmWebTimerRegister(pmWebTimerCallBack, void *);
 extern int pmWebTimerRelease(int); /* deregister one timer */
-extern void pmWebTimerReleaseAll(void); /* stop and free all registered timers */
 
 /*
  * Asynchronous archive location and contents discovery services

--- a/src/include/pcp/pmwebapi.h
+++ b/src/include/pcp/pmwebapi.h
@@ -169,6 +169,13 @@ extern int pmSeriesValues(pmSeriesSettings *, pmSeriesTimeWindow *, int, sds *, 
 extern int pmSeriesQuery(pmSeriesSettings *, sds, pmSeriesFlags, void *);
 extern int pmSeriesLoad(pmSeriesSettings *, sds, pmSeriesFlags, void *);
 
+/* libpcp_web timer list interface - global, thread-safe */
+typedef void (*pmServerTimerCallBack)(void *);
+extern int pmServerSetMetricRegistry(struct mmv_registry *); /* for generic server metrics */
+extern int pmServerRegisterTimer(pmServerTimerCallBack, void *);
+extern int pmServerReleaseTimer(void *); /* deregister one timer */
+extern void pmServerReleaseAllTimers(void); /* stop and free all registered timers */
+
 /*
  * Asynchronous archive location and contents discovery services
  */

--- a/src/libpcp_web/src/GNUmakefile
+++ b/src/libpcp_web/src/GNUmakefile
@@ -32,7 +32,7 @@ HIREDIS_CLUSTER_XFILES = $(HIREDIS_CLUSTER_HFILES) $(HIREDIS_CLUSTER_CFILES)
 CFILES = jsmn.c http_client.c http_parser.c sds.c siphash.c \
 	 query.c schema.c load.c sha1.c util.c slots.c \
 	 redis.c dict.c ini.c maps.c batons.c encoding.c \
-	 search.c json_helpers.c config.c \
+	 search.c json_helpers.c config.c timer.c \
 	 $(HIREDIS_CFILES) $(HIREDIS_CLUSTER_CFILES)
 HFILES = jsmn.h http_client.h http_parser.h sdsalloc.h zmalloc.h \
 	 query.h schema.h load.h sha1.h util.h slots.h \

--- a/src/libpcp_web/src/exports
+++ b/src/libpcp_web/src/exports
@@ -228,3 +228,11 @@ PCP_WEB_1.16 {
     redisSlotsSetupMetrics;
     redisSlotsSetMetricRegistry;
 } PCP_WEB_1.15;
+
+PCP_WEB_1.17 {
+  global:
+    pmServerSetMetricRegistry;
+    pmServerRegisterTimer;
+    pmServerReleaseTimer;
+    pmServerReleaseAllTimers;
+} PCP_WEB_1.16;

--- a/src/libpcp_web/src/exports
+++ b/src/libpcp_web/src/exports
@@ -231,8 +231,8 @@ PCP_WEB_1.16 {
 
 PCP_WEB_1.17 {
   global:
-    pmServerSetMetricRegistry;
-    pmServerRegisterTimer;
-    pmServerReleaseTimer;
-    pmServerReleaseAllTimers;
+    pmWebTimerSetMetricRegistry;
+    pmWebTimerRegister;
+    pmWebTimerRelease;
+    pmWebTimerReleaseAll;
 } PCP_WEB_1.16;

--- a/src/libpcp_web/src/exports
+++ b/src/libpcp_web/src/exports
@@ -234,5 +234,4 @@ PCP_WEB_1.17 {
     pmWebTimerSetMetricRegistry;
     pmWebTimerRegister;
     pmWebTimerRelease;
-    pmWebTimerReleaseAll;
 } PCP_WEB_1.16;

--- a/src/libpcp_web/src/nowebgroup.c
+++ b/src/libpcp_web/src/nowebgroup.c
@@ -124,9 +124,3 @@ pmWebTimerRelease(int seq)
     (void)seq;
     return -ENOTSUPP;
 }
-
-void
-pmWebTimerReleaseAll(void)
-{
-    return;
-}

--- a/src/libpcp_web/src/nowebgroup.c
+++ b/src/libpcp_web/src/nowebgroup.c
@@ -92,6 +92,26 @@ pmWebGroupSetConfiguration(pmWebGroupModule *module, struct dict *config)
 }
 
 int
+pmServerRegisterTimer(void *data, pmServerTimerCallBack *callback)
+{
+    (void)data; (void)callback;
+    return -EOPNOTSUPP;
+}
+
+void
+pmServerReleaseTimer(void *data)
+{
+    (void)data;
+    return;
+}
+
+void
+pmServerReleaseAllTimers(void)
+{
+    return;
+}
+
+int
 pmWebGroupSetMetricRegistry(pmWebGroupModule *module, struct mmv_registry *mmv)
 {
     (void)module; (void)mmv;

--- a/src/libpcp_web/src/nowebgroup.c
+++ b/src/libpcp_web/src/nowebgroup.c
@@ -92,26 +92,6 @@ pmWebGroupSetConfiguration(pmWebGroupModule *module, struct dict *config)
 }
 
 int
-pmServerRegisterTimer(void *data, pmServerTimerCallBack *callback)
-{
-    (void)data; (void)callback;
-    return -EOPNOTSUPP;
-}
-
-void
-pmServerReleaseTimer(void *data)
-{
-    (void)data;
-    return;
-}
-
-void
-pmServerReleaseAllTimers(void)
-{
-    return;
-}
-
-int
 pmWebGroupSetMetricRegistry(pmWebGroupModule *module, struct mmv_registry *mmv)
 {
     (void)module; (void)mmv;
@@ -122,4 +102,31 @@ void
 pmWebGroupClose(pmWebGroupModule *module)
 {
     (void)module;
+}
+
+int
+pmWebTimerSetMetricRegistry(struct mmv_registry *registry)
+{
+    (void)registry;
+    return -EOPNOTSUPP;
+}
+
+int
+pmWebTimerRegister(pmWebTimerCallBack callback, void *data)
+{
+    (void)data; (void)callback;
+    return -EOPNOTSUPP;
+}
+
+int
+pmWebTimerRelease(int seq)
+{
+    (void)seq;
+    return -ENOTSUPP;
+}
+
+void
+pmWebTimerReleaseAll(void)
+{
+    return;
 }

--- a/src/libpcp_web/src/timer.c
+++ b/src/libpcp_web/src/timer.c
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2021 Red Hat.
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ */
+#include <assert.h>
+#include <sys/resource.h>
+#include "pmapi.h"
+#include "pmda.h"
+#include "pmwebapi.h"
+#include "schema.h"
+
+typedef enum server_metric {
+    SERVER_PID,
+    SERVER_CPU_USR,
+    SERVER_CPU_SYS,
+    SERVER_CPU_TOT,
+    SERVER_MEM_MAXRSS,
+    SERVER_MEM_DATASZ,
+    NUM_SERVER_METRIC
+} server_metric;
+
+typedef struct timerCallback {
+    void			*data;
+    pmServerTimerCallBack	callback;
+    struct timerCallback	*next;
+} timerCallback;
+
+static timerCallback	*timerCallbackList;
+static uv_timer_t	pmwebapi_timer;
+static int		callseq;
+static uv_mutex_t	timerCallbackMutex = PTHREAD_MUTEX_INITIALIZER;
+static struct mmv_registry *server_registry; /* global generic server metrics */
+static void		*server_map;
+
+static void
+webapi_timer_worker(uv_timer_t *arg)
+{
+    timerCallback	*timer;
+    uv_handle_t         *handle = (uv_handle_t *)arg;
+
+    (void)handle;
+    uv_mutex_lock(&timerCallbackMutex);
+    callseq++;
+    for (timer = timerCallbackList; timer; timer = timer->next) {
+    	if (timer->callback)
+	    timer->callback(timer->data);
+    }
+    uv_mutex_unlock(&timerCallbackMutex);
+}
+
+/*
+ * Register given callback function and it's private data in the
+ * global timer list. Callbacks must be non-blocking and short,
+ * e.g. to refresh instrumentation, garbage collection, etc.
+ */
+int
+pmServerRegisterTimer(pmServerTimerCallBack callback, void *data)
+{
+    timerCallback	*timer = (timerCallback *)malloc(sizeof(timerCallback));
+
+    if (timer == NULL)
+    	return -ENOMEM;
+    timer->data = data;
+    timer->callback = callback;
+    uv_mutex_lock(&timerCallbackMutex);
+    if (timerCallbackList == NULL) {
+    	uv_timer_init(uv_default_loop(), &pmwebapi_timer);
+	uv_timer_start(&pmwebapi_timer, webapi_timer_worker, 1000, 1000);
+    }
+    timer->next = timerCallbackList;
+    timerCallbackList = timer;
+    uv_mutex_unlock(&timerCallbackMutex);
+
+    return 0;
+}
+
+int
+pmServerReleaseTimer(void *data)
+{
+    timerCallback	*timer;
+
+    uv_mutex_lock(&timerCallbackMutex);
+    /* TODO */
+    uv_mutex_unlock(&timerCallbackMutex);
+
+    return -EINVAL; /* not found */
+}
+
+/* stop timer and free all timers */
+void
+pmServerReleaseAllTimers(void)
+{
+    timerCallback	*timer, *next;
+
+    uv_mutex_lock(&timerCallbackMutex);
+    uv_timer_stop(&pmwebapi_timer);
+    for (timer = timerCallbackList; timer; timer = next) {
+	next = timer->next;
+	free(timer);
+    }
+    timerCallbackList = NULL;
+    uv_mutex_unlock(&timerCallbackMutex);
+}
+
+/*
+ * timer callback to refresh generic server metrics
+ */
+static void
+server_metrics_refresh(void *data)
+{
+    double		usr, sys;
+    unsigned long	datasz = 0;
+    struct rusage	usage = {0};
+    pmAtomValue		*value;
+
+    __pmProcessDataSize(&datasz);
+    __pmProcessRunTimes(&usr, &sys);
+    usr *= 1000.0; /* milliseconds */
+    sys *= 1000.0;
+    if (getrusage(RUSAGE_SELF, &usage) < 0)
+	return;
+
+    if ((value = mmv_lookup_value_desc(server_map, "cpu.user", NULL)) != NULL)
+	mmv_set_value(server_map, value, usr);
+    if ((value = mmv_lookup_value_desc(server_map, "cpu.sys", NULL)) != NULL)
+	mmv_set_value(server_map, value, sys);
+    if ((value = mmv_lookup_value_desc(server_map, "cpu.total", NULL)) != NULL)
+	mmv_set_value(server_map, value, usr+sys);
+    if ((value = mmv_lookup_value_desc(server_map, "mem.maxrss", NULL)) != NULL)
+	mmv_set_value(server_map, value, usage.ru_maxrss);
+    if ((value = mmv_lookup_value_desc(server_map, "mem.datasz", NULL)) != NULL)
+	mmv_set_value(server_map, value, (double)datasz);
+}
+
+/*
+ * Register and set up generic server metrics.
+ * See pmproxy/src/server.c for calling example.
+ */
+int
+pmServerSetMetricRegistry(struct mmv_registry *registry)
+{
+
+    pmAtomValue		*value;
+    pmInDom		noindom = MMV_INDOM_NULL;
+    pmUnits		nounits = MMV_UNITS(0,0,0,0,0,0);
+    pmUnits		units_kbytes = MMV_UNITS(1, 0, 0, PM_SPACE_KBYTE, 0, 0);
+    pmUnits		units_msec = MMV_UNITS(0, 1, 0, 0, PM_TIME_MSEC, 0);
+
+    pid_t		pid = getpid();
+    char		buffer[64];
+
+    if (server_registry) {
+	fprintf(stderr, "%s: Error: server instrumentation already registered\n", pmGetProgname());
+    	return -EINVAL;
+    }
+
+    server_registry = registry;
+    mmv_stats_add_metric(registry, "pid", SERVER_PID,
+		MMV_TYPE_U32, MMV_SEM_DISCRETE, nounits, noindom,
+		"server PID",
+		"PID for the current server invocation");
+    pmsprintf(buffer, sizeof(buffer), "%u", pid);
+    mmv_stats_add_metric_label(registry, SERVER_PID,
+		"pid", buffer, MMV_NUMBER_TYPE, 0);
+
+    mmv_stats_add_metric(registry, "cpu.user", SERVER_CPU_USR,
+	MMV_TYPE_U64, MMV_SEM_COUNTER, units_msec, noindom,
+	"server user CPU",
+	"server process user CPU time counter");
+
+    mmv_stats_add_metric(registry, "cpu.sys", SERVER_CPU_SYS,
+	MMV_TYPE_U64, MMV_SEM_COUNTER, units_msec, noindom,
+	"server system CPU",
+	"server process system CPU time counter");
+
+    mmv_stats_add_metric(registry, "cpu.total", SERVER_CPU_TOT,
+	MMV_TYPE_U64, MMV_SEM_COUNTER, units_msec, noindom,
+	"server system + user CPU",
+	"server process system + user CPU time");
+
+    mmv_stats_add_metric(registry, "mem.maxrss", SERVER_MEM_MAXRSS,
+	MMV_TYPE_U64, MMV_SEM_INSTANT, units_kbytes, noindom,
+	"server maximum RSS",
+	"server process maximum resident set memory size");
+
+    mmv_stats_add_metric(registry, "mem.datasz", SERVER_MEM_DATASZ,
+	MMV_TYPE_U64, MMV_SEM_INSTANT, units_kbytes, noindom,
+	"server virtual data size",
+	"server process data memory size, returned from sbrk(2)");
+
+    if ((server_map = mmv_stats_start(registry)) == NULL) {
+	fprintf(stderr, "%s: Error: server instrumentation disabled\n", pmGetProgname());
+	return -EINVAL;
+    }
+
+    /* PID doesn't change, register it once */
+    if ((value = mmv_lookup_value_desc(server_map, "pid", NULL)) != NULL)
+	mmv_set_value(server_map, value, pid);
+
+    /* register the refresh timer */
+    pmServerRegisterTimer(server_metrics_refresh, server_map);
+
+    /* success */
+    return 0;
+}

--- a/src/libpcp_web/src/webgroup.c
+++ b/src/libpcp_web/src/webgroup.c
@@ -52,6 +52,7 @@ typedef struct webgroups {
     unsigned int	active;
     uv_timer_t		timer;
     uv_mutex_t		mutex;
+    int			stats_timer;
 } webgroups;
 
 static struct webgroups *
@@ -63,6 +64,7 @@ webgroups_lookup(pmWebGroupModule *module)
 	module->privdata = calloc(1, sizeof(struct webgroups));
 	groups = (struct webgroups *)module->privdata;
 	uv_mutex_init(&groups->mutex);
+	groups->stats_timer = -1;
     }
     return groups;
 }
@@ -300,9 +302,15 @@ webgroup_garbage_collect(struct webgroups *groups)
 	uv_mutex_unlock(&groups->mutex);
     }
 
-    /* TODO - trim maps, particularly instmap if proc metrics are not excluded */
+    if (pmDebugOptions.http || pmDebugOptions.libweb)
+	fprintf(stderr, "%s: finished\n", "webgroup_garbage_collect");
+}
 
-    /* TODO move the following to a new stats timer */
+static void
+refresh_maps_metrics(void *data)
+{
+    struct webgroups	*groups = (struct webgroups *)data;
+
     if (groups->metrics_handle) {
 	mmv_stats_set(groups->metrics_handle, "contextmap.size",
 	    NULL, dictSize(contextmap));
@@ -313,19 +321,15 @@ webgroup_garbage_collect(struct webgroups *groups)
 	mmv_stats_set(groups->metrics_handle, "instmap.size",
 	    NULL, dictSize(instmap));
     }
-
-    if (pmDebugOptions.http || pmDebugOptions.libweb)
-	fprintf(stderr, "%s: finished\n", "webgroup_garbage_collect");
 }
 
 static void
-webgroup_worker(void *data)
+webgroup_worker(uv_timer_t *arg)
 {
-    static int		seq = 0;
-    struct webgroups	*groups = (struct webgroups *)data;
+    uv_handle_t		*handle = (uv_handle_t *)arg;
+    struct webgroups	*groups = (struct webgroups *)handle->data;
 
-    if (seq++ % 2 == 0) /* every 2 seconds */
-	webgroup_garbage_collect(groups);
+    webgroup_garbage_collect(groups);
 }
 
 static struct context *
@@ -382,8 +386,13 @@ webgroup_lookup_context(pmWebGroupSettings *sp, sds *id, dict *params,
 
     if (groups->active == 0) {
 	groups->active = 1;
-	/* install timer for periodic garbage collection */
-	pmServerRegisterTimer(webgroup_worker, (void *)groups);
+	/* install general background work timer (GC) */
+	uv_timer_init(groups->events, &groups->timer);
+	groups->timer.data = (void *)groups;
+	uv_timer_start(&groups->timer, webgroup_worker,
+			default_worker, default_worker);
+	/* timer for map stats refresh */
+	groups->stats_timer = pmWebTimerRegister(refresh_maps_metrics, (void *)groups);
     }
 
     if (*id == NULL) {
@@ -2334,8 +2343,6 @@ pmWebGroupSetupMetrics(pmWebGroupModule *module)
 	"instance name map dictionary size",
 	"number of entries in the instance name map dictionary");
 
-    /* TODO add call counter metrics for pmWebgroup* API functions */
-
     webgroups->metrics_handle = mmv_stats_start(webgroups->metrics);
 }
 
@@ -2365,6 +2372,8 @@ pmWebGroupClose(pmWebGroupModule *module)
 	if (groups->active) {
 	    groups->active = 0;
 	    uv_timer_stop(&groups->timer);
+	    pmWebTimerRelease(groups->stats_timer);
+	    groups->stats_timer = -1;
 	}
 	iterator = dictGetIterator(groups->contexts);
 	while ((entry = dictNext(iterator)) != NULL)

--- a/src/pmproxy/src/server.c
+++ b/src/pmproxy/src/server.c
@@ -141,8 +141,7 @@ server_init(int portcount, const char *localpath)
     proxy->config = config;
 
     if ((registry = proxymetrics(proxy, METRICS_SERVER)) != NULL)
-	pmServerSetMetricRegistry(registry);
-    /* server_metrics_init(proxy); */
+	pmWebTimerSetMetricRegistry(registry);
 
     proxy->events = uv_default_loop();
 
@@ -738,7 +737,7 @@ shutdown_ports(void *arg)
     }
 
     uv_loop_close(proxy->events);
-    pmServerReleaseAllTimers();
+    pmWebTimerReleaseAll();
     proxymetrics_close(proxy, METRICS_SERVER);
 
     free(proxy->servers);

--- a/src/pmproxy/src/server.c
+++ b/src/pmproxy/src/server.c
@@ -737,7 +737,6 @@ shutdown_ports(void *arg)
     }
 
     uv_loop_close(proxy->events);
-    pmWebTimerReleaseAll();
     proxymetrics_close(proxy, METRICS_SERVER);
 
     free(proxy->servers);

--- a/src/pmproxy/src/server.h
+++ b/src/pmproxy/src/server.h
@@ -43,11 +43,6 @@ typedef enum proxy_registry {
     NUM_REGISTRY
 } proxy_registry;
 
-typedef enum server_metric {
-    SERVER_PID,
-    NUM_SERVER_METRIC
-} server_metric;
-
 typedef struct stream_write_baton {
     uv_write_t		writer;
     uv_buf_t		buffer[2];

--- a/src/pmrep/conf/pmproxy.conf
+++ b/src/pmrep/conf/pmproxy.conf
@@ -23,6 +23,17 @@ pmproxy.redis.responses.error = resp err,,,,,0
 pmproxy.discover.changed_callbacks = changed,,,,,1
 pmproxy.discover.throttled_changed_callbacks = throttled,,,,,1
 
+[pmproxy-resource]
+timestamp = yes
+repeat_header = auto
+cpu_percent = pmproxy.cpu.percent
+cpu_percent.label = %%CPU
+cpu_percent.formula = 100 * pmproxy.cpu.total
+cpu_percent.unit = s
+pmproxy.mem.datasz = Datasz,,,,6
+pmproxy.mem.maxrss = MaxRss,,,,6
+
+
 [pmproxy-series]
 timestamp = yes
 repeat_header = auto


### PR DESCRIPTION
Add new thread-safe timer registeration API to libpcp_web. Also
add generic CPU and mem server metrics to libpcp_web using an
mmv_registry that is set up and passed in by the calling server.
Switch pmproxy to use this interface, replacing server_metrics_init().

Add new pmrep config for :pmproxy-resource. Remake qa/1689 with new
metrics for pmproxy.mem.datasz/maxrss and pmproxy.cpu.total/sys/user.

Still TODO doc/man updates and a bit more QA.