### PR TITLE
pmdalinux: add -A option for overriding permissions checks

### DIFF
--- a/man/man1/pmdakernel.1
+++ b/man/man1/pmdakernel.1
@@ -39,6 +39,7 @@
 [\f3\-U\f1 \f2username\f1]
 .br
 \f3$PCP_PMDAS_DIR/linux/pmdalinux\f1
+[\f3\-A\f1]
 [\f3\-d\f1 \f2domain\f1]
 [\f3\-l\f1 \f2logfile\f1]
 [\f3\-U\f1 \f2username\f1]
@@ -93,6 +94,21 @@ for example.
 In this case (but not for shared libraries), the following
 command line options are available:
 .TP 5
+.B \-A
+Disables use of the credentials provided by
+.B PMAPI
+client tools,
+and simply runs everything under the "root" account.
+Only enable this option if you understand the risks involved, and
+are sure that all remote accesses will be from benevolent users.
+If enabled, unauthenticated remote
+.B PMAPI
+clients will be able to access potentially sensitive performance
+metric values which an unauthenticated
+.B PMAPI
+client usually would not be able to.
+Refer to CVE-2012-3419 for additional details.
+.TP
 .B \-d
 It is absolutely crucial that the performance metrics
 .I domain
@@ -117,8 +133,9 @@ be created or is not writable, output is written to the standard error instead.
 .TP
 .B \-U
 User account under which to run the agent.
-The default is the unprivileged "pcp" account in current versions of PCP,
-but in older versions the superuser account ("root") was used by default.
+The default is either the privileged "root" account on some
+platforms (Linux, for example) or the unprivileged "pcp"
+account (wherever possible).
 .SH INSTALLATION
 Access to the names, help text and values for the kernel performance
 metrics is available by default - unlike most other agents, no action

--- a/qa/1956
+++ b/qa/1956
@@ -1,0 +1,50 @@
+#!/bin/sh
+# PCP QA Test No. 1956
+# Exercise Linux PMDA slabinfo access with -A option.
+#
+# Copyright (c) 2021 Red Hat.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+[ $PCP_PLATFORM = linux ] || _notrun "Linux-specific memory metric testing"
+userid=`id -u`  # test exercises procfs access from both root and non-root
+[ "$userid" != 0 ] || _notrun "Test cannot be run as privileged root user"
+
+_cleanup()
+{
+    cd $here
+    _restore_config $PCP_PMCDCONF_PATH
+    _service pmcd restart 2>&1 | _filter_pcp_start
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=0	# success is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+# real QA test starts here
+_save_config $PCP_PMCDCONF_PATH
+
+# append -A option to the pmdalinux line
+$sudo sed -i -e '/^\(linux.*pmdalinux.*\)$/s//\1 -A/' $PCP_PMCDCONF_PATH
+_service pmcd restart 2>&1 | _filter_pcp_start
+
+# check access, stash for later
+echo == pminfo >> $here/$seq.full
+pminfo -f mem.slabinfo >> $here/$seq.full
+
+# check access, reflect to output
+echo == pmprobe >> $here/$seq.full
+pmprobe mem.slabinfo | tee -a $here/$seq.full | $PCP_AWK_PROG '
+	$2 >= 1 { print $1, "values" }
+	$2 <= 0 { print $1, "no values" }'
+
+# success, all done
+exit

--- a/qa/1956.out
+++ b/qa/1956.out
@@ -1,0 +1,9 @@
+QA output created by 1956
+mem.slabinfo.objects.active values
+mem.slabinfo.objects.total values
+mem.slabinfo.objects.size values
+mem.slabinfo.slabs.active values
+mem.slabinfo.slabs.total values
+mem.slabinfo.slabs.pages_per_slab values
+mem.slabinfo.slabs.objects_per_slab values
+mem.slabinfo.slabs.total_size values

--- a/qa/group
+++ b/qa/group
@@ -1952,4 +1952,5 @@ x11
 1902 help local
 1937 pmlogrewrite pmda.xfs local
 1955 libpcp pmda pmda.pmcd local
+1956 pmda.linux pmcd local
 4751 libpcp threads valgrind local pcp helgrind

--- a/src/pmdas/linux/linux.h
+++ b/src/pmdas/linux/linux.h
@@ -200,9 +200,8 @@ extern pmdaIndom *linux_pmda_indom(int);
  */
 #define	LINUX_TEST_MODE		(1<<0)
 #define	LINUX_TEST_STATSPATH	(1<<1)
-#define	LINUX_TEST_MEMINFO	(1<<2)
-#define	LINUX_TEST_NCPUS	(1<<3)
-#define	LINUX_TEST_NNODES	(1<<4)
+#define	LINUX_TEST_NCPUS	(1<<2)
+#define	LINUX_TEST_NNODES	(1<<3)
 extern int linux_test_mode;
 
 /*  

--- a/src/pmdas/linux/proc_interrupts.c
+++ b/src/pmdas/linux/proc_interrupts.c
@@ -373,7 +373,7 @@ proc_interrupts_fetch(int cluster, int item, unsigned int inst, pmAtomValue *ato
 
     case CLUSTER_SOFTIRQS_TOTAL:
 	if (item == 0) {	/* kernel.all.softirqs.total */
-	    pmInDom indom = INDOM(SOFTIRQ_INDOM);
+	    indom = INDOM(SOFTIRQ_INDOM);
 	    sts = pmdaCacheLookup(indom, inst, NULL, (void **)&ip);
 	    if (sts < 0)
 		return sts;

--- a/src/pmdas/linux/proc_meminfo.c
+++ b/src/pmdas/linux/proc_meminfo.c
@@ -125,8 +125,7 @@ refresh_proc_meminfo(proc_meminfo_t *proc_meminfo)
      * MemAvailable is only in 3.x or later kernels but we can calculate it
      * using other values, similar to upstream kernel commit 34e431b0ae.
      */
-    if (!MEMINFO_VALID_VALUE(proc_meminfo->MemAvailable) ||
-	(linux_test_mode & LINUX_TEST_MEMINFO)) {
+    if (!MEMINFO_VALID_VALUE(proc_meminfo->MemAvailable)) {
 	if (MEMINFO_VALID_VALUE(proc_meminfo->MemTotal) &&
 	    MEMINFO_VALID_VALUE(proc_meminfo->MemFree) &&
 	    MEMINFO_VALID_VALUE(proc_meminfo->Active_file) &&


### PR DESCRIPTION
The mem.slabinfo metrics enforce by default the same access
requirements of the kernel when sampling /proc/slabinfo i.e.
only root users have access.  This change provides the same
mechanism pmdaproc(1) has for overriding these changes, i.e.
an opt-in, security-override command line option for folks
who want to open up access.  This is important when logging
these metrics, for example, as pmlogger runs unprivileged -
but the same rule applies to all other PMAPI client tools.

A brief man page note and new test 1956 to exercise the code
are added as well.

Resolves Red Hat BZ #1962902