### PR TITLE
pmdaproc: add proc.autogroup scheduling metrics

### DIFF
--- a/qa/022.out.linux
+++ b/qa/022.out.linux
@@ -1,4 +1,7 @@
 QA output created by 022
+proc.autogroup.enabled
+proc.autogroup.id
+proc.autogroup.nice
 proc.control.all.threads
 proc.control.perclient.cgroups
 proc.control.perclient.threads

--- a/qa/1222.out
+++ b/qa/1222.out
@@ -123,6 +123,9 @@ proc.schedstat.pcount: >10 values
 proc.schedstat.run_delay: >10 values
 proc.schedstat.cpu_time: >10 values
 proc.fd.count: >10 values
+proc.autogroup.nice: >10 values
+proc.autogroup.id: >10 values
+proc.autogroup.enabled: 1 value
 proc.runq.runnable: some values
 proc.runq.blocked: some values
 proc.runq.sleeping: some values

--- a/qa/974.out
+++ b/qa/974.out
@@ -3,6 +3,11 @@ QA output created by 974
 == Checking namespace and metric numbering - procpid-2.6.32-root-001.tgz
 == Checking metric descriptors and a fetch - procpid-2.6.32-root-001.tgz
 
+proc.autogroup.enabled
+    Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: instant  Units: none
+    value 0
+
 proc.control.all.threads
     Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: instant  Units: none
@@ -673,6 +678,11 @@ No value(s) available!
 == Extracting subtrees for later use - procpid-3.19.0-root-002.tgz
 == Checking namespace and metric numbering - procpid-3.19.0-root-002.tgz
 == Checking metric descriptors and a fetch - procpid-3.19.0-root-002.tgz
+
+proc.autogroup.enabled
+    Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: instant  Units: none
+    value 0
 
 proc.control.all.threads
     Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
@@ -1396,6 +1406,11 @@ No value(s) available!
 == Checking namespace and metric numbering - procpid-3.2.0-root-003.tgz
 == Checking metric descriptors and a fetch - procpid-3.2.0-root-003.tgz
 
+proc.autogroup.enabled
+    Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: instant  Units: none
+    value 0
+
 proc.control.all.threads
     Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: instant  Units: none
@@ -1944,6 +1959,11 @@ No value(s) available!
 == Checking namespace and metric numbering - procpid-4.14.5-root-005.tgz
 == Checking metric descriptors and a fetch - procpid-4.14.5-root-005.tgz
 
+proc.autogroup.enabled
+    Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: instant  Units: none
+    value 0
+
 proc.control.all.threads
     Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: instant  Units: none
@@ -2012,6 +2032,11 @@ No value(s) available!
 == Checking namespace and metric numbering - procpid-4.18.13-root-006.tgz
 == Checking metric descriptors and a fetch - procpid-4.18.13-root-006.tgz
 
+proc.autogroup.enabled
+    Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: instant  Units: none
+    value 0
+
 proc.control.all.threads
     Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: instant  Units: none
@@ -2077,6 +2102,11 @@ No value(s) available!
 == Extracting subtrees for later use - procpid-4.2.3-root-004.tgz
 == Checking namespace and metric numbering - procpid-4.2.3-root-004.tgz
 == Checking metric descriptors and a fetch - procpid-4.2.3-root-004.tgz
+
+proc.autogroup.enabled
+    Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: instant  Units: none
+    value 0
 
 proc.control.all.threads
     Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
@@ -2457,6 +2487,11 @@ No value(s) available!
 == Extracting subtrees for later use - procpid-5.5.7-root-007.tgz
 == Checking namespace and metric numbering - procpid-5.5.7-root-007.tgz
 == Checking metric descriptors and a fetch - procpid-5.5.7-root-007.tgz
+
+proc.autogroup.enabled
+    Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: instant  Units: none
+    value 0
 
 proc.control.all.threads
     Data Type: 32-bit unsigned int  InDom: PM_INDOM_NULL 0xffffffff

--- a/src/pmdas/linux_proc/clusters.h
+++ b/src/pmdas/linux_proc/clusters.h
@@ -67,8 +67,10 @@
 #define CLUSTER_HOTPROC_PID_EXE		71 /* /proc/<pid>/exe */
 #define CLUSTER_PID_CWD			72 /* /proc/<pid>/cwd */
 #define CLUSTER_HOTPROC_PID_CWD		73 /* /proc/<pid>/cwd */
+#define CLUSTER_PID_AUTOGROUP		74 /* /proc/<pid>/autogroup */
+#define CLUSTER_HOTPROC_PID_AUTOGROUP	75 /* /proc/<pid>/autogroup */
 
 #define MIN_CLUSTER  8		/* first cluster number we use here */
-#define MAX_CLUSTER 74		/* one more than highest cluster number used */
+#define MAX_CLUSTER 76		/* one more than highest cluster number used */
 
 #endif /* _CLUSTERS_H */

