### PR TITLE
redis reconnect improvements

### DIFF
--- a/qa/1355
+++ b/qa/1355
@@ -48,9 +48,9 @@ redis-server --port $redisport --save "" > $tmp.redis.log 2>&1 &
 redis_pid=$!
 pmsleep 0.125
 
-echo "Start Redis proxy to fake loading error"
+echo "Start Redis proxy to fake loading error for first 3 seconds"
 redisproxyport=`_find_free_port`
-$python src/redis_proxy.py --loading_delay 30 127.0.0.1:$redisproxyport 127.0.0.1:$redisport > $tmp.redisproxy.log &
+$python src/redis_proxy.py --loading_delay 3 127.0.0.1:$redisproxyport 127.0.0.1:$redisport > $tmp.redisproxy.log &
 redisproxy_pid=$!
 pmsleep 0.125
 
@@ -61,15 +61,9 @@ pmproxy_pid=$!
 pmsleep 0.125
 
 echo
-echo "== Observe a loading error"
-sleep 30
+echo "== Observe a loading error and reconnect"
+sleep 6
 lineno=1
-tail -n +$lineno $tmp.pmproxy.log | _filter_pmproxy_log
-lineno=$((`wc -l < $tmp.pmproxy.log` + 1))
-
-echo
-echo "== Observe a reconnect"
-sleep 40
 tail -n +$lineno $tmp.pmproxy.log | _filter_pmproxy_log
 lineno=$((`wc -l < $tmp.pmproxy.log` + 1))
 
@@ -78,20 +72,20 @@ echo "Stop redis proxy"
 $signal -s TERM $redisproxy_pid
 
 echo
-echo "== Observe a connection lost error"
-sleep 60
+echo "== Observe a connection lost error and failed reconnect"
+sleep 6
 tail -n +$lineno $tmp.pmproxy.log | _filter_pmproxy_log
 lineno=$((`wc -l < $tmp.pmproxy.log` + 1))
 
 echo
-echo "Start Redis proxy again"
-$python src/redis_proxy.py --loading_delay 30 127.0.0.1:$redisproxyport 127.0.0.1:$redisport > $tmp.redisproxy.log &
+echo "Start Redis proxy again (loading error for first 3 seconds)"
+$python src/redis_proxy.py --loading_delay 3 127.0.0.1:$redisproxyport 127.0.0.1:$redisport > $tmp.redisproxy.log &
 redisproxy_pid=$!
 pmsleep 0.125
 
 echo
-echo "== Observer a reconnect"
-sleep 70
+echo "== Observe a reconnect"
+sleep 6
 tail -n +$lineno $tmp.pmproxy.log | _filter_pmproxy_log
 lineno=$((`wc -l < $tmp.pmproxy.log` + 1))
 

--- a/qa/1355.out
+++ b/qa/1355.out
@@ -1,24 +1,19 @@
 QA output created by 1355
 Start Redis server
-Start Redis proxy to fake loading error
+Start Redis proxy to fake loading error for first 3 seconds
 Start pmproxy
 
-== Observe a loading error
+== Observe a loading error and reconnect
 Cannot connect to Redis: LOADING Redis is loading the dataset in memory
-
-== Observe a reconnect
-Trying to connect to Redis ...
 Redis slots, command keys, schema version setup
 
 Stop redis proxy
 
-== Observe a connection lost error
+== Observe a connection lost error and failed reconnect
 Lost connection to Redis.
-Trying to connect to Redis ...
 Cannot connect to Redis: Connection refused
 
-Start Redis proxy again
+Start Redis proxy again (loading error for first 3 seconds)
 
-== Observer a reconnect
-Trying to connect to Redis ...
+== Observe a reconnect
 Redis slots, command keys, schema version setup

--- a/src/libpcp_web/src/slots.c
+++ b/src/libpcp_web/src/slots.c
@@ -487,11 +487,13 @@ redisSlotsReplyCallback(redisClusterAsyncContext *c, void *r, void *arg)
      *   connection (to handle the case where a Redis callback returns after a new
      *   connection was already established)
      * * ignore any errors if the state is already set to SLOTS_DISCONNECTED
