### PR TITLE
man/man1/pmseries.1: fix ":" operator description

### DIFF
--- a/man/man1/pmseries.1
+++ b/man/man1/pmseries.1
@@ -194,8 +194,7 @@ inequality ("!=").
 Strings can be subject to pattern matching in the form of
 glob matching ("~~"), regular expression matching ("=~"),
 and regular expression non-matching ("!~").
-The ":" operator is equivalent to "~~" - i.e., regular expression
-matching.
+The ":" operator is equivalent to "~~" - i.e., glob matching.
 .SS Relational operators (numeric label values only)
 Numeric label values can be subject to the less than ("<"),
 greater than (">"), less than or equal ("<="), greater than


### PR DESCRIPTION
The explanation seems to be incorrect.
I checked the followings:

```
# pmseries 'kernel.all.load{hostname:".*"}'
# pmseries 'kernel.all.load{hostname:"*"}'
65a90920c72e890bd50333fa73cf23fd757d6377

# pmseries 'kernel.all.load{hostname~~".*"}'
# pmseries 'kernel.all.load{hostname~~"*"}'
65a90920c72e890bd50333fa73cf23fd757d6377

# pmseries 'kernel.all.load{hostname=~".*"}'
65a90920c72e890bd50333fa73cf23fd757d6377
# pmseries 'kernel.all.load{hostname=~"*"}'
pmseries: [Bad request] invalid regular expression "*"
```