### PR TITLE
pmieconf: add several per-disk pmie rule templates

### DIFF
--- a/qa/1051.out.linux
+++ b/qa/1051.out.linux
@@ -29,6 +29,10 @@ Warning - failed to expand action for rule per_cpu.some_util
   string: "$syslog_prefix$$rule$^ $action_expand$"
 Warning - failed to expand action for rule per_cpu.system
   string: "$syslog_prefix$$rule$^ $action_expand$"
+Warning - failed to expand action for rule per_disk.average_queue_length
+  string: "$syslog_prefix$$rule$^ $action_expand$"
+Warning - failed to expand action for rule per_disk.average_wait_time
+  string: "$syslog_prefix$$rule$^ $action_expand$"
 Warning - failed to expand action for rule per_netif.collisions
   string: "$syslog_prefix$$rule$^ $action_expand$"
 Warning - failed to expand action for rule per_netif.errors

--- a/src/pmieconf/.gitignore
+++ b/src/pmieconf/.gitignore
@@ -5,6 +5,7 @@ global/GNUmakefile
 memory/GNUmakefile
 network/GNUmakefile
 percpu/GNUmakefile
+perdisk/GNUmakefile
 pernetif/GNUmakefile
 power/GNUmakefile
 primary/GNUmakefile

--- a/src/pmieconf/GNUmakefile
+++ b/src/pmieconf/GNUmakefile
@@ -17,8 +17,8 @@ TOPDIR = ../..
 include	$(TOPDIR)/src/include/builddefs
 include $(TOPDIR)/src/libpcp/src/GNUlibrarydefs
 
-MKFILE_SUBDIRS = cpu entropy filesys memory network percpu pernetif power \
-		 global primary zeroconf
+MKFILE_SUBDIRS = cpu entropy filesys memory network percpu perdisk pernetif \
+		 power global primary zeroconf
 SUBDIRS	= $(MKFILE_SUBDIRS)
 
 CMDTARGET = pmieconf$(EXECSUFFIX)

--- a/src/pmieconf/perdisk/average_queue_length
+++ b/src/pmieconf/perdisk/average_queue_length
@@ -1,0 +1,48 @@
+#pmieconf-rules 1
+# --- DO NOT MODIFY THIS FILE --- see pmieconf(5)
+#
+
+rule	per_disk.average_queue_length
+	summary	= "$rule$"
+	predicate =
+"some_host (
+    some_inst (
+      ( disk.dev.aveq $hosts$ @0 > disk.dev.aveq $hosts$ @1 )
+        &&
+      ( disk.dev.avactive $hosts$ * 100 > $threshold$ )
+    )
+)"
+	enabled	= yes
+	version	= 1
+	help	=
+"The disk device utilization for at least one disk exceeded the
+given threshold percent of time during the last sample interval
+and the average queue length has been observed to be increasing
+from the previous sample.";
+
+string	rule
+	default	= "High per disk average queue length"
+	modify	= no
+	display	= no;
+
+percent	threshold
+	default	= 95
+	help	=
+"Threshold percentage of time for I/O utilisation, in the range
+0 (idle) to 100 (busy).  Busy is defined as the percentage of
+time during the evaluation interval that the device was busy
+processing requests (reads and writes).  A value of 100 percent
+indicates possible device saturation.";
+
+string	action_expand
+	default	= %vaveq[%i]@%h
+	display	= no
+	modify	= no;
+
+string	email_expand
+	default	= "host: %h disk: %i aveq: %v"
+	display	= no
+	modify	= no;
+
+#
+# --- DO NOT MODIFY THIS FILE --- see pmieconf(5)

--- a/src/pmieconf/perdisk/average_wait_time
+++ b/src/pmieconf/perdisk/average_wait_time
@@ -1,0 +1,49 @@
+#pmieconf-rules 1
+# --- DO NOT MODIFY THIS FILE --- see pmieconf(5)
+#
+
+rule	per_disk.average_wait_time
+	summary	= "$rule$"
+	predicate =
+"some_host (
+  some_inst (
+    ( disk.dev.total_rawactive $hosts$ @0 / disk.dev.total $hosts$ @0 ) * 100
+      >
+    ( disk.dev.total_rawactive $hosts$ @1 / disk.dev.total $hosts$ @1 ) * 100
+      &&
+    ( disk.dev.avactive $hosts$ * 100 > $threshold$ )
+  )
+)"
+	enabled	= yes
+	version	= 1
+	help	=
+"The disk device utilization for at least one disk exceeded the
+given threshold percent of time during the last sample interval
+and the average wait time has been observed to be increasing.";
+
+string	rule
+	default	= "High per disk average queue length"
+	modify	= no
+	display	= no;
+
+percent	threshold
+	default	= 95
+	help	=
+"Threshold percentage of time for I/O utilisation, in the range
+0 (idle) to 100 (busy).  Busy is defined as the percentage of
+time during the evaluation interval that the device was busy
+processing requests (reads and writes).  A value of 100 percent
+indicates possible device saturation.";
+
+string	action_expand
+	default	= %v%await[%i]@%h
+	display	= no
+	modify	= no;
+
+string	email_expand
+	default	= "host: %h disk: %i await: %v"
+	display	= no
+	modify	= no;
+
+#
+# --- DO NOT MODIFY THIS FILE --- see pmieconf(5)

