### PR TITLE
libpcp_mmv: add new convenience routines for value set/inc

### DIFF
--- a/debian/libpcp-mmv1-dev.install
+++ b/debian/libpcp-mmv1-dev.install
@@ -4,6 +4,7 @@ usr/lib/libpcp_mmv.a
 usr/lib/libpcp_mmv.so
 usr/share/man/man3/mmv_inc_value.3.gz
 usr/share/man/man3/mmv_lookup_value_desc.3.gz
+usr/share/man/man3/mmv_set_value.3.gz
 usr/share/man/man3/mmv_stats2_init.3.gz
 usr/share/man/man3/mmv_stats_init.3.gz
 usr/share/man/man3/mmv_stats_registry.3.gz

--- a/man/man3/mmv_inc_value.3
+++ b/man/man3/mmv_inc_value.3
@@ -1,5 +1,6 @@
 '\"macro stdmacro
 .\"
+.\" Copyright (c) 2021 Red Hat.
 .\" Copyright (c) 2009 Max Matveev
 .\" Copyright (c) 2009 Aconex.  All Rights Reserved.
 .\"
@@ -23,18 +24,39 @@
 .br
 #include <pcp/mmv_stats.h>
 .sp
-void mmv_inc_value(void *\fIaddr\fP, pmAtomValue *\fIval\fP, double \fIinc\fP);
+void mmv_inc_value(void *\fIaddr\fP, pmAtomValue *\fIav\fP, double \fIinc\fP);
+.br
+void mmv_inc_atomvalue(void *\fIaddr\fP, pmAtomValue *\fIav\fP, pmAtomValue *\fIinc\fP);
 .sp
 cc ... \-lpcp_mmv \-lpcp
 .ft 1
 .SH DESCRIPTION
-\f3mmv_inc_value\f1 provides a convenient way of updating a value
-returned by the \f3mmv_lookup_value_desc\f1.
-\f2addr\f1 is the address returned from \f3mmv_stats_init\f1().
+\f3mmv_inc_value\f1
+and
+\f3mmv_inc_atomvalue\f1
+provide convenient ways of updating a metric \f2av\f1 previously
+returned by the
+.BR mmv_lookup_value_desc (3)
+interface.
+\f2addr\f1 is the address returned from
+.BR mmv_stats_init (3).
 .P
-The value of the \f2inc\f1 is internally cast to match the type of
+These interfaces are most commonly used with counter type metrics.
+Refer to
+.BR mmv_set_value (3)
+for a mechanism suited to instantaneous and discrete metrics.
+.P
+With
+\f3mmv_inc_atomvalue\f1 the value provided via the \f2inc\f1
+pointer must match the type of the metric, and will be added
+to the previous value of the metric.
+.P
+In the case of
+\f3mmv_inc_value\f1
+the value of \f2inc\f1 is internally cast to match the type of
 the metric and then added to the previous value of the metric.
 .SH SEE ALSO
+.BR mmv_set_value (3),
 .BR mmv_stats_init (3),
 .BR mmv_lookup_value_desc (3)
 and

--- a/man/man3/mmv_set_value.3
+++ b/man/man3/mmv_set_value.3
@@ -1,0 +1,62 @@
+'\"macro stdmacro
+.\"
+.\" Copyright (c) 2021 Red Hat.
+.\"
+.\" This program is free software; you can redistribute it and/or modify it
+.\" under the terms of the GNU General Public License as published by the
+.\" Free Software Foundation; either version 2 of the License, or (at your
+.\" option) any later version.
+.\"
+.\" This program is distributed in the hope that it will be useful, but
+.\" WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+.\" or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+.\" for more details.
+.\"
+.\"
+.TH MMV_SET_VALUE 3 "" "Performance Co-Pilot"
+.SH NAME
+\f3mmv_set_value\f1 \- set a value in a Memory Mapped Value file
+.SH "C SYNOPSIS"
+.ft 3
+#include <pcp/pmapi.h>
+.br
+#include <pcp/mmv_stats.h>
+.sp
+void mmv_set_value(void *\fIaddr\fP, pmAtomValue *\fIav\fP, double \fIval\fP);
+.br
+void mmv_set_atomvalue(void *\fIaddr\fP, pmAtomValue *\fIav\fP, pmAtomValue *\fIval\fP);
+.sp
+cc ... \-lpcp_mmv \-lpcp
+.ft 1
+.SH DESCRIPTION
+\f3mmv_set_value\f1
+and
+\f3mmv_set_atomvalue\f1
+provide convenient ways of directly setting a value for a
+metric \f2av\f1 previously returned by the
+.BR mmv_lookup_value_desc (3)
+interface.
+\f2addr\f1 is the address returned from
+.BR mmv_stats_init (3).
+.P
+These interfaces are typically used with instantaneous and
+discrete metrics.
+Refer to
+.BR mmv_inc_value (3)
+for a mechanism suited to monotonic increasing counter metrics.
+.P
+With
+\f3mmv_set_atomvalue\f1 the value provided via the \f2inc\f1
+pointer must match the type of the metric and will be used as
+the new value of the metric.
+.P
+In the case of
+\f3mmv_set_value\f1
+the value \f2val\f1 is internally cast to match the type of
+the metric and then used as the value for the metric.
+.SH SEE ALSO
+.BR mmv_inc_value (3),
+.BR mmv_stats_init (3),
+.BR mmv_lookup_value_desc (3)
+and
+.BR mmv (5).

