### PR TITLE
pmlogger: Implement zeroconf defaults using an additional env file

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -2526,11 +2526,6 @@ for PMDA in dm nfsclient openmetrics ; do
 	%{install_file "$PCP_PMDAS_DIR/$PMDA" .NeedInstall}
     fi
 done
-# Increase default pmlogger recording frequency.
-# Note on systemd platforms, we ship pmlogger.service.d/zeroconf.conf instead
-%if "@enable_systemd@" != "true"
-    sed -i 's/^\#\ PMLOGGER_INTERVAL.*/PMLOGGER_INTERVAL=10/g' "$PCP_SYSCONFIG_DIR/pmlogger"
-%endif
 # auto-enable these usually optional pmie rules
 pmieconf -c enable dmthin
 

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -2982,11 +2982,6 @@ for PMDA in dm nfsclient openmetrics ; do
         %{install_file "$PCP_PMDAS_DIR/$PMDA" .NeedInstall}
     fi
 done
-# Increase default pmlogger recording frequency
-# Note on systemd platforms, we ship pmlogger.service.d/zeroconf.conf instead
-%if %{disable_systemd}
-    sed -i 's/^\#\ PMLOGGER_INTERVAL.*/PMLOGGER_INTERVAL=10/g' "$PCP_SYSCONFIG_DIR/pmlogger"
-%endif
 # auto-enable these usually optional pmie rules
 pmieconf -c enable dmthin
 %if 0%{?rhel}

--- a/debian/pcp-zeroconf.dirs
+++ b/debian/pcp-zeroconf.dirs
@@ -1,5 +1,4 @@
 etc/pcp/pmieconf/zeroconf
 etc/pcp/pmlogconf/zeroconf
-lib/systemd/system/pmlogger.service.d
 var/lib/pcp/config/pmieconf/zeroconf
 var/lib/pcp/config/pmlogconf/zeroconf

--- a/debian/pcp-zeroconf.install
+++ b/debian/pcp-zeroconf.install
@@ -1,3 +1,4 @@
+etc/default/pmlogger_zeroconf
 etc/pcp/pmieconf/zeroconf/all_threads
 etc/pcp/pmlogconf/zeroconf/atop-proc
 etc/pcp/pmlogconf/zeroconf/interrupts
@@ -7,7 +8,6 @@ etc/pcp/pmlogconf/zeroconf/pidstat
 etc/pcp/pmlogconf/zeroconf/pidstat-summary
 etc/pcp/pmlogconf/zeroconf/tapestat
 etc/pcp/pmlogconf/zeroconf/xfs-perdev
-lib/systemd/system/pmlogger.service.d/zeroconf.conf
 var/lib/pcp/config/pmieconf/zeroconf/all_threads
 var/lib/pcp/config/pmlogconf/zeroconf/atop-proc
 var/lib/pcp/config/pmlogconf/zeroconf/interrupts

--- a/debian/pcp-zeroconf.postinst
+++ b/debian/pcp-zeroconf.postinst
@@ -11,10 +11,5 @@ for PMDA in dm nfsclient openmetrics ; do
     fi
 done
 
-# increase default pmlogger recording frequency
-if [ ! -e /run/systemd ] ; then
-    sed -i 's/^\#\ PMLOGGER_INTERVAL.*/PMLOGGER_INTERVAL=10/g' /etc/default/pmlogger
-fi
-
 # auto-enable these usually optional pmie rules
 pmieconf -c enable dmthin

--- a/src/pmlogger/GNUmakefile
+++ b/src/pmlogger/GNUmakefile
@@ -44,6 +44,7 @@ install:: $(SUBDIRS)
 install:: default
 	$(INSTALL) -m 775 -o $(PCP_USER) -g $(PCP_GROUP) -d $(PCP_VAR_DIR)/config/pmlogger
 	$(INSTALL) -m 644 pmlogger.defaults $(PCP_SYSCONFIG_DIR)/pmlogger
