### PR TITLE
Add pmlogger_check --only-primary option flag

### DIFF
--- a/man/man1/pmlogger_check.1
+++ b/man/man1/pmlogger_check.1
@@ -19,7 +19,7 @@
 \f3pmlogger_daily\f1 \- administration of Performance Co-Pilot archive log files
 .SH SYNOPSIS
 .B $PCP_BINADM_DIR/pmlogger_check
-[\f3\-CNpqsTV?\f1]
+[\f3\-CNPpqsTV?\f1]
 [\f3\-c\f1 \f2control\f1]
 [\f3\-l\f1 \f2logfile\f1]
 .br
@@ -364,6 +364,17 @@ is responsible for controlling (starting, stopping, restarting, etc.) the
 .I primary
 .BR pmlogger .
 .TP
+\fB\-P\fR, \fB\-\-only\-primary\fR
+If this option is specified for
+.B pmlogger_check
+then only the primary logger entry in the control files will be processed.
+This is the logical opposite of the \fB\-p\fP option described above
+and is intended for use by RC scripts that start only the primary logger,
+such as the
+.B pmlogger.service
+unit.
+The \fB\-p\fP and \fB\-P\fP options to \fBpmlogger_check\fP are mutually exclusive.
+.TP
 \fB\-p\fR
 If this option is specified for
 .B pmlogger_daily
@@ -385,6 +396,12 @@ With this option
 .B pmlogger_daily
 simply exits if the previous day's processing has already been
 done.
+Note that this option is not used on platforms supporting
+.BR systemd (1)
+because the
+.B pmlogger_daily.timer
+service unit specifies a timer setting with
+.BR Persistent=true .
 The
 .B \-K
 and

--- a/src/pmlogger/pmlogger.service.in
+++ b/src/pmlogger/pmlogger.service.in
@@ -9,7 +9,9 @@ Wants=pmcd.service
 [Service]
 Type=notify
 NotifyAccess=all
-TimeoutSec=120
+# no start timeout - for logger farms
+TimeoutStartSec=infinity
+TimeoutStopSec=120
 Restart=always
 ExecStart=@PCP_RC_DIR@/pmlogger start-systemd
 ExecStop=@PCP_RC_DIR@/pmlogger stop-systemd

--- a/src/pmlogger/pmlogger_check.sh
+++ b/src/pmlogger/pmlogger_check.sh
@@ -114,6 +114,7 @@ START_PMLOGGER=true
 STOP_PMLOGGER=false
 QUICKSTART=false
 SKIP_PRIMARY=false
+ONLY_PRIMARY=false
 
 echo > $tmp/usage
 cat >> $tmp/usage << EOF
@@ -123,6 +124,7 @@ Options:
   -C                      query system service runlevel information
   -N,--showme             perform a dry run, showing what would be done
   -p,--skip-primary       do not start or stop the primary pmlogger instance
+  -P,--only-primary       only start or stop the primary pmlogger, no others
   -q,--quick              quick start, no compression
   -s,--stop               stop pmlogger processes instead of starting them
   -T,--terse              produce a terser form of output
@@ -161,6 +163,8 @@ do
 		daily_args="${daily_args} -N"
 		;;
 	-p)	SKIP_PRIMARY=true
+		;;
+	-P)	ONLY_PRIMARY=true
 		;;
 	-q)	QUICKSTART=true
 		;;
@@ -720,6 +724,15 @@ s/^\([A-Za-z][A-Za-z0-9_]*\)=/export \1; \1=/p
 	if $SKIP_PRIMARY && [ $primary = y ]
 	then
 	    $VERY_VERBOSE && echo "Skip, -s/--skip-primary on command line"
+	    continue
+	fi
+
+	# if -P/--only-primary on the command line, only process
+	# the control file line for the primary pmlogger
+	#
+	if $ONLY_PRIMARY && [ $primary != y ]
+	then
+	    $VERY_VERBOSE && echo "Skip non-primary, -P/--only-primary on command line"
 	    continue
 	fi
 


### PR DESCRIPTION
Logical opposite of pmlogger_check --skip-primary. Will be used (in subsequent commits) by pmlogger.service to start only the primary logger. Man page for pmlogger_check(1) is also updated. 