### PR TITLE
__pmLogLabel: move to fixed-sized v3 log file labels

### DIFF
--- a/qa/327.out
+++ b/qa/327.out
@@ -105,6 +105,8 @@ Archive timezone: EST-11EST-10,87/2:00,297/2:00
 PID for pmlogger: 5407
 Bad data volume 1 label: Illegal label record at start of a PCP archive log file
 Bad prefix sentinel value for data volume 1: 825363076 (label length)
+Bad suffix sentinel read for data volume 1: file too short
+Bad suffix sentinel value for data volume 1: -2079706575 (label length)
 Note: timezone set to local timezone of host "gonzo" from archive
 
 Log Label (Log Format Version 2)
@@ -159,8 +161,6 @@ Performance metrics from host gonzo
 Archive timezone: EST-11EST-10,87/2:00,297/2:00
 PID for pmlogger: 12345
 Bad data volume 1 label: Illegal label record at start of a PCP archive log file
-Mismatched hostname length (0/6) between data volume 1 and data volume 0
-Mismatched timezone length (0/30) between data volume 1 and data volume 0
 Mismatched hostname (""/gonzo) between data volume 1 and data volume 0
 Mismatched timezone (""/EST-11EST-10,87/2:00,297/2:00) between data volume 1 and data volume 0
 Note: timezone set to local timezone of host "gonzo" from archive
@@ -231,6 +231,8 @@ PID for pmlogger: 12345
 pmdumplog: Cannot open archive "<TMPPATH>/ok-mv-foo": Illegal label record at start of a PCP archive log file
 Bad metadata volume label: Illegal label record at start of a PCP archive log file
 Bad prefix sentinel value for metadata volume: 825363076 (label length)
+Bad suffix sentinel read for metadata volume: file too short
+Bad suffix sentinel value for metadata volume: -2079706575 (label length)
 Note: timezone set to local timezone of host "gonzo" from archive
 
 Log Label (Log Format Version 2)
@@ -264,8 +266,6 @@ PID for pmlogger: 12345
 *** bad volume number ***
 pmdumplog: Cannot open archive "<TMPPATH>/ok-mv-foo": Illegal label record at start of a PCP archive log file
 Bad metadata volume label: Illegal label record at start of a PCP archive log file
-Mismatched hostname length (0/6) between metadata volume and data volume 0
-Mismatched timezone length (0/30) between metadata volume and data volume 0
 Mismatched hostname (""/gonzo) between metadata volume and data volume 0
 Mismatched timezone (""/EST-11EST-10,87/2:00,297/2:00) between metadata volume and data volume 0
 Note: timezone set to local timezone of host "gonzo" from archive
@@ -322,6 +322,8 @@ PID for pmlogger: 12345
 pmdumplog: Cannot open archive "<TMPPATH>/ok-mv-foo": Illegal label record at start of a PCP archive log file
 Bad temporal index label: Illegal label record at start of a PCP archive log file
 Bad prefix sentinel value for temporal index: 825363076 (label length)
+Bad suffix sentinel read for temporal index: file too short
+Bad suffix sentinel value for temporal index: -2079706575 (label length)
 Note: timezone set to local timezone of host "gonzo" from archive
 
 Log Label (Log Format Version 2)
@@ -355,8 +357,6 @@ PID for pmlogger: 12345
 *** bad volume number ***
 pmdumplog: Cannot open archive "<TMPPATH>/ok-mv-foo": Illegal label record at start of a PCP archive log file
 Bad temporal index label: Illegal label record at start of a PCP archive log file
-Mismatched hostname length (0/6) between temporal index and data volume 0
-Mismatched timezone length (0/30) between temporal index and data volume 0
 Mismatched hostname (""/gonzo) between temporal index and data volume 0
 Mismatched timezone (""/EST-11EST-10,87/2:00,297/2:00) between temporal index and data volume 0
 Note: timezone set to local timezone of host "gonzo" from archive

--- a/qa/src/checkstructs.c
+++ b/qa/src/checkstructs.c
@@ -254,13 +254,13 @@ main(int argc, char **argv)
      * -1 for each of the hostname, timezone, zoneinfo pointers.
      */
     if (sizeof(char *) == 8)
