### PR TITLE
libpcp: fix authentication on systems where hostname != fqdn

### DIFF
--- a/qa/1388
+++ b/qa/1388
@@ -20,14 +20,6 @@ echo "QA output created by $seq"
 _check_series
 which curl >/dev/null 2>&1 || _notrun "No curl binary installed"
 
-full_hostname=`hostname`
-if echo "$full_hostname" | grep '\.' >/dev/null
-then
-    :
-else
-    _notrun "hostname -> $full_hostname, no domain name part"
-fi
-
 sasl_notrun_checks saslpasswd2 sasldblistusers2
 $pluginviewer -a | grep 'Plugin "sasldb"' >/dev/null
 test $? -eq 0 || _notrun "SASL sasldb auxprop plugin unavailable"

--- a/qa/1391
+++ b/qa/1391
@@ -11,7 +11,6 @@ echo "QA output created by $seq"
 . ./common.filter
 . ./common.secure
 
-_check_series
 which curl >/dev/null 2>&1 || _notrun "No curl binary installed"
 
 full_hostname=`hostname --fqdn`


### PR DESCRIPTION
SASL stores username@hostname in the SASL DB (see sasldblistusers2(8))
saslpasswd2(8) uses gethostname() to determine the hostname
sasl_server_new() uses get_fqhostname() to determine a FQDN if the hostname parameter is NULL

therefore, if the hostname doesn't match the FQDN of the system running pmcd, the authentication was broken
as a workaround, let's use gethostname() as parameter to sasl_server_new