### PR TITLE
logutil: add path handler for pmlogger_farm_check service

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -2861,6 +2861,7 @@ then
 	%systemd_preun pmlogger_daily.timer
 	%systemd_preun pmlogger_check.timer
 	%systemd_preun pmlogger_farm_check.timer
+	%systemd_preun pmlogger_farm_check.path
 	%systemd_preun pmie_farm_check.timer
 
 	systemctl stop pmlogger.service >/dev/null 2>&1
@@ -2904,8 +2905,8 @@ PCP_SA_DIR=@pcp_sa_dir@
 
     # pmlogger_farm service inherits the same initial state as pmlogger service
     if systemctl is-enabled pmlogger.service >/dev/null; then
-	systemctl enable pmlogger_farm.service pmlogger_farm_check.service
-	systemctl start pmlogger_farm.service pmlogger_farm_check.service
+	systemctl enable pmlogger_farm.service pmlogger_farm_check.service pmlogger_farm_check.path
+	systemctl start pmlogger_farm.service pmlogger_farm_check.service pmlogger_farm_check.path
     fi
     # pmie_farm service inherits the same initial state as pmie service
     if systemctl is-enabled pmie.service >/dev/null; then

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -2960,6 +2960,7 @@ then
        %systemd_preun pmlogger_daily.timer
        %systemd_preun pmlogger_check.timer
        %systemd_preun pmlogger_farm_check.timer
+       %systemd_preun pmlogger_farm_check.path
        %systemd_preun pmie_farm_check.timer
 
        systemctl stop pmlogger.service >/dev/null 2>&1
@@ -3050,8 +3051,8 @@ PCP_LOG_DIR=%{_logsdir}
 
     # pmlogger_farm service inherits the same initial state as pmlogger service
     if systemctl is-enabled pmlogger.service >/dev/null; then
-	systemctl enable pmlogger_farm.service pmlogger_farm_check.service
-	systemctl start pmlogger_farm.service pmlogger_farm_check.service
+	systemctl enable pmlogger_farm.service pmlogger_farm_check.service pmlogger_farm_check.path
+	systemctl start pmlogger_farm.service pmlogger_farm_check.service pmlogger_farm_check.path
     fi
     # pmie_farm service inherits the same initial state as pmie service
     if systemctl is-enabled pmie.service >/dev/null; then

--- a/src/pmlogger/.gitignore
+++ b/src/pmlogger/.gitignore
@@ -5,6 +5,7 @@ pmlogger
 pmlogger.service
 pmlogger_farm.service
 pmlogger_farm_check.service
+pmlogger_farm_check.path
 pmlogger_check.service
 pmlogger_daily.service
 pmlogger_daily-poll.service

--- a/src/pmlogger/GNUmakefile
+++ b/src/pmlogger/GNUmakefile
@@ -24,7 +24,8 @@ OTHERS	= pmnewlog.sh control rc_pmlogger \
 	  pmlogger_farm_check.timer pmlogger_farm_check.service
 LDIRT	= crontab crontab.daily_report pmlogger.service \
 	  pmlogger_daily.service pmlogger_daily_report.service \
-	  pmlogger_check.service pmlogger_farm.service pmlogger_farm_check.service
+	  pmlogger_check.service pmlogger_farm.service pmlogger_farm_check.service \
+	  pmlogger_farm_check.path
 
 ifeq ($(TARGET_OS),linux)
 CRONTAB_USER = $(PCP_USER)
@@ -67,6 +68,7 @@ ifeq ($(ENABLE_SYSTEMD),true)
 	$(INSTALL) -m 644 pmlogger_farm.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_farm.service
 	$(INSTALL) -m 644 pmlogger_farm_check.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_farm_check.service
 	$(INSTALL) -m 644 pmlogger_farm_check.timer $(PCP_SYSTEMDUNIT_DIR)/pmlogger_farm_check.timer
+	$(INSTALL) -m 644 pmlogger_farm_check.path $(PCP_SYSTEMDUNIT_DIR)/pmlogger_farm_check.path
 	$(INSTALL) -m 644 pmlogger_daily.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_daily.service
 	$(INSTALL) -m 644 pmlogger_check.timer $(PCP_SYSTEMDUNIT_DIR)/pmlogger_check.timer
 	$(INSTALL) -m 644 pmlogger_check.service $(PCP_SYSTEMDUNIT_DIR)/pmlogger_check.service
@@ -111,6 +113,11 @@ pmlogger_farm.service : pmlogger_farm.service.in
 pmlogger_farm_check.service : pmlogger_farm_check.service.in
 	$(SED) <$< >$@ \
 	    -e 's;@PCP_BIN_DIR@;'$(PCP_BIN_DIR)';' \
+	# END
+	#
+pmlogger_farm_check.path : pmlogger_farm_check.path.in
+	$(SED) <$< >$@ \
+	    -e 's;@PCP_SYSCONF_DIR@;'$(PCP_SYSCONF_DIR)';' \
 	# END
 
 pmlogger_daily.service : pmlogger_daily.service.in

--- a/src/pmlogger/pmlogger_farm_check.path.in
+++ b/src/pmlogger/pmlogger_farm_check.path.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=Activate pmlogger_farm_check when pmlogger control files change
+
+[Path]
+PathChanged=@PCP_SYSCONF_DIR@/pmlogger/control
+PathChanged=@PCP_SYSCONF_DIR@/pmlogger/control.d
+
+[Install]
+RequiredBy=pmlogger_farm_check.service


### PR DESCRIPTION
The pmlogger_farm_check service is responsible for checking pmlogger
farm processes, restarting any pmloggers that have failed and for
starting any new pmlogger farm processes after control file changes.

The service is driven by pmlogger_farm_check.timer, which starts
the service every 5 minutes. When the service is triggered by the
timer, it simply runs 'pmlogctl -m check' and then exits. See
pmlogctl(1) for details. This works fine but it does mean there may
be up to a five minute delay before any pmlogger control file changes
will be automatically applied to the pmlogger farm.

This commit adds a systemd path handler to the pmlogger_farm_check
service to also trigger the service when there are any changes to
$PCP_SYSCONF_DIR/pmlogger/control or to the control file directory
$PCP_SYSCONF_DIR/pmlogger/control.d (i.e. new control files are added
or changes have been made to any existing control files). The trigger
is applied only when an fd for the file or directory is closed (not
when it is opened or written to).

The existing timer is retained - to periodically check/migrate/restart
any dead loggers, regardless of whether there have been any control
file changes.

This has been manually tested but will need a new QA test - TODO.