-	check("__pmLogLabel", sizeof(__pmLogLabel), 16*INT);
+	check("__pmLogLabel", sizeof(__pmLogLabel), 14*INT);
     else if (sizeof(char *) == 4)
-	check("__pmLogLabel", sizeof(__pmLogLabel), 12*INT);
+	check("__pmLogLabel", sizeof(__pmLogLabel), 11*INT);
     else
 	printf("Cannot check __pmLogLabel for sizeof(ptr)=%zd\n", sizeof(char*));
     check("__pmExtLabel_v2", sizeof(__pmExtLabel_v2), 5*INT+PM_LOG_MAXHOSTLEN+PM_TZ_MAXLEN);
-    check("__pmExtLabel_v3", sizeof(__pmExtLabel_v3), 8*INT);
+    check("__pmExtLabel_v3", sizeof(__pmExtLabel_v3), 8*INT+PM_MAX_HOSTNAMELEN+PM_MAX_TIMEZONELEN+PM_MAX_ZONEINFOLEN);
     /*
      * __pmLogTI is now an internal data structure, and for 32-bit
      * platforms there are 4 less words compared to 64-bit platforms:

--- a/qa/src/chkputlogresult.c
+++ b/qa/src/chkputlogresult.c
@@ -102,16 +102,12 @@ Options:\n\
     if (logctl.l_label.hostname)
 	free(logctl.l_label.hostname);
     logctl.l_label.hostname = strdup("happycamper");
-    logctl.l_label.hostname_len = strlen(logctl.l_label.hostname) + 1;
     if (logctl.l_label.timezone)
 	free(logctl.l_label.timezone);
     logctl.l_label.timezone = strdup("UTC");
-    logctl.l_label.timezone_len = strlen(logctl.l_label.timezone) + 1;
     if (logctl.l_label.zoneinfo)
 	free(logctl.l_label.zoneinfo);
     logctl.l_label.zoneinfo = NULL;
-    logctl.l_label.zoneinfo_len = 0;
-    logctl.l_label.total_len = sizeof(__pmExtLabel_v3) + 16;
 
     logctl.l_label.vol = PM_LOG_VOL_TI;
     if ((sts = __pmLogWriteLabel(logctl.l_tifp, &logctl.l_label)) != 0) {

--- a/src/include/pcp/libpcp.h
+++ b/src/include/pcp/libpcp.h
@@ -780,12 +780,8 @@ typedef struct {
     int			pid;		/* PID of logger */
     __pmTimestamp	start;		/* start of this log */
     int			vol;		/* current log volume no. */
-    uint32_t		total_len;	/* on-disk log label length */
-    uint16_t		feature_bits;	/* current enabled features */
-    uint16_t		hostname_len;	/* collection host name length */
-    uint16_t		timezone_len;	/* squashed $TZ label length */
-    uint16_t		zoneinfo_len;	/* detailed $TZ label length */
-    char		*hostname;	/* name of collection host */
+    uint32_t		features;	/* current enabled features */
+    char		*hostname;	/* hostname at collection host */
     char		*timezone;	/* squashed $TZ at collection host */
     char		*zoneinfo;	/* detailed $TZ at collection host */
 } __pmLogLabel;
@@ -812,11 +808,11 @@ typedef struct {
     __int64_t	start_sec;	/* start of this log (__pmTimestamp) */
     __int32_t	start_nsec;
     __int32_t	vol;		/* current log volume no. */
-    __uint16_t	feature_bits;	/* enabled archive features */
-    __uint16_t	hostname_len;	/* collector host name length */
-    __uint16_t	timezone_len;	/* squashed $TZ label length */
-    __uint16_t	zoneinfo_len;	/* collector zoneinfo length */
-    /* hostname, timezone, zoneinfo strings follow - variable length */
+    __uint32_t	features;	/* enabled archive feature bits */
+    __uint32_t	reserved;	/* reserved for future use, zero padded */
+    char	hostname[PM_MAX_HOSTNAMELEN];  /* collection host full name */
+    char	timezone[PM_MAX_TIMEZONELEN];  /* generic "squashed" $TZ */
+    char	zoneinfo[PM_MAX_ZONEINFOLEN];  /* local platform $TZ */
 } __pmExtLabel_v3;
 
 /*
@@ -960,6 +956,7 @@ typedef struct {
 
 /* internal archive routines */
 PCP_CALL extern int __pmLogVersion(__pmLogCtl *);
