### PR TITLE
pcp-atop: handle different event naming of ix86arch PMUs

### DIFF
--- a/qa/1978
+++ b/qa/1978
@@ -1,0 +1,63 @@
+#!/bin/sh
+# PCP QA Test No. 1978
+# Exercise pcp-atop handling of fallback to alternate hardware
+# (perfevent) counter name for ix86arch.  Red Hat BZ #1986264.
+#
+# Copyright (c) 2021 Red Hat.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+ATOP="$PCP_BINADM_DIR/pcp-atop"
+test -f "$ATOP" || _notrun "$ATOP is not installed, skipped"
+
+status=1	# failure is the default!
+$sudo rm -rf $tmp.* $seq.full
+trap "cd $here; rm -rf $tmp.*; exit \$status" 0 1 2 3 15
+
+# read from the pcp-atop-threads archive with various atop options
+atop()
+{
+    archive="$1"
+    shift
+    options="$@"
+
+    pcp_options="pcp -z --origin=+0.1 --archive $archive"
+    $pcp_options atop $options 1 >$tmp.out 2>$tmp.err
+
+    echo "=== std out"
+    cat $tmp.out
+    echo "=== std err"
+    cat $tmp.err
+    echo "=== done" && echo
+}
+
+plural="perfevent.hwcounters.INSTRUCTIONS_RETIRED.value"
+single="perfevent.hwcounters.INSTRUCTION_RETIRED.value"
+echo "metric $plural { name -> $single }" > $tmp.conf
+
+# real QA test starts here
+options="-L 160" # very long lines to get all information, incl. IPC
+
+echo "Defaults with core metric naming"
+atop "archives/pcp-atop-threads" $options | tee -a $tmp.default
+
+echo "Creating alternate named archive"
+pmlogrewrite -c $tmp.conf archives/pcp-atop-threads $tmp.pcp-atop-threads
+
+echo "Defaults with ix86arch metric naming"
+atop "$tmp.pcp-atop-threads" $options | tee -a $tmp.changed
+
+echo "Checking alternative name output"
+diff $tmp.default $tmp.changed
+[ $? -eq 0 ] && echo OK
+
+# success, all done
+status=0
+exit

