### PR TITLE
pmproxy: don't connect to Redis if it's not required

### DIFF
--- a/src/pmproxy/src/redis.c
+++ b/src/pmproxy/src/redis.c
@@ -212,7 +212,7 @@ setup_redis_module(struct proxy *proxy)
     if ((option = pmIniFileLookup(config, "discover", "enabled")))
 	archive_discovery = (strncmp(option, "true", sdslen(option)) == 0);
 
-    if (proxy->slots == NULL) {
+    if (proxy->slots == NULL && (redis_protocol || series_queries || search_queries || archive_discovery)) {
 	mmv_registry_t	*registry = proxymetrics(proxy, METRICS_REDIS);
 	redisSlotsFlags	flags = get_redis_slots_flags();
 


### PR DESCRIPTION
only connect to Redis if one of the following is enabled
* Redis proxying
* pmseries REST API
* pmsearch REST API
* archive discovery