### PR TITLE
pmproxy: when secure.enabled is false, do not attempt to init ssl context even for https requests

### DIFF
--- a/qa/1458
+++ b/qa/1458
@@ -1,0 +1,218 @@
+#!/bin/sh
+# PCP QA Test No. 1458
+# Exercise access pmproxy with secure.enabled = false
+#
+# The main purpose of this is to test that the component works correctly
+# when secure.enabled = false; we can expect the https URLs to fail.
+#
+# See https://github.com/performancecopilot/pcp/issues/1490
+
+# Copyright (c) 2019,2021 Red Hat
+# Modified by Netflix, Inc.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+_check_valgrind
+openssl help 2>/dev/null || _notrun "No openssl binary found"
+
+if [ -f /etc/lsb-release ]
+then
+    . /etc/lsb-release
+    if [ "$DISTRIB_ID" = Ubuntu ]
+    then
+	# This test fails for Ubuntu 19.10 with a myriad of errors involving
+	# the use of uninitialized values.  The code paths very but typically
+	# involve libuv -> libssl ->  libcrypto
+	#
+	case "$DISTRIB_RELEASE"
+	in
+	    19.10)
+		_notrun "problems with libuv, libssl, libcrypto and valgrind on Ubuntu $DISTRIB_RELEASE"
+		;;
+	esac
+    fi
+fi
+
+_cleanup()
+{
+    cd $here
+    if $need_restore
+    then
+	need_restore=false
+	_restore_config $PCP_SYSCONF_DIR/labels
+	_sighup_pmcd
+    fi
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+need_restore=false
+username=`id -u -n`
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_check_empty()
+{
+    tee -a $seq.full > $tmp.unfiltered
+    if [ -s $tmp.unfiltered ]
+    then
+	echo "Botch: got output from curl"
+    else
+	echo "Good!, empty output from curl"
+    fi
+}
+
+_filter_json()
+{
+    tee -a $seq.full > $tmp.unfiltered
+    if [ -s $tmp.unfiltered ]
+    then
+	pmjson < $tmp.unfiltered > $tmp.filtered
+	status=$?
+	    if [ $status -eq 0 ]; then
+	    cat $tmp.filtered | \
+	    sed \
+		-e '/"machineid": .*/d' \
+		-e 's,"series": .*,"series": "SERIES",g' \
+		-e 's,"context": .*,"context": "CONTEXT",g' \
+		-e 's,"hostname": .*,"hostname": "HOSTNAME",g' \
+		-e 's,"domainname": .*,"domainname": "DOMAINNAME",g' \
+	    #end
+	else
+	    echo "Invalid JSON: $status"
+	    cat $tmp.unfiltered
+	    rm -f $tmp.context
+	fi
+    else
+	echo "Botch: no output from curl"
+    fi
+}
+
+_filter_port()
+{
+    sed \
+        -e '/ ipv6 /d' \
+	-e "s/ $port / PORT /g" \
+    #end
+}
+
+# real QA test starts here
+_save_config $PCP_SYSCONF_DIR/labels
+need_restore=true
+
+$sudo rm -rf $PCP_SYSCONF_DIR/labels/*
+_sighup_pmcd
+
+openssl req \
+	-new -newkey rsa:4096 -days 365 -nodes -x509 \
+	-subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.pcpqa.com" \
+	-keyout $tmp.key -out $tmp.cert >$seq.full 2>&1
+# creates a self-signed (insecure) certificate, so for testing only
+
+echo "[pmproxy]" >> $tmp.conf
+echo "pcp.enabled = true" >> $tmp.conf
+echo "http.enabled = true" >> $tmp.conf
+echo "redis.enabled = false" >> $tmp.conf
+echo "secure.enabled = false" >> $tmp.conf
+
+port=`_find_free_port`
+mkdir -p $tmp.pmproxy/pmproxy
+export PCP_RUN_DIR=$tmp.pmproxy
+export PCP_TMP_DIR=$tmp.pmproxy
+
+$_valgrind_clean_assert pmproxy -f -l- --timeseries \
+	-c $tmp.conf -p $port -U $username \
+	>$tmp.valout 2>$tmp.valerr &
+pid=$!
+
+echo "valgrind pid: $pid" >>$seq.full
+echo "pmproxy port: $port" >>$seq.full
+
+# valgrind takes awhile to fire up
+i=0
+while [ $i -lt 40 ]
+do
+    $PCP_BINADM_DIR/telnet-probe -c localhost $port && break
+    sleep 1
+    i=`expr $i + 1`
+done
+if $PCP_BINADM_DIR/telnet-probe -c localhost $port
+then
+    echo "Startup took $i secs" >>$seq.full
+else
+    echo "Arrgh: valgrind failed start pmproxy and get port $port ready after 30 secs"
+    exit
+fi
+
+date >>$seq.full
+echo "=== checking serial http operation ===" | tee -a $seq.full
+for i in 1 2 3 4; do
+    curl -Gs "http://localhost:$port/pmapi/metric?name=sample.long.ten" 2>$tmp.err$i >$tmp.out$i
+done
+for i in 1 2 3 4; do
+echo === out$i === | tee -a $seq.full
+_filter_json < $tmp.out$i
+done
+
+date >>$seq.full
+echo "=== checking parallel http operation ===" | tee -a $seq.full
+for i in 1 2 3 4; do
+    curl -Gs "http://localhost:$port/pmapi/metric?name=sample.long.ten" 2>$tmp.err$i >$tmp.out$i & 2>/dev/null eval pid$i=$!
+done
+wait $pid1 $pid2 $pid3 $pid4
+for i in 1 2 3 4; do
+echo === out$i === | tee -a $seq.full
+_filter_json < $tmp.out$i
+done
+
+date >>$seq.full
+echo "=== checking serial https/TLS operation ===" | tee -a $seq.full
+for i in 1 2 3 4; do
+    curl -k -Gs "https://localhost:$port/pmapi/metric?name=sample.long.ten" 2>$tmp.err$i >$tmp.out$i
+done
+for i in 1 2 3 4; do
+echo === out$i === | tee -a $seq.full
+_check_empty < $tmp.out$i
+done
+
+date >>$seq.full
+echo "=== checking parallel https/TLS operation ===" | tee -a $seq.full
+for i in 1 2 3 4; do
+    curl -k -Gs "https://localhost:$port/pmapi/metric?name=sample.long.ten" 2>$tmp.err$i >$tmp.out$i & 2>/dev/null eval pid$i=$!
+done
+wait $pid1 $pid2 $pid3 $pid4
+for i in 1 2 3 4; do
+echo === out$i === | tee -a $seq.full
+_check_empty < $tmp.out$i
+done
+
+echo "=== check pmproxy is running ==="
+pminfo -v -h localhost@localhost:$port hinv.ncpu
+if [ $? -eq 0 ]; then
+    echo "pmproxy check passed"
+else
+    echo "pmproxy check failed"
+fi
+
+# valgrind takes awhile to shutdown too
+pmsignal $pid >/dev/null 2>&1
+pmsleep 3.5
+echo "=== valgrind stdout ===" | tee -a $seq.full
+cat $tmp.valout | _filter_valgrind
+
+echo "=== valgrind stderr ===" | tee -a $seq.full
+cat $tmp.valerr | _filter_pmproxy_log | _filter_port
+
+# final kill if it's spinning
+$sudo kill -9 $pid >/dev/null 2>&1
+
+# success, all done
+status=0
+exit

--- a/qa/group
+++ b/qa/group
@@ -1845,6 +1845,7 @@ x11
 1442 pmlogrewrite local
 1455 pmlogrewrite labels pmdumplog local
 1457 pmproxy libpcp_web threads secure local
+1458 pmproxy libpcp_web threads local
 1466 pmlogctl pmcd pmiectl logutil local
 1480 pmda.lmsensors local
 1489 python pmrep pmimport local

--- a/src/pmproxy/src/secure.c
+++ b/src/pmproxy/src/secure.c
@@ -290,8 +290,10 @@ setup_secure_module(struct proxy *proxy)
 				SSL_OP_NO_TLSv1 |SSL_OP_NO_TLSv1_1;
 
     if ((option = pmIniFileLookup(config, "pmproxy", "secure.enabled"))) {
-	if (strncmp(option, "true", sdslen(option)) != 0)
+	if (strncmp(option, "true", sdslen(option)) != 0) {
+	    proxy->ssl = NULL;
 	    return;
+	}
     }
 
     if ((option = pmIniFileLookup(config, "pmproxy", "certificates")))

--- a/src/pmproxy/src/secure.c
+++ b/src/pmproxy/src/secure.c
@@ -290,10 +290,8 @@ setup_secure_module(struct proxy *proxy)
 				SSL_OP_NO_TLSv1 |SSL_OP_NO_TLSv1_1;
 
     if ((option = pmIniFileLookup(config, "pmproxy", "secure.enabled"))) {
-	if (strncmp(option, "true", sdslen(option)) != 0) {
-	    proxy->ssl = NULL;
+	if (strncmp(option, "true", sdslen(option)) != 0)
 	    return;
-	}
     }
 
     if ((option = pmIniFileLookup(config, "pmproxy", "certificates")))

--- a/src/pmproxy/src/server.c
+++ b/src/pmproxy/src/server.c
@@ -257,7 +257,7 @@ client_put(struct client *client)
 	    on_http_client_close(client);
 	if (client->protocol & STREAM_REDIS)
 	    on_redis_client_close(client);
-	if (client->protocol & STREAM_SECURE && client->stream.secure)
+	if ((client->protocol & STREAM_SECURE) && client->stream.secure)
 	    on_secure_client_close(client);
 
 	memset(client, 0, sizeof(*client));
@@ -291,7 +291,7 @@ on_client_write(uv_write_t *writer, int status)
 			"on_client_write", status, client);
 
     if (status == 0) {
-	if (client->protocol & STREAM_SECURE && client->stream.secure)
+	if ((client->protocol & STREAM_SECURE) && client->stream.secure)
 	    on_secure_client_write(client);
 	if (client->protocol & STREAM_PCP)
 	    on_pcp_client_write(client);
@@ -443,7 +443,7 @@ on_client_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf)
 	    client->protocol |= client_protocol(*buf->base);
 
 #ifdef HAVE_OPENSSL
-	if (client->protocol & STREAM_SECURE && proxy->ssl != NULL)
+	if ((client->protocol & STREAM_SECURE) && (proxy->ssl != NULL))
 	    on_secure_client_read(proxy, client, nread, buf);
 	else
 	    on_protocol_read(stream, nread, buf);

--- a/src/pmproxy/src/server.c
+++ b/src/pmproxy/src/server.c
@@ -257,7 +257,7 @@ client_put(struct client *client)
 	    on_http_client_close(client);
 	if (client->protocol & STREAM_REDIS)
 	    on_redis_client_close(client);
-	if (client->protocol & STREAM_SECURE)
+	if (client->protocol & STREAM_SECURE && client->stream.secure)
 	    on_secure_client_close(client);
 
 	memset(client, 0, sizeof(*client));
@@ -291,7 +291,7 @@ on_client_write(uv_write_t *writer, int status)
 			"on_client_write", status, client);
 
     if (status == 0) {
-	if (client->protocol & STREAM_SECURE)
+	if (client->protocol & STREAM_SECURE && client->stream.secure)
 	    on_secure_client_write(client);
 	if (client->protocol & STREAM_PCP)
 	    on_pcp_client_write(client);
@@ -441,7 +441,7 @@ on_client_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf)
     if (nread > 0) {
 	if (client->protocol == STREAM_UNKNOWN)
 	    client->protocol |= client_protocol(*buf->base);
-	if (client->protocol & STREAM_SECURE)
+	if (client->protocol & STREAM_SECURE && proxy->ssl != NULL)
 	    on_secure_client_read(proxy, client, nread, buf);
 	else
 	    on_protocol_read(stream, nread, buf);

--- a/src/pmproxy/src/server.c
+++ b/src/pmproxy/src/server.c
@@ -441,10 +441,16 @@ on_client_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf)
     if (nread > 0) {
 	if (client->protocol == STREAM_UNKNOWN)
 	    client->protocol |= client_protocol(*buf->base);
+
+#ifdef HAVE_OPENSSL
 	if (client->protocol & STREAM_SECURE && proxy->ssl != NULL)
 	    on_secure_client_read(proxy, client, nread, buf);
 	else
 	    on_protocol_read(stream, nread, buf);
+#else
+	on_protocol_read(stream, nread, buf);
+#endif
+
     } else if (nread < 0) {
 	if (pmDebugOptions.af)
 	    fprintf(stderr, "%s: read error %ld "


### PR DESCRIPTION
fixes #1490 
