### PR TITLE
pmdamssql: share username/password with the Assessments API

### DIFF
--- a/qa/1337
+++ b/qa/1337
@@ -1,6 +1,6 @@
 #!/bin/sh
 # PCP QA Test No. 1337
-# Copyright (c) 2019 Red Hat.
+# Copyright (c) 2019,2021 Red Hat.
 #
 # Exercise MSSQL agent Install and Remove scripts,
 # plus metric value validation on select metrics.
@@ -21,9 +21,13 @@ test -d "$PCP_PMDAS_DIR/mssql" || _notrun "Microsoft SQL Server PMDA not install
 
 # extract username and password, check connection to SQL Server
 eval `$sudo egrep 'server=|username=|password=' "$PCP_PMDAS_DIR/mssql/mssql.conf"`
-test -n "$server" || _notrun "Cannot find SQL Server connection setting"
+if $sudo test -f /var/opt/mssql/secrets/assessment; then
+    username=`$sudo head -1 /var/opt/mssql/secrets/assessment`
+    password=`$sudo tail -1 /var/opt/mssql/secrets/assessment`
+fi
 test -n "$username" || _notrun "Cannot find SQL Server username setting"
 test -n "$password" || _notrun "Cannot find SQL Server password setting"
+test -n "$server" || server="tcp:localhost"
 
 _cleanup()
 {

--- a/src/pmdas/mssql/pmdamssql.1
+++ b/src/pmdas/mssql/pmdamssql.1
@@ -1,6 +1,6 @@
 '\"macro stdmacro
 .\"
-.\" Copyright (c) 2019-2020 Red Hat.  All Rights Reserved.
+.\" Copyright (c) 2019-2021 Red Hat.  All Rights Reserved.
 .\"
 .\" This program is free software; you can redistribute it and/or modify it
 .\" under the terms of the GNU General Public License as published by the
@@ -26,8 +26,8 @@ Firstly, \f3pmdamssql\f1 requires installation of these support packages:
 .B mssql-server
 The primary Microsoft SQL Server database package.
 .TP
-.BR msodbcsql17 " or (" msodbcsql )
-Latest Microsoft SQL Server ODBC bindings.
+\fBmsodbcsql18\fR, \fBmsodbcsql17\fR or \fBmsodbcsql\fR
+Microsoft SQL Server ODBC bindings.
 .TP
 .B pyodbc
 General Python ODBC module with Microsoft SQL Server support enabled.
@@ -66,11 +66,18 @@ provided.
 These are the following configuration settings
 (their default values are shown in parenthesis):
 .TP 15
-.B username \fR(\fP\fIsa\fP\fR)\fP
+.B username \fR(\fP\fIpcp\fP\fR)\fP
 Username to connect to the database.
 .TP
-.B password \fR(unset)\fP
+.B password \fR(empty)\fP
 Password to connect to the database.
+.PP
+Note that if a SQL Server Assessments API configuration file is
+found at \fI/var/opt/mssql/secrets/assessment\fP, then
+.B pmdamssql
+reads the username and password from that file preferentially.
+The format is simply a two line text file, the first containing
+the username and the second the password.
 .PP
 The second option is Windows authentication mode,
 where logins are created in SQL Server that are not

--- a/src/pmdas/mssql/pmdamssql.python
+++ b/src/pmdas/mssql/pmdamssql.python
@@ -1,6 +1,6 @@
 #!/usr/bin/env pmpython
 
-# Copyright (c) 2019 Red Hat.  All Rights Reserved.
+# Copyright (c) 2019,2021 Red Hat.  All Rights Reserved.
 # Copyright (c) 2011 Aconex.  All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -47,6 +47,13 @@ class MSSQLPMDA(PMDA):
     def INDOM_ID(self, serial):
         """ indom id from PMDA domain and serial """
         return PMDA.indom(serial)
+
+    def sanitize(self, string):
+        """ quoting - escape backslashes, single quotes and semi colons """
+        string = string.replace("\\", "\\\\")
+        string = string.replace("'", "\\'")
+        string = string.replace(";", "\\;")
+        return string
 
     def __init__(self, name, domain):
         """ constructor """
@@ -1001,8 +1008,14 @@ class MSSQLPMDA(PMDA):
 
         # parse config for connection settings
         conf_vars = self.config(conf_file, ['authentication', 'connection'])
-        self.driver = conf_vars["connection.driver"]
-        self.server = conf_vars["connection.server"]
+        try:
+            self.driver = conf_vars["connection.driver"]
+        except:
+            self.driver = "{ODBC Driver 17 for SQL Server}" # default driver
+        try:
+            self.server = conf_vars["connection.server"]
+        except:
+            self.server = "tcp:localhost" # local default
         try:
             self.timeout = int(conf_vars["connection.timeout"])
         except:
@@ -1011,18 +1024,19 @@ class MSSQLPMDA(PMDA):
             self.trusted = bool(conf_vars["authentication.trusted"])
         except:
             self.trusted = False
+        # first try Assessment API credentials, else our local config file,
+        # otherwise just use defaults of user 'pcp' with an empty password.
+        self.username = pmContext.pmGetConfig('PCP_USER')
+        self.password = ''
         try:
+            with open('/var/opt/mssql/secrets/assessment', 'r') as assessment:
+                self.username = assessment.readline().strip()
+                self.password = assessment.readline().strip()
+        except:
             self.username = conf_vars["authentication.username"]
-        except:
-            self.username = pmContext.pmGetConfig('PCP_USER')
-        try:
             self.password = str(conf_vars["authentication.password"])
-        except:
-            self.password = ''
-        # need to escape backslashes, single quotes and semi colons
-        self.password = self.password.replace("\\", "\\\\")
-        self.password = self.password.replace("'", "\\'")
-        self.password = self.password.replace(";", "\\;")
+        self.username = self.sanitize(self.username)
+        self.password = self.sanitize(self.password)
 
         self.log("Connecting to %s as user %s" % (self.server, self.username))
         retries = 0


### PR DESCRIPTION
For admin simplicity, if a SQL Server Assessments API install
is detected we now use the username/password combo setup for
this service so that no PCP mssql configuration is required.

Resolves Red Hat BZ #1951342