--- a/src/pmdas/linux_proc/help_text.h
+++ b/src/pmdas/linux_proc/help_text.h
@@ -151,4 +151,7 @@ help_text_t  help_text[] = {
 { .name = "smaps.swap",    .shorthelp = "Swap size from /proc/<pid>/smaps_rollup", .longhelp = "Swap shows how much would-be-anonymous memory is also used, but out on swap.\nFor shmem mappings, Swap includes also the size of the mapped (and not\nreplaced by copy-on-write) part of the underlying shmem object out on swap.\n" },
 { .name = "smaps.swappss",    .shorthelp = "SwapPss size from /proc/<pid>/smaps_rollup", .longhelp = "SwapPss shows proportional swap share of this mapping. Unlike Swap, this\ndoes not take into account swapped out page of underlying shmem objects." },
 { .name = "smaps.locked",    .shorthelp = "Locked mappings size from /proc/<pid>/smaps_rollup",   .longhelp = "Locked indicates whether the mapping is locked in memory or not." },
+{ .name = "autogroup.enabled",    .shorthelp = "Scheduling autogroup feature for CFS is enabled in the kernel",   .longhelp = "Contents of /proc/sys/kernel/sched_autogroup_enabled as described in sched(7)." },
+{ .name = "autogroup.id",    .shorthelp = "Process autogroup identifier from /proc/<pid>/autogroup",   .longhelp = "Process scheduling autogroup identifier as described in sched(7)." },
+{ .name = "autogroup.nice",    .shorthelp = "Process autogroup nice level from /proc/<pid>/autogroup",   .longhelp = "Process scheduling autogroup nice level as described in sched(7)." },
 };

--- a/src/pmdas/linux_proc/proc_dynamic.c
+++ b/src/pmdas/linux_proc/proc_dynamic.c
@@ -39,6 +39,7 @@ enum {
     DYNPROC_GROUP_SCHEDSTAT,
     DYNPROC_GROUP_NAMESPACE,
     DYNPROC_GROUP_SMAPS,
+    DYNPROC_GROUP_AUTOGROUP,
 
     NUM_DYNPROC_GROUPS
 };
@@ -67,6 +68,7 @@ static int proc_hotproc_cluster_list[][2] = {
 	{ CLUSTER_PID_SMAPS,	    CLUSTER_HOTPROC_PID_SMAPS },
 	{ CLUSTER_PID_EXE,	    CLUSTER_HOTPROC_PID_EXE },
 	{ CLUSTER_PID_CWD,	    CLUSTER_HOTPROC_PID_CWD },
+	{ CLUSTER_PID_AUTOGROUP,    CLUSTER_HOTPROC_PID_AUTOGROUP },
 };
 
 
@@ -205,6 +207,12 @@ static dynproc_metric_t namespace_metrics[] = {
         { .name = "envid",  .cluster = CLUSTER_PID_STATUS, .item=42 },
 };
 
+static dynproc_metric_t autogroup_metrics[] = {
+        { .name = "enabled",  .cluster = CLUSTER_PID_AUTOGROUP, .item=0 },
+        { .name = "id",       .cluster = CLUSTER_PID_AUTOGROUP, .item=1 },
+        { .name = "nice",     .cluster = CLUSTER_PID_AUTOGROUP, .item=2 },
+};
+
 static dynproc_metric_t io_metrics[] = {
         { .name = "rchar",		    .cluster = CLUSTER_PID_IO,  .item=0 },
         { .name = "wchar",		    .cluster = CLUSTER_PID_IO,  .item=1 },
@@ -257,6 +265,7 @@ static dynproc_group_t dynproc_groups[] = {
 	[DYNPROC_GROUP_SCHEDSTAT] = { .name = "schedstat",  .metrics = schedstat_metrics,   .nmetrics = sizeof(schedstat_metrics)/sizeof(dynproc_metric_t) },
 	[DYNPROC_GROUP_NAMESPACE] = { .name = "namespaces", .metrics = namespace_metrics,   .nmetrics = sizeof(namespace_metrics)/sizeof(dynproc_metric_t) },
 	[DYNPROC_GROUP_SMAPS]     = { .name = "smaps",	    .metrics = smaps_metrics,	    .nmetrics = sizeof(smaps_metrics)/sizeof(dynproc_metric_t)},
+	[DYNPROC_GROUP_AUTOGROUP] = { .name = "autogroup", .metrics = autogroup_metrics,   .nmetrics = sizeof(autogroup_metrics)/sizeof(dynproc_metric_t) },
 };
 
 /*
@@ -267,9 +276,9 @@ static int
 get_hot_cluster(int proc_cluster)
 {
     int i;
-    int num_mapings = sizeof(proc_hotproc_cluster_list)/(sizeof(int)*2);
+    int num_mappings = sizeof(proc_hotproc_cluster_list)/(sizeof(int)*2);
 
-    for (i = 0; i < num_mapings; i++) {
+    for (i = 0; i < num_mappings; i++) {
 	if (proc_hotproc_cluster_list[i][0] == proc_cluster)
 	    return proc_hotproc_cluster_list[i][1];
     }

--- a/src/pmdas/linux_proc/root_proc
+++ b/src/pmdas/linux_proc/root_proc
@@ -439,6 +439,7 @@ proc {
     fd			PROC:*:*
     namespaces		PROC:*:*
     smaps		PROC:*:*
+    autogroup		PROC:*:*
     control
 }
 
@@ -452,6 +453,7 @@ hotproc {
     fd			PROC:*:*
     namespaces		PROC:*:*
     smaps		PROC:*:*
+    autogroup		PROC:*:*
     control
     total
     predicate


### PR DESCRIPTION
Two new metrics to help with tracking current the current
process prioritization with the Linux CFS implementation,
using /proc/PID/autogroup.

Internally in pmdaproc this new cluster bumped us over the
32bit boundary on the per-process flags field, so I split
that into two separate fields now (actually makes managing
the FLAG macros simpler).