### PR TITLE
pmproxy: more robust fix for instname/instid duplicates

### DIFF
--- a/qa/1543.out
+++ b/qa/1543.out
@@ -968,52 +968,52 @@ sample_long_write_me{hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAI
 # PCP5 sample.dupnames.five.long_bin 29.0.103 32 29.2 instant none
 # HELP sample_dupnames_five_long_bin like sample.bin but type 32
 # TYPE sample_dupnames_five_long_bin gauge
-sample_dupnames_five_long_bin{instname="bin-100",instid="100",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="100"} 100
-sample_dupnames_five_long_bin{instname="bin-200",instid="200",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="200"} 200
-sample_dupnames_five_long_bin{instname="bin-300",instid="300",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="300"} 300
-sample_dupnames_five_long_bin{instname="bin-400",instid="400",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="400"} 400
-sample_dupnames_five_long_bin{instname="bin-500",instid="500",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="500"} 500
-sample_dupnames_five_long_bin{instname="bin-600",instid="600",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="600"} 600
-sample_dupnames_five_long_bin{instname="bin-700",instid="700",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="700"} 700
-sample_dupnames_five_long_bin{instname="bin-800",instid="800",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="800"} 800
-sample_dupnames_five_long_bin{instname="bin-900",instid="900",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="900"} 900
+sample_dupnames_five_long_bin{hostname="HOSTNAME",instid="100",instname="bin-100",domainname="DOMAINNAME",machineid="MACHINEID",bin="100"} 100
+sample_dupnames_five_long_bin{hostname="HOSTNAME",instid="200",instname="bin-200",domainname="DOMAINNAME",machineid="MACHINEID",bin="200"} 200
+sample_dupnames_five_long_bin{hostname="HOSTNAME",instid="300",instname="bin-300",domainname="DOMAINNAME",machineid="MACHINEID",bin="300"} 300
+sample_dupnames_five_long_bin{hostname="HOSTNAME",instid="400",instname="bin-400",domainname="DOMAINNAME",machineid="MACHINEID",bin="400"} 400
+sample_dupnames_five_long_bin{hostname="HOSTNAME",instid="500",instname="bin-500",domainname="DOMAINNAME",machineid="MACHINEID",bin="500"} 500
+sample_dupnames_five_long_bin{hostname="HOSTNAME",instid="600",instname="bin-600",domainname="DOMAINNAME",machineid="MACHINEID",bin="600"} 600
+sample_dupnames_five_long_bin{hostname="HOSTNAME",instid="700",instname="bin-700",domainname="DOMAINNAME",machineid="MACHINEID",bin="700"} 700
+sample_dupnames_five_long_bin{hostname="HOSTNAME",instid="800",instname="bin-800",domainname="DOMAINNAME",machineid="MACHINEID",bin="800"} 800
+sample_dupnames_five_long_bin{hostname="HOSTNAME",instid="900",instname="bin-900",domainname="DOMAINNAME",machineid="MACHINEID",bin="900"} 900
 # PCP5 sample.long.bin 29.0.103 32 29.2 instant none
 # HELP sample_long_bin like sample.bin but type 32
 # TYPE sample_long_bin gauge
-sample_long_bin{instname="bin-100",instid="100",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="100"} 100
-sample_long_bin{instname="bin-200",instid="200",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="200"} 200
-sample_long_bin{instname="bin-300",instid="300",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="300"} 300
-sample_long_bin{instname="bin-400",instid="400",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="400"} 400
-sample_long_bin{instname="bin-500",instid="500",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="500"} 500
-sample_long_bin{instname="bin-600",instid="600",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="600"} 600
-sample_long_bin{instname="bin-700",instid="700",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="700"} 700
-sample_long_bin{instname="bin-800",instid="800",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="800"} 800
-sample_long_bin{instname="bin-900",instid="900",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="900"} 900
+sample_long_bin{hostname="HOSTNAME",instid="100",instname="bin-100",domainname="DOMAINNAME",machineid="MACHINEID",bin="100"} 100
+sample_long_bin{hostname="HOSTNAME",instid="200",instname="bin-200",domainname="DOMAINNAME",machineid="MACHINEID",bin="200"} 200
+sample_long_bin{hostname="HOSTNAME",instid="300",instname="bin-300",domainname="DOMAINNAME",machineid="MACHINEID",bin="300"} 300
+sample_long_bin{hostname="HOSTNAME",instid="400",instname="bin-400",domainname="DOMAINNAME",machineid="MACHINEID",bin="400"} 400
+sample_long_bin{hostname="HOSTNAME",instid="500",instname="bin-500",domainname="DOMAINNAME",machineid="MACHINEID",bin="500"} 500
+sample_long_bin{hostname="HOSTNAME",instid="600",instname="bin-600",domainname="DOMAINNAME",machineid="MACHINEID",bin="600"} 600
+sample_long_bin{hostname="HOSTNAME",instid="700",instname="bin-700",domainname="DOMAINNAME",machineid="MACHINEID",bin="700"} 700
+sample_long_bin{hostname="HOSTNAME",instid="800",instname="bin-800",domainname="DOMAINNAME",machineid="MACHINEID",bin="800"} 800
+sample_long_bin{hostname="HOSTNAME",instid="900",instname="bin-900",domainname="DOMAINNAME",machineid="MACHINEID",bin="900"} 900
 # PCP5 sample.long.bin_ctr 29.0.104 32 29.2 counter Kbyte
 # HELP sample_long_bin_ctr like sample.bin but type 32, SEM_COUNTER and SPACE_KBYTE
 # TYPE sample_long_bin_ctr counter
-sample_long_bin_ctr{instname="bin-100",instid="100",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="100"} 100
-sample_long_bin_ctr{instname="bin-200",instid="200",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="200"} 200
-sample_long_bin_ctr{instname="bin-300",instid="300",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="300"} 300
-sample_long_bin_ctr{instname="bin-400",instid="400",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="400"} 400
-sample_long_bin_ctr{instname="bin-500",instid="500",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="500"} 500
-sample_long_bin_ctr{instname="bin-600",instid="600",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="600"} 600
-sample_long_bin_ctr{instname="bin-700",instid="700",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="700"} 700
-sample_long_bin_ctr{instname="bin-800",instid="800",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="800"} 800
-sample_long_bin_ctr{instname="bin-900",instid="900",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME",bin="900"} 900
+sample_long_bin_ctr{hostname="HOSTNAME",instid="100",instname="bin-100",domainname="DOMAINNAME",machineid="MACHINEID",bin="100"} 100
+sample_long_bin_ctr{hostname="HOSTNAME",instid="200",instname="bin-200",domainname="DOMAINNAME",machineid="MACHINEID",bin="200"} 200
+sample_long_bin_ctr{hostname="HOSTNAME",instid="300",instname="bin-300",domainname="DOMAINNAME",machineid="MACHINEID",bin="300"} 300
+sample_long_bin_ctr{hostname="HOSTNAME",instid="400",instname="bin-400",domainname="DOMAINNAME",machineid="MACHINEID",bin="400"} 400
+sample_long_bin_ctr{hostname="HOSTNAME",instid="500",instname="bin-500",domainname="DOMAINNAME",machineid="MACHINEID",bin="500"} 500
+sample_long_bin_ctr{hostname="HOSTNAME",instid="600",instname="bin-600",domainname="DOMAINNAME",machineid="MACHINEID",bin="600"} 600
+sample_long_bin_ctr{hostname="HOSTNAME",instid="700",instname="bin-700",domainname="DOMAINNAME",machineid="MACHINEID",bin="700"} 700
+sample_long_bin_ctr{hostname="HOSTNAME",instid="800",instname="bin-800",domainname="DOMAINNAME",machineid="MACHINEID",bin="800"} 800
+sample_long_bin_ctr{hostname="HOSTNAME",instid="900",instname="bin-900",domainname="DOMAINNAME",machineid="MACHINEID",bin="900"} 900
 == scrape metric instances ==
 # PCP5 sample.dupnames.four.colour 29.0.5 32 29.1 instant none
 # HELP sample_dupnames_four_colour Metrics with a "saw-tooth" trend over time
 # TYPE sample_dupnames_four_colour gauge
-sample_dupnames_four_colour{instname="red",instid="0",model="RGB",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME"} 143
-sample_dupnames_four_colour{instname="green",instid="1",model="RGB",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME"} 244
-sample_dupnames_four_colour{instname="blue",instid="2",model="RGB",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME"} 345
+sample_dupnames_four_colour{model="RGB",hostname="HOSTNAME",instid="0",instname="red",domainname="DOMAINNAME",machineid="MACHINEID"} 143
+sample_dupnames_four_colour{model="RGB",hostname="HOSTNAME",instid="1",instname="green",domainname="DOMAINNAME",machineid="MACHINEID"} 244
+sample_dupnames_four_colour{model="RGB",hostname="HOSTNAME",instid="2",instname="blue",domainname="DOMAINNAME",machineid="MACHINEID"} 345
 # PCP5 sample.colour 29.0.5 32 29.1 instant none
 # HELP sample_colour Metrics with a "saw-tooth" trend over time
 # TYPE sample_colour gauge
-sample_colour{instname="red",instid="0",model="RGB",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME"} 143
-sample_colour{instname="green",instid="1",model="RGB",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME"} 244
-sample_colour{instname="blue",instid="2",model="RGB",hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME"} 345
+sample_colour{model="RGB",hostname="HOSTNAME",instid="0",instname="red",domainname="DOMAINNAME",machineid="MACHINEID"} 143
+sample_colour{model="RGB",hostname="HOSTNAME",instid="1",instname="green",domainname="DOMAINNAME",machineid="MACHINEID"} 244
+sample_colour{model="RGB",hostname="HOSTNAME",instid="2",instname="blue",domainname="DOMAINNAME",machineid="MACHINEID"} 345
 == scrape all metrics ==
 done full scrape
 == check pmproxy is running ==

--- a/qa/662.out
+++ b/qa/662.out
@@ -318,78 +318,78 @@ metrics: success
 #### PCP5 sample.dupnames.five.bin 29.0.6 32 29.2 instant none
 #### HELP sample_dupnames_five_bin Several constant instances
 #### TYPE sample_dupnames_five_bin gauge
-sample_dupnames_five_bin{instname="bin-100",instid="100",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
-sample_dupnames_five_bin{instname="bin-200",instid="200",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
-sample_dupnames_five_bin{instname="bin-300",instid="300",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
-sample_dupnames_five_bin{instname="bin-400",instid="400",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
-sample_dupnames_five_bin{instname="bin-500",instid="500",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
-sample_dupnames_five_bin{instname="bin-600",instid="600",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
-sample_dupnames_five_bin{instname="bin-700",instid="700",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
-sample_dupnames_five_bin{instname="bin-800",instid="800",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
-sample_dupnames_five_bin{instname="bin-900",instid="900",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
+sample_dupnames_five_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-100",instid="100",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
+sample_dupnames_five_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-200",instid="200",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
+sample_dupnames_five_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-300",instid="300",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
+sample_dupnames_five_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-400",instid="400",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
+sample_dupnames_five_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-500",instid="500",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
+sample_dupnames_five_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-600",instid="600",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
+sample_dupnames_five_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-700",instid="700",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
+sample_dupnames_five_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-800",instid="800",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
+sample_dupnames_five_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-900",instid="900",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
 #### PCP5 sample.dupnames.four.bin 29.0.6 32 29.2 instant none
 #### HELP sample_dupnames_four_bin Several constant instances
 #### TYPE sample_dupnames_four_bin gauge
-sample_dupnames_four_bin{instname="bin-100",instid="100",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
-sample_dupnames_four_bin{instname="bin-200",instid="200",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
-sample_dupnames_four_bin{instname="bin-300",instid="300",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
-sample_dupnames_four_bin{instname="bin-400",instid="400",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
-sample_dupnames_four_bin{instname="bin-500",instid="500",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
-sample_dupnames_four_bin{instname="bin-600",instid="600",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
-sample_dupnames_four_bin{instname="bin-700",instid="700",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
-sample_dupnames_four_bin{instname="bin-800",instid="800",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
-sample_dupnames_four_bin{instname="bin-900",instid="900",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
+sample_dupnames_four_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-100",instid="100",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
+sample_dupnames_four_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-200",instid="200",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
+sample_dupnames_four_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-300",instid="300",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
+sample_dupnames_four_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-400",instid="400",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
+sample_dupnames_four_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-500",instid="500",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
+sample_dupnames_four_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-600",instid="600",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
+sample_dupnames_four_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-700",instid="700",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
+sample_dupnames_four_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-800",instid="800",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
+sample_dupnames_four_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-900",instid="900",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
 #### PCP5 sample.dupnames.three.bin 29.0.6 32 29.2 instant none
 #### HELP sample_dupnames_three_bin Several constant instances
 #### TYPE sample_dupnames_three_bin gauge
-sample_dupnames_three_bin{instname="bin-100",instid="100",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
-sample_dupnames_three_bin{instname="bin-200",instid="200",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
-sample_dupnames_three_bin{instname="bin-300",instid="300",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
-sample_dupnames_three_bin{instname="bin-400",instid="400",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
-sample_dupnames_three_bin{instname="bin-500",instid="500",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
-sample_dupnames_three_bin{instname="bin-600",instid="600",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
-sample_dupnames_three_bin{instname="bin-700",instid="700",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
-sample_dupnames_three_bin{instname="bin-800",instid="800",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
-sample_dupnames_three_bin{instname="bin-900",instid="900",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
+sample_dupnames_three_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-100",instid="100",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
+sample_dupnames_three_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-200",instid="200",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
+sample_dupnames_three_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-300",instid="300",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
+sample_dupnames_three_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-400",instid="400",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
+sample_dupnames_three_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-500",instid="500",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
+sample_dupnames_three_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-600",instid="600",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
+sample_dupnames_three_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-700",instid="700",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
+sample_dupnames_three_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-800",instid="800",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
+sample_dupnames_three_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-900",instid="900",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
 #### PCP5 sample.dupnames.two.bin 29.0.6 32 29.2 instant none
 #### HELP sample_dupnames_two_bin Several constant instances
 #### TYPE sample_dupnames_two_bin gauge
-sample_dupnames_two_bin{instname="bin-100",instid="100",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
-sample_dupnames_two_bin{instname="bin-200",instid="200",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
-sample_dupnames_two_bin{instname="bin-300",instid="300",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
-sample_dupnames_two_bin{instname="bin-400",instid="400",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
-sample_dupnames_two_bin{instname="bin-500",instid="500",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
-sample_dupnames_two_bin{instname="bin-600",instid="600",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
-sample_dupnames_two_bin{instname="bin-700",instid="700",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
-sample_dupnames_two_bin{instname="bin-800",instid="800",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
-sample_dupnames_two_bin{instname="bin-900",instid="900",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
+sample_dupnames_two_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-100",instid="100",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
+sample_dupnames_two_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-200",instid="200",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
+sample_dupnames_two_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-300",instid="300",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
+sample_dupnames_two_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-400",instid="400",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
+sample_dupnames_two_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-500",instid="500",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
+sample_dupnames_two_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-600",instid="600",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
+sample_dupnames_two_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-700",instid="700",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
+sample_dupnames_two_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-800",instid="800",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
+sample_dupnames_two_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-900",instid="900",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
 #### PCP5 sample.bin 29.0.6 32 29.2 instant none
 #### HELP sample_bin Several constant instances
 #### TYPE sample_bin gauge
-sample_bin{instname="bin-100",instid="100",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
-sample_bin{instname="bin-200",instid="200",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
-sample_bin{instname="bin-300",instid="300",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
-sample_bin{instname="bin-400",instid="400",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
-sample_bin{instname="bin-500",instid="500",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
-sample_bin{instname="bin-600",instid="600",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
-sample_bin{instname="bin-700",instid="700",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
-sample_bin{instname="bin-800",instid="800",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
-sample_bin{instname="bin-900",instid="900",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
+sample_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-100",instid="100",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
+sample_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-200",instid="200",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
+sample_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-300",instid="300",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
+sample_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-400",instid="400",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
+sample_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-500",instid="500",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
+sample_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-600",instid="600",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
+sample_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-700",instid="700",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
+sample_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-800",instid="800",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
+sample_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-900",instid="900",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
 
 context #### metrics target=sample.float.bin response code 200
 metrics: success
 #### PCP5 sample.float.bin 29.0.107 float 29.2 instant none
 #### HELP sample_float_bin like sample.bin but type FLOAT
 #### TYPE sample_float_bin gauge
-sample_float_bin{instname="bin-100",instid="100",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
-sample_float_bin{instname="bin-200",instid="200",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
-sample_float_bin{instname="bin-300",instid="300",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
-sample_float_bin{instname="bin-400",instid="400",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
-sample_float_bin{instname="bin-500",instid="500",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
-sample_float_bin{instname="bin-600",instid="600",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
-sample_float_bin{instname="bin-700",instid="700",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
-sample_float_bin{instname="bin-800",instid="800",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
-sample_float_bin{instname="bin-900",instid="900",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
+sample_float_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-100",instid="100",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
+sample_float_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-200",instid="200",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
+sample_float_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-300",instid="300",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
+sample_float_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-400",instid="400",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
+sample_float_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-500",instid="500",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
+sample_float_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-600",instid="600",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
+sample_float_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-700",instid="700",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
+sample_float_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-800",instid="800",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
+sample_float_bin{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-900",instid="900",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
 
 context #### metrics target=sample.double.one response code 200
 metrics: success
@@ -403,30 +403,30 @@ metrics: success
 #### PCP5 sample.long.bin_ctr 29.0.104 32 29.2 counter Kbyte
 #### HELP sample_long_bin_ctr like sample.bin but type 32, SEM_COUNTER and SPACE_KBYTE
 #### TYPE sample_long_bin_ctr counter
-sample_long_bin_ctr{instname="bin-100",instid="100",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
-sample_long_bin_ctr{instname="bin-200",instid="200",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
-sample_long_bin_ctr{instname="bin-300",instid="300",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
-sample_long_bin_ctr{instname="bin-400",instid="400",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
-sample_long_bin_ctr{instname="bin-500",instid="500",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
-sample_long_bin_ctr{instname="bin-600",instid="600",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
-sample_long_bin_ctr{instname="bin-700",instid="700",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
-sample_long_bin_ctr{instname="bin-800",instid="800",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
-sample_long_bin_ctr{instname="bin-900",instid="900",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
+sample_long_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-100",instid="100",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
+sample_long_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-200",instid="200",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
+sample_long_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-300",instid="300",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
+sample_long_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-400",instid="400",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
+sample_long_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-500",instid="500",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
+sample_long_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-600",instid="600",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
+sample_long_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-700",instid="700",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
+sample_long_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-800",instid="800",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
+sample_long_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-900",instid="900",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
 
 context #### metrics target=sample.ulong.bin_ctr response code 200
 metrics: success
 #### PCP5 sample.ulong.bin_ctr 29.0.106 u32 29.2 counter Kbyte
 #### HELP sample_ulong_bin_ctr like sample.bin but type U32, SEM_COUNTER and SPACE_KBYTE
 #### TYPE sample_ulong_bin_ctr counter
-sample_ulong_bin_ctr{instname="bin-100",instid="100",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
-sample_ulong_bin_ctr{instname="bin-200",instid="200",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
-sample_ulong_bin_ctr{instname="bin-300",instid="300",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
-sample_ulong_bin_ctr{instname="bin-400",instid="400",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
-sample_ulong_bin_ctr{instname="bin-500",instid="500",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
-sample_ulong_bin_ctr{instname="bin-600",instid="600",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
-sample_ulong_bin_ctr{instname="bin-700",instid="700",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
-sample_ulong_bin_ctr{instname="bin-800",instid="800",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
-sample_ulong_bin_ctr{instname="bin-900",instid="900",role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
+sample_ulong_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-100",instid="100",domainname="DOMAIN",machineid="MACHINE",bin="100"} 100
+sample_ulong_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-200",instid="200",domainname="DOMAIN",machineid="MACHINE",bin="200"} 200
+sample_ulong_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-300",instid="300",domainname="DOMAIN",machineid="MACHINE",bin="300"} 300
+sample_ulong_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-400",instid="400",domainname="DOMAIN",machineid="MACHINE",bin="400"} 400
+sample_ulong_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-500",instid="500",domainname="DOMAIN",machineid="MACHINE",bin="500"} 500
+sample_ulong_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-600",instid="600",domainname="DOMAIN",machineid="MACHINE",bin="600"} 600
+sample_ulong_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-700",instid="700",domainname="DOMAIN",machineid="MACHINE",bin="700"} 700
+sample_ulong_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-800",instid="800",domainname="DOMAIN",machineid="MACHINE",bin="800"} 800
+sample_ulong_bin_ctr{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",instname="bin-900",instid="900",domainname="DOMAIN",machineid="MACHINE",bin="900"} 900
 
 sleeping briefly to expire contexts
 context #### metadata names=kernel.all.nprocs response code 400

--- a/src/include/pcp/pmwebapi.h
+++ b/src/include/pcp/pmwebapi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2020 Red Hat.
+ * Copyright (c) 2017-2021 Red Hat.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -319,6 +319,8 @@ typedef struct pmWebLabelSet {
     pmLabelSet		*sets[6];
     int			nsets;
     sds			buffer;
+    unsigned int	instid;
+    sds			instname;
 } pmWebLabelSet;
 
 typedef void (*pmWebContextCallBack)(sds, pmWebSource *, void *);

--- a/src/libpcp_web/src/webgroup.c
+++ b/src/libpcp_web/src/webgroup.c
@@ -1664,6 +1664,8 @@ scrape_metric_labelsets(metric_t *metric, pmWebLabelSet *labels)
 	labels->sets[nsets++] = metric->labelset;
     labels->nsets = nsets;
     sdsclear(labels->buffer);
+    labels->instid = PM_IN_NULL;
+    labels->instname = NULL;
 }
 
 static void
@@ -1689,6 +1691,8 @@ scrape_instance_labelsets(metric_t *metric, indom_t *indom, instance_t *inst,
 	labels->sets[nsets++] = inst->labelset;
     labels->nsets = nsets;
     sdsclear(labels->buffer);
+    labels->instid = inst->inst;
+    labels->instname = inst->name.sds;
 }
 
 static int

--- a/src/pmproxy/src/webapi.c
+++ b/src/pmproxy/src/webapi.c
@@ -525,23 +525,9 @@ value:
 	labels = instance->labels;
     if (labels == NULL)
 	labels = metric->labels;
-
-    if (labels) {
-	result = sdscatfmt(result, "%S{", name);
-	if (metric->indom != PM_INDOM_NULL) {
-	    if (strstr(labels, "instname=") == NULL) {
-		/* insert the instname and instid labels */
-		quoted = sdscatrepr(sdsempty(), instance->name, sdslen(instance->name));
-		result = sdscatfmt(result, "instname=%S,instid=\"%u\"",
-					    quoted, instance->inst);
-		sdsfree(quoted);
-		result = sdscatfmt(result, ",%S}", labels);
-	    }
-	    else /* instname and instid labels already provided by PMDA */
-		result = sdscatfmt(result, "%S}", labels);
-	} else
-	    result = sdscatfmt(result, "%S}", labels);
-    } else /* no labels */
+    if (labels)
+	result = sdscatfmt(result, "%S{%S}", name, labels);
+    else /* no labels */
 	result = sdscatsds(result, name);
 
     /* append the value */


### PR DESCRIPTION
Reworks the previous change to ensure duplicate labels for
openmetrics scraping are not created, for the special case
of the instname and instid pseudo-labels.

This removes the use of strstr to detect instname inside the
JSON label string as this approach produces false positives
when instname= is embedded within a label value or simply a
similar label name like myinstname.  The approach now makes
use of the pmLabelSet information before merging it to form
the final combined labels string.

Related to #1407