### PR TITLE
pmieconf: improve the CPU saturation rules

### DIFF
--- a/src/pmieconf/percpu/many_util
+++ b/src/pmieconf/percpu/many_util
@@ -7,13 +7,13 @@ rule	per_cpu.many_util
 	enumerate = hosts
 	predicate =
 "some_host (
+    hinv.ncpu $hosts$ > $min_cpu_count$ &&
     $pct$ %_inst (
 	100 * ( kernel.percpu.cpu.user $hosts$ +
 		kernel.percpu.cpu.sys $hosts$ +
 		kernel.percpu.cpu.intr $hosts$ )
 	    > $threshold$
     )
-    && hinv.ncpu $hosts$ > $min_cpu_count$
 )"
 	enabled	= yes
 	version	= 1
@@ -44,7 +44,7 @@ than threshold percent, in the range 0 (no processors utilized)
 to 100 (all processors).";
 
 unsigned	min_cpu_count
-	default	= 4
+	default	= 12
 	help	=
 "Lower limit on number of processors for this rule - this rule will
 apply to configurations of greater than min_cpu_count CPUs.
@@ -52,7 +52,7 @@ For smaller processor counts, the per_cpu.some_util rule may be more
 appropriate.";
 
 string	action_expand
-	default	= "\\\\>$pct$%cpus@%h"
+	default	= ">$pct$%CPUs@%h"
 	display	= no
 	modify	= no;
 

--- a/src/pmieconf/percpu/some_util
+++ b/src/pmieconf/percpu/some_util
@@ -38,7 +38,7 @@ percent	threshold
 to 100 (completely busy)";
 
 unsigned	max_cpu_count
-	default	= 4
+	default	= 12
 	help	=
 "Upper limit on number of processors for this rule - this rule will
 apply to configurations of between two and max_cpu_count CPUs.


### PR DESCRIPTION
Resolves some formatting issues with the many_util pmie rule.
The back-quoting was incorrect, resulting in quotes appearing
in the syslog message strings.  The message accidentally used
the %c (source) pmie formatting string in %cpus as well.  One
other change here is to refactor the many_util rule so that a
singelton metric is the first part of the expression, not the
per-CPU metrics, so that the %h pmie format expansion gives a
single string when the rule evaluates to true.

Finally, bump up the min/max CPU count threshold that we use
to indicate a small/moderate-sized server (from 4 to 12) - we
use this to transition between different rules' effeciveness.