### PR TITLE
pmlogger: install a zeroconf file for setting interval

### DIFF
--- a/debian/pcp-zeroconf.dirs
+++ b/debian/pcp-zeroconf.dirs
@@ -1,4 +1,5 @@
 etc/pcp/pmieconf/zeroconf
 etc/pcp/pmlogconf/zeroconf
+lib/systemd/system/pmlogger.service.d
 var/lib/pcp/config/pmieconf/zeroconf
 var/lib/pcp/config/pmlogconf/zeroconf

--- a/debian/pcp-zeroconf.install
+++ b/debian/pcp-zeroconf.install
@@ -7,6 +7,7 @@ etc/pcp/pmlogconf/zeroconf/pidstat
 etc/pcp/pmlogconf/zeroconf/pidstat-summary
 etc/pcp/pmlogconf/zeroconf/tapestat
 etc/pcp/pmlogconf/zeroconf/xfs-perdev
+lib/systemd/system/pmlogger.service.d/zeroconf.conf
 var/lib/pcp/config/pmieconf/zeroconf/all_threads
 var/lib/pcp/config/pmlogconf/zeroconf/atop-proc
 var/lib/pcp/config/pmlogconf/zeroconf/interrupts

--- a/debian/pcp-zeroconf.postinst
+++ b/debian/pcp-zeroconf.postinst
@@ -12,7 +12,9 @@ for PMDA in dm nfsclient openmetrics ; do
 done
 
 # increase default pmlogger recording frequency
-sed -i 's/^\#\ PMLOGGER_INTERVAL.*/PMLOGGER_INTERVAL=10/g' /etc/default/pmlogger
+if [ ! -e /run/systemd ] ; then
+    sed -i 's/^\#\ PMLOGGER_INTERVAL.*/PMLOGGER_INTERVAL=10/g' /etc/default/pmlogger
+fi
 
 # auto-enable these usually optional pmie rules
 pmieconf -c enable dmthin

--- a/src/pmlogger/GNUmakefile
+++ b/src/pmlogger/GNUmakefile
@@ -58,6 +58,7 @@ endif
 	$(INSTALL) -m 755 rc_pmlogger $(PCP_RC_DIR)/pmlogger
 ifeq ($(ENABLE_SYSTEMD),true)
 	$(INSTALL) -m 644 pmlogger.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger.service
+	$(INSTALL) -m 644 pmlogger_service_zeroconf.conf $(PCP_SYSTEMDUNIT_DIR)/pmlogger.service.d/zeroconf.conf
 	$(INSTALL) -m 644 pmlogger_daily.timer $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily.timer
 	$(INSTALL) -m 644 pmlogger_daily.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily.service
 	$(INSTALL) -m 644 pmlogger_check.timer $(PCP_SYSTEMDUNIT_DIR)/pmlogger_check.timer

--- a/src/pmlogger/pmlogger_service_zeroconf.conf
+++ b/src/pmlogger/pmlogger_service_zeroconf.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=PMLOGGER_INTERVAL=10


### PR DESCRIPTION
On Debian, a package may not modify configuration files of other packages in
maintainer scripts. This fails the puiparts test[1] will result in eventual
removal[2] of the package and its dependents from Debian.

10.7.3: "[...] The easy way to achieve this behavior is to make the
configuration file a conffile. [...] This implies that the default
version will be part of the package distribution, and must not be
modified by the maintainer scripts during installation (or at any
other time)."

On systemd systems, avoid editing the configuration file installed by the pcp
package from pcp-zeroconf. Ship a systemd service drop-in configuration file
with the pcp-zeroconf which adds an extra environmental variable when running
pmlogger. This can be overridden by a user by creating a file in
/etc/systemd/system/pmlogger.service.d/. Removing the pcp-zeroconf package and
keeping pcp package will remove the configuration brought in by pcp-zeroconf.

Tests performed:

- Build with ./Makepkgs --nonrpm . Build succeeds and built all the .deb file.

- Install the .deb files specifically pcp and pcp-zeroconf on Debian unstable.
Install succeeds.

- After installation the file /etc/default/pmlogger is not modified.

- systemctl show pmlogger.service | grep Environment shows:
Environment=PMLOGGER_INTERVAL=10

- After installation, pmlogger service is running. systemctl status
pmlogger.service

- The pmlogger service has received the environmental variable. cat
/proc/{pid}/environ | tr '\0' '\n' | grep PMLOGGER_INTERVAL
PMLOGGER_INTERVAL=10

- Remove pcp-zeroconf. systemctl daemon-reload. systemctl restart
pmlogger.service. systemctl show pmlogger.service | grep Environment shows empty
output.

Links:

1) https://piuparts.debian.org/sid/fail/pcp-zeroconf_5.3.3-1.log

2) https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=990223

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>