### PR TITLE
libpcp_web: avoid duplicate instname labels in /metrics response

### DIFF
--- a/qa/1191.out
+++ b/qa/1191.out
@@ -761,8 +761,15 @@ Help:
 Simple gauge metric singular instance domain
     value 456
 
+openmetrics.duplicate_hostname_label.somenumber [number with value]
+    Data Type: double  InDom: 144.12288 0x24003000
+    Semantics: instant  Units: none
+Help:
+number with value
+    inst [0 or "0 hostname:shack"] value 258
+
 openmetrics.good_summary_nometa.sample_counter0010 [Sample counter metric.]
-    Data Type: double  InDom: 144.12289 0x24003001
+    Data Type: double  InDom: 144.13313 0x24003401
     Semantics: counter  Units: none
 Help:
 Sample counter metric.
@@ -773,7 +780,7 @@ Sample counter metric.
     inst [4 or "4 baz:2.8"] value 6808215760
 
 openmetrics.good_summary_nometa.sample_gauge0009 [Sample gauge metric.]
-    Data Type: double  InDom: 144.12288 0x24003000
+    Data Type: double  InDom: 144.13312 0x24003400
     Semantics: instant  Units: none
 Help:
 Sample gauge metric.
@@ -784,7 +791,7 @@ Sample gauge metric.
     inst [4 or "4 bar:4"] value 193.6
 
 openmetrics.good_summary_nometa.sample_summary0011 [Sample summary metric has instances.]
-    Data Type: double  InDom: 144.12290 0x24003002
+    Data Type: double  InDom: 144.13314 0x24003402
     Semantics: instant  Units: none
 Help:
 Sample summary metric has instances.
