### PR TITLE
services: disable service advertising by default in pmcd and pmproxy

### DIFF
--- a/src/pmcd/pmcd.options
+++ b/src/pmcd/pmcd.options
@@ -19,6 +19,9 @@
 # run in the foreground (not as a daemon)
 # -f
 
+# disable service advertising (comment out to enable)
+-A
+
 # maximum incoming PDU size (default 64KB)
 # -L 16384 
 

--- a/src/pmcd/pmcd.service.in
+++ b/src/pmcd/pmcd.service.in
@@ -1,7 +1,6 @@
 [Unit]
 Description=Performance Metrics Collector Daemon
 Documentation=man:pmcd(1)
-Wants=avahi-daemon.service
 After=network-online.target avahi-daemon.service
 Before=zabbix-agent.service
  

--- a/src/pmproxy/pmproxy.options
+++ b/src/pmproxy/pmproxy.options
@@ -4,6 +4,9 @@
 # run in the foreground
 # -f
 
+# disable service advertising (comment out to enable)
+-A
+
 # restrict PCP monitoring client connections to these interfaces
 # -i gateway-public-0.foo.bar.com
 # -i gateway-public-1.foo.bar.com

--- a/src/pmproxy/pmproxy.service.in
+++ b/src/pmproxy/pmproxy.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Proxy for Performance Metrics Collector Daemon
 Documentation=man:pmproxy(1)
-After=network-online.target pmcd.service redis.service
+After=network-online.target pmcd.service redis.service avahi-daemon.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
Tweak pmcd.options and pmproxy.options to set -A by default. The -A
flag disables service advertising, which is otherwise enabled by
default. With hindsight, -A should have had the opposite semantics,
i.e. -A should have enabled service advertising .. but we can't
change that retrospectfully. Since pmcd.options and pmproxy.options
are config files, the existing settings (if altered from default)
will be retained on upgrade.

Also tweak systemd unit configs to remove Wants=avahi-daemon.service.
This was causing pmcd's systemd deps to trigger Insights warnings,
see BZ1899625 - "Enabling pmcd leads to Insights warning about avahi".

We retain the After=avahi-daemon.service setting in pmcd and add it
to pmproxy service units to ensure avahi starts before the PCP daemons.
This is not a hard dependency, it just specifies the service start
order.

Resolves: RHBZ#1899625