+     * * ignore errors if cluster mode is enabled (for now, will change in a later release)
      */
     if (((reply == NULL && c->err == REDIS_ERR_IO) ||
          (reply != NULL && reply->type == REDIS_REPLY_ERROR && strcmp(reply->str, REDIS_ELOADING) == 0)) &&
 	srd->conn_seq == srd->slots->conn_seq &&
-	srd->slots->state != SLOTS_DISCONNECTED) {
+	srd->slots->state != SLOTS_DISCONNECTED &&
+	srd->slots->cluster == 0) {
 	pmNotifyErr(LOG_ERR, "Lost connection to Redis.\n");
 	srd->slots->state = SLOTS_DISCONNECTED;
     }

--- a/src/libpcp_web/src/slots.c
+++ b/src/libpcp_web/src/slots.c
@@ -281,6 +281,7 @@ redisSlotsReconnect(redisSlots *slots, redisSlotsFlags flags,
     dictIterator	*iterator;
     dictEntry		*entry;
     int			sts = 0;
+    static int		log_connection_errors = 1;
 
     slots->state = SLOTS_CONNECTING;
 
@@ -325,13 +326,17 @@ redisSlotsReconnect(redisSlots *slots, redisSlotsFlags flags,
 	dictReleaseIterator(iterator);
     }
     else {
-	pmNotifyErr(LOG_INFO, "Cannot connect to Redis: %s\n",
+	if (log_connection_errors) {
+	    pmNotifyErr(LOG_INFO, "Cannot connect to Redis: %s\n",
 			slots->acc->cc->errstr);
+	    log_connection_errors = 0;
+	}
 	slots->state = SLOTS_DISCONNECTED;
 	return;
     }
 
     slots->state = SLOTS_CONNECTED;
+    log_connection_errors = 1;
     redisSchemaLoad(slots, flags, info, done, userdata, events, arg);
 }
 

--- a/src/libpcp_web/src/slots.c
+++ b/src/libpcp_web/src/slots.c
@@ -166,12 +166,20 @@ redisSlotsInit(dict *config, void *events)
     struct timeval	connection_timeout = {5, 0}; // 5s
     struct timeval	command_timeout = {60, 0}; // 1m
 
-    if ((slots = (redisSlots *)calloc(1, sizeof(redisSlots))) == NULL)
+    if ((slots = (redisSlots *)calloc(1, sizeof(redisSlots))) == NULL) {
+	pmNotifyErr(LOG_ERR, "%s: failed to allocate redisSlots\n",
+			"redisSlotsInit");
 	return NULL;
+    }
 
     slots->state = SLOTS_DISCONNECTED;
     slots->events = events;
     slots->keymap = dictCreate(&sdsKeyDictCallBacks, "keymap");
+    if (slots->keymap == NULL) {
+	pmNotifyErr(LOG_ERR, "%s: failed to allocate keymap\n",
+			"redisSlotsInit");
+	return NULL;
+    }
 
     servers = pmIniFileLookup(config, "pmseries", "servers");
     if (servers == NULL)
@@ -284,6 +292,7 @@ redisSlotsReconnect(redisSlots *slots, redisSlotsFlags flags,
     static int		log_connection_errors = 1;
 
     slots->state = SLOTS_CONNECTING;
+    slots->conn_seq++;
 
     /* reset Redis context in case of reconnect */
     if (slots->acc->err) {
@@ -326,7 +335,7 @@ redisSlotsReconnect(redisSlots *slots, redisSlotsFlags flags,
 	dictReleaseIterator(iterator);
     }
     else {
-	if (log_connection_errors) {
+	if (log_connection_errors || pmDebugOptions.desperate) {
 	    pmNotifyErr(LOG_INFO, "Cannot connect to Redis: %s\n",
 			slots->acc->cc->errstr);
 	    log_connection_errors = 0;
@@ -396,6 +405,7 @@ redisSlotsReplyDataAlloc(redisSlots *slots, size_t req_size,
     }
 
     srd->slots = slots;
+    srd->conn_seq = slots->conn_seq;
     srd->start = gettimeusec();
     srd->req_size = req_size;
     srd->callback = callback;
@@ -466,11 +476,22 @@ redisSlotsReplyCallback(redisClusterAsyncContext *c, void *r, void *arg)
      * member to the async cluster context, analogue to the 'data' member of
      * hiredis, update the disconnect callback to return the cluster context and
      * use this new disconnect callback instead of the conditional below.
+     *
+     * Register a Redis disconnect if:
+     * * Redis returns an I/O error. In this case errno is also set, but
+     *   there are lots of different error codes for connection failures (for example
+     *   ECONNRESET, ENETUNREACH, ENETDOWN, ...) - defensively assume all require a
+     *   reconnect
+     * * Redis returns the "LOADING Redis is loading the dataset in memory" error
+     * * ignore any errors for Redis requests pre-dating the latest (current) Redis
+     *   connection (to handle the case where a Redis callback returns after a new
+     *   connection was already established)
+     * * ignore any errors if the state is already set to SLOTS_DISCONNECTED
      */
-    if (srd->slots->state == SLOTS_READY && (
-	(reply == NULL && c->err == REDIS_ERR_IO) ||
-	(reply != NULL && reply->type == REDIS_REPLY_ERROR && strcmp(reply->str, REDIS_ELOADING) == 0)
-	)) {
+    if (((reply == NULL && c->err == REDIS_ERR_IO) ||
+         (reply != NULL && reply->type == REDIS_REPLY_ERROR && strcmp(reply->str, REDIS_ELOADING) == 0)) &&
+	srd->conn_seq == srd->slots->conn_seq &&
+	srd->slots->state != SLOTS_DISCONNECTED) {
 	pmNotifyErr(LOG_ERR, "Lost connection to Redis.\n");
 	srd->slots->state = SLOTS_DISCONNECTED;
     }

--- a/src/libpcp_web/src/slots.h
+++ b/src/libpcp_web/src/slots.h
@@ -60,6 +60,7 @@ typedef enum redisSlotsState {
 typedef struct redisSlots {
     redisClusterAsyncContext *acc;	/* cluster context */
     redisSlotsState	state;		/* connection state */
+    unsigned int	conn_seq;	/* connection sequence (incremented for every connection) */
     unsigned int	search : 1;	/* RediSearch use enabled */
     unsigned int	cluster : 1;	/* Redis cluster mode enabled */
     redisMap		*keymap;	/* map command names to key position */
@@ -72,6 +73,7 @@ typedef struct redisSlots {
 /* wraps the actual Redis callback and data */
 typedef struct redisSlotsReplyData {
     redisSlots			*slots;
+    unsigned int		conn_seq;	/* connection sequence when this request was issued */
     uint64_t			start;		/* time of the request (usec) */
     size_t			req_size;	/* size of request */
 

--- a/src/pmproxy/src/redis.c
+++ b/src/pmproxy/src/redis.c
@@ -14,7 +14,7 @@
 #include "server.h"
 #include "discover.h"
 
-#define REDIS_RECONNECT_INTERVAL 60
+#define REDIS_RECONNECT_INTERVAL 2
 
 static int search_queries;
 static int series_queries;
@@ -239,11 +239,9 @@ redis_reconnect_worker(void *arg)
     wait_sec = REDIS_RECONNECT_INTERVAL;
 
     /*
-     * skip if Redis is disabled, state is SLOTS_READY or SLOTS_ERR_FATAL
-     * however: also perform a reconnect if the state is stuck in connecting
-     * or some other state
+     * skip if Redis is disabled or state is not SLOTS_DISCONNECTED
      */
-    if (!proxy->slots || proxy->slots->state == SLOTS_READY || proxy->slots->state == SLOTS_ERR_FATAL)
+    if (!proxy->slots || proxy->slots->state != SLOTS_DISCONNECTED)
 	return;
 
     if (pmDebugOptions.desperate)

--- a/src/pmproxy/src/redis.c
+++ b/src/pmproxy/src/redis.c
@@ -246,7 +246,9 @@ redis_reconnect_worker(void *arg)
     if (!proxy->slots || proxy->slots->state == SLOTS_READY || proxy->slots->state == SLOTS_ERR_FATAL)
 	return;
 
-    proxylog(PMLOG_INFO, "Trying to connect to Redis ...", arg);
+    if (pmDebugOptions.desperate)
+	proxylog(PMLOG_INFO, "Trying to connect to Redis ...", arg);
+
     redisSlotsFlags	flags = get_redis_slots_flags();
     redisSlotsReconnect(proxy->slots, flags, proxylog, on_redis_connected,
 			proxy, proxy->events, proxy);


### PR DESCRIPTION
* do not log more than one failed Redis connection attempt in a row
* show "trying to reconnect" message only if logging is set to desperate
* track Redis connection sequence numbers
* reduce check interval to 2s

See #1464 for details.