### PR TITLE
pmdabpf: resolve help text warning from pmdaInit

### DIFF
--- a/src/pmdas/bpf/GNUmakefile
+++ b/src/pmdas/bpf/GNUmakefile
@@ -7,7 +7,7 @@ LIBTARGET = pmda_bpf.$(DSOSUFFIX)
 LLDLIBS = $(PCP_PMDALIB) -lbpf -lelf -lz -lm -ldl
 LCFLAGS = -I.
 CONFIG	= bpf.conf
-DFILES	= README help
+DFILES	= README
 SUBDIRS	= modules
 
 IAM	= bpf

--- a/src/pmdas/bpf/bpf.c
+++ b/src/pmdas/bpf/bpf.c
@@ -34,13 +34,12 @@
 #define CACHE_INDOM_IDS 1
 
 static int	isDSO = 1;		/* =0 I am a daemon */
-static char	mypath[MAXPATHLEN];
 
 /* metric and indom configuration will be dynamically filled in by modules */
 static pmdaMetric * metrictab;
 static pmdaIndom * indomtab;
-static int metric_count = 0;
-static int indom_count = 0;
+static int metric_count;
+static int indom_count;
 static pmdaNameSpace *pmns;
 
 /* command line option handling - both short and long options */
@@ -481,12 +480,8 @@ dict * bpf_config_load()
 void 
 bpf_init(pmdaInterface *dp)
 {
-    if (isDSO) {
-        int sep = pmPathSeparator();
-        pmsprintf(mypath, sizeof(mypath), "%s%c" "bpf" "%c" "help",
-            pmGetConfig("PCP_PMDAS_DIR"), sep, sep);
-        pmdaDSO(dp, PMDA_INTERFACE_7, "bpf", mypath);
-    }
+    if (isDSO)
+        pmdaDSO(dp, PMDA_INTERFACE_7, "bpf", NULL);
 
     if (dp->status != 0)
         return;
@@ -525,16 +520,13 @@ bpf_init(pmdaInterface *dp)
 int
 main(int argc, char **argv)
 {
-    int sep = pmPathSeparator();
     pmdaInterface dispatch;
 
     isDSO = 0;
     pmSetProgname(argv[0]);
 
-    pmsprintf(mypath, sizeof(mypath), "%s%c" "bpf" "%c" "help",
-        pmGetConfig("PCP_PMDAS_DIR"), sep, sep);
     pmdaDaemon(&dispatch, PMDA_INTERFACE_7, pmGetProgname(), BPF,
-        "bpf.log", mypath);
+        "bpf.log", NULL);
 
     pmdaGetOptions(argc, argv, &opts, &dispatch);
     if (opts.errors) {

--- a/src/pmdas/bpf/help
+++ b/src/pmdas/bpf/help
@@ -1,2 +1,0 @@
-@ bpf.runq.latency CPU run queue latency (nanos)
-@ bpf.disk.all.latency disk block io latency (micros)


### PR DESCRIPTION
Help text is generated dynamically by pmdabpf nowadays so
pass NULL to interfaces setting up static help text files
used by other PMDAs.

Fixes: #1419