### PR TITLE
logutil: tweak pmlogger and pmlogger_farm_check deps

### DIFF
--- a/src/pmlogger/pmlogger.service.in
+++ b/src/pmlogger/pmlogger.service.in
@@ -5,6 +5,7 @@ After=network-online.target pmcd.service
 Before=pmlogger_check.timer pmlogger_daily.timer
 BindsTo=pmlogger_check.timer pmlogger_daily.timer
 Wants=pmcd.service
+Wants=pmlogger_farm.service
 
 [Service]
 Type=notify

--- a/src/pmlogger/pmlogger_farm_check.timer
+++ b/src/pmlogger/pmlogger_farm_check.timer
@@ -2,10 +2,10 @@
 Description=5 minute check of pmlogger farm instances
 
 [Timer]
-# if enabled, runs 1m after boot and every 5 mins
+# if enabled, runs 1m after boot and every 2 mins
 OnBootSec=1min
-OnCalendar=*:00/5
+OnCalendar=*:00/2
 
 [Install]
 WantedBy=timers.target
-RequiredBy=pmlogger_farm.service
+RequiredBy=pmlogger_farm.service pmlogger_farm_check.service


### PR DESCRIPTION
Fix missing dep so pmlogger_farm_check.timer is now required by
pmlogger_farm_check.service (which in turn is required by the
pmlogger_farm.service) so control file changes will be checked and
applied when the timer goes off (now every 2 mins).  Previously the
timer was not started on virgin installs due to the missing dep,
probably resulting in RHBZ#2027753.

Also strengthen deps so pmlogger.service "wants" pmlogger_farm
(so systemd will try and start/stop the farm service when the pmlogger
service is started/stopped).

Resolves: RHBZ#2027753
Related: https://github.com/performancecopilot/pcp/pull/1489