### PR TITLE
pmlogconf: fix reprobing with interactive changes

### DIFF
--- a/qa/368.out
+++ b/qa/368.out
@@ -80,44 +80,10 @@ Differences ...
 Keep changes? [y] 
 Group: qa group one
 Log this group? [y] ...
-Differences ...
-*** TMP.orig ...
---- TMP.conf.new ...
-***************
-*** 22,35 ****
-  	sample.long.million
-  }
-  #----
-! #+ 02:x::
-! #----
-! #+ 03:y:default:
-! ## qa group three
-  log advisory on default {
-! 	sample.longlong.ten
-  }
-  #----
-  #+ 04:n:default:
-  ## qa group four
-  #----
---- 22,36 ----
-  	sample.long.million
-  }
-  #----
-! #+ 02:y:default:
-! ## qa group two
-  log advisory on default {
-! 	sample.ulong.ten
-  }
-  #----
-+ #+ 03:n:default:
-+ ## qa group three
-+ #----
-  #+ 04:n:default:
-  ## qa group four
-  #----
-Keep changes? [y] 
+No changes
+
 Group: qa group one
-Log this group? [y] ......
+Log this group? [y] .....
 Differences ...
 *** TMP.orig ...
 --- TMP.conf.new ...
@@ -132,18 +98,8 @@ Differences ...
   #----
 --- 18,23 ----
 ***************
-*** 26,31 ****
---- 25,31 ----
-  ## qa group two
-  log advisory on default {
-  	sample.ulong.ten
-+ 	sample.ulong.million
-  }
-  #----
-  #+ 03:n:default:
-***************
-*** 37,42 ****
---- 37,53 ----
+*** 36,41 ****
+--- 35,51 ----
   #+ 05:n:default:
   ## qa group five
   #----
@@ -185,15 +141,13 @@ log advisory on default {
 	sample.long.million
 }
 #----
-#+ 02:y:default:
-## qa group two
-log advisory on default {
-	sample.ulong.ten
-	sample.ulong.million
-}
+#+ 02:x::
 #----
-#+ 03:n:default:
+#+ 03:y:default:
 ## qa group three
+log advisory on default {
+	sample.longlong.ten
+}
 #----
 #+ 04:n:default:
 ## qa group four

--- a/src/pmlogconf/pmlogconf.c
+++ b/src/pmlogconf/pmlogconf.c
@@ -913,13 +913,13 @@ evaluate_state(group_t *group)
     if ((group->pmlogger || group->pmrep) && !group->pmlogconf) {
 	state = group->saved_state;
     } else if (evaluate_group(group)) {	/* probe */
-	if (reprobe == 0 && group->saved_state != 0)
+	if (group->saved_state != 0)
 	    state = group->saved_state;
 	else
 	    state = group->true_state;
 	group->success = 1;
     } else {
-	if (reprobe == 0 && group->saved_state != 0)
+	if (group->saved_state != 0)
 	    state = group->saved_state;
 	else
 	    state = group->false_state;


### PR DESCRIPTION
In testing an earlier persistance fix it was discovered
that reprobe was inadvertently overwriting user requests
for changes interactively.

Related to Red Hat BZ #2017632