--- a/src/pmieconf/perdisk/bandwidth
+++ b/src/pmieconf/perdisk/bandwidth
@@ -1,0 +1,63 @@
+#pmieconf-rules 1
+# --- DO NOT MODIFY THIS FILE --- see pmieconf(5)
+#
+
+rule	per_disk.bandwidth
+	summary	= "$rule$"
+	enumerate = hosts
+	predicate =
+"some_inst (
+    ( disk.dev.total_bytes $hosts$ $disks$ > $bandwidth$ Mbytes/sec )
+      &&
+    ( disk.dev.avactive $hosts$ $disks$ * 100 > $threshold$ )
+)"
+	enabled	= no
+	version	= 1
+	help	=
+"The disk device utilization for at least one disk exceeded the
+given threshold percent of time during the last sample interval
+and for at least one device the average transfer rate (reads and
+writes) exceeded the configured bandwidth limit.";
+
+string	rule
+	default	= "High system device bandwidth utilization"
+	modify	= no
+	display	= no;
+
+unsigned	bandwidth
+	default	= 100
+	help	=
+"The total bandwidth, such as 100 megabytes per second, at which
+we consider the system block device to be bandwidth saturated.";
+
+percent	threshold
+	default	= 95
+	help	=
+"Threshold percentage of time for I/O utilisation, in the range
+0 (idle) to 100 (busy).  Busy is defined as the percentage of
+time during the evaluation interval that the device was busy
+processing requests (reads and writes).
+A value of 100 percent indicates possible device saturation.";
+
+instlist	disks
+	default	= "sda"
+	help	=
+"Set to a list of local disk device names for which the rule will
+be evaluated, as a subset of available block devices.  The device
+names should be separated by white space and may be enclosed in
+single quotes, eg. \"sda 'sdb' sdc\".  Use the command:
+	$ pminfo -f disk.dev.total_bytes
+to discover the names of the available block devices.";
+
+string	action_expand
+	default	= "%vb/s[%i]@%h"
+	display	= no
+	modify	= no;
+
+string	email_expand
+	default	= "host: %h disk: %i b/s: %v"
+	display	= no
+	modify	= no;
+
+#
+# --- DO NOT MODIFY THIS FILE --- see pmieconf(5)

--- a/src/pmieconf/perdisk/iops
+++ b/src/pmieconf/perdisk/iops
@@ -1,0 +1,65 @@
+#pmieconf-rules 1
+# --- DO NOT MODIFY THIS FILE --- see pmieconf(5)
+#
+
+rule	per_disk.iops
+	summary	= "$rule$"
+	enumerate = hosts
+	predicate =
+"some_inst (
+    ( disk.dev.total $hosts$ $disks$ > $iops$ count/sec )
+      &&
+    ( disk.dev.avactive $hosts$ $disks$ * 100 > $threshold$ )
+)"
+	enabled	= no
+	version	= 1
+	help	=
+"The disk device utilization for at least one disk exceeded the
+given threshold percent of time during the last sample interval
+and for at least one device the average Input/Ouput Operations
+Per Second (IOPS) rate (reads and writes) exceeded a configured
+IOPS limit.";
+
+string	rule
+	default	= "High system device IOPS utilization"
+	modify	= no
+	display	= no;
+
+unsigned	iops
+	default	= 120
+	help	=
+"The total Input/Ouput Operations Per Second (IOPS) rate (reads
+and writes), such as 120 per second, at which we consider the
+system block device to be IOPS saturated.";
+
+percent	threshold
+	default	= 95
+	help	=
+"Threshold percentage of time for I/O utilisation, in the range
+0 (idle) to 100 (busy).  Busy is defined as the percentage of
+time during the evaluation interval that the device was busy
+processing requests (reads and writes).
+A value of 100 percent indicates possible device saturation.";
+
+instlist	disks
+	default	= "sda"
+	help	=
+"Set to a list of local disk device names for which the rule will
+be evaluated, as a subset of available block devices.  The device
+names should be separated by white space and may be enclosed in
+single quotes, eg. \"sda 'sdb' sdc\".  Use the command:
+	$ pminfo -f disk.dev.total
+to discover the names of the available block devices.";
+
+string	action_expand
+	default	= "%viops[%i]@%h"
+	display	= no
+	modify	= no;
+
+string	email_expand
+	default	= "host: %h disk: %i iops: %v"
+	display	= no
+	modify	= no;
+
+#
+# --- DO NOT MODIFY THIS FILE --- see pmieconf(5)

--- a/src/pmieconf/perdisk/localdefs
+++ b/src/pmieconf/perdisk/localdefs
@@ -1,0 +1,3 @@
+ALL_RULES = average_queue_length average_wait_time bandwidth iops
+
+LOCAL_RULES = $(ALL_RULES)


### PR DESCRIPTION
New rules to detect several scenarios:
- high device utilization and increasing queue length (mgoodwin)
- high device utilization and increasing avg wait time (mgoodwin)
- high system device utilization and high bandwidth (pportante)
- high system device utilization and high iops (pportante)

The latter two require explict enabling in pmieconf as well as
customization per host to set the bandwidth/iops thresholds to
use for each host (and possibly system device name if not sda).