### PR TITLE
services: migrate all oneshot systemd services to type=simple

### DIFF
--- a/src/pmfind/GNUmakefile
+++ b/src/pmfind/GNUmakefile
@@ -36,6 +36,8 @@ CRONTAB_USER =
 CRONTAB_PATH = $(PCP_SYSCONF_DIR)/pmfind/crontab
 endif
 
+LDIRT   = pmfind.service
+
 default : $(CMDTARGET) crontab pmfind.service
 
 include $(BUILDRULES)

--- a/src/pmfind/pmfind.service.in
+++ b/src/pmfind/pmfind.service.in
@@ -6,8 +6,8 @@ After=pmie_check.timer pmlogger_check.timer
 BindsTo=pmfind.timer
 
 [Service]
-Type=oneshot
-KillMode=none
+Type=simple
+Restart=no
 TimeoutSec=60
 Environment="PMFIND_CHECK_PARAMS=-C -q"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmfind

--- a/src/pmie/pmie_check.service.in
+++ b/src/pmie/pmie_check.service.in
@@ -5,8 +5,8 @@ ConditionPathExists=!@CRONTAB_PATH@
 PartOf=pmie.service
 
 [Service]
-Type=oneshot
-KillMode=none
+Type=simple
+Restart=no
 TimeoutStartSec=25m
 Environment="PMIE_CHECK_PARAMS=-C"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmie_timers

--- a/src/pmie/pmie_daily.service.in
+++ b/src/pmie/pmie_daily.service.in
@@ -4,8 +4,8 @@ Documentation=man:pmie_daily(1)
 ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
-Type=oneshot
-KillMode=none
+Type=simple
+Restart=no
 Environment="PMIE_DAILY_PARAMS=-X xz -x 3"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmie_timers
 ExecStart=@PCP_BINADM_DIR@/pmie_daily $PMIE_DAILY_PARAMS

--- a/src/pmlogger/pmlogger_check.service.in
+++ b/src/pmlogger/pmlogger_check.service.in
@@ -4,8 +4,8 @@ Documentation=man:pmlogger_check(1)
 ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
-Type=oneshot
-KillMode=none
+Type=simple
+Restart=no
 TimeoutStartSec=25m
 Environment="PMLOGGER_CHECK_PARAMS=-C --skip-primary"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers

--- a/src/pmlogger/pmlogger_daily-poll.service.in
+++ b/src/pmlogger/pmlogger_daily-poll.service.in
@@ -4,8 +4,8 @@ Documentation=man:pmlogger_daily(1)
 ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
-Type=oneshot
-KillMode=none
+Type=simple
+Restart=no
 Environment="PMLOGGER_DAILY_POLL_PARAMS=-p"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
 ExecStart=@PCP_BINADM_DIR@/pmlogger_daily $PMLOGGER_DAILY_POLL_PARAMS

--- a/src/pmlogger/pmlogger_daily.service.in
+++ b/src/pmlogger/pmlogger_daily.service.in
@@ -4,8 +4,8 @@ Documentation=man:pmlogger_daily(1)
 ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
-Type=oneshot
-KillMode=none
+Type=simple
+Restart=no
 TimeoutStartSec=1h
 Environment="PMLOGGER_DAILY_PARAMS=-E"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers

--- a/src/pmlogger/pmlogger_daily_report-poll.service.in
+++ b/src/pmlogger/pmlogger_daily_report-poll.service.in
@@ -4,8 +4,8 @@ Documentation=man:pmlogger_daily_report(1)
 ConditionPathExists=!@CRONTAB_DAILY_REPORT_PATH@
 
 [Service]
-Type=oneshot
-KillMode=none
+Type=simple
+Restart=no
 Environment="PMLOGGER_DAILY_REPORT_POLL_PARAMS=-o @PCP_SA_DIR@ -p"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
 ExecStart=@PCP_BINADM_DIR@/pmlogger_daily_report $PMLOGGER_DAILY_REPORT_POLL_PARAMS

--- a/src/pmlogger/pmlogger_daily_report.service.in
+++ b/src/pmlogger/pmlogger_daily_report.service.in
@@ -4,8 +4,8 @@ Documentation=man:pmlogger_daily_report(1)
 ConditionPathExists=!@CRONTAB_DAILY_REPORT_PATH@
 
 [Service]
-Type=oneshot
-KillMode=none
+Type=simple
+Restart=no
 TimeoutSec=120
 Environment="PMLOGGER_DAILY_REPORT_PARAMS=-o @PCP_SA_DIR@"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers


### PR DESCRIPTION
Systemd type=simple services (with Restart=no) can run for
a short time and then exit, much like a type=oneshot service
but without the need for all the KillMode=none baggage.

Systemd has a much more hands-off approach to simple services,
including not minding if forked subprocesses continue after a
oneshot script has exited.

This essentially changes all oneshot services from:
Type=oneshot
KillMode=none

To:
Type=simple
Restart=no

QA passes for the logctl group but this needs careful review and
a lot of soak time. As such these changes are somewhat experimental
at this stage.

Related: Red Hat BZ#1942844 - systemd-analyze complains about deprecated KillMode directive
Related: Fedora BZ#1897945 - pcp pmlogger services yield systemd killmode warning