### PR TITLE
pmlogger, pmie scripts: fix Before= lines in systemd files

### DIFF
--- a/src/pmie/GNUmakefile
+++ b/src/pmie/GNUmakefile
@@ -96,6 +96,7 @@ pmie_farm.service : pmie_farm.service.in
 pmie_farm_check.service : pmie_farm_check.service.in
 	$(SED) <$< >$@ \
 	    -e 's;@PCP_BIN_DIR@;'$(PCP_BIN_DIR)';' \
+	    -e 's;@PCP_VAR_DIR@;'$(PCP_VAR_DIR)';' \
 	# END
 
 pmie_check.service : pmie_check.service.in

--- a/src/pmie/pmie_farm.service.in
+++ b/src/pmie/pmie_farm.service.in
@@ -2,8 +2,8 @@
 Description=pmie farm service
 Documentation=man:pmie(1)
 After=network-online.target pmcd.service
-Before=pmie_check.timer pmie_daily.timer
-BindsTo=pmie_farm_check.timer pmie_check.timer pmie_daily.timer
+Before=pmie_farm_check.timer pmie_daily.timer
+BindsTo=pmie_farm_check.timer pmie_daily.timer
 
 [Service]
 Type=@SD_SERVICE_TYPE@

--- a/src/pmie/pmie_farm_check.service.in
+++ b/src/pmie/pmie_farm_check.service.in
@@ -9,7 +9,7 @@ Restart=no
 TimeoutStartSec=4h
 TimeoutStopSec=120
 ExecStart=@PCP_BIN_DIR@/pmiectl -m check
-WorkingDirectory=/var/lib/pcp
+WorkingDirectory=@PCP_VAR_DIR@
 
 # root so pmiectl can migrate pmie processes to the pmie_farm service
 Group=root

--- a/src/pmlogger/GNUmakefile
+++ b/src/pmlogger/GNUmakefile
@@ -111,6 +111,7 @@ pmlogger_farm.service : pmlogger_farm.service.in
 pmlogger_farm_check.service : pmlogger_farm_check.service.in
 	$(SED) <$< >$@ \
 	    -e 's;@PCP_BIN_DIR@;'$(PCP_BIN_DIR)';' \
+	    -e 's;@PCP_VAR_DIR@;'$(PCP_VAR_DIR)';' \
 	# END
 
 pmlogger_daily.service : pmlogger_daily.service.in

--- a/src/pmlogger/pmlogger_farm.service.in
+++ b/src/pmlogger/pmlogger_farm.service.in
@@ -2,8 +2,8 @@
 Description=pmlogger farm service
 Documentation=man:pmlogger(1)
 After=network-online.target pmcd.service
-Before=pmlogger_check.timer pmlogger_daily.timer
-BindsTo=pmlogger_farm_check.timer pmlogger_check.timer pmlogger_daily.timer
+Before=pmlogger_farm_check.timer pmlogger_daily.timer
+BindsTo=pmlogger_farm_check.timer pmlogger_daily.timer
 
 [Service]
 Type=@SD_SERVICE_TYPE@

--- a/src/pmlogger/pmlogger_farm_check.service.in
+++ b/src/pmlogger/pmlogger_farm_check.service.in
@@ -9,7 +9,7 @@ Restart=no
 TimeoutStartSec=4h
 TimeoutStopSec=120
 ExecStart=@PCP_BIN_DIR@/pmlogctl -m check
-WorkingDirectory=/var/lib/pcp
+WorkingDirectory=@PCP_VAR_DIR@
 
 # root so pmlogctl can migrate pmloggers to the pmlogger_farm service
 Group=root


### PR DESCRIPTION
The Before= lines in pmie_farm and pmlogger_farm files lacked
a link to the associated timer.  The BindsTo= lines had links
to the unrelated primary pmlogger/pmie_check timers.

Finally, remove a hard-coded path from these .in files, which
was inconsistent with the rest of the systemd files setup.