--- a/qa/src/mmv3_labels.c
+++ b/qa/src/mmv3_labels.c
@@ -58,7 +58,8 @@ main(int argc, char **argv)
 {
     int			i;
     void		*map;
-    pmAtomValue		*value;
+    pmAtomValue		*avp;
+    unsigned int	value;
     char		*file = (argc > 1) ? argv[1] : "labels3";
     mmv_registry_t	*registry = mmv_stats_registry(file, 322, 0);
 
@@ -110,8 +111,11 @@ main(int argc, char **argv)
 	return 1;
     }
 
-    value = mmv_lookup_value_desc(map, "labels3.u32.counter", "cpu0");
-    mmv_inc_value(map, value, 42);
+    avp = mmv_lookup_value_desc(map, "labels3.u32.counter", "cpu0");
+    value = 0;
+    mmv_set_atomvalue(map, avp, (pmAtomValue*) &value);
+    value = 42;
+    mmv_inc_atomvalue(map, avp, (pmAtomValue*) &value);
     mmv_stats_free(registry);
     return 0;
 }

--- a/src/include/pcp/mmv_stats.h
+++ b/src/include/pcp/mmv_stats.h
@@ -147,7 +147,9 @@ extern void * mmv_stats_start(mmv_registry_t *);
 extern void mmv_stats_free(mmv_registry_t *);
 
 extern pmAtomValue * mmv_lookup_value_desc(void *, const char *, const char *);
+extern void mmv_inc_atomvalue(void *, pmAtomValue *, pmAtomValue *);
 extern void mmv_inc_value(void *, pmAtomValue *, double);
+extern void mmv_set_atomvalue(void *, pmAtomValue *, pmAtomValue *);
 extern void mmv_set_value(void *, pmAtomValue *, double);
 extern void mmv_set_string(void *, pmAtomValue *, const char *, int);
 

--- a/src/libpcp_mmv/src/exports
+++ b/src/libpcp_mmv/src/exports
@@ -43,3 +43,9 @@ PCP_MMV_1.2 {
     mmv_stats_add_instance_label;
     mmv_stats_free;
 } PCP_MMV_1.1;
+
+PCP_MMV_1.3 {
+  global:
+    mmv_inc_atomvalue;
+    mmv_set_atomvalue;
+} PCP_MMV_1.2;

--- a/src/libpcp_mmv/src/mmv_stats.c
+++ b/src/libpcp_mmv/src/mmv_stats.c
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2001,2009 Silicon Graphics, Inc.  All rights reserved.
  * Copyright (C) 2009 Aconex.  All rights reserved.
- * Copyright (C) 2013,2016,2018-2020 Red Hat.
+ * Copyright (C) 2013,2016,2018-2021 Red Hat.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
@@ -1396,6 +1396,56 @@ mmv_inc_value(void *addr, pmAtomValue *av, double inc)
 }
 
 void
+mmv_inc_atomvalue(void *addr, pmAtomValue *av, pmAtomValue *value)
+{
+    if (av != NULL && addr != NULL) {
+	mmv_disk_header_t *hdr = (mmv_disk_header_t *)addr;
+	mmv_disk_value_t *v = (mmv_disk_value_t *)av;
+	int type;
+
+	if (hdr->version == MMV_VERSION1) {
+	    mmv_disk_metric_t *m = (mmv_disk_metric_t *)
+					((char *)addr + v->metric);
+	    type = m->type;
+	} else {
+	    mmv_disk_metric2_t *m = (mmv_disk_metric2_t *)
+					((char *)addr + v->metric);
+	    type = m->type;
+	}
+	switch (type) {
+	case MMV_TYPE_I32:
+	    v->value.l += value->l;
+	    break;
+	case MMV_TYPE_U32:
+	    v->value.ul += value->ul;
+	    break;
+	case MMV_TYPE_I64:
+	    v->value.ll += value->ll;
+	    break;
+	case MMV_TYPE_U64:
+	    v->value.ull += value->ull;
+	    break;
+	case MMV_TYPE_FLOAT:
+	    v->value.f += value->f;
+	    break;
+	case MMV_TYPE_DOUBLE:
+	    v->value.d += value->d;
+	    break;
+	case MMV_TYPE_ELAPSED:
+	    if (value->ll < 0)
+		v->extra = value->ll;
+	    else {
+		v->value.ll += v->extra + value->ll;
+		v->extra = 0;
+	    }
+	    break;
+	default:
+	    break;
+	}
+    }
+}
+
+void
 mmv_set_value(void *addr, pmAtomValue *av, double val)
 {
     if (av != NULL && addr != NULL) {
@@ -1472,6 +1522,32 @@ mmv_set_string(void *addr, pmAtomValue *av, const char *string, int size)
 	    s->payload[size] = '\0';
 	    v->value.l = size;
 	}
+    }
+}
+
+void
+mmv_set_atomvalue(void *addr, pmAtomValue *av, pmAtomValue *value)
+{
+    if (av != NULL && addr != NULL) {
+	mmv_disk_header_t *hdr = (mmv_disk_header_t *)addr;
+	mmv_disk_value_t *v = (mmv_disk_value_t *)av;
+	int type;
+
+	if (hdr->version == MMV_VERSION1) {
+	    mmv_disk_metric_t *m = (mmv_disk_metric_t *)
+					((char *)addr + v->metric);
+	    type = m->type;
+	} else {
+	    mmv_disk_metric2_t *m = (mmv_disk_metric2_t *)
+					((char *)addr + v->metric);
+	    type = m->type;
+	}
+	if (type == MMV_TYPE_ELAPSED)
+	    v->extra = 0;
+	if (type != MMV_TYPE_STRING)
+	    v->value = *value;
+	else
+	    mmv_set_string(addr, av, value->cp, strlen(value->cp));
     }
 }
 