@@ -1201,7 +1208,7 @@ Generated from Dropwizard metric import (metric=http.activeRequests, type=com.co
     value 1
 
 openmetrics.jenkins_prometheus_plugin.http_requests [Generated from Dropwizard metric import (metric=http.requests, type=com.codahale.metrics.Timer)]
-    Data Type: double  InDom: 144.14685 0x2400395d
+    Data Type: double  InDom: 144.15709 0x24003d5d
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=http.requests, type=com.codahale.metrics.Timer)
@@ -1290,7 +1297,7 @@ Generated from Dropwizard metric import (metric=http.responseCodes.serviceUnavai
     value 1
 
 openmetrics.jenkins_prometheus_plugin.jenkins_executor_count_history [Generated from Dropwizard metric import (metric=jenkins.executor.count.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14423 0x24003857
+    Data Type: double  InDom: 144.15447 0x24003c57
     Semantics: counter  Units: count
 Help:
 Generated from Dropwizard metric import (metric=jenkins.executor.count.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1316,7 +1323,7 @@ Generated from Dropwizard metric import (metric=jenkins.executor.count.value, ty
     value 5
 
 openmetrics.jenkins_prometheus_plugin.jenkins_executor_free_history [Generated from Dropwizard metric import (metric=jenkins.executor.free.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14425 0x24003859
+    Data Type: double  InDom: 144.15449 0x24003c59
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.executor.free.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1342,7 +1349,7 @@ Generated from Dropwizard metric import (metric=jenkins.executor.free.value, typ
     value 5
 
 openmetrics.jenkins_prometheus_plugin.jenkins_executor_in_use_history [Generated from Dropwizard metric import (metric=jenkins.executor.in-use.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14427 0x2400385b
+    Data Type: double  InDom: 144.15451 0x24003c5b
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.executor.in-use.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1375,7 +1382,7 @@ Generated from Dropwizard metric import (metric=jenkins.health-check.count, type
     value 4
 
 openmetrics.jenkins_prometheus_plugin.jenkins_health_check_duration [Generated from Dropwizard metric import (metric=jenkins.health-check.duration, type=com.codahale.metrics.Timer)]
-    Data Type: double  InDom: 144.14687 0x2400395f
+    Data Type: double  InDom: 144.15711 0x24003d5f
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.health-check.duration, type=com.codahale.metrics.Timer)
@@ -1415,7 +1422,7 @@ Generated from Dropwizard metric import (metric=jenkins.job.averageDepth, type=j
     value 1
 
 openmetrics.jenkins_prometheus_plugin.jenkins_job_blocked_duration [Generated from Dropwizard metric import (metric=jenkins.job.blocked.duration, type=com.codahale.metrics.Timer)]
-    Data Type: double  InDom: 144.14689 0x24003961
+    Data Type: double  InDom: 144.15713 0x24003d61
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.job.blocked.duration, type=com.codahale.metrics.Timer)
@@ -1434,7 +1441,7 @@ Generated from Dropwizard metric import (metric=jenkins.job.blocked.duration, ty
     value 0
 
 openmetrics.jenkins_prometheus_plugin.jenkins_job_buildable_duration [Generated from Dropwizard metric import (metric=jenkins.job.buildable.duration, type=com.codahale.metrics.Timer)]
-    Data Type: double  InDom: 144.14691 0x24003963
+    Data Type: double  InDom: 144.15715 0x24003d63
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.job.buildable.duration, type=com.codahale.metrics.Timer)
@@ -1453,7 +1460,7 @@ Generated from Dropwizard metric import (metric=jenkins.job.buildable.duration, 
     value 0
 
 openmetrics.jenkins_prometheus_plugin.jenkins_job_building_duration [Generated from Dropwizard metric import (metric=jenkins.job.building.duration, type=com.codahale.metrics.Timer)]
-    Data Type: double  InDom: 144.14693 0x24003965
+    Data Type: double  InDom: 144.15717 0x24003d65
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.job.building.duration, type=com.codahale.metrics.Timer)
@@ -1472,7 +1479,7 @@ Generated from Dropwizard metric import (metric=jenkins.job.building.duration, t
     value 0
 
 openmetrics.jenkins_prometheus_plugin.jenkins_job_count_history [Generated from Dropwizard metric import (metric=jenkins.job.count.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14429 0x2400385d
+    Data Type: double  InDom: 144.15453 0x24003c5d
     Semantics: counter  Units: count
 Help:
 Generated from Dropwizard metric import (metric=jenkins.job.count.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1498,7 +1505,7 @@ Generated from Dropwizard metric import (metric=jenkins.job.count.value, type=je
     value 1
 
 openmetrics.jenkins_prometheus_plugin.jenkins_job_queuing_duration [Generated from Dropwizard metric import (metric=jenkins.job.queuing.duration, type=com.codahale.metrics.Timer)]
-    Data Type: double  InDom: 144.14695 0x24003967
+    Data Type: double  InDom: 144.15719 0x24003d67
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.job.queuing.duration, type=com.codahale.metrics.Timer)
@@ -1524,7 +1531,7 @@ Generated from Dropwizard metric import (metric=jenkins.job.scheduled, type=com.
     value 0
 
 openmetrics.jenkins_prometheus_plugin.jenkins_job_total_duration [Generated from Dropwizard metric import (metric=jenkins.job.total.duration, type=com.codahale.metrics.Timer)]
-    Data Type: double  InDom: 144.14697 0x24003969
+    Data Type: double  InDom: 144.15721 0x24003d69
     Semantics: counter  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.job.total.duration, type=com.codahale.metrics.Timer)
@@ -1543,7 +1550,7 @@ Generated from Dropwizard metric import (metric=jenkins.job.total.duration, type
     value 0
 
 openmetrics.jenkins_prometheus_plugin.jenkins_job_waiting_duration [Generated from Dropwizard metric import (metric=jenkins.job.waiting.duration, type=com.codahale.metrics.Timer)]
-    Data Type: double  InDom: 144.14699 0x2400396b
+    Data Type: double  InDom: 144.15723 0x24003d6b
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.job.waiting.duration, type=com.codahale.metrics.Timer)
@@ -1562,7 +1569,7 @@ Generated from Dropwizard metric import (metric=jenkins.job.waiting.duration, ty
     value 0
 
 openmetrics.jenkins_prometheus_plugin.jenkins_node_count_history [Generated from Dropwizard metric import (metric=jenkins.node.count.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14431 0x2400385f
+    Data Type: double  InDom: 144.15455 0x24003c5f
     Semantics: counter  Units: count
 Help:
 Generated from Dropwizard metric import (metric=jenkins.node.count.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1588,7 +1595,7 @@ Generated from Dropwizard metric import (metric=jenkins.node.count.value, type=j
     value 1
 
 openmetrics.jenkins_prometheus_plugin.jenkins_node_offline_history [Generated from Dropwizard metric import (metric=jenkins.node.offline.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14433 0x24003861
+    Data Type: double  InDom: 144.15457 0x24003c61
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.node.offline.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1614,7 +1621,7 @@ Generated from Dropwizard metric import (metric=jenkins.node.offline.value, type
     value 0
 
 openmetrics.jenkins_prometheus_plugin.jenkins_node_online_history [Generated from Dropwizard metric import (metric=jenkins.node.online.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14435 0x24003863
+    Data Type: double  InDom: 144.15459 0x24003c63
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.node.online.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1668,7 +1675,7 @@ Generated from Dropwizard metric import (metric=jenkins.plugins.withUpdate, type
     value 48
 
 openmetrics.jenkins_prometheus_plugin.jenkins_project_count_history [Generated from Dropwizard metric import (metric=jenkins.project.count.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14437 0x24003865
+    Data Type: double  InDom: 144.15461 0x24003c65
     Semantics: counter  Units: count
 Help:
 Generated from Dropwizard metric import (metric=jenkins.project.count.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1694,7 +1701,7 @@ Generated from Dropwizard metric import (metric=jenkins.project.count.value, typ
     value 1
 
 openmetrics.jenkins_prometheus_plugin.jenkins_project_disabled_count_history [Generated from Dropwizard metric import (metric=jenkins.project.disabled.count.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14439 0x24003867
+    Data Type: double  InDom: 144.15463 0x24003c67
     Semantics: counter  Units: count
 Help:
 Generated from Dropwizard metric import (metric=jenkins.project.disabled.count.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1720,7 +1727,7 @@ Generated from Dropwizard metric import (metric=jenkins.project.disabled.count.v
     value 0
 
 openmetrics.jenkins_prometheus_plugin.jenkins_project_enabled_count_history [Generated from Dropwizard metric import (metric=jenkins.project.enabled.count.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14441 0x24003869
+    Data Type: double  InDom: 144.15465 0x24003c69
     Semantics: counter  Units: count
 Help:
 Generated from Dropwizard metric import (metric=jenkins.project.enabled.count.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1746,7 +1753,7 @@ Generated from Dropwizard metric import (metric=jenkins.project.enabled.count.va
     value 1
 
 openmetrics.jenkins_prometheus_plugin.jenkins_queue_blocked_history [Generated from Dropwizard metric import (metric=jenkins.queue.blocked.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14443 0x2400386b
+    Data Type: double  InDom: 144.15467 0x24003c6b
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.queue.blocked.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1772,7 +1779,7 @@ Generated from Dropwizard metric import (metric=jenkins.queue.blocked.value, typ
     value 0
 
 openmetrics.jenkins_prometheus_plugin.jenkins_queue_buildable_history [Generated from Dropwizard metric import (metric=jenkins.queue.buildable.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14445 0x2400386d
+    Data Type: double  InDom: 144.15469 0x24003c6d
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.queue.buildable.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1798,7 +1805,7 @@ Generated from Dropwizard metric import (metric=jenkins.queue.buildable.value, t
     value 0
 
 openmetrics.jenkins_prometheus_plugin.jenkins_queue_pending_history [Generated from Dropwizard metric import (metric=jenkins.queue.pending.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14447 0x2400386f
+    Data Type: double  InDom: 144.15471 0x24003c6f
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.queue.pending.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1824,7 +1831,7 @@ Generated from Dropwizard metric import (metric=jenkins.queue.pending.value, typ
     value 0
 
 openmetrics.jenkins_prometheus_plugin.jenkins_queue_size_history [Generated from Dropwizard metric import (metric=jenkins.queue.size.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14449 0x24003871
+    Data Type: double  InDom: 144.15473 0x24003c71
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.queue.size.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1850,7 +1857,7 @@ Generated from Dropwizard metric import (metric=jenkins.queue.size.value, type=j
     value 0
 
 openmetrics.jenkins_prometheus_plugin.jenkins_queue_stuck_history [Generated from Dropwizard metric import (metric=jenkins.queue.stuck.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14451 0x24003873
+    Data Type: double  InDom: 144.15475 0x24003c73
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=jenkins.queue.stuck.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1925,7 +1932,7 @@ Generated from Dropwizard metric import (metric=system.cpu.load, type=jenkins.me
     value 0.51
 
 openmetrics.jenkins_prometheus_plugin.system_cpu_load_x100_history [Generated from Dropwizard metric import (metric=system.cpu.load.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14453 0x24003875
+    Data Type: double  InDom: 144.15477 0x24003c75
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=system.cpu.load.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1944,7 +1951,7 @@ Generated from Dropwizard metric import (metric=system.cpu.load.x100.history, ty
     value 33
 
 openmetrics.jenkins_prometheus_plugin.system_cpu_load_x100_window_15m [Generated from Dropwizard metric import (metric=system.cpu.load.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14455 0x24003877
+    Data Type: double  InDom: 144.15479 0x24003c77
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=system.cpu.load.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1963,7 +1970,7 @@ Generated from Dropwizard metric import (metric=system.cpu.load.x100.window.15m,
     value 33
 
 openmetrics.jenkins_prometheus_plugin.system_cpu_load_x100_window_1h [Generated from Dropwizard metric import (metric=system.cpu.load.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14457 0x24003879
+    Data Type: double  InDom: 144.15481 0x24003c79
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=system.cpu.load.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -1982,7 +1989,7 @@ Generated from Dropwizard metric import (metric=system.cpu.load.x100.window.1h, 
     value 33
 
 openmetrics.jenkins_prometheus_plugin.system_cpu_load_x100_window_5m [Generated from Dropwizard metric import (metric=system.cpu.load.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14459 0x2400387b
+    Data Type: double  InDom: 144.15483 0x24003c7b
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=system.cpu.load.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2036,7 +2043,7 @@ Generated from Dropwizard metric import (metric=vm.cpu.load, type=jenkins.metric
     value 0.03193113980285992
 
 openmetrics.jenkins_prometheus_plugin.vm_cpu_load_x100_history [Generated from Dropwizard metric import (metric=vm.cpu.load.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14461 0x2400387d
+    Data Type: double  InDom: 144.15485 0x24003c7d
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.cpu.load.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2055,7 +2062,7 @@ Generated from Dropwizard metric import (metric=vm.cpu.load.x100.history, type=j
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_cpu_load_x100_window_15m [Generated from Dropwizard metric import (metric=vm.cpu.load.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14463 0x2400387f
+    Data Type: double  InDom: 144.15487 0x24003c7f
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.cpu.load.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2074,7 +2081,7 @@ Generated from Dropwizard metric import (metric=vm.cpu.load.x100.window.15m, typ
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_cpu_load_x100_window_1h [Generated from Dropwizard metric import (metric=vm.cpu.load.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14465 0x24003881
+    Data Type: double  InDom: 144.15489 0x24003c81
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.cpu.load.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2093,7 +2100,7 @@ Generated from Dropwizard metric import (metric=vm.cpu.load.x100.window.1h, type
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_cpu_load_x100_window_5m [Generated from Dropwizard metric import (metric=vm.cpu.load.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14467 0x24003883
+    Data Type: double  InDom: 144.15491 0x24003c83
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.cpu.load.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2133,7 +2140,7 @@ Generated from Dropwizard metric import (metric=vm.file.descriptor.ratio, type=c
     value 0.000431060791015625
 
 openmetrics.jenkins_prometheus_plugin.vm_file_descriptor_ratio_x100_history [Generated from Dropwizard metric import (metric=vm.file.descriptor.ratio.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14469 0x24003885
+    Data Type: double  InDom: 144.15493 0x24003c85
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.file.descriptor.ratio.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2152,7 +2159,7 @@ Generated from Dropwizard metric import (metric=vm.file.descriptor.ratio.x100.hi
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_file_descriptor_ratio_x100_window_15m [Generated from Dropwizard metric import (metric=vm.file.descriptor.ratio.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14471 0x24003887
+    Data Type: double  InDom: 144.15495 0x24003c87
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.file.descriptor.ratio.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2171,7 +2178,7 @@ Generated from Dropwizard metric import (metric=vm.file.descriptor.ratio.x100.wi
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_file_descriptor_ratio_x100_window_1h [Generated from Dropwizard metric import (metric=vm.file.descriptor.ratio.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14473 0x24003889
+    Data Type: double  InDom: 144.15497 0x24003c89
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.file.descriptor.ratio.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2190,7 +2197,7 @@ Generated from Dropwizard metric import (metric=vm.file.descriptor.ratio.x100.wi
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_file_descriptor_ratio_x100_window_5m [Generated from Dropwizard metric import (metric=vm.file.descriptor.ratio.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14475 0x2400388b
+    Data Type: double  InDom: 144.15499 0x24003c8b
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.file.descriptor.ratio.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2244,7 +2251,7 @@ Generated from Dropwizard metric import (metric=vm.memory.heap.committed, type=c
     value 210763776
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_heap_committed_history [Generated from Dropwizard metric import (metric=vm.memory.heap.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14477 0x2400388d
+    Data Type: double  InDom: 144.15501 0x24003c8d
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.heap.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2263,7 +2270,7 @@ Generated from Dropwizard metric import (metric=vm.memory.heap.committed.history
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_heap_committed_window_15m [Generated from Dropwizard metric import (metric=vm.memory.heap.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14479 0x2400388f
+    Data Type: double  InDom: 144.15503 0x24003c8f
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.heap.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2282,7 +2289,7 @@ Generated from Dropwizard metric import (metric=vm.memory.heap.committed.window.
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_heap_committed_window_1h [Generated from Dropwizard metric import (metric=vm.memory.heap.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14481 0x24003891
+    Data Type: double  InDom: 144.15505 0x24003c91
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.heap.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2301,7 +2308,7 @@ Generated from Dropwizard metric import (metric=vm.memory.heap.committed.window.
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_heap_committed_window_5m [Generated from Dropwizard metric import (metric=vm.memory.heap.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14483 0x24003893
+    Data Type: double  InDom: 144.15507 0x24003c93
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.heap.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2341,7 +2348,7 @@ Generated from Dropwizard metric import (metric=vm.memory.heap.usage, type=com.c
     value 0.01512031704855607
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_heap_usage_x100_history [Generated from Dropwizard metric import (metric=vm.memory.heap.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14485 0x24003895
+    Data Type: double  InDom: 144.15509 0x24003c95
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.heap.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2360,7 +2367,7 @@ Generated from Dropwizard metric import (metric=vm.memory.heap.usage.x100.histor
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_heap_usage_x100_window_15m [Generated from Dropwizard metric import (metric=vm.memory.heap.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14487 0x24003897
+    Data Type: double  InDom: 144.15511 0x24003c97
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.heap.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2379,7 +2386,7 @@ Generated from Dropwizard metric import (metric=vm.memory.heap.usage.x100.window
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_heap_usage_x100_window_1h [Generated from Dropwizard metric import (metric=vm.memory.heap.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14489 0x24003899
+    Data Type: double  InDom: 144.15513 0x24003c99
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.heap.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2398,7 +2405,7 @@ Generated from Dropwizard metric import (metric=vm.memory.heap.usage.x100.window
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_heap_usage_x100_window_5m [Generated from Dropwizard metric import (metric=vm.memory.heap.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14491 0x2400389b
+    Data Type: double  InDom: 144.15515 0x24003c9b
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.heap.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2424,7 +2431,7 @@ Generated from Dropwizard metric import (metric=vm.memory.heap.used, type=com.co
     value 113139864
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_heap_used_history [Generated from Dropwizard metric import (metric=vm.memory.heap.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14493 0x2400389d
+    Data Type: double  InDom: 144.15517 0x24003c9d
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.heap.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2443,7 +2450,7 @@ Generated from Dropwizard metric import (metric=vm.memory.heap.used.history, typ
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_heap_used_window_15m [Generated from Dropwizard metric import (metric=vm.memory.heap.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14495 0x2400389f
+    Data Type: double  InDom: 144.15519 0x24003c9f
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.heap.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2462,7 +2469,7 @@ Generated from Dropwizard metric import (metric=vm.memory.heap.used.window.15m, 
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_heap_used_window_1h [Generated from Dropwizard metric import (metric=vm.memory.heap.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14497 0x240038a1
+    Data Type: double  InDom: 144.15521 0x24003ca1
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.heap.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2481,7 +2488,7 @@ Generated from Dropwizard metric import (metric=vm.memory.heap.used.window.1h, t
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_heap_used_window_5m [Generated from Dropwizard metric import (metric=vm.memory.heap.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14499 0x240038a3
+    Data Type: double  InDom: 144.15523 0x24003ca3
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.heap.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2507,7 +2514,7 @@ Generated from Dropwizard metric import (metric=vm.memory.non-heap.committed, ty
     value 110100480
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_non_heap_committed_history [Generated from Dropwizard metric import (metric=vm.memory.non-heap.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14501 0x240038a5
+    Data Type: double  InDom: 144.15525 0x24003ca5
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.non-heap.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2526,7 +2533,7 @@ Generated from Dropwizard metric import (metric=vm.memory.non-heap.committed.his
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_non_heap_committed_window_15m [Generated from Dropwizard metric import (metric=vm.memory.non-heap.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14503 0x240038a7
+    Data Type: double  InDom: 144.15527 0x24003ca7
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.non-heap.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2545,7 +2552,7 @@ Generated from Dropwizard metric import (metric=vm.memory.non-heap.committed.win
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_non_heap_committed_window_1h [Generated from Dropwizard metric import (metric=vm.memory.non-heap.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14505 0x240038a9
+    Data Type: double  InDom: 144.15529 0x24003ca9
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.non-heap.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2564,7 +2571,7 @@ Generated from Dropwizard metric import (metric=vm.memory.non-heap.committed.win
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_non_heap_committed_window_5m [Generated from Dropwizard metric import (metric=vm.memory.non-heap.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14507 0x240038ab
+    Data Type: double  InDom: 144.15531 0x24003cab
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.non-heap.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2604,7 +2611,7 @@ Generated from Dropwizard metric import (metric=vm.memory.non-heap.usage, type=c
     value -102205944
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_non_heap_usage_x100_history [Generated from Dropwizard metric import (metric=vm.memory.non-heap.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14509 0x240038ad
+    Data Type: double  InDom: 144.15533 0x24003cad
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.non-heap.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2623,7 +2630,7 @@ Generated from Dropwizard metric import (metric=vm.memory.non-heap.usage.x100.hi
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_non_heap_usage_x100_window_15m [Generated from Dropwizard metric import (metric=vm.memory.non-heap.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14511 0x240038af
+    Data Type: double  InDom: 144.15535 0x24003caf
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.non-heap.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2642,7 +2649,7 @@ Generated from Dropwizard metric import (metric=vm.memory.non-heap.usage.x100.wi
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_non_heap_usage_x100_window_1h [Generated from Dropwizard metric import (metric=vm.memory.non-heap.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14513 0x240038b1
+    Data Type: double  InDom: 144.15537 0x24003cb1
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.non-heap.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2661,7 +2668,7 @@ Generated from Dropwizard metric import (metric=vm.memory.non-heap.usage.x100.wi
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_non_heap_usage_x100_window_5m [Generated from Dropwizard metric import (metric=vm.memory.non-heap.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14515 0x240038b3
+    Data Type: double  InDom: 144.15539 0x24003cb3
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.non-heap.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2687,7 +2694,7 @@ Generated from Dropwizard metric import (metric=vm.memory.non-heap.used, type=co
     value 102205944
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_non_heap_used_history [Generated from Dropwizard metric import (metric=vm.memory.non-heap.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14517 0x240038b5
+    Data Type: double  InDom: 144.15541 0x24003cb5
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.non-heap.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2706,7 +2713,7 @@ Generated from Dropwizard metric import (metric=vm.memory.non-heap.used.history,
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_non_heap_used_window_15m [Generated from Dropwizard metric import (metric=vm.memory.non-heap.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14519 0x240038b7
+    Data Type: double  InDom: 144.15543 0x24003cb7
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.non-heap.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2725,7 +2732,7 @@ Generated from Dropwizard metric import (metric=vm.memory.non-heap.used.window.1
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_non_heap_used_window_1h [Generated from Dropwizard metric import (metric=vm.memory.non-heap.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14521 0x240038b9
+    Data Type: double  InDom: 144.15545 0x24003cb9
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.non-heap.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2744,7 +2751,7 @@ Generated from Dropwizard metric import (metric=vm.memory.non-heap.used.window.1
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_non_heap_used_window_5m [Generated from Dropwizard metric import (metric=vm.memory.non-heap.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14523 0x240038bb
+    Data Type: double  InDom: 144.15547 0x24003cbb
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.non-heap.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2770,7 +2777,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.commi
     value 25952256
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Code_Cache_committed_history [Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14525 0x240038bd
+    Data Type: double  InDom: 144.15549 0x24003cbd
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2789,7 +2796,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.commi
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Code_Cache_committed_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14527 0x240038bf
+    Data Type: double  InDom: 144.15551 0x24003cbf
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2808,7 +2815,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.commi
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Code_Cache_committed_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14529 0x240038c1
+    Data Type: double  InDom: 144.15553 0x24003cc1
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2827,7 +2834,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.commi
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Code_Cache_committed_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14531 0x240038c3
+    Data Type: double  InDom: 144.15555 0x24003cc3
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2867,7 +2874,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.usage
     value 0.1022811889648438
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Code_Cache_usage_x100_history [Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14533 0x240038c5
+    Data Type: double  InDom: 144.15557 0x24003cc5
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2886,7 +2893,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.usage
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Code_Cache_usage_x100_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14535 0x240038c7
+    Data Type: double  InDom: 144.15559 0x24003cc7
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2905,7 +2912,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.usage
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Code_Cache_usage_x100_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14537 0x240038c9
+    Data Type: double  InDom: 144.15561 0x24003cc9
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2924,7 +2931,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.usage
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Code_Cache_usage_x100_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14539 0x240038cb
+    Data Type: double  InDom: 144.15563 0x24003ccb
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2950,7 +2957,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.used,
     value 25739904
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Code_Cache_used_history [Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14541 0x240038cd
+    Data Type: double  InDom: 144.15565 0x24003ccd
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2969,7 +2976,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.used.
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Code_Cache_used_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14543 0x240038cf
+    Data Type: double  InDom: 144.15567 0x24003ccf
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -2988,7 +2995,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.used.
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Code_Cache_used_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14545 0x240038d1
+    Data Type: double  InDom: 144.15569 0x24003cd1
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3007,7 +3014,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.used.
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Code_Cache_used_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14547 0x240038d3
+    Data Type: double  InDom: 144.15571 0x24003cd3
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Code-Cache.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3033,7 +3040,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class
     value 9437184
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Compressed_Class_Space_committed_history [Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14549 0x240038d5
+    Data Type: double  InDom: 144.15573 0x24003cd5
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3052,7 +3059,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Compressed_Class_Space_committed_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14551 0x240038d7
+    Data Type: double  InDom: 144.15575 0x24003cd7
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3071,7 +3078,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Compressed_Class_Space_committed_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14553 0x240038d9
+    Data Type: double  InDom: 144.15577 0x24003cd9
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3090,7 +3097,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Compressed_Class_Space_committed_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14555 0x240038db
+    Data Type: double  InDom: 144.15579 0x24003cdb
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3130,7 +3137,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class
     value 0.007225163280963898
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Compressed_Class_Space_usage_x100_history [Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14557 0x240038dd
+    Data Type: double  InDom: 144.15581 0x24003cdd
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3149,7 +3156,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Compressed_Class_Space_usage_x100_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14559 0x240038df
+    Data Type: double  InDom: 144.15583 0x24003cdf
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3168,7 +3175,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Compressed_Class_Space_usage_x100_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14561 0x240038e1
+    Data Type: double  InDom: 144.15585 0x24003ce1
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3187,7 +3194,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Compressed_Class_Space_usage_x100_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14563 0x240038e3
+    Data Type: double  InDom: 144.15587 0x24003ce3
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3213,7 +3220,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class
     value 7757960
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Compressed_Class_Space_used_history [Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14565 0x240038e5
+    Data Type: double  InDom: 144.15589 0x24003ce5
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3232,7 +3239,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Compressed_Class_Space_used_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14567 0x240038e7
+    Data Type: double  InDom: 144.15591 0x24003ce7
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3251,7 +3258,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Compressed_Class_Space_used_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14569 0x240038e9
+    Data Type: double  InDom: 144.15593 0x24003ce9
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3270,7 +3277,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Compressed_Class_Space_used_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14571 0x240038eb
+    Data Type: double  InDom: 144.15595 0x24003ceb
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Compressed-Class-Space.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3296,7 +3303,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.commit
     value 74711040
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Metaspace_committed_history [Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14573 0x240038ed
+    Data Type: double  InDom: 144.15597 0x24003ced
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3315,7 +3322,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.commit
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Metaspace_committed_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14575 0x240038ef
+    Data Type: double  InDom: 144.15599 0x24003cef
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3334,7 +3341,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.commit
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Metaspace_committed_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14577 0x240038f1
+    Data Type: double  InDom: 144.15601 0x24003cf1
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3353,7 +3360,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.commit
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Metaspace_committed_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14579 0x240038f3
+    Data Type: double  InDom: 144.15603 0x24003cf3
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3393,7 +3400,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.usage,
     value 0.9196526778371711
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Metaspace_usage_x100_history [Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14581 0x240038f5
+    Data Type: double  InDom: 144.15605 0x24003cf5
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3412,7 +3419,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.usage.
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Metaspace_usage_x100_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14583 0x240038f7
+    Data Type: double  InDom: 144.15607 0x24003cf7
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3431,7 +3438,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.usage.
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Metaspace_usage_x100_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14585 0x240038f9
+    Data Type: double  InDom: 144.15609 0x24003cf9
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3450,7 +3457,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.usage.
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Metaspace_usage_x100_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14587 0x240038fb
+    Data Type: double  InDom: 144.15611 0x24003cfb
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3476,7 +3483,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.used, 
     value 68708208
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Metaspace_used_history [Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14589 0x240038fd
+    Data Type: double  InDom: 144.15613 0x24003cfd
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3495,7 +3502,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.used.h
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Metaspace_used_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14591 0x240038ff
+    Data Type: double  InDom: 144.15615 0x24003cff
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3514,7 +3521,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.used.w
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Metaspace_used_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14593 0x24003901
+    Data Type: double  InDom: 144.15617 0x24003d01
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3533,7 +3540,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.used.w
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_Metaspace_used_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14595 0x24003903
+    Data Type: double  InDom: 144.15619 0x24003d03
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.Metaspace.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3559,7 +3566,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.co
     value 128974848
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Eden_Space_committed_history [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14597 0x24003905
+    Data Type: double  InDom: 144.15621 0x24003d05
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3578,7 +3585,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.co
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Eden_Space_committed_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14599 0x24003907
+    Data Type: double  InDom: 144.15623 0x24003d07
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3597,7 +3604,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.co
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Eden_Space_committed_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14601 0x24003909
+    Data Type: double  InDom: 144.15625 0x24003d09
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3616,7 +3623,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.co
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Eden_Space_committed_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14603 0x2400390b
+    Data Type: double  InDom: 144.15627 0x24003d0b
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3656,7 +3663,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.us
     value 0.01675462257745833
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Eden_Space_usage_x100_history [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14605 0x2400390d
+    Data Type: double  InDom: 144.15629 0x24003d0d
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3675,7 +3682,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.us
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Eden_Space_usage_x100_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14607 0x2400390f
+    Data Type: double  InDom: 144.15631 0x24003d0f
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3694,7 +3701,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.us
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Eden_Space_usage_x100_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14609 0x24003911
+    Data Type: double  InDom: 144.15633 0x24003d11
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3713,7 +3720,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.us
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Eden_Space_usage_x100_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14611 0x24003913
+    Data Type: double  InDom: 144.15635 0x24003d13
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3739,7 +3746,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.us
     value 46837608
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Eden_Space_used_history [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14613 0x24003915
+    Data Type: double  InDom: 144.15637 0x24003d15
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3758,7 +3765,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.us
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Eden_Space_used_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14615 0x24003917
+    Data Type: double  InDom: 144.15639 0x24003d17
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3777,7 +3784,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.us
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Eden_Space_used_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14617 0x24003919
+    Data Type: double  InDom: 144.15641 0x24003d19
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3796,7 +3803,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.us
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Eden_Space_used_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14619 0x2400391b
+    Data Type: double  InDom: 144.15643 0x24003d1b
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Eden-Space.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3822,7 +3829,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.commi
     value 76546048
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Old_Gen_committed_history [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14621 0x2400391d
+    Data Type: double  InDom: 144.15645 0x24003d1d
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3841,7 +3848,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.commi
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Old_Gen_committed_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14623 0x2400391f
+    Data Type: double  InDom: 144.15647 0x24003d1f
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3860,7 +3867,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.commi
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Old_Gen_committed_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14625 0x24003921
+    Data Type: double  InDom: 144.15649 0x24003d21
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3879,7 +3886,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.commi
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Old_Gen_committed_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14627 0x24003923
+    Data Type: double  InDom: 144.15651 0x24003d23
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3919,7 +3926,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.usage
     value 0.01099584918742044
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Old_Gen_usage_x100_history [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14629 0x24003925
+    Data Type: double  InDom: 144.15653 0x24003d25
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3938,7 +3945,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.usage
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Old_Gen_usage_x100_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14631 0x24003927
+    Data Type: double  InDom: 144.15655 0x24003d27
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3957,7 +3964,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.usage
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Old_Gen_usage_x100_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14633 0x24003929
+    Data Type: double  InDom: 144.15657 0x24003d29
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -3976,7 +3983,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.usage
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Old_Gen_usage_x100_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14635 0x2400392b
+    Data Type: double  InDom: 144.15659 0x24003d2b
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4002,7 +4009,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.used,
     value 61708472
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Old_Gen_used_history [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14637 0x2400392d
+    Data Type: double  InDom: 144.15661 0x24003d2d
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4021,7 +4028,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.used.
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Old_Gen_used_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14639 0x2400392f
+    Data Type: double  InDom: 144.15663 0x24003d2f
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4040,7 +4047,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.used.
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Old_Gen_used_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14641 0x24003931
+    Data Type: double  InDom: 144.15665 0x24003d31
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4059,7 +4066,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.used.
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Old_Gen_used_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14643 0x24003933
+    Data Type: double  InDom: 144.15667 0x24003d33
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Old-Gen.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4085,7 +4092,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Spac
     value 5242880
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Survivor_Space_committed_history [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14645 0x24003935
+    Data Type: double  InDom: 144.15669 0x24003d35
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4104,7 +4111,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Spac
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Survivor_Space_committed_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14647 0x24003937
+    Data Type: double  InDom: 144.15671 0x24003d37
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4123,7 +4130,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Spac
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Survivor_Space_committed_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14649 0x24003939
+    Data Type: double  InDom: 144.15673 0x24003d39
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4142,7 +4149,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Spac
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Survivor_Space_committed_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14651 0x2400393b
+    Data Type: double  InDom: 144.15675 0x24003d3b
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4182,7 +4189,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Spac
     value 0.937701416015625
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Survivor_Space_usage_x100_history [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14653 0x2400393d
+    Data Type: double  InDom: 144.15677 0x24003d3d
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.usage.x100.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4201,7 +4208,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Spac
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Survivor_Space_usage_x100_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14655 0x2400393f
+    Data Type: double  InDom: 144.15679 0x24003d3f
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.usage.x100.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4220,7 +4227,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Spac
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Survivor_Space_usage_x100_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14657 0x24003941
+    Data Type: double  InDom: 144.15681 0x24003d41
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.usage.x100.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4239,7 +4246,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Spac
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Survivor_Space_usage_x100_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14659 0x24003943
+    Data Type: double  InDom: 144.15683 0x24003d43
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.usage.x100.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4265,7 +4272,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Spac
     value 4916256
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Survivor_Space_used_history [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14661 0x24003945
+    Data Type: double  InDom: 144.15685 0x24003d45
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4284,7 +4291,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Spac
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Survivor_Space_used_window_15m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14663 0x24003947
+    Data Type: double  InDom: 144.15687 0x24003d47
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4303,7 +4310,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Spac
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Survivor_Space_used_window_1h [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14665 0x24003949
+    Data Type: double  InDom: 144.15689 0x24003d49
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4322,7 +4329,7 @@ Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Spac
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_pools_PS_Survivor_Space_used_window_5m [Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14667 0x2400394b
+    Data Type: double  InDom: 144.15691 0x24003d4b
     Semantics: instant  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.pools.PS-Survivor-Space.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4348,7 +4355,7 @@ Generated from Dropwizard metric import (metric=vm.memory.total.committed, type=
     value 320864256
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_total_committed_history [Generated from Dropwizard metric import (metric=vm.memory.total.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14669 0x2400394d
+    Data Type: double  InDom: 144.15693 0x24003d4d
     Semantics: counter  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.total.committed.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4367,7 +4374,7 @@ Generated from Dropwizard metric import (metric=vm.memory.total.committed.histor
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_total_committed_window_15m [Generated from Dropwizard metric import (metric=vm.memory.total.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14671 0x2400394f
+    Data Type: double  InDom: 144.15695 0x24003d4f
     Semantics: counter  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.total.committed.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4386,7 +4393,7 @@ Generated from Dropwizard metric import (metric=vm.memory.total.committed.window
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_total_committed_window_1h [Generated from Dropwizard metric import (metric=vm.memory.total.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14673 0x24003951
+    Data Type: double  InDom: 144.15697 0x24003d51
     Semantics: counter  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.total.committed.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4405,7 +4412,7 @@ Generated from Dropwizard metric import (metric=vm.memory.total.committed.window
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_total_committed_window_5m [Generated from Dropwizard metric import (metric=vm.memory.total.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14675 0x24003953
+    Data Type: double  InDom: 144.15699 0x24003d53
     Semantics: counter  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.total.committed.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4445,7 +4452,7 @@ Generated from Dropwizard metric import (metric=vm.memory.total.used, type=com.c
     value 215670136
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_total_used_history [Generated from Dropwizard metric import (metric=vm.memory.total.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14677 0x24003955
+    Data Type: double  InDom: 144.15701 0x24003d55
     Semantics: counter  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.total.used.history, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4464,7 +4471,7 @@ Generated from Dropwizard metric import (metric=vm.memory.total.used.history, ty
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_total_used_window_15m [Generated from Dropwizard metric import (metric=vm.memory.total.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14679 0x24003957
+    Data Type: double  InDom: 144.15703 0x24003d57
     Semantics: counter  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.total.used.window.15m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4483,7 +4490,7 @@ Generated from Dropwizard metric import (metric=vm.memory.total.used.window.15m,
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_total_used_window_1h [Generated from Dropwizard metric import (metric=vm.memory.total.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14681 0x24003959
+    Data Type: double  InDom: 144.15705 0x24003d59
     Semantics: counter  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.total.used.window.1h, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4502,7 +4509,7 @@ Generated from Dropwizard metric import (metric=vm.memory.total.used.window.1h, 
     value 33
 
 openmetrics.jenkins_prometheus_plugin.vm_memory_total_used_window_5m [Generated from Dropwizard metric import (metric=vm.memory.total.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)]
-    Data Type: double  InDom: 144.14683 0x2400395b
+    Data Type: double  InDom: 144.15707 0x24003d5b
     Semantics: counter  Units: none
 Help:
 Generated from Dropwizard metric import (metric=vm.memory.total.used.window.5m, type=jenkins.metrics.util.AutoSamplingHistogram)
@@ -4563,21 +4570,21 @@ Generated from Dropwizard metric import (metric=vm.waiting.count, type=com.codah
     value 13
 
 openmetrics.labelfiltering.metric1 [local metric]
-    Data Type: double  InDom: 144.15360 0x24003c00
+    Data Type: double  InDom: 144.16384 0x24004000
     Semantics: instant  Units: none
 Help:
 local metric
     inst [0 or "0 foo:abc uninteresting:123"] value 1
 
 openmetrics.labelfiltering.metric2 [local metric]
-    Data Type: double  InDom: 144.15361 0x24003c01
+    Data Type: double  InDom: 144.16385 0x24004001
     Semantics: instant  Units: none
 Help:
 local metric
     inst [0 or "0 removeme:something"] value 8
 
 openmetrics.labelfiltering.metric3 [Simple gauge metric with two instances]
-    Data Type: double  InDom: 144.15363 0x24003c03
+    Data Type: double  InDom: 144.16387 0x24004003
     Semantics: instant  Units: none
 Help:
 Simple gauge metric with two instances
@@ -4585,7 +4592,7 @@ Simple gauge metric with two instances
     inst [1 or "1 abc:0 def:1"] value 458
 
 openmetrics.labelfiltering.metric4 [Simple gauge metric with one instance]
-    Data Type: double  InDom: 144.15364 0x24003c04
+    Data Type: double  InDom: 144.16388 0x24004004
     Semantics: instant  Units: none
 Help:
 Simple gauge metric with one instance
@@ -4599,46 +4606,6 @@ local metric
     value 9
 
 openmetrics.multiple.namespace.levels.some_metric000 [Simple gauge metric with some instances]
-    Data Type: double  InDom: 144.16384 0x24004000
-    Semantics: instant  Units: none
-Help:
-Simple gauge metric with some instances
-    inst [0 or "0 someinst:000"] value 0
-    inst [1 or "1 someinst:001"] value 0
-
-openmetrics.multiple.namespace.levels.some_metric001 [Simple gauge metric with some instances]
-    Data Type: double  InDom: 144.16385 0x24004001
-    Semantics: instant  Units: none
-Help:
-Simple gauge metric with some instances
-    inst [0 or "0 someinst:000"] value 0
-    inst [1 or "1 someinst:001"] value 1
-
-openmetrics.multiple.namespace.levels.some_metric002 [Simple gauge metric with some instances]
-    Data Type: double  InDom: 144.16386 0x24004002
-    Semantics: instant  Units: none
-Help:
-Simple gauge metric with some instances
-    inst [0 or "0 someinst:000"] value 0
-    inst [1 or "1 someinst:001"] value 2
-
-openmetrics.multiple.namespace.levels.some_metric003 [Simple gauge metric with some instances]
-    Data Type: double  InDom: 144.16387 0x24004003
-    Semantics: instant  Units: none
-Help:
-Simple gauge metric with some instances
-    inst [0 or "0 someinst:000"] value 0
-    inst [1 or "1 someinst:001"] value 3
-
-openmetrics.multiple.namespace.levels.some_metric004 [Simple gauge metric with some instances]
-    Data Type: double  InDom: 144.16388 0x24004004
-    Semantics: instant  Units: none
-Help:
-Simple gauge metric with some instances
-    inst [0 or "0 someinst:000"] value 0
-    inst [1 or "1 someinst:001"] value 4
-
-openmetrics.multiple.namespace.more.some_metric000 [Simple gauge metric with some instances]
     Data Type: double  InDom: 144.17408 0x24004400
     Semantics: instant  Units: none
 Help:
@@ -4646,7 +4613,7 @@ Simple gauge metric with some instances
     inst [0 or "0 someinst:000"] value 0
     inst [1 or "1 someinst:001"] value 0
 
-openmetrics.multiple.namespace.more.some_metric001 [Simple gauge metric with some instances]
+openmetrics.multiple.namespace.levels.some_metric001 [Simple gauge metric with some instances]
     Data Type: double  InDom: 144.17409 0x24004401
     Semantics: instant  Units: none
 Help:
@@ -4654,7 +4621,7 @@ Simple gauge metric with some instances
     inst [0 or "0 someinst:000"] value 0
     inst [1 or "1 someinst:001"] value 1
 
-openmetrics.multiple.namespace.more.some_metric002 [Simple gauge metric with some instances]
+openmetrics.multiple.namespace.levels.some_metric002 [Simple gauge metric with some instances]
     Data Type: double  InDom: 144.17410 0x24004402
     Semantics: instant  Units: none
 Help:
@@ -4662,7 +4629,7 @@ Simple gauge metric with some instances
     inst [0 or "0 someinst:000"] value 0
     inst [1 or "1 someinst:001"] value 2
 
-openmetrics.multiple.namespace.more.some_metric003 [Simple gauge metric with some instances]
+openmetrics.multiple.namespace.levels.some_metric003 [Simple gauge metric with some instances]
     Data Type: double  InDom: 144.17411 0x24004403
     Semantics: instant  Units: none
 Help:
@@ -4670,7 +4637,7 @@ Simple gauge metric with some instances
     inst [0 or "0 someinst:000"] value 0
     inst [1 or "1 someinst:001"] value 3
 
-openmetrics.multiple.namespace.more.some_metric004 [Simple gauge metric with some instances]
+openmetrics.multiple.namespace.levels.some_metric004 [Simple gauge metric with some instances]
     Data Type: double  InDom: 144.17412 0x24004404
     Semantics: instant  Units: none
 Help:
@@ -4678,99 +4645,139 @@ Simple gauge metric with some instances
     inst [0 or "0 someinst:000"] value 0
     inst [1 or "1 someinst:001"] value 4
 
+openmetrics.multiple.namespace.more.some_metric000 [Simple gauge metric with some instances]
+    Data Type: double  InDom: 144.18432 0x24004800
+    Semantics: instant  Units: none
+Help:
+Simple gauge metric with some instances
+    inst [0 or "0 someinst:000"] value 0
+    inst [1 or "1 someinst:001"] value 0
+
+openmetrics.multiple.namespace.more.some_metric001 [Simple gauge metric with some instances]
+    Data Type: double  InDom: 144.18433 0x24004801
+    Semantics: instant  Units: none
+Help:
+Simple gauge metric with some instances
+    inst [0 or "0 someinst:000"] value 0
+    inst [1 or "1 someinst:001"] value 1
+
+openmetrics.multiple.namespace.more.some_metric002 [Simple gauge metric with some instances]
+    Data Type: double  InDom: 144.18434 0x24004802
+    Semantics: instant  Units: none
+Help:
+Simple gauge metric with some instances
+    inst [0 or "0 someinst:000"] value 0
+    inst [1 or "1 someinst:001"] value 2
+
+openmetrics.multiple.namespace.more.some_metric003 [Simple gauge metric with some instances]
+    Data Type: double  InDom: 144.18435 0x24004803
+    Semantics: instant  Units: none
+Help:
+Simple gauge metric with some instances
+    inst [0 or "0 someinst:000"] value 0
+    inst [1 or "1 someinst:001"] value 3
+
+openmetrics.multiple.namespace.more.some_metric004 [Simple gauge metric with some instances]
+    Data Type: double  InDom: 144.18436 0x24004804
+    Semantics: instant  Units: none
+Help:
+Simple gauge metric with some instances
+    inst [0 or "0 someinst:000"] value 0
+    inst [1 or "1 someinst:001"] value 4
+
 openmetrics.pmwebd_3_12_2.cgroup.blkio.all.throttle.io_service_bytes.async [Per-cgroup throttle async bytes transferred]
-    Data Type: double  InDom: 144.18476 0x2400482c
+    Data Type: double  InDom: 144.19500 0x24004c2c
     Semantics: counter  Units: Kbyte
 Help:
 Per-cgroup throttle async bytes transferred
     inst [0 or "/"] value 321091796992
 
 openmetrics.pmwebd_3_12_2.cgroup.blkio.all.throttle.io_service_bytes.read [Per-cgroup throttle bytes transferred in reads]
-    Data Type: double  InDom: 144.18473 0x24004829
+    Data Type: double  InDom: 144.19497 0x24004c29
     Semantics: counter  Units: Kbyte
 Help:
 Per-cgroup throttle bytes transferred in reads
     inst [0 or "/"] value 320924024832
 
 openmetrics.pmwebd_3_12_2.cgroup.blkio.all.throttle.io_service_bytes.sync [Per-cgroup throttle sync bytes transferred]
-    Data Type: double  InDom: 144.18475 0x2400482b
+    Data Type: double  InDom: 144.19499 0x24004c2b
     Semantics: counter  Units: Kbyte
 Help:
 Per-cgroup throttle sync bytes transferred
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.blkio.all.throttle.io_service_bytes.total [Per-cgroup throttle total bytes transferred]
-    Data Type: double  InDom: 144.18477 0x2400482d
+    Data Type: double  InDom: 144.19501 0x24004c2d
     Semantics: counter  Units: Kbyte
 Help:
 Per-cgroup throttle total bytes transferred
     inst [0 or "/"] value 321091796992
 
 openmetrics.pmwebd_3_12_2.cgroup.blkio.all.throttle.io_service_bytes.write [Per-cgroup throttle bytes transferred to disk in writes]
-    Data Type: double  InDom: 144.18474 0x2400482a
+    Data Type: double  InDom: 144.19498 0x24004c2a
     Semantics: counter  Units: Kbyte
 Help:
 Per-cgroup throttle bytes transferred to disk in writes
     inst [0 or "/"] value 167772160
 
 openmetrics.pmwebd_3_12_2.cgroup.blkio.all.throttle.io_serviced.async [Per-cgroup throttle async operations serviced]
-    Data Type: double  InDom: 144.18481 0x24004831
+    Data Type: double  InDom: 144.19505 0x24004c31
     Semantics: counter  Units: count
 Help:
 Per-cgroup throttle async operations serviced
     inst [0 or "/"] value 4745
 
 openmetrics.pmwebd_3_12_2.cgroup.blkio.all.throttle.io_serviced.read [Per-cgroup throttle read operations serviced]
-    Data Type: double  InDom: 144.18478 0x2400482e
+    Data Type: double  InDom: 144.19502 0x24004c2e
     Semantics: counter  Units: count
 Help:
 Per-cgroup throttle read operations serviced
     inst [0 or "/"] value 4737
 
 openmetrics.pmwebd_3_12_2.cgroup.blkio.all.throttle.io_serviced.sync [Per-cgroup throttle sync operations serviced]
-    Data Type: double  InDom: 144.18480 0x24004830
+    Data Type: double  InDom: 144.19504 0x24004c30
     Semantics: counter  Units: count
 Help:
 Per-cgroup throttle sync operations serviced
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.blkio.all.throttle.io_serviced.total [Per-cgroup total throttle operations serviced]
-    Data Type: double  InDom: 144.18482 0x24004832
+    Data Type: double  InDom: 144.19506 0x24004c32
     Semantics: counter  Units: count
 Help:
 Per-cgroup total throttle operations serviced
     inst [0 or "/"] value 4745
 
 openmetrics.pmwebd_3_12_2.cgroup.blkio.all.throttle.io_serviced.write [Per-cgroup throttle write operations serviced]
-    Data Type: double  InDom: 144.18479 0x2400482f
+    Data Type: double  InDom: 144.19503 0x24004c2f
     Semantics: counter  Units: count
 Help:
 Per-cgroup throttle write operations serviced
     inst [0 or "/"] value 8
 
 openmetrics.pmwebd_3_12_2.cgroup.cpuacct.stat.system [Time spent by tasks of the cgroup in kernel mode]
-    Data Type: double  InDom: 144.18435 0x24004803
+    Data Type: double  InDom: 144.19459 0x24004c03
     Semantics: counter  Units: millisec
 Help:
 Time spent by tasks of the cgroup in kernel mode
     inst [0 or "/"] value 0.258
 
 openmetrics.pmwebd_3_12_2.cgroup.cpuacct.stat.user [Time spent by tasks of the cgroup in user mode]
-    Data Type: double  InDom: 144.18434 0x24004802
+    Data Type: double  InDom: 144.19458 0x24004c02
     Semantics: counter  Units: millisec
 Help:
 Time spent by tasks of the cgroup in user mode
     inst [0 or "/"] value 5.585
 
 openmetrics.pmwebd_3_12_2.cgroup.cpuacct.usage [CPU time consumed by processes in each cgroup]
-    Data Type: double  InDom: 144.18432 0x24004800
+    Data Type: double  InDom: 144.19456 0x24004c00
     Semantics: counter  Units: nanosec
 Help:
 CPU time consumed by processes in each cgroup
     inst [0 or "/"] value 59.30594183300001
 
 openmetrics.pmwebd_3_12_2.cgroup.cpuacct.usage_percpu [Per-CPU time consumed by processes in each cgroup]
-    Data Type: double  InDom: 144.18433 0x24004801
+    Data Type: double  InDom: 144.19457 0x24004c01
     Semantics: counter  Units: nanosec
 Help:
 Per-CPU time consumed by processes in each cgroup
@@ -4780,266 +4787,266 @@ Per-CPU time consumed by processes in each cgroup
     inst [3 or "/::cpu3"] value 12.858868303
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.failcnt [Count of failures to allocate memory due to cgroup limit]
-    Data Type: double  InDom: 144.18438 0x24004806
+    Data Type: double  InDom: 144.19462 0x24004c06
     Semantics: counter  Units: count
 Help:
 Count of failures to allocate memory due to cgroup limit
     inst [0 or "/"] value 27068
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.limit [Maximum memory that can be utilized by each cgroup]
-    Data Type: double  InDom: 144.18437 0x24004805
+    Data Type: double  InDom: 144.19461 0x24004c05
     Semantics: instant  Units: byte
 Help:
 Maximum memory that can be utilized by each cgroup
     inst [0 or "/"] value 629145600
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.active_anon [Anonymous and swap cache memory on active LRU list.]
-    Data Type: double  InDom: 144.18450 0x24004812
+    Data Type: double  InDom: 144.19474 0x24004c12
     Semantics: instant  Units: byte
 Help:
 Anonymous and swap cache memory on active LRU list.
     inst [0 or "/"] value 464416768
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.active_file [File-backed memory on active LRU list]
-    Data Type: double  InDom: 144.18452 0x24004814
+    Data Type: double  InDom: 144.19476 0x24004c14
     Semantics: instant  Units: byte
 Help:
 File-backed memory on active LRU list
     inst [0 or "/"] value 83148800
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.cache [Number of bytes of page cache memory]
-    Data Type: double  InDom: 144.18439 0x24004807
+    Data Type: double  InDom: 144.19463 0x24004c07
     Semantics: instant  Units: byte
 Help:
 Number of bytes of page cache memory
     inst [0 or "/"] value 164532224
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.inactive_anon [Anonymous and swap cache memory on inactive LRU list]
-    Data Type: double  InDom: 144.18449 0x24004811
+    Data Type: double  InDom: 144.19473 0x24004c11
     Semantics: instant  Units: byte
 Help:
 Anonymous and swap cache memory on inactive LRU list
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.inactive_file [File-backed memory on inactive LRU list]
-    Data Type: double  InDom: 144.18451 0x24004813
+    Data Type: double  InDom: 144.19475 0x24004c13
     Semantics: instant  Units: byte
 Help:
 File-backed memory on inactive LRU list
     inst [0 or "/"] value 81383424
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.mapped_file [Bytes of mapped file (incl tmpfs/shmem)]
-    Data Type: double  InDom: 144.18442 0x2400480a
+    Data Type: double  InDom: 144.19466 0x24004c0a
     Semantics: instant  Units: byte
 Help:
 Bytes of mapped file (incl tmpfs/shmem)
     inst [0 or "/"] value 14311424
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.pgfault [Total number of page faults]
-    Data Type: double  InDom: 144.18447 0x2400480f
+    Data Type: double  InDom: 144.19471 0x24004c0f
     Semantics: counter  Units: count
 Help:
 Total number of page faults
     inst [0 or "/"] value 207794
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.pgmajfault [Number of major page faults]
-    Data Type: double  InDom: 144.18448 0x24004810
+    Data Type: double  InDom: 144.19472 0x24004c10
     Semantics: counter  Units: count
 Help:
 Number of major page faults
     inst [0 or "/"] value 196
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.pgpgin [Number of charging events to the memory cgroup]
-    Data Type: double  InDom: 144.18445 0x2400480d
+    Data Type: double  InDom: 144.19469 0x24004c0d
     Semantics: counter  Units: count
 Help:
 Number of charging events to the memory cgroup
     inst [0 or "/"] value 208514
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.pgpgout [Number of uncharging events to the memory cgroup]
-    Data Type: double  InDom: 144.18446 0x2400480e
+    Data Type: double  InDom: 144.19470 0x24004c0e
     Semantics: counter  Units: count
 Help:
 Number of uncharging events to the memory cgroup
     inst [0 or "/"] value 122925
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.recent.rotated_anon [VM internal parameter (see mm/vmscan.c)]
-    Data Type: double  InDom: 144.18469 0x24004825
+    Data Type: double  InDom: 144.19493 0x24004c25
     Semantics: counter  Units: byte
 Help:
 VM internal parameter (see mm/vmscan.c)
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.recent.rotated_file [VM internal parameter (see mm/vmscan.c)]
-    Data Type: double  InDom: 144.18470 0x24004826
+    Data Type: double  InDom: 144.19494 0x24004c26
     Semantics: counter  Units: byte
 Help:
 VM internal parameter (see mm/vmscan.c)
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.recent.scanned_anon [VM internal parameter (see mm/vmscan.c)]
-    Data Type: double  InDom: 144.18471 0x24004827
+    Data Type: double  InDom: 144.19495 0x24004c27
     Semantics: counter  Units: byte
 Help:
 VM internal parameter (see mm/vmscan.c)
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.recent.scanned_file [VM internal parameter (see mm/vmscan.c)]
-    Data Type: double  InDom: 144.18472 0x24004828
+    Data Type: double  InDom: 144.19496 0x24004c28
     Semantics: counter  Units: byte
 Help:
 VM internal parameter (see mm/vmscan.c)
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.rss [Anonymous and swap memory (incl transparent hugepages)]
-    Data Type: double  InDom: 144.18440 0x24004808
+    Data Type: double  InDom: 144.19464 0x24004c08
     Semantics: instant  Units: byte
 Help:
 Anonymous and swap memory (incl transparent hugepages)
     inst [0 or "/"] value 464416768
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.rss_huge [Anonymous transparent hugepages]
-    Data Type: double  InDom: 144.18441 0x24004809
+    Data Type: double  InDom: 144.19465 0x24004c09
     Semantics: instant  Units: byte
 Help:
 Anonymous transparent hugepages
     inst [0 or "/"] value 278921216
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.swap [Number of bytes of swap usage]
-    Data Type: double  InDom: 144.18444 0x2400480c
+    Data Type: double  InDom: 144.19468 0x24004c0c
     Semantics: instant  Units: byte
 Help:
 Number of bytes of swap usage
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.active_anon [Hierarchical, cumulative version of stat.active_anon]
-    Data Type: double  InDom: 144.18465 0x24004821
+    Data Type: double  InDom: 144.19489 0x24004c21
     Semantics: instant  Units: byte
 Help:
 Hierarchical, cumulative version of stat.active_anon
     inst [0 or "/"] value 464416768
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.active_file [Hierarchical, cumulative version of stat.active_file]
-    Data Type: double  InDom: 144.18467 0x24004823
+    Data Type: double  InDom: 144.19491 0x24004c23
     Semantics: instant  Units: byte
 Help:
 Hierarchical, cumulative version of stat.active_file
     inst [0 or "/"] value 83148800
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.cache [Hierarchical, cumulative version of stat.cache]
-    Data Type: double  InDom: 144.18454 0x24004816
+    Data Type: double  InDom: 144.19478 0x24004c16
     Semantics: instant  Units: byte
 Help:
 Hierarchical, cumulative version of stat.cache
     inst [0 or "/"] value 164532224
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.inactive_anon [Hierarchical, cumulative version of stat.inactive_anon]
-    Data Type: double  InDom: 144.18464 0x24004820
+    Data Type: double  InDom: 144.19488 0x24004c20
     Semantics: instant  Units: byte
 Help:
 Hierarchical, cumulative version of stat.inactive_anon
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.inactive_file [Hierarchical, cumulative version of stat.inactive_file]
-    Data Type: double  InDom: 144.18466 0x24004822
+    Data Type: double  InDom: 144.19490 0x24004c22
     Semantics: instant  Units: byte
 Help:
 Hierarchical, cumulative version of stat.inactive_file
     inst [0 or "/"] value 81383424
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.mapped_file [Hierarchical, cumulative version of stat.mapped_file]
-    Data Type: double  InDom: 144.18457 0x24004819
+    Data Type: double  InDom: 144.19481 0x24004c19
     Semantics: instant  Units: byte
 Help:
 Hierarchical, cumulative version of stat.mapped_file
     inst [0 or "/"] value 14311424
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.pgfault [Hierarchical, cumulative version of stat.pgfault]
-    Data Type: double  InDom: 144.18462 0x2400481e
+    Data Type: double  InDom: 144.19486 0x24004c1e
     Semantics: counter  Units: count
 Help:
 Hierarchical, cumulative version of stat.pgfault
     inst [0 or "/"] value 207794
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.pgmajfault [Hierarchical, cumulative version of stat.pgmajfault]
-    Data Type: double  InDom: 144.18463 0x2400481f
+    Data Type: double  InDom: 144.19487 0x24004c1f
     Semantics: counter  Units: count
 Help:
 Hierarchical, cumulative version of stat.pgmajfault
     inst [0 or "/"] value 196
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.pgpgin [Hierarchical, cumulative version of stat.pgpgin]
-    Data Type: double  InDom: 144.18460 0x2400481c
+    Data Type: double  InDom: 144.19484 0x24004c1c
     Semantics: counter  Units: count
 Help:
 Hierarchical, cumulative version of stat.pgpgin
     inst [0 or "/"] value 208514
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.pgpgout [Hierarchical, cumulative version of stat.pgpgout]
-    Data Type: double  InDom: 144.18461 0x2400481d
+    Data Type: double  InDom: 144.19485 0x24004c1d
     Semantics: counter  Units: count
 Help:
 Hierarchical, cumulative version of stat.pgpgout
     inst [0 or "/"] value 122925
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.rss [Hierarchical, cumulative version of stat.rss]
-    Data Type: double  InDom: 144.18455 0x24004817
+    Data Type: double  InDom: 144.19479 0x24004c17
     Semantics: instant  Units: byte
 Help:
 Hierarchical, cumulative version of stat.rss
     inst [0 or "/"] value 464416768
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.rss_huge [Hierarchical, cumulative version of stat.rss_huge]
-    Data Type: double  InDom: 144.18456 0x24004818
+    Data Type: double  InDom: 144.19480 0x24004c18
     Semantics: instant  Units: byte
 Help:
 Hierarchical, cumulative version of stat.rss_huge
     inst [0 or "/"] value 278921216
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.swap [Hierarchical, cumulative version of stat.swap]
-    Data Type: double  InDom: 144.18459 0x2400481b
+    Data Type: double  InDom: 144.19483 0x24004c1b
     Semantics: instant  Units: byte
 Help:
 Hierarchical, cumulative version of stat.swap
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.unevictable [Hierarchical, cumulative version of stat.unevictable]
-    Data Type: double  InDom: 144.18468 0x24004824
+    Data Type: double  InDom: 144.19492 0x24004c24
     Semantics: instant  Units: byte
 Help:
 Hierarchical, cumulative version of stat.unevictable
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.total.writeback [Hierarchical, cumulative version of stat.writeback]
-    Data Type: double  InDom: 144.18458 0x2400481a
+    Data Type: double  InDom: 144.19482 0x24004c1a
     Semantics: instant  Units: byte
 Help:
 Hierarchical, cumulative version of stat.writeback
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.unevictable [Memory that cannot be reclaimed (e.g. mlocked)]
-    Data Type: double  InDom: 144.18453 0x24004815
+    Data Type: double  InDom: 144.19477 0x24004c15
     Semantics: instant  Units: byte
 Help:
 Memory that cannot be reclaimed (e.g. mlocked)
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.stat.writeback [Bytes of file/anonymous cache queued for syncing]
-    Data Type: double  InDom: 144.18443 0x2400480b
+    Data Type: double  InDom: 144.19467 0x24004c0b
     Semantics: instant  Units: byte
 Help:
 Bytes of file/anonymous cache queued for syncing
     inst [0 or "/"] value 0
 
 openmetrics.pmwebd_3_12_2.cgroup.memory.usage [Current physical memory accounted to each cgroup]
-    Data Type: double  InDom: 144.18436 0x24004804
+    Data Type: double  InDom: 144.19460 0x24004c04
     Semantics: instant  Units: byte
 Help:
 Current physical memory accounted to each cgroup
     inst [0 or "/"] value 629055488
 
 openmetrics.problematic_strings.test [The Thing]
-    Data Type: double  InDom: 144.19456 0x24004c00
+    Data Type: double  InDom: 144.20480 0x24005000
     Semantics: instant  Units: none
 Help:
 The Thing
@@ -5056,7 +5063,7 @@ The Thing
     inst [10 or "10 instance:{"] value 10
 
 openmetrics.problematic_strings.test2 [The Other Thing]
-    Data Type: double  InDom: 144.19457 0x24004c01
+    Data Type: double  InDom: 144.20481 0x24005001
     Semantics: instant  Units: count
 Help:
 The Other Thing
@@ -5082,7 +5089,7 @@ and has a \ or two \
     value 0
 
 openmetrics.prom_exposition_formats_example1.http_request_duration_seconds_bucket [A histogram of the request duration.]
-    Data Type: double  InDom: 144.20484 0x24005004
+    Data Type: double  InDom: 144.21508 0x24005404
     Semantics: counter  Units: count
 Help:
 A histogram of the request duration.
@@ -5108,7 +5115,7 @@ A histogram of the request duration.
     value 53423
 
 openmetrics.prom_exposition_formats_example1.http_requests_total [The total number of HTTP requests.]
-    Data Type: double  InDom: 144.20480 0x24005000
+    Data Type: double  InDom: 144.21504 0x24005400
     Semantics: counter  Units: none
 Help:
 The total number of HTTP requests.
@@ -5122,14 +5129,14 @@ Help: <empty entry>
     value 12.47
 
 openmetrics.prom_exposition_formats_example1.msdos_file_access_time_seconds []
-    Data Type: double  InDom: 144.20481 0x24005001
+    Data Type: double  InDom: 144.21505 0x24005401
     Semantics: instant  Units: sec
 Help: <empty entry>
     inst [0 or "0 error:Cannot find file:
 "FILE.TXT" path:C:\DIR\FILE.TXT"] value 1458255915
 
 openmetrics.prom_exposition_formats_example1.rpc_duration_seconds [A summary of the RPC duration in seconds.]
-    Data Type: double  InDom: 144.20487 0x24005007
+    Data Type: double  InDom: 144.21511 0x24005407
     Semantics: instant  Units: sec
 Help:
 A summary of the RPC duration in seconds.
@@ -5154,7 +5161,7 @@ A summary of the RPC duration in seconds.
     value 17560473
 
 openmetrics.prom_exposition_formats_example1.something_weird []
-    Data Type: double  InDom: 144.20483 0x24005003
+    Data Type: double  InDom: 144.21507 0x24005403
     Semantics: instant  Units: none
 Help: <empty entry>
     inst [0 or "0 problem:division by zero"] value inf
@@ -5202,7 +5209,7 @@ Virtual memory size in bytes.
     value 340594688
 
 openmetrics.python_sample_client_server.python_info [Python platform information]
-    Data Type: double  InDom: 144.21504 0x24005400
+    Data Type: double  InDom: 144.22528 0x24005800
     Semantics: instant  Units: none
 Help:
 Python platform information
@@ -5216,7 +5223,7 @@ Sample Gauge of queue size
     value 90
 
 openmetrics.python_sample_client_server.request_latency_seconds_bucket [Sample histogram]
-    Data Type: double  InDom: 144.21515 0x2400540b
+    Data Type: double  InDom: 144.22539 0x2400580b
     Semantics: counter  Units: count
 Help:
 Sample histogram
@@ -5251,7 +5258,7 @@ Sample histogram
     value 4.7
 
 openmetrics.python_sample_client_server.requests_total [Total requests]
-    Data Type: double  InDom: 144.21513 0x24005409
+    Data Type: double  InDom: 144.22537 0x24005809
     Semantics: counter  Units: none
 Help:
 Total requests
@@ -5274,7 +5281,7 @@ Sample summary of requests
     value 4.7
 
 openmetrics.python_scripted.python_scripted_metric [Simple gauge metric with two instances]
-    Data Type: double  InDom: 144.22528 0x24005800
+    Data Type: double  InDom: 144.23552 0x24005c00
     Semantics: instant  Units: none
 Help:
 Simple gauge metric with two instances
@@ -5282,7 +5289,7 @@ Simple gauge metric with two instances
     inst [1 or "1 def:123"] value 123
 
 openmetrics.reordered_labels.http_request_duration_microseconds [The HTTP request latencies in microseconds.]
-    Data Type: double  InDom: 144.23552 0x24005c00
+    Data Type: double  InDom: 144.24576 0x24006000
     Semantics: instant  Units: microsec
 Help:
 The HTTP request latencies in microseconds.
@@ -5298,7 +5305,7 @@ a metric with item number bigger then 2^9
     value 4194303
 
 openmetrics.sample_pmda_3_12_2.sample.bogus_bin [Several constant instances]
-    Data Type: double  InDom: 144.24585 0x24006009
+    Data Type: double  InDom: 144.25609 0x24006409
     Semantics: instant  Units: none
 Help:
 Several constant instances
@@ -5310,7 +5317,7 @@ Several constant instances
     inst [5 or "bin-900"] value 900
 
 openmetrics.sample_pmda_3_12_2.sample.bucket [Several constant instances]
-    Data Type: double  InDom: 144.24583 0x24006007
+    Data Type: double  InDom: 144.25607 0x24006407
     Semantics: instant  Units: none
 Help:
 Several constant instances
@@ -5332,7 +5339,7 @@ counter byte counter
     value 2255
 
 openmetrics.sample_pmda_3_12_2.sample.colour [Metrics with a "saw-tooth" trend over time]
-    Data Type: double  InDom: 144.24581 0x24006005
+    Data Type: double  InDom: 144.25605 0x24006405
     Semantics: instant  Units: none
 Help:
 Metrics with a "saw-tooth" trend over time
@@ -5376,7 +5383,7 @@ control values retured for sample.dodgey.value
     value 5
 
 openmetrics.sample_pmda_3_12_2.sample.dodgey.value [5 unreliable instances]
-    Data Type: double  InDom: 144.24658 0x24006052
+    Data Type: double  InDom: 144.25682 0x24006452
     Semantics: instant  Units: none
 Help:
 5 unreliable instances
@@ -5387,7 +5394,7 @@ Help:
     inst [4 or "d5"] value 55
 
 openmetrics.sample_pmda_3_12_2.sample.double.bin [like sample.bin but type DOUBLE]
-    Data Type: double  InDom: 144.24649 0x24006049
+    Data Type: double  InDom: 144.25673 0x24006449
     Semantics: instant  Units: none
 Help:
 like sample.bin but type DOUBLE
@@ -5402,7 +5409,7 @@ like sample.bin but type DOUBLE
     inst [8 or "bin-900"] value 900
 
 openmetrics.sample_pmda_3_12_2.sample.double.bin_ctr [like sample.bin but type DOUBLE, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.24650 0x2400604a
+    Data Type: double  InDom: 144.25674 0x2400644a
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type DOUBLE, SEM_COUNTER and SPACE_KBYTE
@@ -5459,7 +5466,7 @@ Process id of PMDA daemon
     value 12301
 
 openmetrics.sample_pmda_3_12_2.sample.dupnames.three.bin [Several constant instances]
-    Data Type: double  InDom: 144.24582 0x24006006
+    Data Type: double  InDom: 144.25606 0x24006406
     Semantics: instant  Units: none
 Help:
 Several constant instances
@@ -5495,7 +5502,7 @@ Elapsed time (seconds)
     value 770
 
 openmetrics.sample_pmda_3_12_2.sample.dynamic.counter [counter metric with dynamic indom]
-    Data Type: double  InDom: 144.24659 0x24006053
+    Data Type: double  InDom: 144.25683 0x24006453
     Semantics: counter  Units: count
 Help:
 counter metric with dynamic indom
@@ -5503,7 +5510,7 @@ counter metric with dynamic indom
     inst [1 or "two"] value 1178
 
 openmetrics.sample_pmda_3_12_2.sample.dynamic.discrete [discrete metric with dynamic indom]
-    Data Type: double  InDom: 144.24660 0x24006054
+    Data Type: double  InDom: 144.25684 0x24006454
     Semantics: discrete  Units: count
 Help:
 discrete metric with dynamic indom
@@ -5511,7 +5518,7 @@ discrete metric with dynamic indom
     inst [1 or "two"] value 1178
 
 openmetrics.sample_pmda_3_12_2.sample.dynamic.instant [instant metric with dynamic indom]
-    Data Type: double  InDom: 144.24661 0x24006055
+    Data Type: double  InDom: 144.25685 0x24006455
     Semantics: instant  Units: count
 Help:
 instant metric with dynamic indom
@@ -5575,7 +5582,7 @@ reset highres event record state
     value 3
 
 openmetrics.sample_pmda_3_12_2.sample.float.bin [like sample.bin but type FLOAT]
-    Data Type: double  InDom: 144.24642 0x24006042
+    Data Type: double  InDom: 144.25666 0x24006442
     Semantics: instant  Units: none
 Help:
 like sample.bin but type FLOAT
@@ -5590,7 +5597,7 @@ like sample.bin but type FLOAT
     inst [8 or "bin-900"] value 900
 
 openmetrics.sample_pmda_3_12_2.sample.float.bin_ctr [like sample.bin but type FLOAT, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.24643 0x24006043
+    Data Type: double  InDom: 144.25667 0x24006443
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type FLOAT, SEM_COUNTER and SPACE_KBYTE
@@ -5633,7 +5640,7 @@ a 32-bit floating-point value that can be modified
     value 13
 
 openmetrics.sample_pmda_3_12_2.sample.hordes.one [500 instances]
-    Data Type: double  InDom: 144.24651 0x2400604b
+    Data Type: double  InDom: 144.25675 0x2400644b
     Semantics: instant  Units: none
 Help:
 500 instances
@@ -6139,7 +6146,7 @@ Help:
     inst [499 or "499"] value 499
 
 openmetrics.sample_pmda_3_12_2.sample.hordes.two [500 instances]
-    Data Type: double  InDom: 144.24652 0x2400604c
+    Data Type: double  InDom: 144.25676 0x2400644c
     Semantics: instant  Units: none
 Help:
 500 instances
@@ -6659,7 +6666,7 @@ Hypothetical load
     value 42
 
 openmetrics.sample_pmda_3_12_2.sample.long.bin [like sample.bin but type 32]
-    Data Type: double  InDom: 144.24614 0x24006026
+    Data Type: double  InDom: 144.25638 0x24006426
     Semantics: instant  Units: none
 Help:
 like sample.bin but type 32
@@ -6674,7 +6681,7 @@ like sample.bin but type 32
     inst [8 or "bin-900"] value 900
 
 openmetrics.sample_pmda_3_12_2.sample.long.bin_ctr [like sample.bin but type 32, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.24615 0x24006027
+    Data Type: double  InDom: 144.25639 0x24006427
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type 32, SEM_COUNTER and SPACE_KBYTE
@@ -6724,7 +6731,7 @@ a 32-bit integer that can be modified
     value 13
 
 openmetrics.sample_pmda_3_12_2.sample.longlong.bin [like sample.bin but type 64]
-    Data Type: double  InDom: 144.24628 0x24006034
+    Data Type: double  InDom: 144.25652 0x24006434
     Semantics: instant  Units: none
 Help:
 like sample.bin but type 64
@@ -6739,7 +6746,7 @@ like sample.bin but type 64
     inst [8 or "bin-900"] value 900
 
 openmetrics.sample_pmda_3_12_2.sample.longlong.bin_ctr [like sample.bin but type 64, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.24629 0x24006035
+    Data Type: double  InDom: 144.25653 0x24006435
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type 64, SEM_COUNTER and SPACE_KBYTE
@@ -6803,7 +6810,7 @@ number of instances in sample.many.int's domain
     value 5
 
 openmetrics.sample_pmda_3_12_2.sample.many.int [variable sized instance domain]
-    Data Type: double  InDom: 144.24674 0x24006062
+    Data Type: double  InDom: 144.25698 0x24006462
     Semantics: instant  Units: count
 Help:
 variable sized instance domain
@@ -6912,7 +6919,7 @@ interval (in seconds) during which PMDA does not respond to PDUs
     value 0
 
 openmetrics.sample_pmda_3_12_2.sample.part_bin [Several constant instances]
-    Data Type: double  InDom: 144.24584 0x24006008
+    Data Type: double  InDom: 144.25608 0x24006408
     Semantics: instant  Units: none
 Help:
 Several constant instances
@@ -7028,7 +7035,7 @@ count up seconds by multiples of 10, wrap back to 1 second at 1 day
     value 1
 
 openmetrics.sample_pmda_3_12_2.sample.scramble.bin [Several constant instances, instances scrambled]
-    Data Type: double  InDom: 144.24676 0x24006064
+    Data Type: double  InDom: 144.25700 0x24006464
     Semantics: instant  Units: none
 Help:
 Several constant instances, instances scrambled
@@ -7073,7 +7080,7 @@ dynamic *.secret.foo.bar.grunt.snort.six metric
     value 6
 
 openmetrics.sample_pmda_3_12_2.sample.secret.foo.bar.max.redirect [PMDA status]
-    Data Type: double  InDom: 144.24601 0x24006019
+    Data Type: double  InDom: 144.25625 0x24006419
     Semantics: discrete  Units: none
 Help:
 PMDA status
@@ -7127,7 +7134,7 @@ A step function (counter)
     value 520
 
 openmetrics.sample_pmda_3_12_2.sample.ulong.bin [like sample.bin but type U32]
-    Data Type: double  InDom: 144.24621 0x2400602d
+    Data Type: double  InDom: 144.25645 0x2400642d
     Semantics: instant  Units: none
 Help:
 like sample.bin but type U32
@@ -7142,7 +7149,7 @@ like sample.bin but type U32
     inst [8 or "bin-900"] value 900
 
 openmetrics.sample_pmda_3_12_2.sample.ulong.bin_ctr [like sample.bin but type U32, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.24622 0x2400602e
+    Data Type: double  InDom: 144.25646 0x2400642e
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type U32, SEM_COUNTER and SPACE_KBYTE
@@ -7192,7 +7199,7 @@ a 32-bit unsigned integer that can be modified
     value 13
 
 openmetrics.sample_pmda_3_12_2.sample.ulonglong.bin [like sample.bin but type U64]
-    Data Type: double  InDom: 144.24635 0x2400603b
+    Data Type: double  InDom: 144.25659 0x2400643b
     Semantics: instant  Units: none
 Help:
 like sample.bin but type U64
@@ -7207,7 +7214,7 @@ like sample.bin but type U64
     inst [8 or "bin-900"] value 900
 
 openmetrics.sample_pmda_3_12_2.sample.ulonglong.bin_ctr [like sample.bin but type U64, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.24636 0x2400603c
+    Data Type: double  InDom: 144.25660 0x2400643c
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type U64, SEM_COUNTER and SPACE_KBYTE
@@ -7299,7 +7306,7 @@ a metric with item number bigger then 2^9
     value 4194303
 
 openmetrics.sample_pmda_instname_5_0_0.sample.bogus_bin [Several constant instances]
-    Data Type: double  InDom: 144.25609 0x24006409
+    Data Type: double  InDom: 144.26633 0x24006809
     Semantics: instant  Units: none
 Help:
 Several constant instances
@@ -7311,7 +7318,7 @@ Several constant instances
     inst [5 or "bin-900"] value 900
 
 openmetrics.sample_pmda_instname_5_0_0.sample.bucket [Several constant instances]
-    Data Type: double  InDom: 144.25607 0x24006407
+    Data Type: double  InDom: 144.26631 0x24006807
     Semantics: instant  Units: none
 Help:
 Several constant instances
@@ -7333,7 +7340,7 @@ counter byte counter
     value 2255
 
 openmetrics.sample_pmda_instname_5_0_0.sample.colour [Metrics with a "saw-tooth" trend over time]
-    Data Type: double  InDom: 144.25605 0x24006405
+    Data Type: double  InDom: 144.26629 0x24006805
     Semantics: instant  Units: none
 Help:
 Metrics with a "saw-tooth" trend over time
@@ -7377,7 +7384,7 @@ control values retured for sample.dodgey.value
     value 5
 
 openmetrics.sample_pmda_instname_5_0_0.sample.dodgey.value [5 unreliable instances]
-    Data Type: double  InDom: 144.25682 0x24006452
+    Data Type: double  InDom: 144.26706 0x24006852
     Semantics: instant  Units: none
 Help:
 5 unreliable instances
@@ -7388,7 +7395,7 @@ Help:
     inst [4 or "d5"] value 55
 
 openmetrics.sample_pmda_instname_5_0_0.sample.double.bin [like sample.bin but type DOUBLE]
-    Data Type: double  InDom: 144.25673 0x24006449
+    Data Type: double  InDom: 144.26697 0x24006849
     Semantics: instant  Units: none
 Help:
 like sample.bin but type DOUBLE
@@ -7403,7 +7410,7 @@ like sample.bin but type DOUBLE
     inst [8 or "bin-900"] value 900
 
 openmetrics.sample_pmda_instname_5_0_0.sample.double.bin_ctr [like sample.bin but type DOUBLE, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.25674 0x2400644a
+    Data Type: double  InDom: 144.26698 0x2400684a
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type DOUBLE, SEM_COUNTER and SPACE_KBYTE
@@ -7460,7 +7467,7 @@ Process id of PMDA daemon
     value 12301
 
 openmetrics.sample_pmda_instname_5_0_0.sample.dupnames.three.bin [Several constant instances]
-    Data Type: double  InDom: 144.25606 0x24006406
+    Data Type: double  InDom: 144.26630 0x24006806
     Semantics: instant  Units: none
 Help:
 Several constant instances
@@ -7496,7 +7503,7 @@ Elapsed time (seconds)
     value 770
 
 openmetrics.sample_pmda_instname_5_0_0.sample.dynamic.counter [counter metric with dynamic indom]
-    Data Type: double  InDom: 144.25683 0x24006453
+    Data Type: double  InDom: 144.26707 0x24006853
     Semantics: counter  Units: count
 Help:
 counter metric with dynamic indom
@@ -7504,7 +7511,7 @@ counter metric with dynamic indom
     inst [1 or "two"] value 1178
 
 openmetrics.sample_pmda_instname_5_0_0.sample.dynamic.discrete [discrete metric with dynamic indom]
-    Data Type: double  InDom: 144.25684 0x24006454
+    Data Type: double  InDom: 144.26708 0x24006854
     Semantics: discrete  Units: count
 Help:
 discrete metric with dynamic indom
@@ -7512,7 +7519,7 @@ discrete metric with dynamic indom
     inst [1 or "two"] value 1178
 
 openmetrics.sample_pmda_instname_5_0_0.sample.dynamic.instant [instant metric with dynamic indom]
-    Data Type: double  InDom: 144.25685 0x24006455
+    Data Type: double  InDom: 144.26709 0x24006855
     Semantics: instant  Units: count
 Help:
 instant metric with dynamic indom
@@ -7576,7 +7583,7 @@ reset highres event record state
     value 3
 
 openmetrics.sample_pmda_instname_5_0_0.sample.float.bin [like sample.bin but type FLOAT]
-    Data Type: double  InDom: 144.25666 0x24006442
+    Data Type: double  InDom: 144.26690 0x24006842
     Semantics: instant  Units: none
 Help:
 like sample.bin but type FLOAT
@@ -7591,7 +7598,7 @@ like sample.bin but type FLOAT
     inst [8 or "bin-900"] value 900
 
 openmetrics.sample_pmda_instname_5_0_0.sample.float.bin_ctr [like sample.bin but type FLOAT, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.25667 0x24006443
+    Data Type: double  InDom: 144.26691 0x24006843
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type FLOAT, SEM_COUNTER and SPACE_KBYTE
@@ -7634,7 +7641,7 @@ a 32-bit floating-point value that can be modified
     value 13
 
 openmetrics.sample_pmda_instname_5_0_0.sample.hordes.one [500 instances]
-    Data Type: double  InDom: 144.25675 0x2400644b
+    Data Type: double  InDom: 144.26699 0x2400684b
     Semantics: instant  Units: none
 Help:
 500 instances
@@ -8140,7 +8147,7 @@ Help:
     inst [499 or "499"] value 499
 
 openmetrics.sample_pmda_instname_5_0_0.sample.hordes.two [500 instances]
-    Data Type: double  InDom: 144.25676 0x2400644c
+    Data Type: double  InDom: 144.26700 0x2400684c
     Semantics: instant  Units: none
 Help:
 500 instances
@@ -8660,7 +8667,7 @@ Hypothetical load
     value 42
 
 openmetrics.sample_pmda_instname_5_0_0.sample.long.bin [like sample.bin but type 32]
-    Data Type: double  InDom: 144.25638 0x24006426
+    Data Type: double  InDom: 144.26662 0x24006826
     Semantics: instant  Units: none
 Help:
 like sample.bin but type 32
@@ -8675,7 +8682,7 @@ like sample.bin but type 32
     inst [8 or "bin-900"] value 900
 
 openmetrics.sample_pmda_instname_5_0_0.sample.long.bin_ctr [like sample.bin but type 32, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.25639 0x24006427
+    Data Type: double  InDom: 144.26663 0x24006827
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type 32, SEM_COUNTER and SPACE_KBYTE
@@ -8725,7 +8732,7 @@ a 32-bit integer that can be modified
     value 13
 
 openmetrics.sample_pmda_instname_5_0_0.sample.longlong.bin [like sample.bin but type 64]
-    Data Type: double  InDom: 144.25652 0x24006434
+    Data Type: double  InDom: 144.26676 0x24006834
     Semantics: instant  Units: none
 Help:
 like sample.bin but type 64
@@ -8740,7 +8747,7 @@ like sample.bin but type 64
     inst [8 or "bin-900"] value 900
 
 openmetrics.sample_pmda_instname_5_0_0.sample.longlong.bin_ctr [like sample.bin but type 64, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.25653 0x24006435
+    Data Type: double  InDom: 144.26677 0x24006835
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type 64, SEM_COUNTER and SPACE_KBYTE
@@ -8804,7 +8811,7 @@ number of instances in sample.many.int's domain
     value 5
 
 openmetrics.sample_pmda_instname_5_0_0.sample.many.int [variable sized instance domain]
-    Data Type: double  InDom: 144.25698 0x24006462
+    Data Type: double  InDom: 144.26722 0x24006862
     Semantics: instant  Units: count
 Help:
 variable sized instance domain
@@ -8913,7 +8920,7 @@ interval (in seconds) during which PMDA does not respond to PDUs
     value 0
 
 openmetrics.sample_pmda_instname_5_0_0.sample.part_bin [Several constant instances]
-    Data Type: double  InDom: 144.25608 0x24006408
+    Data Type: double  InDom: 144.26632 0x24006808
     Semantics: instant  Units: none
 Help:
 Several constant instances
@@ -9029,7 +9036,7 @@ count up seconds by multiples of 10, wrap back to 1 second at 1 day
     value 1
 
 openmetrics.sample_pmda_instname_5_0_0.sample.scramble.bin [Several constant instances, instances scrambled]
-    Data Type: double  InDom: 144.25700 0x24006464
+    Data Type: double  InDom: 144.26724 0x24006864
     Semantics: instant  Units: none
 Help:
 Several constant instances, instances scrambled
@@ -9074,7 +9081,7 @@ dynamic *.secret.foo.bar.grunt.snort.six metric
     value 6
 
 openmetrics.sample_pmda_instname_5_0_0.sample.secret.foo.bar.max.redirect [PMDA status]
-    Data Type: double  InDom: 144.25625 0x24006419
+    Data Type: double  InDom: 144.26649 0x24006819
     Semantics: discrete  Units: none
 Help:
 PMDA status
@@ -9128,7 +9135,7 @@ A step function (counter)
     value 520
 
 openmetrics.sample_pmda_instname_5_0_0.sample.ulong.bin [like sample.bin but type U32]
-    Data Type: double  InDom: 144.25645 0x2400642d
+    Data Type: double  InDom: 144.26669 0x2400682d
     Semantics: instant  Units: none
 Help:
 like sample.bin but type U32
@@ -9143,7 +9150,7 @@ like sample.bin but type U32
     inst [8 or "bin-900"] value 900
 
 openmetrics.sample_pmda_instname_5_0_0.sample.ulong.bin_ctr [like sample.bin but type U32, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.25646 0x2400642e
+    Data Type: double  InDom: 144.26670 0x2400682e
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type U32, SEM_COUNTER and SPACE_KBYTE
@@ -9193,7 +9200,7 @@ a 32-bit unsigned integer that can be modified
     value 13
 
 openmetrics.sample_pmda_instname_5_0_0.sample.ulonglong.bin [like sample.bin but type U64]
-    Data Type: double  InDom: 144.25659 0x2400643b
+    Data Type: double  InDom: 144.26683 0x2400683b
     Semantics: instant  Units: none
 Help:
 like sample.bin but type U64
@@ -9208,7 +9215,7 @@ like sample.bin but type U64
     inst [8 or "bin-900"] value 900
 
 openmetrics.sample_pmda_instname_5_0_0.sample.ulonglong.bin_ctr [like sample.bin but type U64, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.25660 0x2400643c
+    Data Type: double  InDom: 144.26684 0x2400683c
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type U64, SEM_COUNTER and SPACE_KBYTE
@@ -9293,7 +9300,7 @@ Count of PDUs transmitted
     value 1854
 
 openmetrics.sample_pmda_pcp5_metadata.sample.colour [Metrics with a "saw-tooth" trend over time]
-    Data Type: 32-bit int  InDom: 144.26627 0x24006803
+    Data Type: 32-bit int  InDom: 144.27651 0x24006c03
     Semantics: instant  Units: none
 Help:
 Metrics with a "saw-tooth" trend over time
@@ -9309,7 +9316,7 @@ A control variable for the "sample" PMDA
     value 0
 
 openmetrics.sample_pmda_pcp5_metadata.sample.double.bin_ctr [like sample.bin but type DOUBLE, SEM_COUNTER and SPACE_KBYTE]
-    Data Type: double  InDom: 144.26626 0x24006802
+    Data Type: double  InDom: 144.27650 0x24006c02
     Semantics: counter  Units: Kbyte
 Help:
 like sample.bin but type DOUBLE, SEM_COUNTER and SPACE_KBYTE
@@ -9331,7 +9338,7 @@ Help:
     value 1
 
 openmetrics.sample_pmda_pcp5_metadata.sample.mirage_longlong [Simple saw-tooth rate, but instances come and go]
-    Data Type: 64-bit int  InDom: 144.26628 0x24006804
+    Data Type: 64-bit int  InDom: 144.27652 0x24006c04
     Semantics: instant  Units: byte / millisec
 Help:
 Simple saw-tooth rate, but instances come and go
@@ -9352,7 +9359,7 @@ long counter that wraps
     value -344
 
 openmetrics.sample_prometheus_metrics.go_gc_duration_seconds [A summary of the GC invocation durations.]
-    Data Type: double  InDom: 144.27648 0x24006c00
+    Data Type: double  InDom: 144.28672 0x24007000
     Semantics: instant  Units: sec
 Help:
 A summary of the GC invocation durations.
@@ -9545,7 +9552,7 @@ Number of bytes obtained by system. Sum of all system allocations.
     value 133160936
 
 openmetrics.sample_prometheus_metrics.http_request_duration_microseconds [The HTTP request latencies in microseconds.]
-    Data Type: double  InDom: 144.27675 0x24006c1b
+    Data Type: double  InDom: 144.28699 0x2400701b
     Semantics: instant  Units: microsec
 Help:
 The HTTP request latencies in microseconds.
@@ -9611,7 +9618,7 @@ The HTTP request latencies in microseconds.
     inst [59 or "59 handler:version quantile:0.99"] value nan
 
 openmetrics.sample_prometheus_metrics.http_request_duration_microseconds_count [The HTTP request latencies in microseconds.]
-    Data Type: double  InDom: 144.27677 0x24006c1d
+    Data Type: double  InDom: 144.28701 0x2400701d
     Semantics: counter  Units: count
 Help:
 The HTTP request latencies in microseconds.
@@ -9637,7 +9644,7 @@ The HTTP request latencies in microseconds.
     inst [19 or "19 handler:version"] value 0
 
 openmetrics.sample_prometheus_metrics.http_request_duration_microseconds_sum [The HTTP request latencies in microseconds.]
-    Data Type: double  InDom: 144.27676 0x24006c1c
+    Data Type: double  InDom: 144.28700 0x2400701c
     Semantics: counter  Units: microsec
 Help:
 The HTTP request latencies in microseconds.
@@ -9663,7 +9670,7 @@ The HTTP request latencies in microseconds.
     inst [19 or "19 handler:version"] value 0
 
 openmetrics.sample_prometheus_metrics.http_request_size_bytes [The HTTP request sizes in bytes.]
-    Data Type: double  InDom: 144.27678 0x24006c1e
+    Data Type: double  InDom: 144.28702 0x2400701e
     Semantics: instant  Units: byte
 Help:
 The HTTP request sizes in bytes.
@@ -9729,7 +9736,7 @@ The HTTP request sizes in bytes.
     inst [59 or "59 handler:version quantile:0.99"] value nan
 
 openmetrics.sample_prometheus_metrics.http_request_size_bytes_count [The HTTP request sizes in bytes.]
-    Data Type: double  InDom: 144.27680 0x24006c20
+    Data Type: double  InDom: 144.28704 0x24007020
     Semantics: counter  Units: count
 Help:
 The HTTP request sizes in bytes.
@@ -9755,7 +9762,7 @@ The HTTP request sizes in bytes.
     inst [19 or "19 handler:version"] value 0
 
 openmetrics.sample_prometheus_metrics.http_request_size_bytes_sum [The HTTP request sizes in bytes.]
-    Data Type: double  InDom: 144.27679 0x24006c1f
+    Data Type: double  InDom: 144.28703 0x2400701f
     Semantics: counter  Units: byte
 Help:
 The HTTP request sizes in bytes.
@@ -9781,7 +9788,7 @@ The HTTP request sizes in bytes.
     inst [19 or "19 handler:version"] value 0
 
 openmetrics.sample_prometheus_metrics.http_requests_total [Total number of HTTP requests made.]
-    Data Type: double  InDom: 144.27681 0x24006c21
+    Data Type: double  InDom: 144.28705 0x24007021
     Semantics: counter  Units: none
 Help:
 Total number of HTTP requests made.
@@ -9795,7 +9802,7 @@ Total number of HTTP requests made.
     inst [7 or "7 code:200 handler:status method:get"] value 1
 
 openmetrics.sample_prometheus_metrics.http_response_size_bytes [The HTTP response sizes in bytes.]
-    Data Type: double  InDom: 144.27682 0x24006c22
+    Data Type: double  InDom: 144.28706 0x24007022
     Semantics: instant  Units: byte
 Help:
 The HTTP response sizes in bytes.
@@ -9861,7 +9868,7 @@ The HTTP response sizes in bytes.
     inst [59 or "59 handler:version quantile:0.99"] value nan
 
 openmetrics.sample_prometheus_metrics.http_response_size_bytes_count [The HTTP response sizes in bytes.]
-    Data Type: double  InDom: 144.27684 0x24006c24
+    Data Type: double  InDom: 144.28708 0x24007024
     Semantics: counter  Units: count
 Help:
 The HTTP response sizes in bytes.
@@ -9887,7 +9894,7 @@ The HTTP response sizes in bytes.
     inst [19 or "19 handler:version"] value 0
 
 openmetrics.sample_prometheus_metrics.http_response_size_bytes_sum [The HTTP response sizes in bytes.]
-    Data Type: double  InDom: 144.27683 0x24006c23
+    Data Type: double  InDom: 144.28707 0x24007023
     Semantics: counter  Units: byte
 Help:
 The HTTP response sizes in bytes.
@@ -9955,7 +9962,7 @@ Virtual memory size in bytes.
     value 170373120
 
 openmetrics.sample_prometheus_metrics.prometheus_build_info [A metric with a constant '1' value labeled by version, revision, branch, and goversion from which prometheus was built.]
-    Data Type: double  InDom: 144.27691 0x24006c2b
+    Data Type: double  InDom: 144.28715 0x2400702b
     Semantics: instant  Units: none
 Help:
 A metric with a constant '1' value labeled by version, revision, branch, and goversion from which prometheus was built.
@@ -9990,7 +9997,7 @@ The max number of concurrent queries.
     value 20
 
 openmetrics.sample_prometheus_metrics.prometheus_evaluator_duration_seconds [The duration of rule group evaluations.]
-    Data Type: double  InDom: 144.27696 0x24006c30
+    Data Type: double  InDom: 144.28720 0x24007030
     Semantics: instant  Units: sec
 Help:
 The duration of rule group evaluations.
@@ -10022,7 +10029,7 @@ The total number of rule group evaluations skipped due to throttled metric stora
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_local_storage_checkpoint_duration_seconds [The duration in seconds taken for checkpointing open chunks and chunks yet to be persisted]
-    Data Type: double  InDom: 144.27700 0x24006c34
+    Data Type: double  InDom: 144.28724 0x24007034
     Semantics: instant  Units: sec
 Help:
 The duration in seconds taken for checkpointing open chunks and chunks yet to be persisted
@@ -10059,7 +10066,7 @@ The size of the last checkpoint of open chunks and chunks yet to be persisted
     value 1584792
 
 openmetrics.sample_prometheus_metrics.prometheus_local_storage_checkpoint_series_chunks_written [The number of chunk written per series while checkpointing open chunks and chunks yet to be persisted.]
-    Data Type: double  InDom: 144.27705 0x24006c39
+    Data Type: double  InDom: 144.28729 0x24007039
     Semantics: instant  Units: none
 Help:
 The number of chunk written per series while checkpointing open chunks and chunks yet to be persisted.
@@ -10089,7 +10096,7 @@ Help:
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_local_storage_chunk_ops_total [The total number of chunk operations by their type.]
-    Data Type: double  InDom: 144.27709 0x24006c3d
+    Data Type: double  InDom: 144.28733 0x2400703d
     Semantics: counter  Units: none
 Help:
 The total number of chunk operations by their type.
@@ -10121,7 +10128,7 @@ A counter incremented each time an inconsistency in the local storage is detecte
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_local_storage_indexing_batch_duration_seconds [Quantiles for batch indexing duration in seconds.]
-    Data Type: double  InDom: 144.27713 0x24006c41
+    Data Type: double  InDom: 144.28737 0x24007041
     Semantics: instant  Units: sec
 Help:
 Quantiles for batch indexing duration in seconds.
@@ -10144,7 +10151,7 @@ Quantiles for batch indexing duration in seconds.
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_local_storage_indexing_batch_sizes [Quantiles for indexing batch sizes (number of metrics per batch).]
-    Data Type: double  InDom: 144.27716 0x24006c44
+    Data Type: double  InDom: 144.28740 0x24007044
     Semantics: instant  Units: none
 Help:
 Quantiles for indexing batch sizes (number of metrics per batch).
@@ -10188,7 +10195,7 @@ The total number of samples ingested.
     value 7177706
 
 openmetrics.sample_prometheus_metrics.prometheus_local_storage_maintain_series_duration_seconds [The duration in seconds it took to perform maintenance on a series.]
-    Data Type: double  InDom: 144.27722 0x24006c4a
+    Data Type: double  InDom: 144.28746 0x2400704a
     Semantics: instant  Units: sec
 Help:
 The duration in seconds it took to perform maintenance on a series.
@@ -10200,7 +10207,7 @@ The duration in seconds it took to perform maintenance on a series.
     inst [5 or "5 location:memory quantile:0.99"] value 0.371275481
 
 openmetrics.sample_prometheus_metrics.prometheus_local_storage_maintain_series_duration_seconds_count [The duration in seconds it took to perform maintenance on a series.]
-    Data Type: double  InDom: 144.27724 0x24006c4c
+    Data Type: double  InDom: 144.28748 0x2400704c
     Semantics: counter  Units: count
 Help:
 The duration in seconds it took to perform maintenance on a series.
@@ -10208,7 +10215,7 @@ The duration in seconds it took to perform maintenance on a series.
     inst [1 or "1 location:memory"] value 20978
 
 openmetrics.sample_prometheus_metrics.prometheus_local_storage_maintain_series_duration_seconds_sum [The duration in seconds it took to perform maintenance on a series.]
-    Data Type: double  InDom: 144.27723 0x24006c4b
+    Data Type: double  InDom: 144.28747 0x2400704b
     Semantics: counter  Units: sec
 Help:
 The duration in seconds it took to perform maintenance on a series.
@@ -10265,7 +10272,7 @@ How often a non-existent series was referred to during label matching or chunk p
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_local_storage_out_of_order_samples_total [The total number of samples that were discarded because their timestamps were at or before the last received sample for a series.]
-    Data Type: double  InDom: 144.27732 0x24006c54
+    Data Type: double  InDom: 144.28756 0x24007054
     Semantics: counter  Units: none
 Help:
 The total number of samples that were discarded because their timestamps were at or before the last received sample for a series.
@@ -10301,7 +10308,7 @@ Help:
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_local_storage_series_chunks_persisted_bucket [The number of chunks persisted per series.]
-    Data Type: double  InDom: 144.27737 0x24006c59
+    Data Type: double  InDom: 144.28761 0x24007059
     Semantics: counter  Units: count
 Help:
 The number of chunks persisted per series.
@@ -10330,7 +10337,7 @@ The number of chunks persisted per series.
     value 45157
 
 openmetrics.sample_prometheus_metrics.prometheus_local_storage_series_ops_total [The total number of series operations by their type.]
-    Data Type: double  InDom: 144.27740 0x24006c5c
+    Data Type: double  InDom: 144.28764 0x2400705c
     Semantics: counter  Units: none
 Help:
 The total number of series operations by their type.
@@ -10375,7 +10382,7 @@ The number of alert notifications in the queue.
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_rule_evaluation_failures_total [The total number of rule evaluation failures.]
-    Data Type: double  InDom: 144.27745 0x24006c61
+    Data Type: double  InDom: 144.28769 0x24007061
     Semantics: counter  Units: none
 Help:
 The total number of rule evaluation failures.
@@ -10383,7 +10390,7 @@ The total number of rule evaluation failures.
     inst [1 or "1 rule_type:recording"] value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_sd_azure_refresh_duration_seconds [The duration of a Azure-SD refresh in seconds.]
-    Data Type: double  InDom: 144.27746 0x24006c62
+    Data Type: double  InDom: 144.28770 0x24007062
     Semantics: instant  Units: sec
 Help:
 The duration of a Azure-SD refresh in seconds.
@@ -10413,7 +10420,7 @@ Number of Azure-SD refresh failures.
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_sd_consul_rpc_duration_seconds [The duration of a Consul RPC call in seconds.]
-    Data Type: double  InDom: 144.27750 0x24006c66
+    Data Type: double  InDom: 144.28774 0x24007066
     Semantics: instant  Units: sec
 Help:
 The duration of a Consul RPC call in seconds.
@@ -10425,7 +10432,7 @@ The duration of a Consul RPC call in seconds.
     inst [5 or "5 call:services endpoint:catalog quantile:0.99"] value nan
 
 openmetrics.sample_prometheus_metrics.prometheus_sd_consul_rpc_duration_seconds_count [The duration of a Consul RPC call in seconds.]
-    Data Type: double  InDom: 144.27752 0x24006c68
+    Data Type: double  InDom: 144.28776 0x24007068
     Semantics: counter  Units: count
 Help:
 The duration of a Consul RPC call in seconds.
@@ -10433,7 +10440,7 @@ The duration of a Consul RPC call in seconds.
     inst [1 or "1 call:services endpoint:catalog"] value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_sd_consul_rpc_duration_seconds_sum [The duration of a Consul RPC call in seconds.]
-    Data Type: double  InDom: 144.27751 0x24006c67
+    Data Type: double  InDom: 144.28775 0x24007067
     Semantics: counter  Units: sec
 Help:
 The duration of a Consul RPC call in seconds.
@@ -10462,7 +10469,7 @@ The number of DNS-SD lookups.
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_sd_ec2_refresh_duration_seconds [The duration of a EC2-SD refresh in seconds.]
-    Data Type: double  InDom: 144.27756 0x24006c6c
+    Data Type: double  InDom: 144.28780 0x2400706c
     Semantics: instant  Units: sec
 Help:
 The duration of a EC2-SD refresh in seconds.
@@ -10499,7 +10506,7 @@ The number of File-SD read errors.
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_sd_file_scan_duration_seconds [The duration of the File-SD scan in seconds.]
-    Data Type: double  InDom: 144.27761 0x24006c71
+    Data Type: double  InDom: 144.28785 0x24007071
     Semantics: instant  Units: sec
 Help:
 The duration of the File-SD scan in seconds.
@@ -10522,7 +10529,7 @@ The duration of the File-SD scan in seconds.
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_sd_gce_refresh_duration [The duration of a GCE-SD refresh in seconds.]
-    Data Type: double  InDom: 144.27764 0x24006c74
+    Data Type: double  InDom: 144.28788 0x24007074
     Semantics: instant  Units: none
 Help:
 The duration of a GCE-SD refresh in seconds.
@@ -10552,7 +10559,7 @@ The number of GCE-SD refresh failures.
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_sd_kubernetes_events_total [The number of Kubernetes events handled.]
-    Data Type: double  InDom: 144.27768 0x24006c78
+    Data Type: double  InDom: 144.28792 0x24007078
     Semantics: counter  Units: none
 Help:
 The number of Kubernetes events handled.
@@ -10570,7 +10577,7 @@ The number of Kubernetes events handled.
     inst [11 or "11 event:update role:service"] value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_sd_marathon_refresh_duration_seconds [The duration of a Marathon-SD refresh in seconds.]
-    Data Type: double  InDom: 144.27769 0x24006c79
+    Data Type: double  InDom: 144.28793 0x24007079
     Semantics: instant  Units: sec
 Help:
 The duration of a Marathon-SD refresh in seconds.
@@ -10600,7 +10607,7 @@ The number of Marathon-SD refresh failures.
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_sd_triton_refresh_duration_seconds [The duration of a Triton-SD refresh in seconds.]
-    Data Type: double  InDom: 144.27773 0x24006c7d
+    Data Type: double  InDom: 144.28797 0x2400707d
     Semantics: instant  Units: sec
 Help:
 The duration of a Triton-SD refresh in seconds.
@@ -10630,7 +10637,7 @@ The number of Triton-SD scrape failures.
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_target_interval_length_seconds [Actual intervals between scrapes.]
-    Data Type: double  InDom: 144.27777 0x24006c81
+    Data Type: double  InDom: 144.28801 0x24007081
     Semantics: instant  Units: sec
 Help:
 Actual intervals between scrapes.
@@ -10641,21 +10648,21 @@ Actual intervals between scrapes.
     inst [4 or "4 interval:15s quantile:0.99"] value 15.000321589
 
 openmetrics.sample_prometheus_metrics.prometheus_target_interval_length_seconds_count [Actual intervals between scrapes.]
-    Data Type: double  InDom: 144.27779 0x24006c83
+    Data Type: double  InDom: 144.28803 0x24007083
     Semantics: counter  Units: count
 Help:
 Actual intervals between scrapes.
     inst [0 or "0 interval:15s"] value 14012
 
 openmetrics.sample_prometheus_metrics.prometheus_target_interval_length_seconds_sum [Actual intervals between scrapes.]
-    Data Type: double  InDom: 144.27778 0x24006c82
+    Data Type: double  InDom: 144.28802 0x24007082
     Semantics: counter  Units: sec
 Help:
 Actual intervals between scrapes.
     inst [0 or "0 interval:15s"] value 507078.1890832364
 
 openmetrics.sample_prometheus_metrics.prometheus_target_scrape_pool_sync_total [Total number of syncs that were executed on a scrape pool.]
-    Data Type: double  InDom: 144.27780 0x24006c84
+    Data Type: double  InDom: 144.28804 0x24007084
     Semantics: counter  Units: none
 Help:
 Total number of syncs that were executed on a scrape pool.
@@ -10676,7 +10683,7 @@ Total number of scrapes that were skipped because the metric storage was throttl
     value 0
 
 openmetrics.sample_prometheus_metrics.prometheus_target_sync_length_seconds [Actual interval to sync the scrape pool.]
-    Data Type: double  InDom: 144.27783 0x24006c87
+    Data Type: double  InDom: 144.28807 0x24007087
     Semantics: instant  Units: sec
 Help:
 Actual interval to sync the scrape pool.
@@ -10687,14 +10694,14 @@ Actual interval to sync the scrape pool.
     inst [4 or "4 quantile:0.99 scrape_job:prometheus"] value nan
 
 openmetrics.sample_prometheus_metrics.prometheus_target_sync_length_seconds_count [Actual interval to sync the scrape pool.]
-    Data Type: double  InDom: 144.27785 0x24006c89
+    Data Type: double  InDom: 144.28809 0x24007089
     Semantics: counter  Units: count
 Help:
 Actual interval to sync the scrape pool.
     inst [0 or "0 scrape_job:prometheus"] value 1
 
 openmetrics.sample_prometheus_metrics.prometheus_target_sync_length_seconds_sum [Actual interval to sync the scrape pool.]
-    Data Type: double  InDom: 144.27784 0x24006c88
+    Data Type: double  InDom: 144.28808 0x24007088
     Semantics: counter  Units: sec
 Help:
 Actual interval to sync the scrape pool.
@@ -10715,46 +10722,6 @@ The total number of ZooKeeper failures.
     value 0
 
 openmetrics.sh_script_no_suffix.some_metric000 [Simple gauge metric with some instances]
-    Data Type: double  InDom: 144.29696 0x24007400
-    Semantics: instant  Units: none
-Help:
-Simple gauge metric with some instances
-    inst [0 or "0 someinst:000"] value 0
-    inst [1 or "1 someinst:001"] value 0
-
-openmetrics.sh_script_no_suffix.some_metric001 [Simple gauge metric with some instances]
-    Data Type: double  InDom: 144.29697 0x24007401
-    Semantics: instant  Units: none
-Help:
-Simple gauge metric with some instances
-    inst [0 or "0 someinst:000"] value 0
-    inst [1 or "1 someinst:001"] value 1
-
-openmetrics.sh_script_no_suffix.some_metric002 [Simple gauge metric with some instances]
-    Data Type: double  InDom: 144.29698 0x24007402
-    Semantics: instant  Units: none
-Help:
-Simple gauge metric with some instances
-    inst [0 or "0 someinst:000"] value 0
-    inst [1 or "1 someinst:001"] value 2
-
-openmetrics.sh_script_no_suffix.some_metric003 [Simple gauge metric with some instances]
-    Data Type: double  InDom: 144.29699 0x24007403
-    Semantics: instant  Units: none
-Help:
-Simple gauge metric with some instances
-    inst [0 or "0 someinst:000"] value 0
-    inst [1 or "1 someinst:001"] value 3
-
-openmetrics.sh_script_no_suffix.some_metric004 [Simple gauge metric with some instances]
-    Data Type: double  InDom: 144.29700 0x24007404
-    Semantics: instant  Units: none
-Help:
-Simple gauge metric with some instances
-    inst [0 or "0 someinst:000"] value 0
-    inst [1 or "1 someinst:001"] value 4
-
-openmetrics.sh_scripted.some_metric000 [Simple gauge metric with some instances]
     Data Type: double  InDom: 144.30720 0x24007800
     Semantics: instant  Units: none
 Help:
@@ -10762,7 +10729,7 @@ Simple gauge metric with some instances
     inst [0 or "0 someinst:000"] value 0
     inst [1 or "1 someinst:001"] value 0
 
-openmetrics.sh_scripted.some_metric001 [Simple gauge metric with some instances]
+openmetrics.sh_script_no_suffix.some_metric001 [Simple gauge metric with some instances]
     Data Type: double  InDom: 144.30721 0x24007801
     Semantics: instant  Units: none
 Help:
@@ -10770,7 +10737,7 @@ Simple gauge metric with some instances
     inst [0 or "0 someinst:000"] value 0
     inst [1 or "1 someinst:001"] value 1
 
-openmetrics.sh_scripted.some_metric002 [Simple gauge metric with some instances]
+openmetrics.sh_script_no_suffix.some_metric002 [Simple gauge metric with some instances]
     Data Type: double  InDom: 144.30722 0x24007802
     Semantics: instant  Units: none
 Help:
@@ -10778,7 +10745,7 @@ Simple gauge metric with some instances
     inst [0 or "0 someinst:000"] value 0
     inst [1 or "1 someinst:001"] value 2
 
-openmetrics.sh_scripted.some_metric003 [Simple gauge metric with some instances]
+openmetrics.sh_script_no_suffix.some_metric003 [Simple gauge metric with some instances]
     Data Type: double  InDom: 144.30723 0x24007803
     Semantics: instant  Units: none
 Help:
@@ -10786,7 +10753,7 @@ Simple gauge metric with some instances
     inst [0 or "0 someinst:000"] value 0
     inst [1 or "1 someinst:001"] value 3
 
-openmetrics.sh_scripted.some_metric004 [Simple gauge metric with some instances]
+openmetrics.sh_script_no_suffix.some_metric004 [Simple gauge metric with some instances]
     Data Type: double  InDom: 144.30724 0x24007804
     Semantics: instant  Units: none
 Help:
@@ -10794,8 +10761,48 @@ Simple gauge metric with some instances
     inst [0 or "0 someinst:000"] value 0
     inst [1 or "1 someinst:001"] value 4
 
-openmetrics.simple_metric.metric1 [Simple gauge metric with three instances]
+openmetrics.sh_scripted.some_metric000 [Simple gauge metric with some instances]
     Data Type: double  InDom: 144.31744 0x24007c00
+    Semantics: instant  Units: none
+Help:
+Simple gauge metric with some instances
+    inst [0 or "0 someinst:000"] value 0
+    inst [1 or "1 someinst:001"] value 0
+
+openmetrics.sh_scripted.some_metric001 [Simple gauge metric with some instances]
+    Data Type: double  InDom: 144.31745 0x24007c01
+    Semantics: instant  Units: none
+Help:
+Simple gauge metric with some instances
+    inst [0 or "0 someinst:000"] value 0
+    inst [1 or "1 someinst:001"] value 1
+
+openmetrics.sh_scripted.some_metric002 [Simple gauge metric with some instances]
+    Data Type: double  InDom: 144.31746 0x24007c02
+    Semantics: instant  Units: none
+Help:
+Simple gauge metric with some instances
+    inst [0 or "0 someinst:000"] value 0
+    inst [1 or "1 someinst:001"] value 2
+
+openmetrics.sh_scripted.some_metric003 [Simple gauge metric with some instances]
+    Data Type: double  InDom: 144.31747 0x24007c03
+    Semantics: instant  Units: none
+Help:
+Simple gauge metric with some instances
+    inst [0 or "0 someinst:000"] value 0
+    inst [1 or "1 someinst:001"] value 3
+
+openmetrics.sh_scripted.some_metric004 [Simple gauge metric with some instances]
+    Data Type: double  InDom: 144.31748 0x24007c04
+    Semantics: instant  Units: none
+Help:
+Simple gauge metric with some instances
+    inst [0 or "0 someinst:000"] value 0
+    inst [1 or "1 someinst:001"] value 4
+
+openmetrics.simple_metric.metric1 [Simple gauge metric with three instances]
+    Data Type: double  InDom: 144.32768 0x24008000
     Semantics: instant  Units: none
 Help:
 Simple gauge metric with three instances
@@ -10804,14 +10811,14 @@ Simple gauge metric with three instances
     inst [2 or "2 hig:246 xyz:something"] value 128
 
 openmetrics.simple_metric.metric2 [Simple gauge metric with one instance]
-    Data Type: double  InDom: 144.31745 0x24007c01
+    Data Type: double  InDom: 144.32769 0x24008001
     Semantics: instant  Units: none
 Help:
 Simple gauge metric with one instance
     inst [0 or "0 efg:0"] value 121
 
 openmetrics.stderr_check.stderr_check [Simple gauge metric with one instance]
-    Data Type: double  InDom: 144.32768 0x24008000
+    Data Type: double  InDom: 144.33792 0x24008400
     Semantics: instant  Units: none
 Help:
 Simple gauge metric with one instance
@@ -10846,7 +10853,7 @@ CPU load for b5be5b9f_b0f1_47de_b436_27f167daf396
     value 0.6245374825293383
 
 openmetrics.thermostat.tms_jvm_gc_4099dd5b_8226_4c13_a697_5e669380060b_wallTime [GC Wall Time for 4099dd5b_8226_4c13_a697_5e669380060b]
-    Data Type: double  InDom: 144.33797 0x24008405
+    Data Type: double  InDom: 144.34821 0x24008805
     Semantics: instant  Units: none
 Help:
 GC Wall Time for 4099dd5b_8226_4c13_a697_5e669380060b
@@ -10854,7 +10861,7 @@ GC Wall Time for 4099dd5b_8226_4c13_a697_5e669380060b
     inst [1 or "1 collector_name:PSScavenge"] value 120532
 
 openmetrics.thermostat.tms_jvm_gc_44157db5_4922_49d0_89de_f20f8bf71ceb_wallTime [GC Wall Time for 44157db5_4922_49d0_89de_f20f8bf71ceb]
-    Data Type: double  InDom: 144.33794 0x24008402
+    Data Type: double  InDom: 144.34818 0x24008802
     Semantics: instant  Units: none
 Help:
 GC Wall Time for 44157db5_4922_49d0_89de_f20f8bf71ceb
@@ -10862,7 +10869,7 @@ GC Wall Time for 44157db5_4922_49d0_89de_f20f8bf71ceb
     inst [1 or "1 collector_name:PSScavenge"] value 4539165
 
 openmetrics.thermostat.tms_jvm_gc_641b7232_19dd_47ae_9cc1_8294b2a09774_wallTime [GC Wall Time for 641b7232_19dd_47ae_9cc1_8294b2a09774]
-    Data Type: double  InDom: 144.33798 0x24008406
+    Data Type: double  InDom: 144.34822 0x24008806
     Semantics: instant  Units: none
 Help:
 GC Wall Time for 641b7232_19dd_47ae_9cc1_8294b2a09774
@@ -10870,7 +10877,7 @@ GC Wall Time for 641b7232_19dd_47ae_9cc1_8294b2a09774
     inst [1 or "1 collector_name:CMS"] value 2932705
 
 openmetrics.thermostat.tms_jvm_gc_b5be5b9f_b0f1_47de_b436_27f167daf396_wallTime [GC Wall Time for b5be5b9f_b0f1_47de_b436_27f167daf396]
-    Data Type: double  InDom: 144.33793 0x24008401
+    Data Type: double  InDom: 144.34817 0x24008801
     Semantics: instant  Units: none
 Help:
 GC Wall Time for b5be5b9f_b0f1_47de_b436_27f167daf396

--- a/qa/1221.out
+++ b/qa/1221.out
@@ -443,6 +443,10 @@ openmetrics.curl_scripted.metric1
 openmetrics.curl_scripted.metric2
     labels {"agent":"openmetrics","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"script":"PCP_PMDAS_DIR/openmetrics/config.d/curl_scripted.sh","source":"curl_scripted","userid":NUM}
 
+openmetrics.duplicate_hostname_label.somenumber
+    labels {"agent":"openmetrics","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"duplicate_hostname_label","url":FILEURL,"userid":NUM}
+    inst [0 or "0 hostname:shack"] labels {"agent":"openmetrics","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"instname":"0 hostname:shack","machineid":MACHINEID,"source":"duplicate_hostname_label","url":FILEURL,"userid":NUM}
+
 openmetrics.good_summary_nometa.sample_counter0010
     labels {"agent":"openmetrics","baz":"2.8","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"good_summary_nometa","url":FILEURL,"userid":NUM}
     inst [0 or "0 baz:0.0"] labels {"agent":"openmetrics","baz":"0.0","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"instname":"0 baz:0.0","machineid":MACHINEID,"source":"good_summary_nometa","url":FILEURL,"userid":NUM}
@@ -7541,6 +7545,10 @@ openmetrics.curl_scripted.metric1
 
 openmetrics.curl_scripted.metric2
     labels {"agent":"openmetrics","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"script":"PCP_PMDAS_DIR/openmetrics/config.d/curl_scripted.sh","source":"curl_scripted","userid":NUM}
+
+openmetrics.duplicate_hostname_label.somenumber
+    labels {"agent":"openmetrics","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"duplicate_hostname_label","url":FILEURL,"userid":NUM}
+    inst [0 or "0 hostname:shack"] labels {"agent":"openmetrics","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"instname":"0 hostname:shack","machineid":MACHINEID,"source":"duplicate_hostname_label","url":FILEURL,"userid":NUM}
 
 openmetrics.good_summary_nometa.sample_counter0010
     labels {"agent":"openmetrics","baz":"2.8","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"good_summary_nometa","url":FILEURL,"userid":NUM}

--- a/qa/openmetrics/samples/duplicate_hostname_label.txt
+++ b/qa/openmetrics/samples/duplicate_hostname_label.txt
@@ -1,0 +1,3 @@
+# HELP somenumber number with value
+# TYPE somenumber gauge
+somenumber {hostname="shack"} 258


### PR DESCRIPTION
If a PMDA already returns instname and instid labels for a
non-singular metric, don't insert them again in the /metrics
webscrape response because they will be duplicates. Duplicate
labels are not OpenMetrics compliant and break some downstream
consumers of the /metrics end-point, e.g. prometheus.

qa/1191 and 1221 are remade with duplicate_hostname_label.txt,
which tickles this bug. An additional QA test to exercise the
updated webapi /metrics code is still coming.