--- a/qa/1978.out
+++ b/qa/1978.out
@@ -1,0 +1,1164 @@
+QA output created by 1978
+Defaults with core metric naming
+=== std out
+
+
+ATOP - shard                                 2021/04/20  15:30:37                                 -----------------                                   2s elapsed
+PRC | sys   56m45s |  user   4h29m | #proc    377 |  #trun      1 | #tslpi   290 |  #tslpu     0 | #zombie    0 |  clones 570e3 |              |  no  procacct |
+CPU | sys       5% |  user     15% | irq      25% |  idle    753% | wait      1% |  guest     0% | ipc     0.45 |  cycl 1.47THz | curf 3.61GHz |  curscal   ?% |
+cpu | sys       1% |  user      3% | irq       3% |  idle     93% | cpu002 w  0% |  guest     0% | ipc     0.49 |  cycl 1.70THz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       1% |  user      2% | irq       3% |  idle     93% | cpu004 w  0% |  guest     0% | ipc     0.48 |  cycl 1.68THz | curf 2.86GHz |  curscal   ?% |
+cpu | sys       1% |  user      2% | irq       3% |  idle     94% | cpu006 w  0% |  guest     0% | ipc     0.49 |  cycl 1.72THz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       1% |  user      2% | irq       3% |  idle     94% | cpu000 w  0% |  guest     0% | ipc     0.45 |  cycl 1.65THz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      1% | irq       3% |  idle     94% | cpu007 w  0% |  guest     0% | ipc     0.38 |  cycl 1.38THz | curf 3.19GHz |  curscal   ?% |
+cpu | sys       0% |  user      1% | irq       3% |  idle     95% | cpu003 w  0% |  guest     0% | ipc     0.43 |  cycl 1.29THz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      1% | irq       3% |  idle     95% | cpu001 w  0% |  guest     0% | ipc     0.44 |  cycl 1.19THz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      1% | irq       3% |  idle     95% | cpu005 w  0% |  guest     0% | ipc     0.42 |  cycl 1.18THz | curf 3.80GHz |  curscal   ?% |
+CPL | avg1    0.16 |  avg5    0.15 | avg15   0.21 |               |              |  csw 721109e3 | intr 33227e5 |               |              |  numcpu     8 |
+MEM | tot    15.3G |  free    2.3G | cache   4.6G |  dirty   2.1M | buff  947.6M |  slab  620.1M | shrss   0.0M |  vmbal   0.0M | zfarc   0.0M |  hptot 512.0M |
+SWP | tot    11.7G |  free   11.7G | swcac   2.1M |  zpool   0.0M | zstor   0.0M |  ksuse   0.0M | kssav   0.0M |               | vmcom  22.9G |  vmlim  19.1G |
+PAG | scan       0 |  steal      0 | stall      0 |               |              |               |              |  swin    1981 | swout  16278 |  oomkill    0 |
+LVM | a_shard-root |  busy      0% | read  345684 |  write 498098 | KiB/r     19 |  KiB/w     40 | MBr/s 3337.9 |  MBw/s 9761.0 | avq     0.00 |  avio  0.0 ns |
+LVM | a_shard-swap |  busy      0% | read      97 |  write      0 | KiB/r     22 |  KiB/w      0 | MBr/s    1.1 |  MBw/s    0.0 | avq     0.00 |  avio  0.0 ns |
+LVM | a_shard-home |  busy      0% | read  693963 |  write 3813e3 | KiB/r      8 |  KiB/w     14 | MBr/s 2785.7 |  MBw/s 26515.8 | avq     0.00 |  avio  0.0 ns |
+DSK |          sda |  busy      1% | read  581080 |  write 2060e3 | KiB/r     21 |  KiB/w     35 | MBr/s 6130.0 |  MBw/s 35802.8 | avq     2.55 |  avio 1.07 ms |
+NET | transport    |  tcpi 2038357 | tcpo 1960897 |  udpi  757044 | udpo  900331 |  tcpao  41287 | tcppo    181 |  tcprs   3111 | tcpie     16 |  udpie      0 |
+NET | network      |  ipi  2699225 | ipo  2740508 |  ipfrw      0 | deliv 2698e3 |               |              |               | icmpi   4670 |  icmpo    211 |
+NET | enp0s25 ---- |  pcki 18188e3 | pcko 2571238 |  sp    0 Mbps | si 8295 Mbps |  so 3718 Mbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+NET | lo      ---- |  pcki  200935 | pcko  200935 |  sp    0 Mbps | si  809 Mbps |  so  809 Mbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+NET | tun0    ---- |  pcki   93648 | pcko  100194 |  sp    0 Mbps | si  245 Mbps |  so   62 Mbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+WWW | reqs      60 | totKB    133 | byt/rq  2269 | iwork     74 | bwork      1 |
+
+    PID SYSCPU USRCPU RDELAY  VGROW  RGROW  RDDSK  WRDSK RUID     EUID     ST EXC  THR S CPUNR  CPU CMD            
+   6532  5m23s 61m35s  0.00s   3.1G 273.8M 21664K     0K nathans  nathans  N-   -   48 S     4   2% Web Content    
+   4307 16m38s 42m05s  0.00s   5.5G 328.5M 17224K    68K nathans  nathans  N-   -   21 S     3   2% gnome-shell    
+   6569  2m25s 42m00s  0.00s   3.6G 799.2M 36924K     0K nathans  nathans  N-   -   46 S     3   1% Web Content    
+   6098  6m43s 28m44s  0.00s   4.9G 835.7M 106.3M   184K nathans  nathans  N-   -  160 S     4   1% firefox        
+   6968 67.28s 17m41s  0.00s  36.7G 207.9M 18164K     0K nathans  nathans  N-   -   15 S     6   1% slack          
+   1242  4m42s  8m04s  0.00s 909.6M 121.3M 40848K   960K redis    redis    N-   -   37 S     4   0% redis-server   
+   7581 64.04s  9m45s  0.00s  36.8G 411.3M  4924K     0K nathans  nathans  N-   -   17 S     2   0% chrome         
+   7465  2m45s  7m31s  0.00s  32.9G 272.6M 114.9M   1.2G nathans  nathans  N-   -   26 S     0   0% chrome         
+   6667 44.76s  8m38s  0.00s   3.0G 291.9M  8860K     0K nathans  nathans  N-   -   43 S     0   0% Web Content    
+   5913 35.93s  8m06s  0.00s 892.0M 157.2M  1496K     0K nathans  nathans  N-   -    4 S     4   0% gnome-terminal 
+ 112368 53.63s  5m29s  0.00s   3.2G 471.2M 15984K     0K nathans  nathans  N-   -   42 S     4   0% Web Content    
+   4471  2m52s  2m45s  0.00s   1.9G 58648K  2964K   144K nathans  nathans  N-   -   25 S     1   0% Xwayland       
+   6289 37.86s  4m42s  0.00s   3.0G 199.4M  5696K     0K nathans  nathans  N-   -   51 S     3   0% Web Content    
+   6234 41.49s  3m41s  0.00s   3.3G 258.5M 13780K     0K nathans  nathans  N-   -   45 S     4   0% Web Content    
+   7505 63.55s  2m31s  0.00s  32.7G 139.6M 10272K   320K nathans  nathans  N-   -   12 S     5   0% chrome         
+ 112334 39.39s  2m31s  0.00s   3.0G 298.6M 11236K     0K nathans  nathans  N-   -   42 S     7   0% Web Content    
+   6860 19.84s 85.94s  0.00s   4.8G 141.8M 99768K  5552K nathans  nathans  N-   -   32 S     5   0% slack          
+   7672 17.36s 87.06s  0.00s  36.6G 159.8M  5096K     0K nathans  nathans  N-   -   15 S     6   0% chrome         
+     58 79.50s  0.28s  0.96s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% kcompactd0     
+    937 40.30s 36.88s  0.00s 11288K  6796K   244K     0K dbus     dbus     N-   -    1 S     7   0% dbus-broker    
+   8038  6.39s 67.50s  0.00s  40.7G 281.4M  1468K     0K nathans  nathans  N-   -   16 S     2   0% chrome         
+ 512101  0.80s 62.63s  0.14s 384.6M 152.7M     0K     0K root     root     N-   -    1 S     3   0% python3        
+   4311 38.58s 21.12s  0.00s   2.6G 15216K  2704K    48K nathans  nathans  N-   -    4 S     6   0% pulseaudio     
+   5896  9.77s 45.79s  1.03s 726.1M 64764K 20464K 60924K nathans  nathans  N-   -    3 S     4   0% hexchat        
+ 149648  8.03s 47.42s  0.00s   2.9G 147.9M 15104K     0K nathans  nathans  N-   -   42 S     1   0% Web Content    
+    848 16.55s 36.70s  1.39s 43748K 20484K  6472K     0K systemd- systemd- N-   -    1 S     2   0% systemd-resolv 
+   6902 14.42s 27.26s  1.45s 573.0M 78016K 10428K    16K nathans  nathans  N-   -   10 S     5   0% slack          
+   4916  5.80s 31.71s  1.00s 524.1M 12032K   120K     0K nathans  nathans  N-   -    3 S     6   0% ibus-daemon    
+     14 33.26s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% rcu_sched      
+   2725  9.26s 18.00s  0.00s 538.8M 21388K   296K     0K geoclue  geoclue  N-   -    4 S     4   0% geoclue        
+   6351  3.21s 23.26s  0.00s   2.6G 103.6M   128K     0K nathans  nathans  N-   -   35 S     6   0% WebExtensions  
+    881 10.41s 14.20s  0.87s 34724K  4140K   836K     0K avahi    avahi    N-   -    1 S     4   0% avahi-daemon   
+    835 20.21s  0.00s  1.64s     0K     0K     0K   2.4G root     root     N-   -    1 S     7   0% jbd2/dm-2-8    
+    905  4.79s 15.10s  1.02s 302.5M  8028K  2288K     0K root     root     N-   -    2 S     5   0% thermald       
+ 510378  6.78s  7.24s  0.05s 136.1M  6476K    48K    48K pcp      pcp      N-   -    2 S     6   0% pmcd           
+ 511132  0.44s 13.47s  0.01s 95564K 65080K   108K 402.9M pcp      pcp      N-   -    1 S     2   0% pmlogger       
+   6475  1.63s 10.86s  0.00s   2.6G 85724K   776K     0K nathans  nathans  N-   -   42 S     1   0% Privileged Con 
+    139 12.39s  0.00s  0.54s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% kswapd0        
+   5007  1.78s  8.92s  0.26s 366.4M  6736K     0K     0K nathans  nathans  N-   -    3 S     7   0% ibus-engine-si 
+ 122007  0.79s  9.68s  0.84s  36.6G 132.6M     4K     0K nathans  nathans  N-   -   13 S     3   0% chrome         
+   4972  2.19s  7.64s  1.13s 478.3M 15392K   152K     0K root     root     N-   -    3 S     2   0% abrt-dbus      
+    960  2.48s  7.14s  1.00s   2.8G 20864K 16720K     0K polkitd  polkitd  N-   -   12 S     1   0% polkitd        
+ 251337  1.64s  7.66s  0.15s  36.6G 128.2M   336K     0K nathans  nathans  N-   -   14 S     2   0% chrome         
+   5620  5.98s  2.42s  0.09s 28200K  8348K     4K     0K nm-openv nm-openv N-   -    1 S     6   0% openvpn        
+ 127014  3.08s  5.27s  0.00s 515.8M  8420K   104K     0K nathans  nathans  N-   -    3 S     7   0% gvfsd-dnssd    
+    995  3.83s  4.51s  0.22s 687.2M 19612K  5520K 18616K root     root     N-   -    3 S     5   0% NetworkManager 
+      1  4.12s  4.05s  0.14s 174.3M 20140K 58136K   200K root     root     N-   -    1 S     2   0% systemd        
+   7539  0.90s  6.58s  0.37s  36.6G 86808K  7832K     0K nathans  nathans  N-   -   13 S     6   0% chrome         
+ 122029  0.89s  6.13s  0.50s  52.7G 161.4M   468K     0K nathans  nathans  N-   -   18 S     6   0% chrome         
+    883  5.14s  1.65s  0.18s  2496K  1848K   248K     0K 61876    61876    N-   -    1 S     4   0% earlyoom       
+   1239  0.87s  5.91s  0.21s   1.9G 56896K 58628K   764K grafana  grafana  N-   -   17 S     5   0% grafana-server 
+ 567882  4.07s  2.10s  0.09s 67172K 31588K    16K     4K nathans  nathans  N-   -    1 R     2   0% pmdaproc       
+ 510402  0.17s  5.71s  0.01s 477.8M 31168K   116K   180K root     root     N-   -    1 S     0   0% python3        
+   4945  0.75s  4.91s  0.49s 545.0M 23384K     0K     0K nathans  nathans  N-   -    4 S     7   0% ibus-extension 
+ 148070  0.40s  4.46s  0.45s  40.6G 131.0M     0K     0K nathans  nathans  N-   -   14 S     0   0% chrome         
+ 507752  0.81s  3.47s  0.03s 188.0M 91044K   976K   544K pcp      pcp      N-   -    2 S     6   0% pmproxy        
+ 510388  1.84s  2.20s  0.01s 26548K  8236K    80K    32K root     root     N-   -    1 S     4   0% pmdalinux      
+ 251324  0.63s  3.38s  0.05s  36.6G 109.1M  3040K     0K nathans  nathans  N-   -   13 S     5   0% chrome         
+    219  4.01s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kworker/7:1H-k 
+   7803  0.34s  3.49s  0.78s  40.6G 136.8M   636K     0K nathans  nathans  N-   -   14 S     5   0% chrome         
+    946  1.58s  2.14s  0.12s 271.9M 12276K  2716K 31788K root     root     N-   -    1 S     6   0% sssd_nss       
+ 536542  0.41s  3.21s  0.02s  36.6G 119.6M   568K     0K nathans  nathans  N-   -   13 S     4   0% chrome         
+ 520551  3.55s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% kworker/3:3-ev 
+     34  3.30s  0.04s  0.50s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% ksoftirqd/4    
+   2658  1.31s  2.02s  0.06s 451.8M  8632K   644K    96K root     root     N-   -    3 S     1   0% upowerd        
+     44  3.02s  0.05s  0.58s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% ksoftirqd/6    
+ 147351  0.21s  2.77s  0.70s  36.6G 128.6M     0K     0K nathans  nathans  N-   -   13 S     1   0% chrome         
+    639  1.73s  1.22s  0.18s 96000K 24664K  1992K 308.8M root     root     N-   -    1 S     1   0% systemd-journa 
+     13  2.94s  0.01s  0.83s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% ksoftirqd/0    
+     24  2.80s  0.15s  0.75s     0K     0K     0K     0K root     root     N-   -    1 S     2   0% ksoftirqd/2    
+   4636  0.56s  2.31s  0.04s 512.4M  7144K  5136K     0K nathans  nathans  N-   -    4 S     1   0% gsd-housekeepi 
+    541  2.61s  0.00s  0.28s     0K     0K     0K 456.8M root     root     N-   -    1 S     5   0% jbd2/dm-0-8    
+   4697  0.12s  2.46s  0.11s   1.1G 338.4M 27128K 15120K nathans  nathans  N-   -    4 S     7   0% gnome-software 
+   7480  2.38s  0.14s  0.03s  32.5G 15792K   128K     0K nathans  nathans  N-   -    1 S     2   0% chrome         
+ 259641  0.76s  1.65s  0.06s 558.1M 40076K 12172K    80K nathans  nathans  N-   -    2 S     6   0% kded4          
+     49  2.17s  0.00s  0.63s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% ksoftirqd/7    
+ 536069  1.94s  0.00s  0.14s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% kworker/u17:0- 
+ 148425  0.18s  1.75s  0.67s  36.6G 121.6M     0K     0K nathans  nathans  N-   -   13 S     2   0% chrome         
+     19  1.92s  0.00s  0.38s     0K     0K     0K     0K root     root     N-   -    1 S     1   0% ksoftirqd/1    
+     39  1.72s  0.01s  0.24s     0K     0K     0K     0K root     root     N-   -    1 S     5   0% ksoftirqd/5    
+    276  1.69s  0.00s  0.65s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kworker/4:1H-k 
+     29  1.64s  0.01s  1.10s     0K     0K     0K     0K root     root     N-   -    1 S     3   0% ksoftirqd/3    
+ 258588  1.64s  0.00s  0.74s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kworker/7:0-kd 
+ 536169  1.60s  0.00s  0.03s     0K     0K    12K     0K root     root     N-   -    1 I     2   0% kworker/u16:4- 
+    318  1.58s  0.00s  0.46s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% kworker/6:1H-k 
+    163  1.55s  0.00s  0.33s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/0:1H-k 
+   5919  0.65s  0.88s  0.00s 230.2M  8508K  6768K     0K nathans  nathans  N-   -    1 S     0   0% bash           
+    955  1.10s  0.39s  0.06s 832.2M 13508K   484K     0K root     root     N-   -    1 S     3   0% systemd-logind 
+ 115755  0.18s  1.09s  0.39s  36.6G 122.6M   260K     0K nathans  nathans  N-   -   13 S     6   0% chrome         
+   4203  0.57s  0.66s  0.48s  7208K  4748K     0K     0K nathans  nathans  N-   -    1 S     4   0% dbus-broker    
+ 116371  0.47s  0.69s  0.00s 230.5M  6948K   660K     0K nathans  nathans  N-   -    1 S     2   0% bash           
+   7521  0.36s  0.72s  0.08s  32.5G 48792K   368K     0K nathans  nathans  N-   -    5 S     2   0% chrome         
+   4538  0.25s  0.72s  0.00s 528.8M  9348K  1180K     0K nathans  nathans  N-   -    4 S     7   0% gvfs-udisks2-v 
+    884  0.18s  0.73s  0.05s 562.6M 43984K 17200K     0K root     root     N-   -    4 S     3   0% firewalld      
+    218  0.90s  0.00s  0.32s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% kworker/3:1H-e 
+ 532562  0.87s  0.00s  0.22s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% kworker/2:0-ev 
+    936  0.27s  0.55s  0.06s 259.9M 10964K  1356K   856K root     root     N-   -    1 S     4   0% sssd_be        
+   7877  0.12s  0.69s  0.00s 237.5M 10016K  4680K   824K nathans  nathans  N-   -    1 S     5   0% vim            
+    904  0.26s  0.54s  0.10s 20716K  9488K   140K     0K root     root     N-   -    1 S     2   0% systemd-machin 
+    137  0.78s  0.00s  0.28s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% kworker/2:1H-e 
+   1981  0.13s  0.63s  0.04s 289.5M 54972K   108K     0K root     root     N-   -    1 S     2   0% python3        
+    416  0.74s  0.00s  0.16s     0K     0K     0K     0K root     root     N-   -    1 I     1   0% kworker/1:1H-k 
+    285  0.73s  0.00s  0.18s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% kworker/5:1H-k 
+   4628  0.30s  0.39s  0.06s 791.2M 23368K  1132K     0K nathans  nathans  N-   -    4 S     1   0% gsd-color      
+ 510389  0.17s  0.50s  0.00s 251.7M 20684K     0K     4K root     root     N-   -    1 S     2   0% python3        
+ 123743  0.12s  0.52s  0.31s  36.6G 97632K     4K     0K nathans  nathans  N-   -   13 S     7   0% chrome         
+    665  0.33s  0.27s  0.30s 53440K 13136K  7248K     0K root     root     N-   -    1 S     6   0% systemd-udevd  
+   1274  0.19s  0.36s  0.05s 27876K 16888K  1516K     0K nathans  nathans  N-   -    1 S     2   0% systemd        
+ 540473  0.51s  0.00s  0.09s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/0:0-cg 
+   2838  0.16s  0.34s  0.03s   1.3G 728.3M 13688K  3284K root     root     N-   -    3 S     4   0% packagekitd    
+   7646  0.14s  0.34s  0.14s  36.6G 76932K   872K     0K nathans  nathans  N-   -   13 S     7   0% chrome         
+   4586  0.07s  0.41s  0.02s 516.9M  6984K   136K     0K nathans  nathans  N-   -    4 S     6   0% goa-identity-s 
+ 558573  0.46s  0.00s  0.00s     0K     0K     8K     0K root     root     N-   -    1 I     7   0% kworker/u16:3- 
+   4642  0.07s  0.37s  0.10s 695.6M 22676K   708K     0K nathans  nathans  N-   -    4 S     3   0% gsd-power      
+   4653  0.02s  0.40s  0.05s 663.2M  9868K   360K     0K nathans  nathans  N-   -    4 S     1   0% gsd-sharing    
+ 533793  0.41s  0.01s  0.07s     0K     0K     0K     0K root     root     N-   -    1 I     1   0% kworker/1:3-ev 
+   4639  0.08s  0.33s  0.11s   1.1G 24128K    96K     0K nathans  nathans  N-   -    4 S     5   0% gsd-media-keys 
+   4652  0.03s  0.37s  0.16s   1.2G 48284K  1508K     0K nathans  nathans  N-   -    6 S     2   0% evolution-alar 
+   4521  0.04s  0.30s  0.02s   1.3G 43212K 30284K    24K nathans  nathans  N-   -    4 S     1   0% evolution-sour 
+ 558544  0.34s  0.00s  0.02s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% kworker/u17:2- 
+    901  0.12s  0.21s  0.09s 257.2M  8740K  4208K   120K root     root     N-   -    1 S     4   0% sssd           
+    849  0.17s  0.16s  0.01s 99572K  2700K   332K  4900K root     root     N-   -    3 S     5   0% auditd         
+    893  0.18s  0.14s  0.00s 300.7M  6452K  1256K     0K root     root     N-   -    5 S     6   0% rngd           
+   4605  0.02s  0.29s  0.16s   1.5G 49368K   704K     0K nathans  nathans  N-   -   11 S     6   0% evolution-cale 
+ 510399  0.19s  0.10s  0.00s 48472K  8996K    28K    56K pcp      pcp      N-   -    2 S     3   0% pmdaperfevent  
+   1258  0.25s  0.04s  0.01s 227.9M  3776K   240K     0K root     root     N-   -    1 S     2   0% crond          
+   1635  0.22s  0.07s  0.05s 25428K  1972K     0K     0K dnsmasq  dnsmasq  N-   -    1 S     0   0% dnsmasq        
+   1673  0.21s  0.07s  0.07s 25436K  1792K     0K     0K dnsmasq  dnsmasq  N-   -    1 S     7   0% dnsmasq        
+   7263  0.14s  0.11s  0.00s 363.4M  4112K     0K     0K nathans  nathans  N-   -    3 S     4   0% speech-dispatc 
+   4924  0.04s  0.20s  0.06s 858.5M 25336K   128K     0K nathans  nathans  N-   -    8 S     6   0% gsd-xsettings  
+   4802  0.01s  0.21s  0.08s   1.0G 36884K   780K     0K nathans  nathans  N-   -    6 S     1   0% evolution-addr 
+    902  0.12s  0.10s  0.01s 437.8M  6264K   164K     0K root     root     N-   -    3 S     4   0% switcheroo-con 
+ 558402  0.21s  0.00s  0.05s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kworker/4:3-mm 
+ 510395  0.06s  0.14s  0.00s 266.9M 24284K     0K     4K pcp      pcp      N-   -    1 S     6   0% python3        
+ 529850  0.07s  0.13s  0.00s 229.0M  7352K   360K     0K nathans  nathans  N-   -    1 S     0   0% bash           
+   7762  0.07s  0.12s  0.07s  32.7G 68236K     0K     0K nathans  nathans  N-   -    6 S     4   0% chrome         
+   1157  0.09s  0.10s  0.00s 374.3M 15880K  1392K     0K root     root     N-   -    1 S     4   0% abrt-dump-jour 
+   4541  0.08s  0.11s  0.00s 394.4M 13076K  1848K     0K root     root     N-   -    5 S     6   0% udisksd        
+ 510387  0.11s  0.08s  0.00s 37404K  7664K    32K     4K pcp      pcp      N-   -    1 S     5   0% pmdasample     
+ 558565  0.19s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% kworker/u16:2- 
+   1158  0.08s  0.10s  0.00s 359.2M 16748K  1180K     0K root     root     N-   -    1 S     3   0% abrt-dump-jour 
+   3365  0.03s  0.15s  0.03s 527.0M 11208K   908K     0K colord   colord   N-   -    4 S     1   0% colord         
+    851  0.06s  0.12s  0.00s  8120K  3996K   348K     0K root     root     N-   -    1 S     5   0% sedispatch     
+ 559476  0.17s  0.00s  0.03s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% kworker/5:2-ev 
+   1156  0.08s  0.08s  0.01s 358.0M 15692K  1376K     8K root     root     N-   -    1 S     5   0% abrt-dump-jour 
+      2  0.16s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% kthreadd       
+     43  0.16s  0.00s  1.08s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% migration/6    
+     48  0.16s  0.00s  0.51s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% migration/7    
+   1275  0.04s  0.11s  0.01s 25144K 14012K   452K     0K pcpqa    pcpqa    N-   -    1 S     1   0% systemd        
+     18  0.15s  0.00s  0.59s     0K     0K     0K     0K root     root     N-   -    1 S     1   0% migration/1    
+     23  0.15s  0.00s  0.34s     0K     0K     0K     0K root     root     N-   -    1 S     2   0% migration/2    
+     28  0.15s  0.00s  0.59s     0K     0K     0K     0K root     root     N-   -    1 S     3   0% migration/3    
+     33  0.15s  0.00s  0.37s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% migration/4    
+     38  0.15s  0.00s  0.30s     0K     0K     0K     0K root     root     N-   -    1 S     5   0% migration/5    
+    926  0.10s  0.04s  0.01s 94000K  3544K   388K   188K chrony   chrony   N-   -    1 S     0   0% chronyd        
+   4678  0.01s  0.12s  0.09s 614.1M 21316K     0K     0K nathans  nathans  N-   -    4 S     7   0% gsd-wacom      
+ 510394  0.08s  0.05s  0.00s 16548K  6632K     0K     4K root     root     N-   -    1 S     1   0% pmdakvm        
+   4951  0.02s  0.10s  0.04s 540.0M 20808K   136K     0K nathans  nathans  N-   -    3 S     1   0% ibus-x11       
+   4638  0.01s  0.10s  0.06s 613.7M 20880K    48K     0K nathans  nathans  N-   -    4 S     7   0% gsd-keyboard   
+   4274  0.03s  0.08s  0.03s 816.5M 12400K   384K     0K nathans  nathans  N-   -    4 S     7   0% gnome-session- 
+ 547825  0.11s  0.00s  0.02s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% kworker/5:0-cg 
+ 510406  0.07s  0.03s  0.00s 16608K  6604K     4K  1548K root     root     N-   -    1 S     5   0% pmdazfs        
+   4515  0.02s  0.08s  0.08s 913.9M 33692K  9088K     0K nathans  nathans  N-   -    6 S     3   0% gnome-shell-ca 
+ 530954  0.05s  0.05s  0.00s 228.8M  7204K     0K     0K nathans  nathans  N-   -    1 S     4   0% bash           
+   4063  0.02s  0.08s  0.01s 729.8M  6300K   480K    16K nathans  nathans  N-   -    4 S     1   0% gnome-keyring- 
+   4608  0.01s  0.08s  0.00s   3.1G 20196K     0K     0K nathans  nathans  N-   -   11 S     5   0% gjs            
+ 537161  0.03s  0.06s  0.00s 229.0M  7344K     8K     0K nathans  nathans  N-   -    1 S     2   0% bash           
+ 553270  0.09s  0.00s  0.01s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% kworker/6:3-ev 
+ 565955  0.09s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/u16:0- 
+   4565  0.01s  0.07s  0.01s 817.1M 28972K   588K     4K nathans  nathans  N-   -    4 S     0   0% goa-daemon     
+     55  0.08s  0.00s  0.01s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% kauditd        
+    943  0.06s  0.02s  0.19s     0K     0K     0K     0K root     root     N-   -    1 S     5   0% psimon         
+ 558607  0.04s  0.03s  0.00s 312.0M 27720K 12764K     4K root     root     N-   -    1 S     4   0% php-fpm        
+   4701  0.01s  0.06s  0.03s 481.1M 17320K  1268K     0K nathans  nathans  N-   -    4 S     3   0% abrt-applet    
+ 561037  0.03s  0.04s  0.00s 41096K 16604K    12K     4K root     root     N-   -    1 S     0   0% /usr/sbin/http 
+   7257  0.06s  0.01s  0.00s 647.6M  8632K  2888K     0K nathans  nathans  N-   -    5 S     7   0% sd_espeak-ng   
+ 541441  0.02s  0.05s  0.00s 228.9M  7312K     0K     0K nathans  nathans  N-   -    1 S     4   0% bash           
+ 127103  0.01s  0.05s  0.00s 707.0M 23140K  3480K    32K nathans  nathans  N-   -    5 S     0   0% tracker-store  
+   4672  0.01s  0.05s  0.07s 594.8M 12088K   196K     0K nathans  nathans  N-   -    6 S     5   0% gsd-smartcard  
+   1008  0.04s  0.02s  0.00s 255.7M 10560K  2052K   236K root     root     N-   -    1 S     6   0% cupsd          
+   6807  0.01s  0.05s  0.00s 228.8M  6656K     0K     0K nathans  nathans  N-   -    1 S     6   0% bash           
+    899  0.03s  0.03s  0.00s 11440K  5400K  2280K     0K root     root     N-   -    1 S     7   0% smartd         
+ 561022  0.06s  0.00s  0.01s     0K     0K     0K     0K root     root     N-   -    1 I     1   0% kworker/1:0-mm 
+   7507  0.01s  0.04s  0.01s  32.5G 106.0M   492K     0K nathans  nathans  N-   -    9 S     6   0% chrome         
+   7476  0.02s  0.03s  0.00s  32.5G 53412K  5444K     0K nathans  nathans  N-   -    1 S     7   0% chrome         
+   7475  0.02s  0.03s  0.00s  32.5G 52348K  1672K     0K nathans  nathans  N-   -    1 S     7   0% chrome         
+   6626  0.02s  0.03s  0.00s 180.2M 26664K     0K     0K nathans  nathans  N-   -    3 S     1   0% RDD Process    
+    880  0.02s  0.03s  0.02s 379.8M  8500K  5852K     0K root     root     N-   -    4 S     1   0% ModemManager   
+ 511710  0.03s  0.02s  0.00s 37396K  8308K     0K   620K pcp      pcp      N-   -    1 S     2   0% pmie           
+ 510401  0.04s  0.01s  0.00s 17048K  7092K     0K     4K root     root     N-   -    1 S     1   0% pmdadm         
+   6019  0.01s  0.04s  0.00s 228.8M  6676K    24K     0K nathans  nathans  N-   -    1 S     4   0% bash           
+   1091  0.03s  0.01s  0.00s   1.6G 63748K 23112K     8K mysql    mysql    N-   -   30 S     6   0% mysqld         
+ 536573  0.01s  0.03s  0.00s  36.6G 59428K     0K     0K nathans  nathans  N-   -   13 S     0   0% chrome         
+    954  0.02s  0.02s  0.00s 528.5M  7388K  1552K     8K root     root     N-   -    4 S     2   0% accounts-daemo 
+ 510383  0.03s  0.01s  0.00s 17280K  7144K   432K    12K root     root     N-   -    1 S     6   0% pmdaroot       
+ 566343  0.01s  0.03s  0.00s 228.7M  7052K     0K     0K pcpqa    pcpqa    N-   -    1 S     0   0% bash           
+ 510386  0.02s  0.02s  0.00s 16500K  5940K     0K     4K root     root     N-   -    1 S     3   0% pmdaxfs        
+    917  0.01s  0.03s  0.02s  9552K  4028K  3596K     0K dbus     dbus     N-   -    1 S     1   0% dbus-broker-la 
+    898  0.03s  0.01s  0.00s 150.2M  3276K   204K     0K rtkit    rtkit    N-   -    3 S     5   0% rtkit-daemon   
+   6909  0.01s  0.02s  0.00s 505.3M 67596K   192K     0K nathans  nathans  N-   -    6 S     5   0% slack          
+   6867  0.01s  0.02s  0.00s 413.6M 30892K  2712K     0K nathans  nathans  N-   -    1 S     2   0% slack          
+    935  0.01s  0.02s  0.00s 477.8M 13268K  4960K     0K root     root     N-   -    3 S     7   0% abrtd          
+   4645  0.01s  0.02s  0.06s 462.8M 12276K     0K     0K nathans  nathans  N-   -    3 S     7   0% gsd-print-noti 
+   3464  0.01s  0.02s  0.00s 547.8M 11996K   300K     4K root     root     N-   -    3 S     5   0% gdm-session-wo 
+ 562091  0.02s  0.01s  0.00s 37828K  7712K    48K     4K pcp      pcp      N-   -    1 S     7   0% pmdaapache     
+   4673  0.00s  0.03s  0.02s 226.5M  5928K    52K     0K nathans  nathans  N-   -    3 S     1   0% gsd-disk-utili 
+   8328  0.01s  0.02s  0.00s 234.1M  5812K   204K     0K nathans  nathans  N-   -    1 S     6   0% gconfd-2       
+   2840  0.02s  0.01s  0.01s 13204K  4272K  1756K     0K root     root     N-   -    1 S     5   0% wpa_supplicant 
+    882  0.01s  0.02s  0.00s  9332K  4168K  1476K     0K root     root     N-   -    1 S     2   0% bluetoothd     
+ 567863  0.03s  0.00s  0.01s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/0:1-ev 
+ 567864  0.03s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% kworker/6:1-ev 
+ 569789  0.01s  0.00s  0.00s 16776K  7360K     0K  1189K nathans  nathans  N-   -    1 S     5   0% pmlogger       
+   6868  0.00s  0.02s  0.00s 413.6M 30976K  2340K     0K nathans  nathans  N-   -    1 S     0   0% slack          
+ 259637  0.01s  0.01s  0.00s 301.8M 15860K   844K     0K nathans  nathans  N-   -    1 S     0   0% kdeinit4       
+   4633  0.00s  0.02s  0.04s 542.9M 12252K     0K     0K nathans  nathans  N-   -    4 S     4   0% gsd-datetime   
+   4205  0.01s  0.01s  0.00s 463.8M 10952K   608K     0K nathans  nathans  N-   -    4 S     5   0% gnome-session- 
+   1261  0.01s  0.01s  0.01s 457.4M  8056K   868K     4K root     root     N-   -    3 S     0   0% gdm            
+   4484  0.00s  0.02s  0.00s 441.4M  7196K   332K     0K nathans  nathans  N-   -    3 S     4   0% gvfsd          
+    889  0.01s  0.01s  0.00s 224.1M  4252K   568K     0K root     root     N-   -    3 S     6   0% low-memory-mon 
+ 569076  0.02s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kworker/u16:1- 
+ 259639  0.00s  0.01s  0.00s 306.8M 15200K  3736K     0K nathans  nathans  N-   -    1 S     6   0% klauncher      
+   4821  0.00s  0.01s  0.00s 544.8M 13700K    20K     0K nathans  nathans  N-   -    3 S     6   0% gsd-printer    
+   4675  0.00s  0.01s  0.02s 520.1M  8492K     0K     0K nathans  nathans  N-   -    4 S     5   0% gsd-sound      
+   4609  0.00s  0.01s  0.05s 157.5M  6864K     0K     0K nathans  nathans  N-   -    3 S     6   0% at-spi2-regist 
+   4676  0.01s  0.00s  0.01s 655.7M  6672K    48K     0K nathans  nathans  N-   -    4 S     2   0% gsd-usb-protec 
+    988  0.01s  0.00s  0.00s 227.2M  6432K   304K     0K root     root     N-   -    3 S     3   0% uresourced     
+   4530  0.00s  0.01s  0.00s 152.8M  6200K    76K   700K nathans  nathans  N-   -    3 S     0   0% dconf-service  
+   4646  0.00s  0.01s  0.03s 655.1M  5972K     0K     0K nathans  nathans  N-   -    3 S     7   0% gsd-rfkill     
+   4648  0.00s  0.01s  0.04s 438.7M  5668K    28K     0K nathans  nathans  N-   -    3 S     6   0% gsd-screensave 
+   4202  0.00s  0.01s  0.01s 18248K  3716K   136K     0K nathans  nathans  N-   -    1 S     2   0% dbus-broker-la 
+    944  0.00s  0.01s  0.01s  5136K  3068K    56K   112K root     root     N-   -    1 S     7   0% alsactl        
+   1257  0.01s  0.00s  0.00s 20948K  2860K   168K     0K root     root     N-   -    1 S     6   0% atd            
+     15  0.01s  0.00s  0.72s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% migration/0    
+ 569077  0.01s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kworker/u16:5- 
+   1721  0.00s  0.00s  0.00s   1.6G 14024K 14996K     0K grafana  grafana  N-   -   14 S     4   0% pcp_redis_data 
+ 561042  0.00s  0.00s  0.00s   2.2G 12360K     0K     0K apache   apache   N-   -   65 S     2   0% /usr/sbin/http 
+ 561041  0.00s  0.00s  0.00s   2.2G 12040K     0K     0K apache   apache   N-   -   65 S     5   0% /usr/sbin/http 
+   6870  0.00s  0.00s  0.00s 413.6M 11472K     0K     0K nathans  nathans  N-   -    1 S     6   0% slack          
+ 561040  0.00s  0.00s  0.00s   2.4G 11288K     0K     0K apache   apache   N-   -   81 S     0   0% /usr/sbin/http 
+ 558615  0.00s  0.00s  0.00s 323.5M 10752K     0K     0K apache   apache   N-   -    1 S     4   0% php-fpm        
+ 558616  0.00s  0.00s  0.00s 323.5M 10752K     0K     0K apache   apache   N-   -    1 S     5   0% php-fpm        
+ 558612  0.00s  0.00s  0.00s 323.5M 10748K     0K     0K apache   apache   N-   -    1 S     4   0% php-fpm        
+ 132118  0.00s  0.00s  0.00s 452.5M 10720K    52K     0K nathans  nathans  N-   -    3 S     4   0% gvfsd-http     
+    897  0.00s  0.00s  0.00s 278.9M 10624K  1364K     0K root     root     N-   -    3 S     6   0% rsyslogd       
+ 558613  0.00s  0.00s  0.00s 323.5M 10516K     0K     0K apache   apache   N-   -    1 S     1   0% php-fpm        
+ 558614  0.00s  0.00s  0.00s 323.5M 10508K     0K     0K apache   apache   N-   -    1 S     0   0% php-fpm        
+ 566340  0.00s  0.00s  0.00s 256.3M  9332K     0K     0K nathans  root     N-   -    1 S     3   0% sudo           
+ 561038  0.00s  0.00s  0.00s 52144K  8816K     0K     0K apache   apache   N-   -    1 S     7   0% /usr/sbin/http 
+   5608  0.00s  0.00s  0.00s 388.4M  8668K   196K     0K root     root     N-   -    3 S     7   0% nm-openvpn-ser 
+ 126992  0.00s  0.00s  0.00s 586.2M  8048K   156K     0K nathans  nathans  N-   -    4 S     6   0% gvfsd-network  
+ 126984  0.00s  0.00s  0.00s 513.6M  7904K   184K     0K nathans  nathans  N-   -    3 S     4   0% gvfsd-trash    
+ 566342  0.00s  0.00s  0.00s 254.5M  7504K     0K     4K root     root     N-   -    1 S     3   0% su             
+   1230  0.00s  0.00s  0.00s 812.3M  7492K   304K     0K root     root     N-   -   12 S     0   0% pcscd          
+ 510409  0.00s  0.00s  0.00s 37176K  7344K    52K     4K pcp      pcp      N-   -    1 S     3   0% pmdasimple     
+ 510393  0.00s  0.00s  0.00s 37176K  7280K     0K     4K pcp      pcp      N-   -    1 S     3   0% pmdamounts     
+   4593  0.00s  0.00s  0.00s 514.4M  7248K   100K     0K nathans  nathans  N-   -    4 S     4   0% gvfs-afc-volum 
+   4453  0.00s  0.00s  0.00s 301.1M  7084K     0K     0K nathans  nathans  N-   -    4 S     0   0% at-spi-bus-lau 
+   1012  0.00s  0.00s  0.00s 29964K  6868K  1128K     0K root     root     N-   -    1 S     6   0% sshd           
+   4943  0.00s  0.00s  0.00s 438.6M  6316K     0K     0K nathans  nathans  N-   -    4 S     0   0% ibus-dconf     
+   4958  0.00s  0.00s  0.00s 438.3M  6284K     0K     0K nathans  nathans  N-   -    3 S     1   0% ibus-portal    
+   4575  0.00s  0.00s  0.00s 366.1M  6200K   204K   124K nathans  nathans  N-   -    3 S     6   0% gvfsd-metadata 
+   4627  0.00s  0.00s  0.02s 511.2M  6096K     0K     0K nathans  nathans  N-   -    4 S     5   0% gsd-a11y-setti 
+   4574  0.00s  0.00s  0.00s 438.3M  6036K   112K     0K nathans  nathans  N-   -    3 S     7   0% gvfs-goa-volum 
+   1337  0.00s  0.00s  0.00s 58168K  5972K     0K     0K pcpqa    pcpqa    N-   -    1 S     6   0% (sd-pam        
+   1338  0.00s  0.00s  0.00s 58168K  5968K     0K     0K nathans  nathans  N-   -    1 S     6   0% (sd-pam        
+   4489  0.00s  0.00s  0.00s 370.8M  5928K   316K     0K nathans  nathans  N-   -    6 S     4   0% gvfsd-fuse     
+   4566  0.00s  0.00s  0.00s 440.0M  5812K   620K     0K nathans  nathans  N-   -    3 S     3   0% gvfs-gphoto2-v 
+   4200  0.00s  0.00s  0.00s 365.3M  5396K     4K     0K nathans  nathans  N-   -    3 S     5   0% gdm-wayland-se 
+   4570  0.00s  0.00s  0.00s 437.8M  5148K   104K     0K nathans  nathans  N-   -    3 S     1   0% gvfs-mtp-volum 
+   7253  0.00s  0.00s  0.00s 350.3M  5004K   136K     0K nathans  nathans  N-   -    3 S     2   0% sd_dummy       
+   4511  0.00s  0.00s  0.00s 437.3M  4464K     4K     0K nathans  nathans  N-   -    3 S     1   0% xdg-permission 
+   4271  0.00s  0.00s  0.00s 155.2M  4372K     0K     0K nathans  nathans  N-   -    3 S     5   0% uresourced     
+ 569742  0.00s  0.00s  0.00s 217.3M  4036K     0K     0K nathans  nathans  N-   -    1 S     6   0% mk.atop-thread 
+   4270  0.00s  0.00s  0.00s 296.2M  4008K    20K     0K nathans  nathans  N-   -    2 S     3   0% gnome-session- 
+ 116463  0.00s  0.00s  0.00s  7152K  3984K   268K     0K nathans  nathans  N-   -    1 S     0   0% ssh-agent      
+   4458  0.00s  0.00s  0.00s  9024K  3256K     0K     0K nathans  nathans  N-   -    1 S     2   0% dbus-broker-la 
+   1026  0.00s  0.00s  0.00s 262.9M  3012K    92K     0K root     root     N-   -    6 S     4   0% gssproxy       
+   4461  0.00s  0.00s  0.03s  5244K  2872K     0K     0K nathans  nathans  N-   -    1 S     7   0% dbus-broker    
+   7477  0.00s  0.00s  0.00s  32.0G  2528K  1596K     0K nathans  nathans  N-   -    1 S     5   0% nacl_helper    
+    890  0.00s  0.00s  0.00s 11636K  1968K   272K     0K root     root     N-   -    1 S     1   0% mcelog         
+   7471  0.00s  0.00s  0.00s 215.6M   372K     0K     0K nathans  nathans  N-   -    1 S     3   0% cat            
+    908  0.00s  0.00s  0.00s 34376K   344K     0K     0K avahi    avahi    N-   -    1 S     6   0% avahi-daemon   
+   1636  0.00s  0.00s  0.00s 25332K   344K     0K     0K root     root     N-   -    1 S     0   0% dnsmasq        
+   1675  0.00s  0.00s  0.00s 25332K   340K     0K     0K root     root     N-   -    1 S     4   0% dnsmasq        
+   7472  0.00s  0.00s  0.00s 215.6M   280K     0K     0K nathans  nathans  N-   -    1 S     4   0% cat            
+      3  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% rcu_gp         
+      4  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% rcu_par_gp     
+      6  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/0:0H-e 
+      9  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% mm_percpu_wq   
+     10  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% rcu_tasks_kthr 
+     11  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% rcu_tasks_rude 
+     12  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% rcu_tasks_trac 
+     16  0.00s  0.00s  0.01s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% cpuhp/0        
+     17  0.00s  0.00s  0.01s     0K     0K     0K     0K root     root     N-   -    1 S     1   0% cpuhp/1        
+     21  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     1   0% kworker/1:0H-e 
+     22  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     2   0% cpuhp/2        
+     26  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% kworker/2:0H-e 
+     27  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     3   0% cpuhp/3        
+     31  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% kworker/3:0H-k 
+     32  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% cpuhp/4        
+     36  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kworker/4:0H-e 
+     37  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     5   0% cpuhp/5        
+     41  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% kworker/5:0H-e 
+     42  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% cpuhp/6        
+     46  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% kworker/6:0H-e 
+     47  0.00s  0.00s  0.03s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% cpuhp/7        
+     51  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kworker/7:0H-k 
+     52  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     3   0% kdevtmpfs      
+     53  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% netns          
+     54  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% inet_frag_wq   
+     56  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% oom_reaper     
+     57  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% writeback      
+     59  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% ksmd           
+     60  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     2   0% khugepaged     
+     80  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% cryptd         
+    127  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kintegrityd    
+    128  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kblockd        
+    129  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% blkcg_punt_bio 
+    130  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% tpm_dev_wq     
+    131  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% ata_sff        
+    132  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% md             
+    133  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% edac-poller    
+    135  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% watchdogd      
+    141  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kthrotld       
+    144  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% acpi_thermal_p 
+    145  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     3   0% scsi_eh_0      
+    146  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% scsi_tmf_0     
+    147  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     5   0% scsi_eh_1      
+    148  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% scsi_tmf_1     
+    149  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% scsi_eh_2      
+    150  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% scsi_tmf_2     
+    151  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% scsi_eh_3      
+    152  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% scsi_tmf_3     
+    153  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     5   0% scsi_eh_4      
+    154  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% scsi_tmf_4     
+    155  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     2   0% scsi_eh_5      
+    156  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% scsi_tmf_5     
+    161  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% dm_bufio_cache 
+    164  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% ipv6_addrconf  
+    170  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% kstrp          
+    210  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% zswap-shrink   
+    420  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% sdhci          
+    421  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     1   0% irq/34-mmc0    
+    469  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% card0-crtc0    
+    470  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% card0-crtc1    
+    471  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% card0-crtc2    
+    472  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% nvkm-disp      
+    474  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% ttm_swap       
+    475  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% card1-crtc0    
+    476  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% card1-crtc1    
+    477  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% card1-crtc2    
+    478  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% card1-crtc3    
+    519  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% kdmflush       
+    526  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kdmflush       
+    542  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% ext4-rsv-conve 
+    710  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% irq/37-mei_me  
+    721  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% cfg80211       
+    730  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% ktpacpid       
+    738  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% kdmflush       
+    739  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% irq/38-iwlwifi 
+    820  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     2   0% irq/41-rmi4_sm 
+    833  0.00s  0.00s  0.00s     0K     0K     0K    36K root     root     N-   -    1 S     2   0% jbd2/sda1-8    
+    834  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% ext4-rsv-conve 
+    836  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% ext4-rsv-conve 
+    868  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% rpciod         
+    869  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% xprtiod        
+   4402  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     1   0% krfcommd       
+ 558611  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kworker/7:2-ev 
+ 558619  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% kworker/3:1-ev 
+ 565507  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% kworker/2:1    
+ 568536  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kworker/4:1-ev 
+ 568999  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/u17:1  
+ 569377  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% kworker/6:0    
+ 569608  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kworker/4:0-ev 
+ 569686  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/0:2    
+ 569687  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/0:3-ev 
+ 569799  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    0 -     0   0%                
+
+
+ATOP - shard                                 2021/04/20  15:30:38                                 -----------------                                   1s elapsed
+PRC | sys    0.11s |  user   0.07s | #proc    377 |  #trun      1 | #tslpi   290 |  #tslpu     0 | #zombie    0 |  clones     4 |              |  no  procacct |
+CPU | sys      15% |  user     12% | irq      25% |  idle    748% | wait      0% |  guest     0% | ipc     0.62 |  cycl  186MHz | curf 3.55GHz |  curscal   ?% |
+cpu | sys      11% |  user      5% | irq       3% |  idle     81% | cpu002 w  0% |  guest     0% | ipc     1.03 |  cycl  550MHz | curf 3.50GHz |  curscal   ?% |
+cpu | sys       0% |  user      2% | irq       4% |  idle     94% | cpu006 w  0% |  guest     0% | ipc     0.47 |  cycl  190MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      2% | irq       3% |  idle     95% | cpu004 w  0% |  guest     0% | ipc     0.32 |  cycl  158MHz | curf 2.98GHz |  curscal   ?% |
+cpu | sys       1% |  user      1% | irq       3% |  idle     95% | cpu003 w  0% |  guest     0% | ipc     0.46 |  cycl  127MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       1% |  user      1% | irq       3% |  idle     95% | cpu005 w  0% |  guest     0% | ipc     0.78 |  cycl  130MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      0% | irq       5% |  idle     95% | cpu007 w  0% |  guest     0% | ipc     0.19 |  cycl  118MHz | curf 2.90GHz |  curscal   ?% |
+cpu | sys       1% |  user      1% | irq       2% |  idle     96% | cpu000 w  0% |  guest     0% | ipc     0.15 |  cycl  128MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      0% | irq       4% |  idle     96% | cpu001 w  0% |  guest     0% | ipc     0.16 |  cycl   85MHz | curf 3.80GHz |  curscal   ?% |
+CPL | avg1    0.16 |  avg5    0.15 | avg15   0.21 |               |              |  csw     3214 | intr   16594 |               |              |  numcpu     8 |
+MEM | tot    15.3G |  free    2.3G | cache   4.6G |  dirty   3.5M | buff  947.6M |  slab  620.1M | shrss   0.0M |  vmbal   0.0M | zfarc   0.0M |  hptot 512.0M |
+SWP | tot    11.7G |  free   11.7G | swcac   2.1M |  zpool   0.0M | zstor   0.0M |  ksuse   0.0M | kssav   0.0M |               | vmcom  22.9G |  vmlim  19.1G |
+NET | transport    |  tcpi      33 | tcpo      36 |  udpi       3 | udpo       3 |  tcpao      7 | tcppo      0 |  tcprs      0 | tcpie      0 |  udpie      0 |
+NET | network      |  ipi       23 | ipo       26 |  ipfrw      0 | deliv     23 |               |              |               | icmpi      0 |  icmpo      0 |
+NET | enp0s25 ---- |  pcki      86 | pcko      16 |  sp    0 Mbps | si   61 Kbps |  so   35 Kbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+NET | lo      ---- |  pcki      26 | pcko      26 |  sp    0 Mbps | si   24 Kbps |  so   24 Kbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+
+    PID SYSCPU USRCPU RDELAY  VGROW  RGROW  RDDSK  WRDSK RUID     EUID     ST EXC  THR S CPUNR  CPU CMD            
+ 567882  0.10s  0.04s  0.00s   148K   264K     0K     0K nathans  nathans  --   -    1 R     2  15% pmdaproc       
+   6569  0.00s  0.01s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   46 S     4   2% Web Content    
+ 569789  0.00s  0.01s  0.00s  7144K  4580K     0K  1164K nathans  nathans  --   -    1 S     5   1% pmlogger       
+ 510378  0.00s  0.00s  0.00s     0K     0K     0K     0K pcp      pcp      --   -    2 S     6   0% pmcd           
+   6098  0.00s  0.00s  0.00s     0K -1484K     0K     0K nathans  nathans  --   -  160 S     6   0% firefox        
+ 112334  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     6   0% Web Content    
+   6968  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   15 S     6   0% slack          
+   4311  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    4 S     0   0% pulseaudio     
+ 510388  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     4   0% pmdalinux      
+    905  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    2 S     5   0% thermald       
+ 510406  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     5   0% pmdazfs        
+ 112368  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     0   0% Web Content    
+   6667  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   43 S     0   0% Web Content    
+   8038  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   16 S     2   0% chrome         
+   6532  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   48 S     4   0% Web Content    
+   7465  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   26 S     4   0% chrome         
+   6234  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   45 S     3   0% Web Content    
+   6289  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   51 S     3   0% Web Content    
+ 512101  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     3   0% python3        
+ 149648  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     1   0% Web Content    
+ 251337  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   14 S     2   0% chrome         
+   6351  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   35 S     6   0% WebExtensions  
+ 507752  0.00s  0.00s  0.00s     0K     0K     0K     0K pcp      pcp      --   -    2 S     6   0% pmproxy        
+   6475  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     1   0% Privileged Con 
+ 259641  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    2 S     6   0% kded4          
+ 558607  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     6   0% php-fpm        
+   6626  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    3 S     1   0% RDD Process    
+   2725  0.00s  0.00s  0.00s     0K     0K     0K     0K geoclue  geoclue  --   -    4 S     2   0% geoclue        
+    848  0.00s  0.00s  0.00s     0K     0K     0K     0K systemd- systemd- --   -    1 S     0   0% systemd-resolv 
+      1  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     0   0% systemd        
+   7480  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     2   0% chrome         
+   4972  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    3 S     5   0% abrt-dbus      
+ 561042  0.00s  0.00s  0.00s     0K     0K     0K     0K apache   apache   --   -   65 S     2   0% /usr/sbin/http 
+    904  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     0   0% systemd-machin 
+ 510399  0.00s  0.00s  0.00s     0K     0K     0K     0K pcp      pcp      --   -    2 S     3   0% pmdaperfevent  
+ 127014  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    3 S     6   0% gvfsd-dnssd    
+ 530954  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     4   0% bash           
+   1338  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     6   0% (sd-pam        
+   8328  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     6   0% gconfd-2       
+    881  0.00s  0.00s  0.00s     0K     0K     0K     0K avahi    avahi    --   -    1 S     4   0% avahi-daemon   
+   7263  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    3 S     4   0% speech-dispatc 
+ 569742  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     6   0% mk.atop-thread 
+ 116463  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     0   0% ssh-agent      
+     14  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     1   0% rcu_sched      
+     24  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     2   0% ksoftirqd/2    
+     29  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     3   0% ksoftirqd/3    
+     58  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     7   0% kcompactd0     
+    137  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     2   0% kworker/2:1H-e 
+    276  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     4   0% kworker/4:1H-k 
+ 258588  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     7   0% kworker/7:0-ev 
+ 520551  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     3   0% kworker/3:3-mm 
+ 532562  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     2   0% kworker/2:0-ev 
+ 533793  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     1   0% kworker/1:3-ev 
+ 536169  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     2   0% kworker/u16:4- 
+ 558573  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     7   0% kworker/u16:3- 
+ 559476  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     5   0% kworker/5:2-ev 
+ 561022  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     1   0% kworker/1:0-mm 
+ 567864  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     6   0% kworker/6:1-ev 
+ 569076  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     0   0% kworker/u16:1- 
+ 569608  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     4   0% kworker/4:0-ev 
+ 569687  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     0   0% kworker/0:3-ev 
+ 569803  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    0 -     0   0%                
+
+
+ATOP - shard                                 2021/04/20  15:30:39                                 -----------------                                   1s elapsed
+PRC | sys    0.13s |  user   0.13s | #proc    377 |  #trun      1 | #tslpi   291 |  #tslpu     0 | #zombie    0 |  clones     0 |              |  no  procacct |
+CPU | sys      13% |  user     16% | irq      26% |  idle    745% | wait      0% |  guest     0% | ipc     0.62 |  cycl  175MHz | curf 3.56GHz |  curscal   ?% |
+cpu | sys       9% |  user      6% | irq       3% |  idle     82% | cpu002 w  0% |  guest     0% | ipc     1.09 |  cycl  527MHz | curf 3.50GHz |  curscal   ?% |
+cpu | sys       0% |  user      6% | irq       3% |  idle     91% | cpu003 w  0% |  guest     0% | ipc     0.65 |  cycl  231MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      2% | irq       2% |  idle     96% | cpu005 w  0% |  guest     0% | ipc     0.60 |  cycl   96MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       1% |  user      1% | irq       3% |  idle     95% | cpu006 w  0% |  guest     0% | ipc     0.19 |  cycl  130MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       1% |  user      0% | irq       3% |  idle     96% | cpu007 w  0% |  guest     0% | ipc     0.17 |  cycl  112MHz | curf 2.90GHz |  curscal   ?% |
+cpu | sys       0% |  user      1% | irq       4% |  idle     95% | cpu000 w  0% |  guest     0% | ipc     0.20 |  cycl  116MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       1% |  user      0% | irq       3% |  idle     95% | cpu004 w  1% |  guest     0% | ipc     0.15 |  cycl  109MHz | curf 3.10GHz |  curscal   ?% |
+cpu | sys       1% |  user      0% | irq       3% |  idle     96% | cpu001 w  0% |  guest     0% | ipc     0.12 |  cycl   80MHz | curf 3.80GHz |  curscal   ?% |
+CPL | avg1    0.16 |  avg5    0.15 | avg15   0.21 |               |              |  csw     2200 | intr   16357 |               |              |  numcpu     8 |
+MEM | tot    15.3G |  free    2.3G | cache   4.6G |  dirty   4.7M | buff  947.6M |  slab  620.1M | shrss   0.0M |  vmbal   0.0M | zfarc   0.0M |  hptot 512.0M |
+SWP | tot    11.7G |  free   11.7G | swcac   2.1M |  zpool   0.0M | zstor   0.0M |  ksuse   0.0M | kssav   0.0M |               | vmcom  22.9G |  vmlim  19.1G |
+NET | transport    |  tcpi      44 | tcpo      44 |  udpi       0 | udpo       0 |  tcpao      6 | tcppo      2 |  tcprs      0 | tcpie      0 |  udpie      0 |
+NET | network      |  ipi       24 | ipo       24 |  ipfrw      0 | deliv     24 |               |              |               | icmpi      0 |  icmpo      0 |
+NET | lo      ---- |  pcki      43 | pcko      43 |  sp    0 Mbps | si   44 Kbps |  so   44 Kbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+NET | enp0s25 ---- |  pcki      85 | pcko      10 |  sp    0 Mbps | si   53 Kbps |  so    9 Kbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+
+    PID SYSCPU USRCPU RDELAY  VGROW  RGROW  RDDSK  WRDSK RUID     EUID     ST EXC  THR S CPUNR  CPU CMD            
+ 567882  0.09s  0.05s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 R     2  14% pmdaproc       
+   6569  0.00s  0.06s  0.00s     0K   800K     0K     0K nathans  nathans  --   -   46 S     7   8% Web Content    
+   6098  0.00s  0.00s  0.00s   -20K  1784K     0K     0K nathans  nathans  --   -  160 S     5   2% firefox        
+   4307  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   21 S     4   2% gnome-shell    
+ 569789  0.00s  0.00s  0.00s    -4K   236K     0K  1151K nathans  nathans  --   -    1 S     5   1% pmlogger       
+     24  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     2   1% ksoftirqd/2    
+ 112368  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     3   0% Web Content    
+   7581  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   17 S     4   0% chrome         
+ 112334  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     6   0% Web Content    
+   6667  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   43 S     6   0% Web Content    
+   8038  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   16 S     2   0% chrome         
+   6532  0.00s  0.00s  0.00s     0K   136K     0K     0K nathans  nathans  --   -   48 S     2   0% Web Content    
+   6234  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   45 S     3   0% Web Content    
+   6289  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   51 S     3   0% Web Content    
+   7672  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   15 S     6   0% chrome         
+ 512101  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     3   0% python3        
+ 149648  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     1   0% Web Content    
+   1242  0.00s  0.00s  0.00s     0K     0K     0K     0K redis    redis    --   -   37 S     6   0% redis-server   
+   6351  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   35 S     6   0% WebExtensions  
+   6475  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     1   0% Privileged Con 
+ 259641  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    2 S     6   0% kded4          
+   6626  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    3 S     1   0% RDD Process    
+   2725  0.00s  0.00s  0.00s     0K     0K     0K     0K geoclue  geoclue  --   -    4 S     4   0% geoclue        
+    960  0.00s  0.00s  0.00s     0K     0K     0K     0K polkitd  polkitd  --   -   12 S     5   0% polkitd        
+    848  0.00s  0.00s  0.00s     0K     0K     0K     0K systemd- systemd- --   -    1 S     1   0% systemd-resolv 
+   7480  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     2   0% chrome         
+   4972  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    3 S     0   0% abrt-dbus      
+ 561042  0.00s  0.00s  0.00s     0K     0K     0K     0K apache   apache   --   -   65 S     2   0% /usr/sbin/http 
+ 510399  0.00s  0.00s  0.00s     0K     0K     0K     0K pcp      pcp      --   -    2 S     3   0% pmdaperfevent  
+ 127014  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    3 S     3   0% gvfsd-dnssd    
+    905  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    2 S     4   0% thermald       
+ 530954  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     4   0% bash           
+    937  0.00s  0.00s  0.00s     0K     0K     0K     0K dbus     dbus     --   -    1 S     6   0% dbus-broker    
+ 510378  0.00s  0.00s  0.00s     0K     0K     0K     0K pcp      pcp      --   -    2 S     0   0% pmcd           
+ 569803  0.00s  0.00s  0.00s 16328K  6180K     0K     0K nathans  nathans  N-   -    1 S     0   0% pmsleep        
+   1338  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     6   0% (sd-pam        
+   8328  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     6   0% gconfd-2       
+    881  0.00s  0.00s  0.00s     0K     0K     0K     0K avahi    avahi    --   -    1 S     0   0% avahi-daemon   
+   7263  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    3 S     4   0% speech-dispatc 
+ 569742  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     6   0% mk.atop-thread 
+ 116463  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     0   0% ssh-agent      
+     14  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     0   0% rcu_sched      
+     15  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     0   0% migration/0    
+     18  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     1   0% migration/1    
+     23  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     2   0% migration/2    
+     28  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     3   0% migration/3    
+     33  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     4   0% migration/4    
+     38  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     5   0% migration/5    
+     43  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     6   0% migration/6    
+     48  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     7   0% migration/7    
+     58  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     7   0% kcompactd0     
+    276  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     4   0% kworker/4:1H-e 
+ 520551  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     3   0% kworker/3:3-ev 
+ 532562  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     2   0% kworker/2:0-ev 
+ 533793  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     1   0% kworker/1:3-ev 
+ 536069  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     4   0% kworker/u17:0- 
+ 536169  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     2   0% kworker/u16:4- 
+ 558573  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     7   0% kworker/u16:3- 
+ 559476  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     5   0% kworker/5:2-ev 
+ 561022  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     1   0% kworker/1:0-mm 
+ 567864  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     6   0% kworker/6:1-ev 
+ 569608  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     4   0% kworker/4:0-ev 
+ 569687  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     0   0% kworker/0:3-ev 
+=== std err
+=== done
+
+Creating alternate named archive
+Defaults with ix86arch metric naming
+=== std out
+
+
+ATOP - shard                                 2021/04/20  15:30:37                                 -----------------                                   2s elapsed
+PRC | sys   56m45s |  user   4h29m | #proc    377 |  #trun      1 | #tslpi   290 |  #tslpu     0 | #zombie    0 |  clones 570e3 |              |  no  procacct |
+CPU | sys       5% |  user     15% | irq      25% |  idle    753% | wait      1% |  guest     0% | ipc     0.45 |  cycl 1.47THz | curf 3.61GHz |  curscal   ?% |
+cpu | sys       1% |  user      3% | irq       3% |  idle     93% | cpu002 w  0% |  guest     0% | ipc     0.49 |  cycl 1.70THz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       1% |  user      2% | irq       3% |  idle     93% | cpu004 w  0% |  guest     0% | ipc     0.48 |  cycl 1.68THz | curf 2.86GHz |  curscal   ?% |
+cpu | sys       1% |  user      2% | irq       3% |  idle     94% | cpu006 w  0% |  guest     0% | ipc     0.49 |  cycl 1.72THz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       1% |  user      2% | irq       3% |  idle     94% | cpu000 w  0% |  guest     0% | ipc     0.45 |  cycl 1.65THz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      1% | irq       3% |  idle     94% | cpu007 w  0% |  guest     0% | ipc     0.38 |  cycl 1.38THz | curf 3.19GHz |  curscal   ?% |
+cpu | sys       0% |  user      1% | irq       3% |  idle     95% | cpu003 w  0% |  guest     0% | ipc     0.43 |  cycl 1.29THz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      1% | irq       3% |  idle     95% | cpu001 w  0% |  guest     0% | ipc     0.44 |  cycl 1.19THz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      1% | irq       3% |  idle     95% | cpu005 w  0% |  guest     0% | ipc     0.42 |  cycl 1.18THz | curf 3.80GHz |  curscal   ?% |
+CPL | avg1    0.16 |  avg5    0.15 | avg15   0.21 |               |              |  csw 721109e3 | intr 33227e5 |               |              |  numcpu     8 |
+MEM | tot    15.3G |  free    2.3G | cache   4.6G |  dirty   2.1M | buff  947.6M |  slab  620.1M | shrss   0.0M |  vmbal   0.0M | zfarc   0.0M |  hptot 512.0M |
+SWP | tot    11.7G |  free   11.7G | swcac   2.1M |  zpool   0.0M | zstor   0.0M |  ksuse   0.0M | kssav   0.0M |               | vmcom  22.9G |  vmlim  19.1G |
+PAG | scan       0 |  steal      0 | stall      0 |               |              |               |              |  swin    1981 | swout  16278 |  oomkill    0 |
+LVM | a_shard-root |  busy      0% | read  345684 |  write 498098 | KiB/r     19 |  KiB/w     40 | MBr/s 3337.9 |  MBw/s 9761.0 | avq     0.00 |  avio  0.0 ns |
+LVM | a_shard-swap |  busy      0% | read      97 |  write      0 | KiB/r     22 |  KiB/w      0 | MBr/s    1.1 |  MBw/s    0.0 | avq     0.00 |  avio  0.0 ns |
+LVM | a_shard-home |  busy      0% | read  693963 |  write 3813e3 | KiB/r      8 |  KiB/w     14 | MBr/s 2785.7 |  MBw/s 26515.8 | avq     0.00 |  avio  0.0 ns |
+DSK |          sda |  busy      1% | read  581080 |  write 2060e3 | KiB/r     21 |  KiB/w     35 | MBr/s 6130.0 |  MBw/s 35802.8 | avq     2.55 |  avio 1.07 ms |
+NET | transport    |  tcpi 2038357 | tcpo 1960897 |  udpi  757044 | udpo  900331 |  tcpao  41287 | tcppo    181 |  tcprs   3111 | tcpie     16 |  udpie      0 |
+NET | network      |  ipi  2699225 | ipo  2740508 |  ipfrw      0 | deliv 2698e3 |               |              |               | icmpi   4670 |  icmpo    211 |
+NET | enp0s25 ---- |  pcki 18188e3 | pcko 2571238 |  sp    0 Mbps | si 8295 Mbps |  so 3718 Mbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+NET | lo      ---- |  pcki  200935 | pcko  200935 |  sp    0 Mbps | si  809 Mbps |  so  809 Mbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+NET | tun0    ---- |  pcki   93648 | pcko  100194 |  sp    0 Mbps | si  245 Mbps |  so   62 Mbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+WWW | reqs      60 | totKB    133 | byt/rq  2269 | iwork     74 | bwork      1 |
+
+    PID SYSCPU USRCPU RDELAY  VGROW  RGROW  RDDSK  WRDSK RUID     EUID     ST EXC  THR S CPUNR  CPU CMD            
+   6532  5m23s 61m35s  0.00s   3.1G 273.8M 21664K     0K nathans  nathans  N-   -   48 S     4   2% Web Content    
+   4307 16m38s 42m05s  0.00s   5.5G 328.5M 17224K    68K nathans  nathans  N-   -   21 S     3   2% gnome-shell    
+   6569  2m25s 42m00s  0.00s   3.6G 799.2M 36924K     0K nathans  nathans  N-   -   46 S     3   1% Web Content    
+   6098  6m43s 28m44s  0.00s   4.9G 835.7M 106.3M   184K nathans  nathans  N-   -  160 S     4   1% firefox        
+   6968 67.28s 17m41s  0.00s  36.7G 207.9M 18164K     0K nathans  nathans  N-   -   15 S     6   1% slack          
+   1242  4m42s  8m04s  0.00s 909.6M 121.3M 40848K   960K redis    redis    N-   -   37 S     4   0% redis-server   
+   7581 64.04s  9m45s  0.00s  36.8G 411.3M  4924K     0K nathans  nathans  N-   -   17 S     2   0% chrome         
+   7465  2m45s  7m31s  0.00s  32.9G 272.6M 114.9M   1.2G nathans  nathans  N-   -   26 S     0   0% chrome         
+   6667 44.76s  8m38s  0.00s   3.0G 291.9M  8860K     0K nathans  nathans  N-   -   43 S     0   0% Web Content    
+   5913 35.93s  8m06s  0.00s 892.0M 157.2M  1496K     0K nathans  nathans  N-   -    4 S     4   0% gnome-terminal 
+ 112368 53.63s  5m29s  0.00s   3.2G 471.2M 15984K     0K nathans  nathans  N-   -   42 S     4   0% Web Content    
+   4471  2m52s  2m45s  0.00s   1.9G 58648K  2964K   144K nathans  nathans  N-   -   25 S     1   0% Xwayland       
+   6289 37.86s  4m42s  0.00s   3.0G 199.4M  5696K     0K nathans  nathans  N-   -   51 S     3   0% Web Content    
+   6234 41.49s  3m41s  0.00s   3.3G 258.5M 13780K     0K nathans  nathans  N-   -   45 S     4   0% Web Content    
+   7505 63.55s  2m31s  0.00s  32.7G 139.6M 10272K   320K nathans  nathans  N-   -   12 S     5   0% chrome         
+ 112334 39.39s  2m31s  0.00s   3.0G 298.6M 11236K     0K nathans  nathans  N-   -   42 S     7   0% Web Content    
+   6860 19.84s 85.94s  0.00s   4.8G 141.8M 99768K  5552K nathans  nathans  N-   -   32 S     5   0% slack          
+   7672 17.36s 87.06s  0.00s  36.6G 159.8M  5096K     0K nathans  nathans  N-   -   15 S     6   0% chrome         
+     58 79.50s  0.28s  0.96s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% kcompactd0     
+    937 40.30s 36.88s  0.00s 11288K  6796K   244K     0K dbus     dbus     N-   -    1 S     7   0% dbus-broker    
+   8038  6.39s 67.50s  0.00s  40.7G 281.4M  1468K     0K nathans  nathans  N-   -   16 S     2   0% chrome         
+ 512101  0.80s 62.63s  0.14s 384.6M 152.7M     0K     0K root     root     N-   -    1 S     3   0% python3        
+   4311 38.58s 21.12s  0.00s   2.6G 15216K  2704K    48K nathans  nathans  N-   -    4 S     6   0% pulseaudio     
+   5896  9.77s 45.79s  1.03s 726.1M 64764K 20464K 60924K nathans  nathans  N-   -    3 S     4   0% hexchat        
+ 149648  8.03s 47.42s  0.00s   2.9G 147.9M 15104K     0K nathans  nathans  N-   -   42 S     1   0% Web Content    
+    848 16.55s 36.70s  1.39s 43748K 20484K  6472K     0K systemd- systemd- N-   -    1 S     2   0% systemd-resolv 
+   6902 14.42s 27.26s  1.45s 573.0M 78016K 10428K    16K nathans  nathans  N-   -   10 S     5   0% slack          
+   4916  5.80s 31.71s  1.00s 524.1M 12032K   120K     0K nathans  nathans  N-   -    3 S     6   0% ibus-daemon    
+     14 33.26s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% rcu_sched      
+   2725  9.26s 18.00s  0.00s 538.8M 21388K   296K     0K geoclue  geoclue  N-   -    4 S     4   0% geoclue        
+   6351  3.21s 23.26s  0.00s   2.6G 103.6M   128K     0K nathans  nathans  N-   -   35 S     6   0% WebExtensions  
+    881 10.41s 14.20s  0.87s 34724K  4140K   836K     0K avahi    avahi    N-   -    1 S     4   0% avahi-daemon   
+    835 20.21s  0.00s  1.64s     0K     0K     0K   2.4G root     root     N-   -    1 S     7   0% jbd2/dm-2-8    
+    905  4.79s 15.10s  1.02s 302.5M  8028K  2288K     0K root     root     N-   -    2 S     5   0% thermald       
+ 510378  6.78s  7.24s  0.05s 136.1M  6476K    48K    48K pcp      pcp      N-   -    2 S     6   0% pmcd           
+ 511132  0.44s 13.47s  0.01s 95564K 65080K   108K 402.9M pcp      pcp      N-   -    1 S     2   0% pmlogger       
+   6475  1.63s 10.86s  0.00s   2.6G 85724K   776K     0K nathans  nathans  N-   -   42 S     1   0% Privileged Con 
+    139 12.39s  0.00s  0.54s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% kswapd0        
+   5007  1.78s  8.92s  0.26s 366.4M  6736K     0K     0K nathans  nathans  N-   -    3 S     7   0% ibus-engine-si 
+ 122007  0.79s  9.68s  0.84s  36.6G 132.6M     4K     0K nathans  nathans  N-   -   13 S     3   0% chrome         
+   4972  2.19s  7.64s  1.13s 478.3M 15392K   152K     0K root     root     N-   -    3 S     2   0% abrt-dbus      
+    960  2.48s  7.14s  1.00s   2.8G 20864K 16720K     0K polkitd  polkitd  N-   -   12 S     1   0% polkitd        
+ 251337  1.64s  7.66s  0.15s  36.6G 128.2M   336K     0K nathans  nathans  N-   -   14 S     2   0% chrome         
+   5620  5.98s  2.42s  0.09s 28200K  8348K     4K     0K nm-openv nm-openv N-   -    1 S     6   0% openvpn        
+ 127014  3.08s  5.27s  0.00s 515.8M  8420K   104K     0K nathans  nathans  N-   -    3 S     7   0% gvfsd-dnssd    
+    995  3.83s  4.51s  0.22s 687.2M 19612K  5520K 18616K root     root     N-   -    3 S     5   0% NetworkManager 
+      1  4.12s  4.05s  0.14s 174.3M 20140K 58136K   200K root     root     N-   -    1 S     2   0% systemd        
+   7539  0.90s  6.58s  0.37s  36.6G 86808K  7832K     0K nathans  nathans  N-   -   13 S     6   0% chrome         
+ 122029  0.89s  6.13s  0.50s  52.7G 161.4M   468K     0K nathans  nathans  N-   -   18 S     6   0% chrome         
+    883  5.14s  1.65s  0.18s  2496K  1848K   248K     0K 61876    61876    N-   -    1 S     4   0% earlyoom       
+   1239  0.87s  5.91s  0.21s   1.9G 56896K 58628K   764K grafana  grafana  N-   -   17 S     5   0% grafana-server 
+ 567882  4.07s  2.10s  0.09s 67172K 31588K    16K     4K nathans  nathans  N-   -    1 R     2   0% pmdaproc       
+ 510402  0.17s  5.71s  0.01s 477.8M 31168K   116K   180K root     root     N-   -    1 S     0   0% python3        
+   4945  0.75s  4.91s  0.49s 545.0M 23384K     0K     0K nathans  nathans  N-   -    4 S     7   0% ibus-extension 
+ 148070  0.40s  4.46s  0.45s  40.6G 131.0M     0K     0K nathans  nathans  N-   -   14 S     0   0% chrome         
+ 507752  0.81s  3.47s  0.03s 188.0M 91044K   976K   544K pcp      pcp      N-   -    2 S     6   0% pmproxy        
+ 510388  1.84s  2.20s  0.01s 26548K  8236K    80K    32K root     root     N-   -    1 S     4   0% pmdalinux      
+ 251324  0.63s  3.38s  0.05s  36.6G 109.1M  3040K     0K nathans  nathans  N-   -   13 S     5   0% chrome         
+    219  4.01s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kworker/7:1H-k 
+   7803  0.34s  3.49s  0.78s  40.6G 136.8M   636K     0K nathans  nathans  N-   -   14 S     5   0% chrome         
+    946  1.58s  2.14s  0.12s 271.9M 12276K  2716K 31788K root     root     N-   -    1 S     6   0% sssd_nss       
+ 536542  0.41s  3.21s  0.02s  36.6G 119.6M   568K     0K nathans  nathans  N-   -   13 S     4   0% chrome         
+ 520551  3.55s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% kworker/3:3-ev 
+     34  3.30s  0.04s  0.50s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% ksoftirqd/4    
+   2658  1.31s  2.02s  0.06s 451.8M  8632K   644K    96K root     root     N-   -    3 S     1   0% upowerd        
+     44  3.02s  0.05s  0.58s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% ksoftirqd/6    
+ 147351  0.21s  2.77s  0.70s  36.6G 128.6M     0K     0K nathans  nathans  N-   -   13 S     1   0% chrome         
+    639  1.73s  1.22s  0.18s 96000K 24664K  1992K 308.8M root     root     N-   -    1 S     1   0% systemd-journa 
+     13  2.94s  0.01s  0.83s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% ksoftirqd/0    
+     24  2.80s  0.15s  0.75s     0K     0K     0K     0K root     root     N-   -    1 S     2   0% ksoftirqd/2    
+   4636  0.56s  2.31s  0.04s 512.4M  7144K  5136K     0K nathans  nathans  N-   -    4 S     1   0% gsd-housekeepi 
+    541  2.61s  0.00s  0.28s     0K     0K     0K 456.8M root     root     N-   -    1 S     5   0% jbd2/dm-0-8    
+   4697  0.12s  2.46s  0.11s   1.1G 338.4M 27128K 15120K nathans  nathans  N-   -    4 S     7   0% gnome-software 
+   7480  2.38s  0.14s  0.03s  32.5G 15792K   128K     0K nathans  nathans  N-   -    1 S     2   0% chrome         
+ 259641  0.76s  1.65s  0.06s 558.1M 40076K 12172K    80K nathans  nathans  N-   -    2 S     6   0% kded4          
+     49  2.17s  0.00s  0.63s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% ksoftirqd/7    
+ 536069  1.94s  0.00s  0.14s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% kworker/u17:0- 
+ 148425  0.18s  1.75s  0.67s  36.6G 121.6M     0K     0K nathans  nathans  N-   -   13 S     2   0% chrome         
+     19  1.92s  0.00s  0.38s     0K     0K     0K     0K root     root     N-   -    1 S     1   0% ksoftirqd/1    
+     39  1.72s  0.01s  0.24s     0K     0K     0K     0K root     root     N-   -    1 S     5   0% ksoftirqd/5    
+    276  1.69s  0.00s  0.65s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kworker/4:1H-k 
+     29  1.64s  0.01s  1.10s     0K     0K     0K     0K root     root     N-   -    1 S     3   0% ksoftirqd/3    
+ 258588  1.64s  0.00s  0.74s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kworker/7:0-kd 
+ 536169  1.60s  0.00s  0.03s     0K     0K    12K     0K root     root     N-   -    1 I     2   0% kworker/u16:4- 
+    318  1.58s  0.00s  0.46s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% kworker/6:1H-k 
+    163  1.55s  0.00s  0.33s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/0:1H-k 
+   5919  0.65s  0.88s  0.00s 230.2M  8508K  6768K     0K nathans  nathans  N-   -    1 S     0   0% bash           
+    955  1.10s  0.39s  0.06s 832.2M 13508K   484K     0K root     root     N-   -    1 S     3   0% systemd-logind 
+ 115755  0.18s  1.09s  0.39s  36.6G 122.6M   260K     0K nathans  nathans  N-   -   13 S     6   0% chrome         
+   4203  0.57s  0.66s  0.48s  7208K  4748K     0K     0K nathans  nathans  N-   -    1 S     4   0% dbus-broker    
+ 116371  0.47s  0.69s  0.00s 230.5M  6948K   660K     0K nathans  nathans  N-   -    1 S     2   0% bash           
+   7521  0.36s  0.72s  0.08s  32.5G 48792K   368K     0K nathans  nathans  N-   -    5 S     2   0% chrome         
+   4538  0.25s  0.72s  0.00s 528.8M  9348K  1180K     0K nathans  nathans  N-   -    4 S     7   0% gvfs-udisks2-v 
+    884  0.18s  0.73s  0.05s 562.6M 43984K 17200K     0K root     root     N-   -    4 S     3   0% firewalld      
+    218  0.90s  0.00s  0.32s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% kworker/3:1H-e 
+ 532562  0.87s  0.00s  0.22s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% kworker/2:0-ev 
+    936  0.27s  0.55s  0.06s 259.9M 10964K  1356K   856K root     root     N-   -    1 S     4   0% sssd_be        
+   7877  0.12s  0.69s  0.00s 237.5M 10016K  4680K   824K nathans  nathans  N-   -    1 S     5   0% vim            
+    904  0.26s  0.54s  0.10s 20716K  9488K   140K     0K root     root     N-   -    1 S     2   0% systemd-machin 
+    137  0.78s  0.00s  0.28s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% kworker/2:1H-e 
+   1981  0.13s  0.63s  0.04s 289.5M 54972K   108K     0K root     root     N-   -    1 S     2   0% python3        
+    416  0.74s  0.00s  0.16s     0K     0K     0K     0K root     root     N-   -    1 I     1   0% kworker/1:1H-k 
+    285  0.73s  0.00s  0.18s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% kworker/5:1H-k 
+   4628  0.30s  0.39s  0.06s 791.2M 23368K  1132K     0K nathans  nathans  N-   -    4 S     1   0% gsd-color      
+ 510389  0.17s  0.50s  0.00s 251.7M 20684K     0K     4K root     root     N-   -    1 S     2   0% python3        
+ 123743  0.12s  0.52s  0.31s  36.6G 97632K     4K     0K nathans  nathans  N-   -   13 S     7   0% chrome         
+    665  0.33s  0.27s  0.30s 53440K 13136K  7248K     0K root     root     N-   -    1 S     6   0% systemd-udevd  
+   1274  0.19s  0.36s  0.05s 27876K 16888K  1516K     0K nathans  nathans  N-   -    1 S     2   0% systemd        
+ 540473  0.51s  0.00s  0.09s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/0:0-cg 
+   2838  0.16s  0.34s  0.03s   1.3G 728.3M 13688K  3284K root     root     N-   -    3 S     4   0% packagekitd    
+   7646  0.14s  0.34s  0.14s  36.6G 76932K   872K     0K nathans  nathans  N-   -   13 S     7   0% chrome         
+   4586  0.07s  0.41s  0.02s 516.9M  6984K   136K     0K nathans  nathans  N-   -    4 S     6   0% goa-identity-s 
+ 558573  0.46s  0.00s  0.00s     0K     0K     8K     0K root     root     N-   -    1 I     7   0% kworker/u16:3- 
+   4642  0.07s  0.37s  0.10s 695.6M 22676K   708K     0K nathans  nathans  N-   -    4 S     3   0% gsd-power      
+   4653  0.02s  0.40s  0.05s 663.2M  9868K   360K     0K nathans  nathans  N-   -    4 S     1   0% gsd-sharing    
+ 533793  0.41s  0.01s  0.07s     0K     0K     0K     0K root     root     N-   -    1 I     1   0% kworker/1:3-ev 
+   4639  0.08s  0.33s  0.11s   1.1G 24128K    96K     0K nathans  nathans  N-   -    4 S     5   0% gsd-media-keys 
+   4652  0.03s  0.37s  0.16s   1.2G 48284K  1508K     0K nathans  nathans  N-   -    6 S     2   0% evolution-alar 
+   4521  0.04s  0.30s  0.02s   1.3G 43212K 30284K    24K nathans  nathans  N-   -    4 S     1   0% evolution-sour 
+ 558544  0.34s  0.00s  0.02s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% kworker/u17:2- 
+    901  0.12s  0.21s  0.09s 257.2M  8740K  4208K   120K root     root     N-   -    1 S     4   0% sssd           
+    849  0.17s  0.16s  0.01s 99572K  2700K   332K  4900K root     root     N-   -    3 S     5   0% auditd         
+    893  0.18s  0.14s  0.00s 300.7M  6452K  1256K     0K root     root     N-   -    5 S     6   0% rngd           
+   4605  0.02s  0.29s  0.16s   1.5G 49368K   704K     0K nathans  nathans  N-   -   11 S     6   0% evolution-cale 
+ 510399  0.19s  0.10s  0.00s 48472K  8996K    28K    56K pcp      pcp      N-   -    2 S     3   0% pmdaperfevent  
+   1258  0.25s  0.04s  0.01s 227.9M  3776K   240K     0K root     root     N-   -    1 S     2   0% crond          
+   1635  0.22s  0.07s  0.05s 25428K  1972K     0K     0K dnsmasq  dnsmasq  N-   -    1 S     0   0% dnsmasq        
+   1673  0.21s  0.07s  0.07s 25436K  1792K     0K     0K dnsmasq  dnsmasq  N-   -    1 S     7   0% dnsmasq        
+   7263  0.14s  0.11s  0.00s 363.4M  4112K     0K     0K nathans  nathans  N-   -    3 S     4   0% speech-dispatc 
+   4924  0.04s  0.20s  0.06s 858.5M 25336K   128K     0K nathans  nathans  N-   -    8 S     6   0% gsd-xsettings  
+   4802  0.01s  0.21s  0.08s   1.0G 36884K   780K     0K nathans  nathans  N-   -    6 S     1   0% evolution-addr 
+    902  0.12s  0.10s  0.01s 437.8M  6264K   164K     0K root     root     N-   -    3 S     4   0% switcheroo-con 
+ 558402  0.21s  0.00s  0.05s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kworker/4:3-mm 
+ 510395  0.06s  0.14s  0.00s 266.9M 24284K     0K     4K pcp      pcp      N-   -    1 S     6   0% python3        
+ 529850  0.07s  0.13s  0.00s 229.0M  7352K   360K     0K nathans  nathans  N-   -    1 S     0   0% bash           
+   7762  0.07s  0.12s  0.07s  32.7G 68236K     0K     0K nathans  nathans  N-   -    6 S     4   0% chrome         
+   1157  0.09s  0.10s  0.00s 374.3M 15880K  1392K     0K root     root     N-   -    1 S     4   0% abrt-dump-jour 
+   4541  0.08s  0.11s  0.00s 394.4M 13076K  1848K     0K root     root     N-   -    5 S     6   0% udisksd        
+ 510387  0.11s  0.08s  0.00s 37404K  7664K    32K     4K pcp      pcp      N-   -    1 S     5   0% pmdasample     
+ 558565  0.19s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% kworker/u16:2- 
+   1158  0.08s  0.10s  0.00s 359.2M 16748K  1180K     0K root     root     N-   -    1 S     3   0% abrt-dump-jour 
+   3365  0.03s  0.15s  0.03s 527.0M 11208K   908K     0K colord   colord   N-   -    4 S     1   0% colord         
+    851  0.06s  0.12s  0.00s  8120K  3996K   348K     0K root     root     N-   -    1 S     5   0% sedispatch     
+ 559476  0.17s  0.00s  0.03s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% kworker/5:2-ev 
+   1156  0.08s  0.08s  0.01s 358.0M 15692K  1376K     8K root     root     N-   -    1 S     5   0% abrt-dump-jour 
+      2  0.16s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% kthreadd       
+     43  0.16s  0.00s  1.08s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% migration/6    
+     48  0.16s  0.00s  0.51s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% migration/7    
+   1275  0.04s  0.11s  0.01s 25144K 14012K   452K     0K pcpqa    pcpqa    N-   -    1 S     1   0% systemd        
+     18  0.15s  0.00s  0.59s     0K     0K     0K     0K root     root     N-   -    1 S     1   0% migration/1    
+     23  0.15s  0.00s  0.34s     0K     0K     0K     0K root     root     N-   -    1 S     2   0% migration/2    
+     28  0.15s  0.00s  0.59s     0K     0K     0K     0K root     root     N-   -    1 S     3   0% migration/3    
+     33  0.15s  0.00s  0.37s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% migration/4    
+     38  0.15s  0.00s  0.30s     0K     0K     0K     0K root     root     N-   -    1 S     5   0% migration/5    
+    926  0.10s  0.04s  0.01s 94000K  3544K   388K   188K chrony   chrony   N-   -    1 S     0   0% chronyd        
+   4678  0.01s  0.12s  0.09s 614.1M 21316K     0K     0K nathans  nathans  N-   -    4 S     7   0% gsd-wacom      
+ 510394  0.08s  0.05s  0.00s 16548K  6632K     0K     4K root     root     N-   -    1 S     1   0% pmdakvm        
+   4951  0.02s  0.10s  0.04s 540.0M 20808K   136K     0K nathans  nathans  N-   -    3 S     1   0% ibus-x11       
+   4638  0.01s  0.10s  0.06s 613.7M 20880K    48K     0K nathans  nathans  N-   -    4 S     7   0% gsd-keyboard   
+   4274  0.03s  0.08s  0.03s 816.5M 12400K   384K     0K nathans  nathans  N-   -    4 S     7   0% gnome-session- 
+ 547825  0.11s  0.00s  0.02s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% kworker/5:0-cg 
+ 510406  0.07s  0.03s  0.00s 16608K  6604K     4K  1548K root     root     N-   -    1 S     5   0% pmdazfs        
+   4515  0.02s  0.08s  0.08s 913.9M 33692K  9088K     0K nathans  nathans  N-   -    6 S     3   0% gnome-shell-ca 
+ 530954  0.05s  0.05s  0.00s 228.8M  7204K     0K     0K nathans  nathans  N-   -    1 S     4   0% bash           
+   4063  0.02s  0.08s  0.01s 729.8M  6300K   480K    16K nathans  nathans  N-   -    4 S     1   0% gnome-keyring- 
+   4608  0.01s  0.08s  0.00s   3.1G 20196K     0K     0K nathans  nathans  N-   -   11 S     5   0% gjs            
+ 537161  0.03s  0.06s  0.00s 229.0M  7344K     8K     0K nathans  nathans  N-   -    1 S     2   0% bash           
+ 553270  0.09s  0.00s  0.01s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% kworker/6:3-ev 
+ 565955  0.09s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/u16:0- 
+   4565  0.01s  0.07s  0.01s 817.1M 28972K   588K     4K nathans  nathans  N-   -    4 S     0   0% goa-daemon     
+     55  0.08s  0.00s  0.01s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% kauditd        
+    943  0.06s  0.02s  0.19s     0K     0K     0K     0K root     root     N-   -    1 S     5   0% psimon         
+ 558607  0.04s  0.03s  0.00s 312.0M 27720K 12764K     4K root     root     N-   -    1 S     4   0% php-fpm        
+   4701  0.01s  0.06s  0.03s 481.1M 17320K  1268K     0K nathans  nathans  N-   -    4 S     3   0% abrt-applet    
+ 561037  0.03s  0.04s  0.00s 41096K 16604K    12K     4K root     root     N-   -    1 S     0   0% /usr/sbin/http 
+   7257  0.06s  0.01s  0.00s 647.6M  8632K  2888K     0K nathans  nathans  N-   -    5 S     7   0% sd_espeak-ng   
+ 541441  0.02s  0.05s  0.00s 228.9M  7312K     0K     0K nathans  nathans  N-   -    1 S     4   0% bash           
+ 127103  0.01s  0.05s  0.00s 707.0M 23140K  3480K    32K nathans  nathans  N-   -    5 S     0   0% tracker-store  
+   4672  0.01s  0.05s  0.07s 594.8M 12088K   196K     0K nathans  nathans  N-   -    6 S     5   0% gsd-smartcard  
+   1008  0.04s  0.02s  0.00s 255.7M 10560K  2052K   236K root     root     N-   -    1 S     6   0% cupsd          
+   6807  0.01s  0.05s  0.00s 228.8M  6656K     0K     0K nathans  nathans  N-   -    1 S     6   0% bash           
+    899  0.03s  0.03s  0.00s 11440K  5400K  2280K     0K root     root     N-   -    1 S     7   0% smartd         
+ 561022  0.06s  0.00s  0.01s     0K     0K     0K     0K root     root     N-   -    1 I     1   0% kworker/1:0-mm 
+   7507  0.01s  0.04s  0.01s  32.5G 106.0M   492K     0K nathans  nathans  N-   -    9 S     6   0% chrome         
+   7476  0.02s  0.03s  0.00s  32.5G 53412K  5444K     0K nathans  nathans  N-   -    1 S     7   0% chrome         
+   7475  0.02s  0.03s  0.00s  32.5G 52348K  1672K     0K nathans  nathans  N-   -    1 S     7   0% chrome         
+   6626  0.02s  0.03s  0.00s 180.2M 26664K     0K     0K nathans  nathans  N-   -    3 S     1   0% RDD Process    
+    880  0.02s  0.03s  0.02s 379.8M  8500K  5852K     0K root     root     N-   -    4 S     1   0% ModemManager   
+ 511710  0.03s  0.02s  0.00s 37396K  8308K     0K   620K pcp      pcp      N-   -    1 S     2   0% pmie           
+ 510401  0.04s  0.01s  0.00s 17048K  7092K     0K     4K root     root     N-   -    1 S     1   0% pmdadm         
+   6019  0.01s  0.04s  0.00s 228.8M  6676K    24K     0K nathans  nathans  N-   -    1 S     4   0% bash           
+   1091  0.03s  0.01s  0.00s   1.6G 63748K 23112K     8K mysql    mysql    N-   -   30 S     6   0% mysqld         
+ 536573  0.01s  0.03s  0.00s  36.6G 59428K     0K     0K nathans  nathans  N-   -   13 S     0   0% chrome         
+    954  0.02s  0.02s  0.00s 528.5M  7388K  1552K     8K root     root     N-   -    4 S     2   0% accounts-daemo 
+ 510383  0.03s  0.01s  0.00s 17280K  7144K   432K    12K root     root     N-   -    1 S     6   0% pmdaroot       
+ 566343  0.01s  0.03s  0.00s 228.7M  7052K     0K     0K pcpqa    pcpqa    N-   -    1 S     0   0% bash           
+ 510386  0.02s  0.02s  0.00s 16500K  5940K     0K     4K root     root     N-   -    1 S     3   0% pmdaxfs        
+    917  0.01s  0.03s  0.02s  9552K  4028K  3596K     0K dbus     dbus     N-   -    1 S     1   0% dbus-broker-la 
+    898  0.03s  0.01s  0.00s 150.2M  3276K   204K     0K rtkit    rtkit    N-   -    3 S     5   0% rtkit-daemon   
+   6909  0.01s  0.02s  0.00s 505.3M 67596K   192K     0K nathans  nathans  N-   -    6 S     5   0% slack          
+   6867  0.01s  0.02s  0.00s 413.6M 30892K  2712K     0K nathans  nathans  N-   -    1 S     2   0% slack          
+    935  0.01s  0.02s  0.00s 477.8M 13268K  4960K     0K root     root     N-   -    3 S     7   0% abrtd          
+   4645  0.01s  0.02s  0.06s 462.8M 12276K     0K     0K nathans  nathans  N-   -    3 S     7   0% gsd-print-noti 
+   3464  0.01s  0.02s  0.00s 547.8M 11996K   300K     4K root     root     N-   -    3 S     5   0% gdm-session-wo 
+ 562091  0.02s  0.01s  0.00s 37828K  7712K    48K     4K pcp      pcp      N-   -    1 S     7   0% pmdaapache     
+   4673  0.00s  0.03s  0.02s 226.5M  5928K    52K     0K nathans  nathans  N-   -    3 S     1   0% gsd-disk-utili 
+   8328  0.01s  0.02s  0.00s 234.1M  5812K   204K     0K nathans  nathans  N-   -    1 S     6   0% gconfd-2       
+   2840  0.02s  0.01s  0.01s 13204K  4272K  1756K     0K root     root     N-   -    1 S     5   0% wpa_supplicant 
+    882  0.01s  0.02s  0.00s  9332K  4168K  1476K     0K root     root     N-   -    1 S     2   0% bluetoothd     
+ 567863  0.03s  0.00s  0.01s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/0:1-ev 
+ 567864  0.03s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% kworker/6:1-ev 
+ 569789  0.01s  0.00s  0.00s 16776K  7360K     0K  1189K nathans  nathans  N-   -    1 S     5   0% pmlogger       
+   6868  0.00s  0.02s  0.00s 413.6M 30976K  2340K     0K nathans  nathans  N-   -    1 S     0   0% slack          
+ 259637  0.01s  0.01s  0.00s 301.8M 15860K   844K     0K nathans  nathans  N-   -    1 S     0   0% kdeinit4       
+   4633  0.00s  0.02s  0.04s 542.9M 12252K     0K     0K nathans  nathans  N-   -    4 S     4   0% gsd-datetime   
+   4205  0.01s  0.01s  0.00s 463.8M 10952K   608K     0K nathans  nathans  N-   -    4 S     5   0% gnome-session- 
+   1261  0.01s  0.01s  0.01s 457.4M  8056K   868K     4K root     root     N-   -    3 S     0   0% gdm            
+   4484  0.00s  0.02s  0.00s 441.4M  7196K   332K     0K nathans  nathans  N-   -    3 S     4   0% gvfsd          
+    889  0.01s  0.01s  0.00s 224.1M  4252K   568K     0K root     root     N-   -    3 S     6   0% low-memory-mon 
+ 569076  0.02s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kworker/u16:1- 
+ 259639  0.00s  0.01s  0.00s 306.8M 15200K  3736K     0K nathans  nathans  N-   -    1 S     6   0% klauncher      
+   4821  0.00s  0.01s  0.00s 544.8M 13700K    20K     0K nathans  nathans  N-   -    3 S     6   0% gsd-printer    
+   4675  0.00s  0.01s  0.02s 520.1M  8492K     0K     0K nathans  nathans  N-   -    4 S     5   0% gsd-sound      
+   4609  0.00s  0.01s  0.05s 157.5M  6864K     0K     0K nathans  nathans  N-   -    3 S     6   0% at-spi2-regist 
+   4676  0.01s  0.00s  0.01s 655.7M  6672K    48K     0K nathans  nathans  N-   -    4 S     2   0% gsd-usb-protec 
+    988  0.01s  0.00s  0.00s 227.2M  6432K   304K     0K root     root     N-   -    3 S     3   0% uresourced     
+   4530  0.00s  0.01s  0.00s 152.8M  6200K    76K   700K nathans  nathans  N-   -    3 S     0   0% dconf-service  
+   4646  0.00s  0.01s  0.03s 655.1M  5972K     0K     0K nathans  nathans  N-   -    3 S     7   0% gsd-rfkill     
+   4648  0.00s  0.01s  0.04s 438.7M  5668K    28K     0K nathans  nathans  N-   -    3 S     6   0% gsd-screensave 
+   4202  0.00s  0.01s  0.01s 18248K  3716K   136K     0K nathans  nathans  N-   -    1 S     2   0% dbus-broker-la 
+    944  0.00s  0.01s  0.01s  5136K  3068K    56K   112K root     root     N-   -    1 S     7   0% alsactl        
+   1257  0.01s  0.00s  0.00s 20948K  2860K   168K     0K root     root     N-   -    1 S     6   0% atd            
+     15  0.01s  0.00s  0.72s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% migration/0    
+ 569077  0.01s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kworker/u16:5- 
+   1721  0.00s  0.00s  0.00s   1.6G 14024K 14996K     0K grafana  grafana  N-   -   14 S     4   0% pcp_redis_data 
+ 561042  0.00s  0.00s  0.00s   2.2G 12360K     0K     0K apache   apache   N-   -   65 S     2   0% /usr/sbin/http 
+ 561041  0.00s  0.00s  0.00s   2.2G 12040K     0K     0K apache   apache   N-   -   65 S     5   0% /usr/sbin/http 
+   6870  0.00s  0.00s  0.00s 413.6M 11472K     0K     0K nathans  nathans  N-   -    1 S     6   0% slack          
+ 561040  0.00s  0.00s  0.00s   2.4G 11288K     0K     0K apache   apache   N-   -   81 S     0   0% /usr/sbin/http 
+ 558615  0.00s  0.00s  0.00s 323.5M 10752K     0K     0K apache   apache   N-   -    1 S     4   0% php-fpm        
+ 558616  0.00s  0.00s  0.00s 323.5M 10752K     0K     0K apache   apache   N-   -    1 S     5   0% php-fpm        
+ 558612  0.00s  0.00s  0.00s 323.5M 10748K     0K     0K apache   apache   N-   -    1 S     4   0% php-fpm        
+ 132118  0.00s  0.00s  0.00s 452.5M 10720K    52K     0K nathans  nathans  N-   -    3 S     4   0% gvfsd-http     
+    897  0.00s  0.00s  0.00s 278.9M 10624K  1364K     0K root     root     N-   -    3 S     6   0% rsyslogd       
+ 558613  0.00s  0.00s  0.00s 323.5M 10516K     0K     0K apache   apache   N-   -    1 S     1   0% php-fpm        
+ 558614  0.00s  0.00s  0.00s 323.5M 10508K     0K     0K apache   apache   N-   -    1 S     0   0% php-fpm        
+ 566340  0.00s  0.00s  0.00s 256.3M  9332K     0K     0K nathans  root     N-   -    1 S     3   0% sudo           
+ 561038  0.00s  0.00s  0.00s 52144K  8816K     0K     0K apache   apache   N-   -    1 S     7   0% /usr/sbin/http 
+   5608  0.00s  0.00s  0.00s 388.4M  8668K   196K     0K root     root     N-   -    3 S     7   0% nm-openvpn-ser 
+ 126992  0.00s  0.00s  0.00s 586.2M  8048K   156K     0K nathans  nathans  N-   -    4 S     6   0% gvfsd-network  
+ 126984  0.00s  0.00s  0.00s 513.6M  7904K   184K     0K nathans  nathans  N-   -    3 S     4   0% gvfsd-trash    
+ 566342  0.00s  0.00s  0.00s 254.5M  7504K     0K     4K root     root     N-   -    1 S     3   0% su             
+   1230  0.00s  0.00s  0.00s 812.3M  7492K   304K     0K root     root     N-   -   12 S     0   0% pcscd          
+ 510409  0.00s  0.00s  0.00s 37176K  7344K    52K     4K pcp      pcp      N-   -    1 S     3   0% pmdasimple     
+ 510393  0.00s  0.00s  0.00s 37176K  7280K     0K     4K pcp      pcp      N-   -    1 S     3   0% pmdamounts     
+   4593  0.00s  0.00s  0.00s 514.4M  7248K   100K     0K nathans  nathans  N-   -    4 S     4   0% gvfs-afc-volum 
+   4453  0.00s  0.00s  0.00s 301.1M  7084K     0K     0K nathans  nathans  N-   -    4 S     0   0% at-spi-bus-lau 
+   1012  0.00s  0.00s  0.00s 29964K  6868K  1128K     0K root     root     N-   -    1 S     6   0% sshd           
+   4943  0.00s  0.00s  0.00s 438.6M  6316K     0K     0K nathans  nathans  N-   -    4 S     0   0% ibus-dconf     
+   4958  0.00s  0.00s  0.00s 438.3M  6284K     0K     0K nathans  nathans  N-   -    3 S     1   0% ibus-portal    
+   4575  0.00s  0.00s  0.00s 366.1M  6200K   204K   124K nathans  nathans  N-   -    3 S     6   0% gvfsd-metadata 
+   4627  0.00s  0.00s  0.02s 511.2M  6096K     0K     0K nathans  nathans  N-   -    4 S     5   0% gsd-a11y-setti 
+   4574  0.00s  0.00s  0.00s 438.3M  6036K   112K     0K nathans  nathans  N-   -    3 S     7   0% gvfs-goa-volum 
+   1337  0.00s  0.00s  0.00s 58168K  5972K     0K     0K pcpqa    pcpqa    N-   -    1 S     6   0% (sd-pam        
+   1338  0.00s  0.00s  0.00s 58168K  5968K     0K     0K nathans  nathans  N-   -    1 S     6   0% (sd-pam        
+   4489  0.00s  0.00s  0.00s 370.8M  5928K   316K     0K nathans  nathans  N-   -    6 S     4   0% gvfsd-fuse     
+   4566  0.00s  0.00s  0.00s 440.0M  5812K   620K     0K nathans  nathans  N-   -    3 S     3   0% gvfs-gphoto2-v 
+   4200  0.00s  0.00s  0.00s 365.3M  5396K     4K     0K nathans  nathans  N-   -    3 S     5   0% gdm-wayland-se 
+   4570  0.00s  0.00s  0.00s 437.8M  5148K   104K     0K nathans  nathans  N-   -    3 S     1   0% gvfs-mtp-volum 
+   7253  0.00s  0.00s  0.00s 350.3M  5004K   136K     0K nathans  nathans  N-   -    3 S     2   0% sd_dummy       
+   4511  0.00s  0.00s  0.00s 437.3M  4464K     4K     0K nathans  nathans  N-   -    3 S     1   0% xdg-permission 
+   4271  0.00s  0.00s  0.00s 155.2M  4372K     0K     0K nathans  nathans  N-   -    3 S     5   0% uresourced     
+ 569742  0.00s  0.00s  0.00s 217.3M  4036K     0K     0K nathans  nathans  N-   -    1 S     6   0% mk.atop-thread 
+   4270  0.00s  0.00s  0.00s 296.2M  4008K    20K     0K nathans  nathans  N-   -    2 S     3   0% gnome-session- 
+ 116463  0.00s  0.00s  0.00s  7152K  3984K   268K     0K nathans  nathans  N-   -    1 S     0   0% ssh-agent      
+   4458  0.00s  0.00s  0.00s  9024K  3256K     0K     0K nathans  nathans  N-   -    1 S     2   0% dbus-broker-la 
+   1026  0.00s  0.00s  0.00s 262.9M  3012K    92K     0K root     root     N-   -    6 S     4   0% gssproxy       
+   4461  0.00s  0.00s  0.03s  5244K  2872K     0K     0K nathans  nathans  N-   -    1 S     7   0% dbus-broker    
+   7477  0.00s  0.00s  0.00s  32.0G  2528K  1596K     0K nathans  nathans  N-   -    1 S     5   0% nacl_helper    
+    890  0.00s  0.00s  0.00s 11636K  1968K   272K     0K root     root     N-   -    1 S     1   0% mcelog         
+   7471  0.00s  0.00s  0.00s 215.6M   372K     0K     0K nathans  nathans  N-   -    1 S     3   0% cat            
+    908  0.00s  0.00s  0.00s 34376K   344K     0K     0K avahi    avahi    N-   -    1 S     6   0% avahi-daemon   
+   1636  0.00s  0.00s  0.00s 25332K   344K     0K     0K root     root     N-   -    1 S     0   0% dnsmasq        
+   1675  0.00s  0.00s  0.00s 25332K   340K     0K     0K root     root     N-   -    1 S     4   0% dnsmasq        
+   7472  0.00s  0.00s  0.00s 215.6M   280K     0K     0K nathans  nathans  N-   -    1 S     4   0% cat            
+      3  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% rcu_gp         
+      4  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% rcu_par_gp     
+      6  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/0:0H-e 
+      9  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% mm_percpu_wq   
+     10  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% rcu_tasks_kthr 
+     11  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% rcu_tasks_rude 
+     12  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% rcu_tasks_trac 
+     16  0.00s  0.00s  0.01s     0K     0K     0K     0K root     root     N-   -    1 S     0   0% cpuhp/0        
+     17  0.00s  0.00s  0.01s     0K     0K     0K     0K root     root     N-   -    1 S     1   0% cpuhp/1        
+     21  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     1   0% kworker/1:0H-e 
+     22  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     2   0% cpuhp/2        
+     26  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% kworker/2:0H-e 
+     27  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     3   0% cpuhp/3        
+     31  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% kworker/3:0H-k 
+     32  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% cpuhp/4        
+     36  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kworker/4:0H-e 
+     37  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     5   0% cpuhp/5        
+     41  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% kworker/5:0H-e 
+     42  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% cpuhp/6        
+     46  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% kworker/6:0H-e 
+     47  0.00s  0.00s  0.03s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% cpuhp/7        
+     51  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kworker/7:0H-k 
+     52  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     3   0% kdevtmpfs      
+     53  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% netns          
+     54  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% inet_frag_wq   
+     56  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% oom_reaper     
+     57  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% writeback      
+     59  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% ksmd           
+     60  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     2   0% khugepaged     
+     80  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% cryptd         
+    127  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kintegrityd    
+    128  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kblockd        
+    129  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% blkcg_punt_bio 
+    130  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% tpm_dev_wq     
+    131  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% ata_sff        
+    132  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% md             
+    133  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% edac-poller    
+    135  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% watchdogd      
+    141  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kthrotld       
+    144  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% acpi_thermal_p 
+    145  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     3   0% scsi_eh_0      
+    146  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% scsi_tmf_0     
+    147  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     5   0% scsi_eh_1      
+    148  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% scsi_tmf_1     
+    149  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% scsi_eh_2      
+    150  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% scsi_tmf_2     
+    151  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% scsi_eh_3      
+    152  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% scsi_tmf_3     
+    153  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     5   0% scsi_eh_4      
+    154  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% scsi_tmf_4     
+    155  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     2   0% scsi_eh_5      
+    156  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% scsi_tmf_5     
+    161  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% dm_bufio_cache 
+    164  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% ipv6_addrconf  
+    170  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% kstrp          
+    210  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% zswap-shrink   
+    420  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% sdhci          
+    421  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     1   0% irq/34-mmc0    
+    469  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% card0-crtc0    
+    470  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% card0-crtc1    
+    471  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% card0-crtc2    
+    472  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% nvkm-disp      
+    474  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% ttm_swap       
+    475  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% card1-crtc0    
+    476  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% card1-crtc1    
+    477  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% card1-crtc2    
+    478  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     7   0% card1-crtc3    
+    519  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% kdmflush       
+    526  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kdmflush       
+    542  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% ext4-rsv-conve 
+    710  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     4   0% irq/37-mei_me  
+    721  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% cfg80211       
+    730  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% ktpacpid       
+    738  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% kdmflush       
+    739  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     6   0% irq/38-iwlwifi 
+    820  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     2   0% irq/41-rmi4_sm 
+    833  0.00s  0.00s  0.00s     0K     0K     0K    36K root     root     N-   -    1 S     2   0% jbd2/sda1-8    
+    834  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% ext4-rsv-conve 
+    836  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     5   0% ext4-rsv-conve 
+    868  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% rpciod         
+    869  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% xprtiod        
+   4402  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 S     1   0% krfcommd       
+ 558611  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     7   0% kworker/7:2-ev 
+ 558619  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     3   0% kworker/3:1-ev 
+ 565507  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     2   0% kworker/2:1    
+ 568536  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kworker/4:1-ev 
+ 568999  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/u17:1  
+ 569377  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     6   0% kworker/6:0    
+ 569608  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     4   0% kworker/4:0-ev 
+ 569686  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/0:2    
+ 569687  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     N-   -    1 I     0   0% kworker/0:3-ev 
+ 569799  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    0 -     0   0%                
+
+
+ATOP - shard                                 2021/04/20  15:30:38                                 -----------------                                   1s elapsed
+PRC | sys    0.11s |  user   0.07s | #proc    377 |  #trun      1 | #tslpi   290 |  #tslpu     0 | #zombie    0 |  clones     4 |              |  no  procacct |
+CPU | sys      15% |  user     12% | irq      25% |  idle    748% | wait      0% |  guest     0% | ipc     0.62 |  cycl  186MHz | curf 3.55GHz |  curscal   ?% |
+cpu | sys      11% |  user      5% | irq       3% |  idle     81% | cpu002 w  0% |  guest     0% | ipc     1.03 |  cycl  550MHz | curf 3.50GHz |  curscal   ?% |
+cpu | sys       0% |  user      2% | irq       4% |  idle     94% | cpu006 w  0% |  guest     0% | ipc     0.47 |  cycl  190MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      2% | irq       3% |  idle     95% | cpu004 w  0% |  guest     0% | ipc     0.32 |  cycl  158MHz | curf 2.98GHz |  curscal   ?% |
+cpu | sys       1% |  user      1% | irq       3% |  idle     95% | cpu003 w  0% |  guest     0% | ipc     0.46 |  cycl  127MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       1% |  user      1% | irq       3% |  idle     95% | cpu005 w  0% |  guest     0% | ipc     0.78 |  cycl  130MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      0% | irq       5% |  idle     95% | cpu007 w  0% |  guest     0% | ipc     0.19 |  cycl  118MHz | curf 2.90GHz |  curscal   ?% |
+cpu | sys       1% |  user      1% | irq       2% |  idle     96% | cpu000 w  0% |  guest     0% | ipc     0.15 |  cycl  128MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      0% | irq       4% |  idle     96% | cpu001 w  0% |  guest     0% | ipc     0.16 |  cycl   85MHz | curf 3.80GHz |  curscal   ?% |
+CPL | avg1    0.16 |  avg5    0.15 | avg15   0.21 |               |              |  csw     3214 | intr   16594 |               |              |  numcpu     8 |
+MEM | tot    15.3G |  free    2.3G | cache   4.6G |  dirty   3.5M | buff  947.6M |  slab  620.1M | shrss   0.0M |  vmbal   0.0M | zfarc   0.0M |  hptot 512.0M |
+SWP | tot    11.7G |  free   11.7G | swcac   2.1M |  zpool   0.0M | zstor   0.0M |  ksuse   0.0M | kssav   0.0M |               | vmcom  22.9G |  vmlim  19.1G |
+NET | transport    |  tcpi      33 | tcpo      36 |  udpi       3 | udpo       3 |  tcpao      7 | tcppo      0 |  tcprs      0 | tcpie      0 |  udpie      0 |
+NET | network      |  ipi       23 | ipo       26 |  ipfrw      0 | deliv     23 |               |              |               | icmpi      0 |  icmpo      0 |
+NET | enp0s25 ---- |  pcki      86 | pcko      16 |  sp    0 Mbps | si   61 Kbps |  so   35 Kbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+NET | lo      ---- |  pcki      26 | pcko      26 |  sp    0 Mbps | si   24 Kbps |  so   24 Kbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+
+    PID SYSCPU USRCPU RDELAY  VGROW  RGROW  RDDSK  WRDSK RUID     EUID     ST EXC  THR S CPUNR  CPU CMD            
+ 567882  0.10s  0.04s  0.00s   148K   264K     0K     0K nathans  nathans  --   -    1 R     2  15% pmdaproc       
+   6569  0.00s  0.01s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   46 S     4   2% Web Content    
+ 569789  0.00s  0.01s  0.00s  7144K  4580K     0K  1164K nathans  nathans  --   -    1 S     5   1% pmlogger       
+ 510378  0.00s  0.00s  0.00s     0K     0K     0K     0K pcp      pcp      --   -    2 S     6   0% pmcd           
+   6098  0.00s  0.00s  0.00s     0K -1484K     0K     0K nathans  nathans  --   -  160 S     6   0% firefox        
+ 112334  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     6   0% Web Content    
+   6968  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   15 S     6   0% slack          
+   4311  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    4 S     0   0% pulseaudio     
+ 510388  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     4   0% pmdalinux      
+    905  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    2 S     5   0% thermald       
+ 510406  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     5   0% pmdazfs        
+ 112368  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     0   0% Web Content    
+   6667  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   43 S     0   0% Web Content    
+   8038  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   16 S     2   0% chrome         
+   6532  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   48 S     4   0% Web Content    
+   7465  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   26 S     4   0% chrome         
+   6234  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   45 S     3   0% Web Content    
+   6289  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   51 S     3   0% Web Content    
+ 512101  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     3   0% python3        
+ 149648  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     1   0% Web Content    
+ 251337  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   14 S     2   0% chrome         
+   6351  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   35 S     6   0% WebExtensions  
+ 507752  0.00s  0.00s  0.00s     0K     0K     0K     0K pcp      pcp      --   -    2 S     6   0% pmproxy        
+   6475  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     1   0% Privileged Con 
+ 259641  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    2 S     6   0% kded4          
+ 558607  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     6   0% php-fpm        
+   6626  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    3 S     1   0% RDD Process    
+   2725  0.00s  0.00s  0.00s     0K     0K     0K     0K geoclue  geoclue  --   -    4 S     2   0% geoclue        
+    848  0.00s  0.00s  0.00s     0K     0K     0K     0K systemd- systemd- --   -    1 S     0   0% systemd-resolv 
+      1  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     0   0% systemd        
+   7480  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     2   0% chrome         
+   4972  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    3 S     5   0% abrt-dbus      
+ 561042  0.00s  0.00s  0.00s     0K     0K     0K     0K apache   apache   --   -   65 S     2   0% /usr/sbin/http 
+    904  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     0   0% systemd-machin 
+ 510399  0.00s  0.00s  0.00s     0K     0K     0K     0K pcp      pcp      --   -    2 S     3   0% pmdaperfevent  
+ 127014  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    3 S     6   0% gvfsd-dnssd    
+ 530954  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     4   0% bash           
+   1338  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     6   0% (sd-pam        
+   8328  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     6   0% gconfd-2       
+    881  0.00s  0.00s  0.00s     0K     0K     0K     0K avahi    avahi    --   -    1 S     4   0% avahi-daemon   
+   7263  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    3 S     4   0% speech-dispatc 
+ 569742  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     6   0% mk.atop-thread 
+ 116463  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     0   0% ssh-agent      
+     14  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     1   0% rcu_sched      
+     24  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     2   0% ksoftirqd/2    
+     29  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     3   0% ksoftirqd/3    
+     58  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     7   0% kcompactd0     
+    137  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     2   0% kworker/2:1H-e 
+    276  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     4   0% kworker/4:1H-k 
+ 258588  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     7   0% kworker/7:0-ev 
+ 520551  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     3   0% kworker/3:3-mm 
+ 532562  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     2   0% kworker/2:0-ev 
+ 533793  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     1   0% kworker/1:3-ev 
+ 536169  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     2   0% kworker/u16:4- 
+ 558573  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     7   0% kworker/u16:3- 
+ 559476  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     5   0% kworker/5:2-ev 
+ 561022  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     1   0% kworker/1:0-mm 
+ 567864  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     6   0% kworker/6:1-ev 
+ 569076  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     0   0% kworker/u16:1- 
+ 569608  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     4   0% kworker/4:0-ev 
+ 569687  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     0   0% kworker/0:3-ev 
+ 569803  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    0 -     0   0%                
+
+
+ATOP - shard                                 2021/04/20  15:30:39                                 -----------------                                   1s elapsed
+PRC | sys    0.13s |  user   0.13s | #proc    377 |  #trun      1 | #tslpi   291 |  #tslpu     0 | #zombie    0 |  clones     0 |              |  no  procacct |
+CPU | sys      13% |  user     16% | irq      26% |  idle    745% | wait      0% |  guest     0% | ipc     0.62 |  cycl  175MHz | curf 3.56GHz |  curscal   ?% |
+cpu | sys       9% |  user      6% | irq       3% |  idle     82% | cpu002 w  0% |  guest     0% | ipc     1.09 |  cycl  527MHz | curf 3.50GHz |  curscal   ?% |
+cpu | sys       0% |  user      6% | irq       3% |  idle     91% | cpu003 w  0% |  guest     0% | ipc     0.65 |  cycl  231MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       0% |  user      2% | irq       2% |  idle     96% | cpu005 w  0% |  guest     0% | ipc     0.60 |  cycl   96MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       1% |  user      1% | irq       3% |  idle     95% | cpu006 w  0% |  guest     0% | ipc     0.19 |  cycl  130MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       1% |  user      0% | irq       3% |  idle     96% | cpu007 w  0% |  guest     0% | ipc     0.17 |  cycl  112MHz | curf 2.90GHz |  curscal   ?% |
+cpu | sys       0% |  user      1% | irq       4% |  idle     95% | cpu000 w  0% |  guest     0% | ipc     0.20 |  cycl  116MHz | curf 3.80GHz |  curscal   ?% |
+cpu | sys       1% |  user      0% | irq       3% |  idle     95% | cpu004 w  1% |  guest     0% | ipc     0.15 |  cycl  109MHz | curf 3.10GHz |  curscal   ?% |
+cpu | sys       1% |  user      0% | irq       3% |  idle     96% | cpu001 w  0% |  guest     0% | ipc     0.12 |  cycl   80MHz | curf 3.80GHz |  curscal   ?% |
+CPL | avg1    0.16 |  avg5    0.15 | avg15   0.21 |               |              |  csw     2200 | intr   16357 |               |              |  numcpu     8 |
+MEM | tot    15.3G |  free    2.3G | cache   4.6G |  dirty   4.7M | buff  947.6M |  slab  620.1M | shrss   0.0M |  vmbal   0.0M | zfarc   0.0M |  hptot 512.0M |
+SWP | tot    11.7G |  free   11.7G | swcac   2.1M |  zpool   0.0M | zstor   0.0M |  ksuse   0.0M | kssav   0.0M |               | vmcom  22.9G |  vmlim  19.1G |
+NET | transport    |  tcpi      44 | tcpo      44 |  udpi       0 | udpo       0 |  tcpao      6 | tcppo      2 |  tcprs      0 | tcpie      0 |  udpie      0 |
+NET | network      |  ipi       24 | ipo       24 |  ipfrw      0 | deliv     24 |               |              |               | icmpi      0 |  icmpo      0 |
+NET | lo      ---- |  pcki      43 | pcko      43 |  sp    0 Mbps | si   44 Kbps |  so   44 Kbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+NET | enp0s25 ---- |  pcki      85 | pcko      10 |  sp    0 Mbps | si   53 Kbps |  so    9 Kbps | erri       0 |  erro       0 | drpi       0 |  drpo       0 |
+
+    PID SYSCPU USRCPU RDELAY  VGROW  RGROW  RDDSK  WRDSK RUID     EUID     ST EXC  THR S CPUNR  CPU CMD            
+ 567882  0.09s  0.05s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 R     2  14% pmdaproc       
+   6569  0.00s  0.06s  0.00s     0K   800K     0K     0K nathans  nathans  --   -   46 S     7   8% Web Content    
+   6098  0.00s  0.00s  0.00s   -20K  1784K     0K     0K nathans  nathans  --   -  160 S     5   2% firefox        
+   4307  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   21 S     4   2% gnome-shell    
+ 569789  0.00s  0.00s  0.00s    -4K   236K     0K  1151K nathans  nathans  --   -    1 S     5   1% pmlogger       
+     24  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     2   1% ksoftirqd/2    
+ 112368  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     3   0% Web Content    
+   7581  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   17 S     4   0% chrome         
+ 112334  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     6   0% Web Content    
+   6667  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   43 S     6   0% Web Content    
+   8038  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   16 S     2   0% chrome         
+   6532  0.00s  0.00s  0.00s     0K   136K     0K     0K nathans  nathans  --   -   48 S     2   0% Web Content    
+   6234  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   45 S     3   0% Web Content    
+   6289  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   51 S     3   0% Web Content    
+   7672  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   15 S     6   0% chrome         
+ 512101  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     3   0% python3        
+ 149648  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     1   0% Web Content    
+   1242  0.00s  0.00s  0.00s     0K     0K     0K     0K redis    redis    --   -   37 S     6   0% redis-server   
+   6351  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   35 S     6   0% WebExtensions  
+   6475  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -   42 S     1   0% Privileged Con 
+ 259641  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    2 S     6   0% kded4          
+   6626  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    3 S     1   0% RDD Process    
+   2725  0.00s  0.00s  0.00s     0K     0K     0K     0K geoclue  geoclue  --   -    4 S     4   0% geoclue        
+    960  0.00s  0.00s  0.00s     0K     0K     0K     0K polkitd  polkitd  --   -   12 S     5   0% polkitd        
+    848  0.00s  0.00s  0.00s     0K     0K     0K     0K systemd- systemd- --   -    1 S     1   0% systemd-resolv 
+   7480  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     2   0% chrome         
+   4972  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    3 S     0   0% abrt-dbus      
+ 561042  0.00s  0.00s  0.00s     0K     0K     0K     0K apache   apache   --   -   65 S     2   0% /usr/sbin/http 
+ 510399  0.00s  0.00s  0.00s     0K     0K     0K     0K pcp      pcp      --   -    2 S     3   0% pmdaperfevent  
+ 127014  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    3 S     3   0% gvfsd-dnssd    
+    905  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    2 S     4   0% thermald       
+ 530954  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     4   0% bash           
+    937  0.00s  0.00s  0.00s     0K     0K     0K     0K dbus     dbus     --   -    1 S     6   0% dbus-broker    
+ 510378  0.00s  0.00s  0.00s     0K     0K     0K     0K pcp      pcp      --   -    2 S     0   0% pmcd           
+ 569803  0.00s  0.00s  0.00s 16328K  6180K     0K     0K nathans  nathans  N-   -    1 S     0   0% pmsleep        
+   1338  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     6   0% (sd-pam        
+   8328  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     6   0% gconfd-2       
+    881  0.00s  0.00s  0.00s     0K     0K     0K     0K avahi    avahi    --   -    1 S     0   0% avahi-daemon   
+   7263  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    3 S     4   0% speech-dispatc 
+ 569742  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     6   0% mk.atop-thread 
+ 116463  0.00s  0.00s  0.00s     0K     0K     0K     0K nathans  nathans  --   -    1 S     0   0% ssh-agent      
+     14  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     0   0% rcu_sched      
+     15  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     0   0% migration/0    
+     18  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     1   0% migration/1    
+     23  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     2   0% migration/2    
+     28  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     3   0% migration/3    
+     33  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     4   0% migration/4    
+     38  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     5   0% migration/5    
+     43  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     6   0% migration/6    
+     48  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     7   0% migration/7    
+     58  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 S     7   0% kcompactd0     
+    276  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     4   0% kworker/4:1H-e 
+ 520551  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     3   0% kworker/3:3-ev 
+ 532562  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     2   0% kworker/2:0-ev 
+ 533793  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     1   0% kworker/1:3-ev 
+ 536069  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     4   0% kworker/u17:0- 
+ 536169  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     2   0% kworker/u16:4- 
+ 558573  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     7   0% kworker/u16:3- 
+ 559476  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     5   0% kworker/5:2-ev 
+ 561022  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     1   0% kworker/1:0-mm 
+ 567864  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     6   0% kworker/6:1-ev 
+ 569608  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     4   0% kworker/4:0-ev 
+ 569687  0.00s  0.00s  0.00s     0K     0K     0K     0K root     root     --   -    1 I     0   0% kworker/0:3-ev 
+=== std err
+=== done
+
+Checking alternative name output
+OK

--- a/qa/group
+++ b/qa/group
@@ -1958,4 +1958,5 @@ x11
 1955 libpcp pmda pmda.pmcd local
 1956 pmda.linux pmcd local
 1957 libpcp local valgrind
+1978 atop local
 4751 libpcp threads valgrind local pcp helgrind

--- a/src/pcp/atop/photosyst.c
+++ b/src/pcp/atop/photosyst.c
@@ -148,6 +148,8 @@ update_processor(struct percpu *cpu, int id, pmResult *result, pmDesc *descs, in
 	memset(&cpu->freqcnt, 0, sizeof(cpu->freqcnt));
 	cpu->freqcnt.cnt = extract_count_t_inst(result, descs, PERCPU_FREQCNT_CNT, id, offset);
 	cpu->instr = extract_count_t_inst(result, descs, PERCPU_PERF_INSTR, id, offset);
+	if (cpu->instr == 0)	/* try ix86arch INSTRUCTION_RETIRED fallback */
+		cpu->instr = extract_count_t_inst(result, descs, PERCPU_PERF_INST1, id, offset);
 	cpu->cycle = extract_count_t_inst(result, descs, PERCPU_PERF_CYCLE, id, offset);
 }
 

--- a/src/pcp/atop/systmetrics.map
+++ b/src/pcp/atop/systmetrics.map
@@ -291,6 +291,7 @@ systmetrics {
 	zswap.stored_pages			ZSWAP_STOREDMEM
 
 	# hardware events
+	perfevent.hwcounters.INSTRUCTION_RETIRED.value		PERCPU_PERF_INST1
 	perfevent.hwcounters.INSTRUCTIONS_RETIRED.value		PERCPU_PERF_INSTR
 	perfevent.hwcounters.UNHALTED_REFERENCE_CYCLES.value	PERCPU_PERF_CYCLE
 

--- a/src/pmlogconf/tools/atop-perfevent
+++ b/src/pmlogconf/tools/atop-perfevent
@@ -2,5 +2,6 @@
 ident   perfevent metrics sampled by the atop command
 probe	perfevent.active values ? include : exclude
 
+	perfevent.hwcounters.INSTRUCTION_RETIRED.value
 	perfevent.hwcounters.INSTRUCTIONS_RETIRED.value
 	perfevent.hwcounters.UNHALTED_REFERENCE_CYCLES.value


### PR DESCRIPTION
The ix86arch PMU, and hence [ix86arch] section of perfevent.conf,
uses a different (singular form) name for INSTRUCTIONS_RETIRED to
everyone else.  Deal with this quirk such that we fallback to the
alternate name if the regular plural form cannot be found.

New test qa/1978 emulates this scenario using pmlogrewrite.

Resolves Red Hat BZ #1986264