--- a/src/perl/MMV/MMV.pm
+++ b/src/perl/MMV/MMV.pm
@@ -11,6 +11,7 @@ require DynaLoader;
 @EXPORT = qw(
     mmv_stats_init mmv_stats_stop mmv_units
 	mmv_lookup_value_desc
+	mmv_inc_atomvalue mmv_set_atomvalue
 	mmv_inc_value mmv_set_value mmv_set_string
 	mmv_stats_add mmv_stats_inc mmv_stats_set
 	mmv_stats_add_fallback mmv_stats_inc_fallback
@@ -99,8 +100,8 @@ available as PCP metrics using the MMV PMDA.
 
 =head1 SEE ALSO
 
-mmv_stats_init(3), mmv_inc_value(3), mmv_lookup_value_desc(3),
-mmv(5) and PMDA(3).
+mmv_stats_init(3), mmv_inc_value(3), mm_set_value(3),
+mmv_lookup_value_desc(3), mmv(5) and PMDA(3).
 
 The PCP mailing list pcp@groups.io can be used for questions about
 this module.

--- a/src/perl/MMV/MMV.xs
+++ b/src/perl/MMV/MMV.xs
@@ -284,12 +284,28 @@ mmv_inc_value(handle,atom,value)
 	mmv_inc_value(handle, atom, value);
 
 void
+mmv_inc_atomvalue(handle,atom,value)
+	void *			handle
+	pmAtomValue *		atom
+	pmAtomValue *		value
+    CODE:
+	mmv_inc_atomvalue(handle, atom, value);
+
+void
 mmv_set_value(handle,atom,value)
 	void *			handle
 	pmAtomValue *		atom
 	double			value
     CODE:
 	mmv_set_value(handle, atom, value);
+
+void
+mmv_set_atomvalue(handle,atom,value)
+	void *			handle
+	pmAtomValue *		atom
+	pmAtomValue *		value
+    CODE:
+	mmv_set_atomvalue(handle, atom, value);
 
 void
 mmv_set_string(handle,atom,string)

--- a/src/python/pcp/mmv.py
+++ b/src/python/pcp/mmv.py
@@ -178,8 +178,14 @@ LIBPCP_MMV.mmv_lookup_value_desc.argtypes = [c_void_p, c_char_p, c_char_p]
 LIBPCP_MMV.mmv_inc_value.restype = None
 LIBPCP_MMV.mmv_inc_value.argtypes = [c_void_p, POINTER(pmAtomValue), c_double]
 
+LIBPCP_MMV.mmv_inc_atomvalue.restype = None
+LIBPCP_MMV.mmv_inc_atomvalue.argtypes = [c_void_p, POINTER(pmAtomValue), POINTER(pmAtomValue)]
+
 LIBPCP_MMV.mmv_set_value.restype = None
 LIBPCP_MMV.mmv_set_value.argtypes = [c_void_p, POINTER(pmAtomValue), c_double]
+
+LIBPCP_MMV.mmv_set_atomvalue.restype = None
+LIBPCP_MMV.mmv_set_atomvalue.argtypes = [c_void_p, POINTER(pmAtomValue), POINTER(pmAtomValue)]
 
 LIBPCP_MMV.mmv_set_string.restype = None
 LIBPCP_MMV.mmv_set_string.argtypes = [


### PR DESCRIPTION
Adds two new convenience routines that allow direct value
setting in MMV client libraries instead of casting values
to double first.

A missing man page is added - mmv_set_value(3) - and both
this and an existing mmv_inc_value(3) page are updated to
document the new API variants.