### PR TITLE
libpcp_web: do not log more than one failed Redis connection attempt in a row

### DIFF
--- a/src/libpcp_web/src/slots.c
+++ b/src/libpcp_web/src/slots.c
@@ -281,6 +281,7 @@ redisSlotsReconnect(redisSlots *slots, redisSlotsFlags flags,
     dictIterator	*iterator;
     dictEntry		*entry;
     int			sts = 0;
+    static int		log_connection_errors = 1;
 
     slots->state = SLOTS_CONNECTING;
 
@@ -325,13 +326,17 @@ redisSlotsReconnect(redisSlots *slots, redisSlotsFlags flags,
 	dictReleaseIterator(iterator);
     }
     else {
-	pmNotifyErr(LOG_INFO, "Cannot connect to Redis: %s\n",
+	if (log_connection_errors) {
+	    pmNotifyErr(LOG_INFO, "Cannot connect to Redis: %s\n",
 			slots->acc->cc->errstr);
+	    log_connection_errors = 0;
+	}
 	slots->state = SLOTS_DISCONNECTED;
 	return;
     }
 
     slots->state = SLOTS_CONNECTED;
+    log_connection_errors = 1;
     redisSchemaLoad(slots, flags, info, done, userdata, events, arg);
 }
 

--- a/src/pmproxy/src/redis.c
+++ b/src/pmproxy/src/redis.c
@@ -246,7 +246,9 @@ redis_reconnect_worker(void *arg)
     if (!proxy->slots || proxy->slots->state == SLOTS_READY || proxy->slots->state == SLOTS_ERR_FATAL)
 	return;
 
-    proxylog(PMLOG_INFO, "Trying to connect to Redis ...", arg);
+    if (pmDebugOptions.desperate)
+	proxylog(PMLOG_INFO, "Trying to connect to Redis ...", arg);
+
     redisSlotsFlags	flags = get_redis_slots_flags();
     redisSlotsReconnect(proxy->slots, flags, proxylog, on_redis_connected,
 			proxy, proxy->events, proxy);


### PR DESCRIPTION
and show "trying to reconnect" message only if logging is set to desperate