+PCP_CALL extern size_t __pmLogLabelSize(__pmLogCtl *);
 PCP_CALL extern int __pmLogChkLabel(__pmArchCtl *, __pmFILE *, __pmLogLabel *, int);
 PCP_CALL extern int __pmLogCreate(const char *, const char *, int, __pmArchCtl *);
 PCP_CALL extern __pmFILE *__pmLogNewFile(const char *, int);

--- a/src/include/pcp/pmapi.h
+++ b/src/include/pcp/pmapi.h
@@ -647,6 +647,9 @@ typedef struct pmTimespec {
 #define PM_LOG_VOL_META		-1	/* meta data */
 #define PM_LOG_MAXHOSTLEN	64	/* v2 only, deprecated with v3 */
 #define PM_TZ_MAXLEN		40	/* v2 only, deprecated with v3 */
+#define PM_MAX_HOSTNAMELEN	256	/* max supported for v3 onward */
+#define PM_MAX_TIMEZONELEN	256	/* max supported for v3 onward */
+#define PM_MAX_ZONEINFOLEN	256	/* max supported (new with v3) */
 
 typedef struct pmLogLabel {
     int		ll_magic;	/* PM_LOG_MAGIC | log format version no. */
@@ -661,9 +664,9 @@ typedef struct pmHighResLogLabel {
     int		magic;	/* PM_LOG_MAGIC | log format version no. */
     pid_t	pid;		/* PID of logger */
     struct timespec start;	/* start of this log */
-    char	*hostname;	/* name of collection host */
-    char	*timezone;	/* squashed $TZ at collection host */
-    char	*zoneinfo;	/* detailed $TZ at collection host */
+    char	hostname[PM_MAX_HOSTNAMELEN];	/* collection host full name */
+    char	timezone[PM_MAX_TIMEZONELEN];	/* generic, squashed $TZ */
+    char	zoneinfo[PM_MAX_ZONEINFOLEN];	/* local platform $TZ */
 } pmHighResLogLabel;
 #endif
 
@@ -801,6 +804,12 @@ PCP_CALL extern int pmsprintf(char *, size_t, const char *, ...) __PM_PRINTFLIKE
  * guaranteed to be null-byte terminated and returns strlen(buf)
  */
 PCP_CALL extern size_t pmfstring(FILE *f, char **);
+
+/*
+ * Safe version of strlen(s) that handles null pointer input, in
+ * which case zero is returned.
+ */
+PCP_CALL extern size_t pmstrlen(const char *);
 
 /*
  * Safe version of strncpy() ... args are deliberately different to

--- a/src/libpcp/src/context.c
+++ b/src/libpcp/src/context.c
@@ -950,7 +950,7 @@ initarchive(__pmContext	*ctxp, const char *name)
     ctxp->c_origin.tv_sec = acp->ac_log->l_label.start.sec;
     ctxp->c_origin.tv_usec = acp->ac_log->l_label.start.nsec / 1000;
     ctxp->c_mode = (ctxp->c_mode & 0xffff0000) | PM_MODE_FORW;
-    acp->ac_offset = acp->ac_log->l_label.total_len + 2*sizeof(int);
+    acp->ac_offset = __pmLogLabelSize(acp->ac_log);
     acp->ac_vol = acp->ac_curvol;
     acp->ac_serial = 0;		/* not serial access, yet */
     acp->ac_pmid_hc.nodes = 0;	/* empty hash list */

--- a/src/libpcp/src/e_index.c
+++ b/src/libpcp/src/e_index.c
@@ -247,7 +247,7 @@ __pmLogLoadIndex(__pmLogCtl *lcp)
     }
 
     if (lcp->l_tifp != NULL) {
-	__pmFseek(f, (long)lcp->l_label.total_len + 2 * sizeof(int), SEEK_SET);
+	__pmFseek(f, (long)__pmLogLabelSize(lcp), SEEK_SET);
 	for ( ; ; ) {
 	    __pmLogTI	*tmp;
 	    bytes = (1 + lcp->l_numti) * sizeof(__pmLogTI);

--- a/src/libpcp/src/exports.in
+++ b/src/libpcp/src/exports.in
@@ -745,6 +745,7 @@ PCP_3.32 {
 
 PCP_3.33 {
   global:
+    pmstrlen;
     __pmLogVersion;
     __pmPrintTimespec;
     __pmPrintTimestamp;
@@ -756,6 +757,7 @@ PCP_3.33 {
     __pmPrintResult;
     __htonpmTimestamp;
     __ntohpmTimestamp;
+    __pmLogLabelSize;
     __pmLogLoadInDom;
     __pmLogLoadTimestamp;
     __pmLogLoadTimeval;

--- a/src/libpcp/src/internal.h
+++ b/src/libpcp/src/internal.h
@@ -24,6 +24,9 @@
 #include "compiler.h"
 #include "derive.h"
 
+#define MAXIMUM(x, y)	((x) > (y) ? (x) : (y))
+#define MINIMUM(x, y)	((x) < (y) ? (x) : (y))
+
 extern int __pmConvertTimeout(int) _PCP_HIDDEN;
 extern int __pmConnectWithFNDELAY(int, void *, __pmSockLen) _PCP_HIDDEN;
 
@@ -454,8 +457,5 @@ extern char *__pmLabelFlagString(int, char *, int) _PCP_HIDDEN;
 
 /* logmeta.c hooks */
 extern int addindom(__pmLogCtl *, pmInDom, const __pmTimestamp *, int , int *, char **, __int32_t *, int) _PCP_HIDDEN;
-
-/* logutil.c hooks */
-extern size_t __pmLogLabelTotalSize(__pmLogCtl *) _PCP_HIDDEN;
 
 #endif /* _LIBPCP_INTERNAL_H */

--- a/src/libpcp/src/logmeta.c
+++ b/src/libpcp/src/logmeta.c
@@ -714,7 +714,7 @@ __pmLogLoadMeta(__pmArchCtl *acp)
 	    goto end;
     }
 
-    __pmFseek(f, (long)(lcp->l_label.total_len + 2*sizeof(int)), SEEK_SET);
+    __pmFseek(f, (long)__pmLogLabelSize(lcp), SEEK_SET);
     for ( ; ; ) {
 	n = (int)__pmFread(&h, 1, sizeof(__pmLogHdr), f);
 
@@ -1087,7 +1087,7 @@ end:
     /* Check for duplicate label sets. */
     check_dup_labels(acp);
     
-    __pmFseek(f, (long)(lcp->l_label.total_len + 2*sizeof(int)), SEEK_SET);
+    __pmFseek(f, (long)__pmLogLabelSize(lcp), SEEK_SET);
 
     if (sts == 0) {
 	if (numpmid == 0) {

--- a/src/libpcp/src/strings.c
+++ b/src/libpcp/src/strings.c
@@ -172,3 +172,14 @@ pmstrncat(char *dest, size_t destlen, const char *src)
 
     return *s == '\0' ? 0 : -1;
 }
+
+/*
+ * Safe version of strlen() that guards against NULL pointers.
+ */
+size_t
+pmstrlen(const char *s)
+{
+    if (s != NULL)
+	return strlen(s);
+    return 0;
+}

--- a/src/libpcp_import/src/archive.c
+++ b/src/libpcp_import/src/archive.c
@@ -50,10 +50,8 @@ check_context_start(pmi_context *current)
     if (current->timezone != NULL) {
 	free(lcp->l_label.timezone);
 	lcp->l_label.timezone = strdup(current->timezone);
-	lcp->l_label.timezone_len = strlen(lcp->l_label.timezone) + 1;
 	free(lcp->l_label.zoneinfo);
 	lcp->l_label.zoneinfo = NULL;
-	lcp->l_label.zoneinfo_len = 0;
     }
     pmNewZone(lcp->l_label.timezone);
     current->state = CONTEXT_ACTIVE;

--- a/src/pmdumplog/pmdumplog.c
+++ b/src/pmdumplog/pmdumplog.c
@@ -514,7 +514,7 @@ dumpDiskInDom(__pmContext *ctxp)
 
     printf("\nInstance Domains on-disk ...\n");
 
-    __pmFseek(f, (long)(lcp->l_label.total_len + 2*sizeof(int)), SEEK_SET);
+    __pmFseek(f, (long)__pmLogLabelSize(lcp), SEEK_SET);
     for ( ; ; ) {
 	n = __pmFread(&hdr, 1, sizeof(__pmLogHdr), f);
 	hdr.len = ntohl(hdr.len);

--- a/src/pmlogcheck/pass1.c
+++ b/src/pmlogcheck/pass1.c
@@ -114,9 +114,9 @@ pass1(__pmContext *ctxp, char *archname)
 		archname, i, tip->stamp.sec, tip->stamp.nsec);
 	    index_state = STATE_BAD;
 	}
-	if (tip->off_meta < log->l_label.total_len+2*sizeof(int)) {
+	if (tip->off_meta < __pmLogLabelSize(log)) {
 	    fprintf(stderr, "%s.index[entry %d]: offset to metadata (%lld) before end of label record (%zd)\n",
-		archname, i, (long long)tip->off_meta, log->l_label.total_len+2*sizeof(int));
+		archname, i, (long long)tip->off_meta, __pmLogLabelSize(log));
 	    index_state = STATE_BAD;
 	}
 	if (meta_size != -1 && tip->off_meta > meta_size) {
@@ -124,9 +124,9 @@ pass1(__pmContext *ctxp, char *archname)
 		archname, i, (long long)tip->off_meta, (long long)meta_size);
 	    index_state = STATE_BAD;
 	}
-	if (tip->off_data < log->l_label.total_len+2*sizeof(int)) {
+	if (tip->off_data < __pmLogLabelSize(log)) {
 	    fprintf(stderr, "%s.index[entry %d]: offset to log (%lld) before end of label record (%zd)\n",
-		archname, i, (long long)tip->off_data, log->l_label.total_len+2*sizeof(int));
+		archname, i, (long long)tip->off_data, __pmLogLabelSize(log));
 	    index_state = STATE_BAD;
 	}
 	if (log_size != -1 && tip->off_data > log_size) {

--- a/src/pmlogextract/pmlogextract.c
+++ b/src/pmlogextract/pmlogextract.c
@@ -506,7 +506,6 @@ newlabel(void)
     lp->pid = (int)getpid();
     free(lp->hostname);
     lp->hostname = strdup(f_iap->label.ll_hostname);
-    lp->hostname_len = strlen(lp->hostname) + 1;
     if (farg) {
 	/*
 	 * use timezone from _first_ non-empty archive ...
@@ -514,7 +513,6 @@ newlabel(void)
 	 */
 	free(lp->timezone);
 	lp->timezone = strdup(f_iap->label.ll_tz);
-	lp->timezone_len = strlen(lp->timezone) + 1;
     }
     else {
 	/*
@@ -526,7 +524,6 @@ newlabel(void)
 		l_iap = &inarch[indx];
 		free(lp->timezone);
 		lp->timezone = strdup(l_iap->label.ll_tz);
-		lp->timezone_len = strlen(lp->timezone) + 1;
 		break;
 	    }
 	}
@@ -534,7 +531,6 @@ newlabel(void)
     /* TODO: v3 archive zoneinfo */
     free(lp->zoneinfo);
     lp->zoneinfo = NULL;
-    lp->zoneinfo_len = 0;
 
     /* reset outarch as appropriate, depending on other input archives */
     for (indx=0; indx<inarchnum; indx++) {
@@ -2430,7 +2426,7 @@ fprintf(stderr, " break!\n");
 
 	/* check whether we need to write TI (temporal index) */
 	if (old_log_offset == 0 ||
-	    old_log_offset == logctl.l_label.total_len+2*sizeof(int) ||
+	    old_log_offset == __pmLogLabelSize(&logctl) ||
 	    __pmFtell(archctl.ac_mfp) > flushsize)
 		needti = 1;
 
@@ -2450,7 +2446,7 @@ fprintf(stderr, " break!\n");
 	    __pmFflush(logctl.l_mdfp);
 
 	    if (old_log_offset == 0)
-		old_log_offset = logctl.l_label.total_len+2*sizeof(int);
+		old_log_offset = __pmLogLabelSize(&logctl);
 
             new_log_offset = __pmFtell(archctl.ac_mfp);
 	    assert(new_log_offset >= 0);
@@ -2994,7 +2990,7 @@ cleanup:
 	__pmFflush(logctl.l_mdfp);
 
 	if (old_log_offset == 0)
-	    old_log_offset = logctl.l_label.total_len+2*sizeof(int);
+	    old_log_offset = __pmLogLabelSize(&logctl);
 
 	new_log_offset = __pmFtell(archctl.ac_mfp);
 	assert(new_log_offset >= 0);

--- a/src/pmlogger/src/callback.c
+++ b/src/pmlogger/src/callback.c
@@ -656,7 +656,7 @@ do_work(task_t *tp)
     __pmTimestamp	stamp;
     unsigned long	peek_offset;
 
-    label_offset = archctl.ac_log->l_label.total_len + 2 * sizeof(int);
+    label_offset = __pmLogLabelSize(archctl.ac_log);
 
     if ((pmDebugOptions.appl2) && (pmDebugOptions.desperate)) {
 	struct timeval	now;

--- a/src/pmlogger/src/logue.c
+++ b/src/pmlogger/src/logue.c
@@ -242,7 +242,7 @@ do_logue(int type)
 	}
 
 	/* fudge the temporal index */
-	offset = logctl.l_label.total_len + 2 * sizeof(int);
+	offset = __pmLogLabelSize(&logctl);
 	__pmFseek(archctl.ac_mfp, offset, SEEK_SET);
 	__pmFseek(logctl.l_mdfp, offset, SEEK_SET);
 	__pmLogPutIndex(&archctl, &stamp);

--- a/src/pmlogger/src/pmlogger.c
+++ b/src/pmlogger/src/pmlogger.c
@@ -115,12 +115,10 @@ run_done(int sts, char *msg)
      * _before_ the last log record
      */
     if (last_stamp.tv_sec != 0) {
-	long		off;
 	__pmTimestamp	tmp;
 	tmp.sec = (__int32_t)last_stamp.tv_sec;
 	tmp.nsec = (__int32_t)last_stamp.tv_usec * 1000;;
-	off = archctl.ac_log->l_label.total_len + 2 * sizeof(int);
-	if (last_log_offset < off)
+	if (last_log_offset < __pmLogLabelSize(archctl.ac_log))
 	    fprintf(stderr, "run_done: Botch: last_log_offset = %ld\n", (long)last_log_offset);
 	__pmFseek(archctl.ac_mfp, last_log_offset, SEEK_SET);
 	__pmLogPutIndex(&archctl, &tmp);
@@ -1281,7 +1279,6 @@ main(int argc, char **argv)
 	    if (logctl.l_label.timezone)
 		free(logctl.l_label.timezone);
 	    logctl.l_label.timezone = strdup(vp->vlist[0].value.pval->vbuf);
-	    logctl.l_label.timezone_len = strlen(logctl.l_label.timezone) + 1;
 	    /* prefer to use remote time to avoid clock drift problems */
 	    epoch = resp->timestamp;		/* struct assignment */
 	    if (! use_localtime)

--- a/src/pmloglabel/pmloglabel.c
+++ b/src/pmloglabel/pmloglabel.c
@@ -56,12 +56,11 @@ verify_label(__pmFILE *f, const char *file)
 	    status = 2;
 	}
     }
-    if ((len != sizeof(__pmExtLabel_v2) &&
-	(len <= sizeof(__pmExtLabel_v3) || len > (1 << 16)))) {
+    if (len != sizeof(__pmExtLabel_v2) + 2 * sizeof(int) &&
+	len != sizeof(__pmExtLabel_v3) + 2 * sizeof(int)) {
 	fprintf(stderr, "Bad prefix sentinel value for %s: %d (label length)\n",
 			file, len);
-	status = 2;	/* we don't know which way is up at this point */
-	goto out;	/* cannot attempt to access this label anymore */
+	status = 2;
     }
 
     /* check the suffix integer */
@@ -85,14 +84,13 @@ verify_label(__pmFILE *f, const char *file)
 	    status = 2;
 	}
     }
-    if ((len != sizeof(__pmExtLabel_v2) &&
-	(len <= sizeof(__pmExtLabel_v3) || len > (1 << 16)))) {
+    if (len != sizeof(__pmExtLabel_v2) + 2 * sizeof(int) &&
+	len != sizeof(__pmExtLabel_v3) + 2 * sizeof(int)) {
 	fprintf(stderr, "Bad suffix sentinel value for %s: %d (label length)\n",
 			file, len);
 	status = 2;
     }
 
-out:
     if (memcmp(&logctl.l_label, &zeroes, sizeof(zeroes)) == 0)
 	return 0;	/* no label content was successfully read */
 
@@ -155,21 +153,6 @@ compare_golden(__pmFILE *f, const char *file, int sts, int warnings)
 	if (label->pid != golden.pid) {
 	    fprintf(stderr, "Mismatched PID (%d/%d) between %s and %s\n",
 			    label->pid, golden.pid, file, goldfile);
-	    status = 2;
-	}
-	if (label->hostname_len != golden.hostname_len) {
-	    fprintf(stderr, "Mismatched hostname length (%hu/%hu) between %s and %s\n",
-		    label->hostname_len, golden.hostname_len, file, goldfile);
-	    status = 2;
-	}
-	if (label->timezone_len != golden.timezone_len) {
-	    fprintf(stderr, "Mismatched timezone length (%hu/%hu) between %s and %s\n",
-		    label->timezone_len, golden.timezone_len, file, goldfile);
-	    status = 2;
-	}
-	if (label->zoneinfo_len != golden.zoneinfo_len) {
-	    fprintf(stderr, "Mismatched zoneinfo length (%hu/%hu) between %s and %s\n",
-		    label->zoneinfo_len, golden.zoneinfo_len, file, goldfile);
 	    status = 2;
 	}
 	if (!label->hostname || !golden.hostname ||
@@ -373,16 +356,13 @@ main(int argc, char *argv[])
 	if (host) {
 	    free(golden.hostname);
 	    golden.hostname = strdup(host);
-	    golden.hostname_len = strlen(host) + 1;
 	}
 	if (tz) {
 	    free(golden.timezone);
 	    golden.timezone = strdup(tz);
-	    golden.timezone_len = strlen(tz) + 1;
 	}
 	/* TODO: v3 archive zoneinfo */
 	golden.zoneinfo = NULL;
-	golden.zoneinfo_len = 0;
 
 	if (archctl.ac_mfp)
 	    __pmFclose(archctl.ac_mfp);

--- a/src/pmlogreduce/logio.c
+++ b/src/pmlogreduce/logio.c
@@ -67,16 +67,13 @@ newlabel(void)
     if (lp->hostname)
 	free(lp->hostname);
     lp->hostname = strdup(ilabel.ll_hostname);
-    lp->hostname_len = strlen(lp->hostname) + 1;
     if (lp->timezone)
 	free(lp->timezone);
     lp->timezone = strdup(ilabel.ll_tz);
-    lp->timezone_len = strlen(lp->timezone) + 1;
     if (lp->zoneinfo)
 	free(lp->zoneinfo);
     /* TODO: use v3 archive zoneinfo */
     lp->zoneinfo = NULL;
-    lp->zoneinfo_len = 0;
 }
 
 

--- a/src/pmlogrewrite/pmlogrewrite.c
+++ b/src/pmlogrewrite/pmlogrewrite.c
@@ -159,18 +159,15 @@ newlabel(void)
 	free(lp->hostname);
     lp->hostname = (global.flags & GLOBAL_CHANGE_HOSTNAME) ?
 	strdup(global.hostname) : strdup(inarch.label.ll_hostname);
-    lp->hostname_len = strlen(lp->hostname) + 1;
     if (lp->timezone)
 	free(lp->timezone);
     lp->timezone = (global.flags & GLOBAL_CHANGE_TZ) ?
 	strdup(global.tz) : strdup(inarch.label.ll_tz);
-    lp->timezone_len = strlen(lp->timezone) + 1;
 
     /* TODO: v3 archive zoneinfo support */
     if (lp->zoneinfo)
 	free(lp->zoneinfo);
     lp->zoneinfo = NULL;
-    lp->zoneinfo_len = 0;
 }
 
 /*


### PR DESCRIPTION
For simplicity, sanity and things like pmloglabel(1) that
want to change label hostnames/timezones (without redoing
all following result records), switch to a fixed size v3
label.  This label still has larger start timestamp field
of course, as well as larger hostname, timezone, zoneinfo
fields compared to v2.