+	$(INSTALL) -m 644 pmlogger_zeroconf.defaults $(PCP_SYSCONFIG_DIR)/pmlogger_zeroconf
 ifneq ($(PACKAGE_DISTRIBUTION),debian)
 	$(INSTALL) -m 755 -d $(PCP_SYSCONF_DIR)/pmlogger
 endif
@@ -58,8 +59,6 @@ endif
 	$(INSTALL) -m 755 rc_pmlogger $(PCP_RC_DIR)/pmlogger
 ifeq ($(ENABLE_SYSTEMD),true)
 	$(INSTALL) -m 644 pmlogger.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger.service
-	$(INSTALL) -m 755 -d $(PCP_SYSTEMDUNIT_DIR)/pmlogger.service.d
-	$(INSTALL) -m 644 pmlogger_service_zeroconf.conf $(PCP_SYSTEMDUNIT_DIR)/pmlogger.service.d/zeroconf.conf
 	$(INSTALL) -m 644 pmlogger_daily.timer $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily.timer
 	$(INSTALL) -m 644 pmlogger_daily.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily.service
 	$(INSTALL) -m 644 pmlogger_check.timer $(PCP_SYSTEMDUNIT_DIR)/pmlogger_check.timer

--- a/src/pmlogger/pmlogger_check.sh
+++ b/src/pmlogger/pmlogger_check.sh
@@ -24,6 +24,7 @@
 PMLOGGER="$PCP_BINADM_DIR/pmlogger"
 PMLOGCONF="$PCP_BINADM_DIR/pmlogconf"
 PMLOGGERENVS="$PCP_SYSCONFIG_DIR/pmlogger"
+PMLOGGERZEROCONFENVS="$PCP_SYSCONFIG_DIR/pmlogger_zeroconf"
 
 # error messages should go to stderr, not the GUI notifiers
 #
@@ -951,7 +952,7 @@ END				{ print m }'`
 	then
 	    if [ "X$primary" = Xy ]
 	    then
-		envs=`grep ^PMLOGGER "$PMLOGGERENVS" 2>/dev/null`
+		envs=`grep -h ^PMLOGGER "$PMLOGGERZEROCONFENVS" "$PMLOGGERENVS" 2>/dev/null`
 		args="-P $args"
 		iam=" primary"
 		# clean up port-map, just in case

--- a/src/pmlogger/pmlogger_service_zeroconf.conf
+++ b/src/pmlogger/pmlogger_service_zeroconf.conf
@@ -1,2 +1,0 @@
-[Service]
-Environment=PMLOGGER_INTERVAL=10

--- a/src/pmlogger/pmlogger_zeroconf.defaults
+++ b/src/pmlogger/pmlogger_zeroconf.defaults
@@ -1,0 +1,2 @@
+# Increase default pmlogger recording frequency
+PMLOGGER_INTERVAL=10


### PR DESCRIPTION
Earlier, a new way provide zeroconf values for pmlogger was implemented in
d19714e27677e3148bb0d1ed113ca719a7459044 and
985920112a56ac4506ccc82b4033f745aedebeaf. This solution worked on systems with
systemd but not others. This caused problem for the piuparts test which
apparently does not start under systemd during the test[1].

To implement the solution in a more consistent way across all systems (with and
without systemd), the earlier solution is reverted with a new solution that
drops an additional defaults file with pcp-zeroconf package.

Tests:

- Install on a machine with non-systemd Debian based distribution. When pmlogger
is started, the PMLOGGER_INTERNAL is part in the pmlogger process environment
with value 10.

- Install on a Debian machine with systemd. When pmlogger is started, the
PMLOGGER_INTERNAL is part in the pmlogger process environment with value 10.

- Update /etc/default/pmlogger with a value for PMLOGGER_INTERNAL. That value is
used.

- Install without pcp-zeroconf. When pmlogger is started, the PMLOGGER_INTERNAL
is not part of pmlogger process environment.

- The file /etc/defaults/pmlogger_zeroconf is part of the pcp-zeroconf package.

Links:

1) https://piuparts.debian.org/sid/fail/pcp-zeroconf_5.3.4-1.log

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>