### PR TITLE
pcp-atop: report user and group names using PMAPI calls

### DIFF
--- a/src/pcp/atop/atop.h
+++ b/src/pcp/atop/atop.h
@@ -216,6 +216,11 @@ int		get_instances(const char *, int, struct pmDesc *, int **, char ***);
 int		fetch_instances(const char *, int, struct pmDesc *, int **, char ***);
 int		get_instance_index(pmResult *, int, int);
 
+void		add_username(int, const char *);
+void		add_groupname(int, const char *);
+char		*get_username(int);
+char		*get_groupname(int);
+
 struct sstat	*sstat_alloc(const char *);
 void		sstat_reset(struct sstat *);
 

--- a/src/pcp/atop/photoproc.c
+++ b/src/pcp/atop/photoproc.c
@@ -28,7 +28,10 @@ static pmDesc	descs[TASK_NMETRICS];
 static void
 update_task(struct tstat *task, int pid, char *name, pmResult *rp, pmDesc *dp, int offset)
 {
+	int key;
+	char buf[32];
 	char *nametail = name;
+
 	memset(task, 0, sizeof(struct tstat));
 
 	strsep(&nametail, " ");	/* remove process identifier prefix; might fail */
@@ -86,6 +89,7 @@ update_task(struct tstat *task, int pid, char *name, pmResult *rp, pmDesc *dp, i
 		task->gen.tgid = pid;
 	task->gen.ctid = extract_integer_inst(rp, dp, TASK_GEN_ENVID, pid, offset);
 	task->gen.vpid = extract_integer_inst(rp, dp, TASK_GEN_VPID, pid, offset);
+
 	task->gen.ruid = extract_integer_inst(rp, dp, TASK_GEN_RUID, pid, offset);
 	task->gen.euid = extract_integer_inst(rp, dp, TASK_GEN_EUID, pid, offset);
 	task->gen.suid = extract_integer_inst(rp, dp, TASK_GEN_SUID, pid, offset);
@@ -94,6 +98,7 @@ update_task(struct tstat *task, int pid, char *name, pmResult *rp, pmDesc *dp, i
 	task->gen.egid = extract_integer_inst(rp, dp, TASK_GEN_EGID, pid, offset);
 	task->gen.sgid = extract_integer_inst(rp, dp, TASK_GEN_SGID, pid, offset);
 	task->gen.fsgid = extract_integer_inst(rp, dp, TASK_GEN_FSGID, pid, offset);
+
 	task->mem.vdata = extract_count_t_inst(rp, dp, TASK_MEM_VDATA, pid, offset);
 	task->mem.vstack = extract_count_t_inst(rp, dp, TASK_MEM_VSTACK, pid, offset);
 	task->mem.vexec = extract_count_t_inst(rp, dp, TASK_MEM_VEXEC, pid, offset);
@@ -106,8 +111,38 @@ update_task(struct tstat *task, int pid, char *name, pmResult *rp, pmDesc *dp, i
 	task->dsk.wsz = extract_count_t_inst(rp, dp, TASK_DSK_WSZ, pid, offset);
 	task->dsk.cwsz = extract_count_t_inst(rp, dp, TASK_DSK_CWSZ, pid, offset);
 
+	/* user names (cached) */
+	key = task->gen.ruid;
+	if (get_username(task->gen.ruid) == NULL &&
+	    extract_string_inst(rp, dp, TASK_GEN_RUIDNM, buf, sizeof buf, pid, offset))
+		add_username(key, buf);
+	if (key != task->gen.euid && get_username(task->gen.euid) == NULL &&
+	    extract_string_inst(rp, dp, TASK_GEN_EUIDNM, buf, sizeof buf, pid, offset))
+		add_username(key, buf);
+	if (key != task->gen.suid && get_username(task->gen.suid) == NULL &&
+	    extract_string_inst(rp, dp, TASK_GEN_SUIDNM, buf, sizeof buf, pid, offset))
+		add_username(key, buf);
+	if (key != task->gen.fsuid && get_username(task->gen.fsuid) == NULL &&
+	    extract_string_inst(rp, dp, TASK_GEN_FSUIDNM, buf, sizeof buf, pid, offset))
+		add_username(key, buf);
+
+	/* group names (cached) */
+	key = task->gen.rgid;
+	if (get_groupname(task->gen.rgid) == NULL &&
+	    extract_string_inst(rp, dp, TASK_GEN_RGIDNM, buf, sizeof buf, pid, offset))
+		add_groupname(key, buf);
+	if (key != task->gen.egid && get_groupname(task->gen.egid) == NULL &&
+	    extract_string_inst(rp, dp, TASK_GEN_EGIDNM, buf, sizeof buf, pid, offset))
+		add_groupname(key, buf);
+	if (key != task->gen.sgid && get_groupname(task->gen.sgid) == NULL &&
+	    extract_string_inst(rp, dp, TASK_GEN_SGIDNM, buf, sizeof buf, pid, offset))
+		add_groupname(key, buf);
+	if (key != task->gen.fsgid && get_groupname(task->gen.fsgid) == NULL &&
+	    extract_string_inst(rp, dp, TASK_GEN_FSGIDNM, buf, sizeof buf, pid, offset))
+		add_groupname(key, buf);
+
 	/*
- 	** normalization
+	** normalization
 	*/
 	task->cpu.prio   += 100; 	/* was subtracted by kernel */
 

--- a/src/pcp/atop/procmetrics.map
+++ b/src/pcp/atop/procmetrics.map
@@ -61,6 +61,12 @@ procmetrics {
 	hotproc.id.suid_nm			TASK_GEN_SUIDNM
 	hotproc.id.fsuid_nm			TASK_GEN_FSUIDNM
 
+	# getgruid
+	hotproc.id.gid_nm			TASK_GEN_RGIDNM
+	hotproc.id.egid_nm			TASK_GEN_EGIDNM
+	hotproc.id.sgid_nm			TASK_GEN_SGIDNM
+	hotproc.id.fsgid_nm			TASK_GEN_FSGIDNM
+
 	# /proc/pid/cgroup
 	hotproc.id.container			TASK_GEN_CONTAINER
 

--- a/src/pcp/atop/showprocs.c
+++ b/src/pcp/atop/showprocs.c
@@ -28,9 +28,6 @@
 #else
 #include <curses.h>
 #endif
-#include <pwd.h>
-#include <grp.h>
-#include <regex.h>
 
 #include "atop.h"
 #include "photoproc.h"
@@ -803,15 +800,15 @@ char *
 procprt_RUID_ae(struct tstat *curstat, int avgval, double nsecs)
 {
         static char buf[9];
-        struct passwd   *pwd;
+        char *username;
 
-        if ( (pwd = getpwuid(curstat->gen.ruid)) )
+        if ( (username = get_username(curstat->gen.ruid)) )
         {
-                        pmsprintf(buf, sizeof buf, "%-8.8s", pwd->pw_name);
-        } 
-        else 
+                pmsprintf(buf, sizeof buf, "%-8.8s", username);
+        }
+        else
         {
-                        pmsprintf(buf, sizeof buf, "%-8d", curstat->gen.ruid);
+                pmsprintf(buf, sizeof buf, "%-8d", curstat->gen.ruid);
         }
         return buf;
 }
@@ -823,15 +820,15 @@ char *
 procprt_EUID_a(struct tstat *curstat, int avgval, double nsecs)
 {
         static char buf[9];
-        struct passwd   *pwd;
+        char *username;
 
-        if ( (pwd = getpwuid(curstat->gen.euid)) )
+        if ( (username = get_username(curstat->gen.euid)) )
         {
-                        pmsprintf(buf, sizeof buf, "%-8.8s", pwd->pw_name);
-        } 
-        else 
+                pmsprintf(buf, sizeof buf, "%-8.8s", username);
+        }
+        else
         {
-                        pmsprintf(buf, sizeof buf, "%-8d", curstat->gen.euid);
+                pmsprintf(buf, sizeof buf, "%-8d", curstat->gen.euid);
         }
         return buf;
 }
@@ -849,15 +846,15 @@ char *
 procprt_SUID_a(struct tstat *curstat, int avgval, double nsecs)
 {
         static char buf[9];
-        struct passwd   *pwd;
+        char *username;
 
-        if ( (pwd = getpwuid(curstat->gen.suid)) )
+        if ( (username = get_username(curstat->gen.suid)) )
         {
-                        pmsprintf(buf, sizeof buf, "%-8.8s", pwd->pw_name);
+                pmsprintf(buf, sizeof buf, "%-8.8s", username);
         } 
-        else 
+        else
         {
-                        pmsprintf(buf, sizeof buf, "%-8d", curstat->gen.suid);
+                pmsprintf(buf, sizeof buf, "%-8d", curstat->gen.suid);
         }
         return buf;
 }
@@ -875,15 +872,15 @@ char *
 procprt_FSUID_a(struct tstat *curstat, int avgval, double nsecs)
 {
         static char buf[9];
-        struct passwd   *pwd;
+        char *username;
 
-        if ( (pwd = getpwuid(curstat->gen.fsuid)) )
+        if ( (username = get_username(curstat->gen.fsuid)) )
         {
-                        pmsprintf(buf, sizeof buf, "%-8.8s", pwd->pw_name);
-        } 
-        else 
+                pmsprintf(buf, sizeof buf, "%-8.8s", username);
+        }
+        else
         {
-                        pmsprintf(buf, sizeof buf, "%-8d", curstat->gen.fsuid);
+                pmsprintf(buf, sizeof buf, "%-8d", curstat->gen.fsuid);
         }
         return buf;
 }
@@ -901,18 +898,13 @@ char *
 procprt_RGID_ae(struct tstat *curstat, int avgval, double nsecs)
 {
         static char buf[10];
-        struct group    *grp;
         char *groupname;
         char grname[16];
 
-        if ( (grp = getgrgid(curstat->gen.rgid)) )
+        if ( (groupname = get_groupname(curstat->gen.rgid)) == NULL )
         {
-                        groupname = grp->gr_name;
-        }
-        else
-        {
-                        pmsprintf(grname, sizeof grname, "%d",curstat->gen.rgid);
-                        groupname = grname;
+                pmsprintf(grname, sizeof grname, "%d",curstat->gen.rgid);
+                groupname = grname;
         }
 
         pmsprintf(buf, sizeof buf, "%-8.8s", groupname);
@@ -926,18 +918,13 @@ char *
 procprt_EGID_a(struct tstat *curstat, int avgval, double nsecs)
 {
         static char buf[10];
-        struct group    *grp;
         char *groupname;
         char grname[16];
 
-        if ( (grp = getgrgid(curstat->gen.egid)) )
+        if ( (groupname = get_groupname(curstat->gen.egid)) == NULL )
         {
-                        groupname = grp->gr_name;
-        }
-        else
-        {
-                        pmsprintf(grname, sizeof grname, "%d",curstat->gen.egid);
-                        groupname = grname;
+                pmsprintf(grname, sizeof grname, "%d",curstat->gen.egid);
+                groupname = grname;
         }
 
         pmsprintf(buf, sizeof buf, "%-8.8s", groupname);
@@ -957,18 +944,13 @@ char *
 procprt_SGID_a(struct tstat *curstat, int avgval, double nsecs)
 {
         static char buf[10];
-        struct group    *grp;
         char *groupname;
         char grname[16];
 
-        if ( (grp = getgrgid(curstat->gen.sgid)) )
+        if ( (groupname = get_groupname(curstat->gen.sgid)) == NULL )
         {
-                        groupname = grp->gr_name;
-        }
-        else
-        {
-                        pmsprintf(grname, sizeof grname, "%d",curstat->gen.sgid);
-                        groupname = grname;
+                pmsprintf(grname, sizeof grname, "%d",curstat->gen.sgid);
+                groupname = grname;
         }
 
         pmsprintf(buf, sizeof buf, "%-8.8s", groupname);
@@ -988,18 +970,13 @@ char *
 procprt_FSGID_a(struct tstat *curstat, int avgval, double nsecs)
 {
         static char buf[10];
-        struct group    *grp;
         char *groupname;
         char grname[16];
 
-        if ( (grp = getgrgid(curstat->gen.fsgid)) )
+        if ( (groupname = get_groupname(curstat->gen.fsgid)) == NULL )
         {
-                        groupname = grp->gr_name;
-        }
-        else
-        {
-                        pmsprintf(grname, sizeof grname,"%d",curstat->gen.fsgid);
-                        groupname = grname;
+                pmsprintf(grname, sizeof grname,"%d",curstat->gen.fsgid);
+                groupname = grname;
         }
 
         pmsprintf(buf, sizeof buf, "%-8.8s", groupname);


### PR DESCRIPTION
This tackles a failure in CI of test qa/1978 due to different
user and group names being reported on test systems.  The root
cause turned out to be use of getpwuid and getgrgid inside the
atop printing routines.  These map IDs to localhost names - we
can do better and use the names from the archive or (possibly
remote) pmcd, which contains the actual map from the collector
host.