### PR TITLE
services: remove run-level check in pmlogger systemd service config

### DIFF
--- a/qa/1889
+++ b/qa/1889
@@ -1,0 +1,68 @@
+#!/bin/sh
+# PCP QA Test No. 1889
+# test primary pmlogger starts under systemd when service is disabled
+#
+# Copyright (c) 2021 Red Hat.  All Rights Reserved.
+#
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+# this tests systemd starting pmlogger
+which systemctl >/dev/null 2>&1 || _notrun "systemctl not installed"
+
+_cleanup()
+{
+    cd $here
+    if [ -n "$pid" ]
+    then
+	$sudo rm -f $PCP_TMP_DIR/pmlogger/$pid $PCP_RUN_DIR/pmlogger.$pid.socket
+    fi
+    $sudo rm -f $PCP_RUN_DIR/pmlogger.pid
+    echo "=== enable pmlogger.service"
+    $sudo systemctl enable pmlogger.service >/dev/null 2>&1
+    _restore_auto_restart pmlogger
+    _service pmlogger restart | _filter_pcp_start
+    rm -rf $tmp.*
+}
+
+status=1	# failure is the default!
+$sudo rm -rf $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+# real QA test starts here
+_stop_auto_restart pmlogger
+
+pid=`$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep 'pmlogger.*-P' | \
+grep -v grep | awk '{print $2}'`
+
+if [ ! -S "$PCP_RUN_DIR/pmlogger.$pid.socket" ]; then
+    echo FAIL no primary pmlogger running? pid=$pid
+    status=1
+    exit
+fi
+echo found primary pmlogger and found control socket in PCP_RUN_DIR
+
+echo "=== disable pmlogger.service" | tee -a $seq.full
+$sudo systemctl disable pmlogger.service >>$seq.full 2>&1
+
+echo === start primary logger whilst disabled ===
+_service pmlogger start | _filter_pcp_start
+_wait_for_pmlogger
+
+newpid=`$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep 'pmlogger.*-P' | \
+    grep -v grep | awk '{print $2}'`
+
+if [ -z "$newpid" ]; then
+    echo FAIL pmlogger failed to start whilst disabled
+    status=1
+    exit
+fi
+echo found primary pmlogger and found control socket in PCP_RUN_DIR
+status=0
+
+exit

--- a/qa/1889.out
+++ b/qa/1889.out
@@ -1,0 +1,6 @@
+QA output created by 1889
+found primary pmlogger and found control socket in PCP_RUN_DIR
+=== disable pmlogger.service
+=== start primary logger whilst disabled ===
+found primary pmlogger and found control socket in PCP_RUN_DIR
+=== enable pmlogger.service

--- a/qa/808
+++ b/qa/808
@@ -53,9 +53,9 @@ else
     done
     $sudo kill -0 $pid >/dev/null 2>&1 && echo "Arrggh, pid $pid won't die!"
 
-    echo === running pmlogger_check to restart primary logger ===
-    $sudo $PCP_BINADM_DIR/pmlogger_check -C
-    sleep 2
+    echo === restart primary logger ===
+    _service pmlogger start | _filter_pcp_start
+    _wait_for_pmlogger
 
     newpid=`$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep 'pmlogger.*-P' | \
 	grep -v grep | awk '{print $2}'`
@@ -98,9 +98,9 @@ else
     $sudo rm -f $PCP_RUN_DIR/pmlogger.primary.socket
     $sudo ln $PCP_RUN_DIR/pmlogger.$pid.socket $PCP_RUN_DIR/pmlogger.primary.socket
 
-    echo === running pmlogger_check to restart primary logger ===
-    $sudo $PCP_BINADM_DIR/pmlogger_check -C
-    sleep 2
+    echo === restart primary logger ===
+    _service pmlogger start | _filter_pcp_start
+    _wait_for_pmlogger
 
     newpid=`$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep 'pmlogger.*-P' | \
 	grep -v grep | awk '{print $2}'`

--- a/qa/808.out
+++ b/qa/808.out
@@ -1,7 +1,7 @@
 QA output created by 808
 found primary pmlogger and found control socket in PCP_RUN_DIR
 === killing the primary pmlogger with SIGKILL ===
-=== running pmlogger_check to restart primary logger ===
+=== restart primary logger ===
 === checking with stale legacy hard links
 === killing the primary pmlogger with SIGKILL ===
-=== running pmlogger_check to restart primary logger ===
+=== restart primary logger ===

--- a/qa/group
+++ b/qa/group
@@ -1946,6 +1946,7 @@ x11
 1874 pmseries pmproxy local
 1876 pmcd secure local
 1886 pmseries libpcp_web local
+1889 pmlogger local
 1893 pmda.proc local
 1895 pmda.bpf local
 1896 pmlogger logutil pmlc local

--- a/src/pmlogger/pmlogger.service.in
+++ b/src/pmlogger/pmlogger.service.in
@@ -9,7 +9,7 @@ Wants=pmcd.service
 [Service]
 Type=notify
 NotifyAccess=all
-Environment="PMLOGGER_CHECK_PARAMS=-C --only-primary"
+Environment="PMLOGGER_CHECK_PARAMS=--only-primary"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger
 TimeoutStartSec=120
 TimeoutStopSec=120

--- a/src/pmlogger/pmlogger_check.service.in
+++ b/src/pmlogger/pmlogger_check.service.in
@@ -13,7 +13,7 @@ TimeoutStopSec=120
 # which is timer driven and exits. KillMode is temporary and will
 # not be necessary once we have pmlogger-farm.service.
 KillMode=process
-Environment="PMLOGGER_CHECK_PARAMS=-C --skip-primary"
+Environment="PMLOGGER_CHECK_PARAMS=--skip-primary"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
 ExecStart=@PCP_BINADM_DIR@/pmlogger_check $PMLOGGER_CHECK_PARAMS
 WorkingDirectory=@PCP_VAR_DIR@


### PR DESCRIPTION
Remove the run-level check (pmlogger_check -C flag) since systemd
uses targets for run-level checks. The run-level checks were causing
the pmlogger service to fail to manually start (via systemctl start
pmlogger) when the service is disabled.

New test qa/1889 checks pmlogger still starts even if disabled (on
systemd platforms only). qa/808 is also reworked since it was running
pmlogger_check directly and was failing every *second* run.