### PR TITLE
Resolve inconsistencies in new 'farm' and other systemd units

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -2547,14 +2547,10 @@ pmieconf -c enable dmthin
 %if "@enable_systemd@" == "true"
     systemctl restart pmcd >/dev/null 2>&1
     systemctl restart pmlogger >/dev/null 2>&1
-    systemctl restart pmlogger_farm >/dev/null 2>&1
     systemctl restart pmie >/dev/null 2>&1
-    systemctl restart pmie_farm >/dev/null 2>&1
     systemctl enable pmcd >/dev/null 2>&1
     systemctl enable pmlogger >/dev/null 2>&1
-    systemctl enable pmlogger_farm >/dev/null 2>&1
     systemctl enable pmie >/dev/null 2>&1
-    systemctl enable pmie_farm >/dev/null 2>&1
 %else
     /sbin/chkconfig --add pmcd >/dev/null 2>&1
     /sbin/chkconfig --add pmlogger >/dev/null 2>&1
@@ -2852,23 +2848,24 @@ then
     %if "@enable_systemd@" == "true"
         %systemd_preun pmlogger.service
 	%systemd_preun pmlogger_farm.service
-	%systemd_preun pmfind.service
 	%systemd_preun pmie.service
 	%systemd_preun pmie_farm.service
 	%systemd_preun pmproxy.service
+	%systemd_preun pmfind.service
 	%systemd_preun pmcd.service
-	%systemd_preun pmie_daily.timer
 	%systemd_preun pmlogger_daily.timer
 	%systemd_preun pmlogger_check.timer
 	%systemd_preun pmlogger_farm_check.timer
+	%systemd_preun pmie_daily.timer
+	%systemd_preun pmie_check.timer
 	%systemd_preun pmie_farm_check.timer
 
 	systemctl stop pmlogger.service >/dev/null 2>&1
 	systemctl stop pmlogger_farm.service >/dev/null 2>&1
-	systemctl stop pmfind.service >/dev/null 2>&1
 	systemctl stop pmie.service >/dev/null 2>&1
 	systemctl stop pmie_farm.service >/dev/null 2>&1
 	systemctl stop pmproxy.service >/dev/null 2>&1
+	systemctl stop pmfind.service >/dev/null 2>&1
 	systemctl stop pmcd.service >/dev/null 2>&1
     %else
 	/sbin/service pmlogger stop >/dev/null 2>&1
@@ -2902,29 +2899,19 @@ PCP_SA_DIR=@pcp_sa_dir@
     # clean up any stale symlinks for deprecated pm*-poll services
     rm -f %{_sysconfdir}/systemd/system/pm*.requires/pm*-poll.* >/dev/null 2>&1 || true
 
-    # pmlogger_farm service inherits the same initial state as pmlogger service
-    if systemctl is-enabled pmlogger.service >/dev/null; then
-	systemctl enable pmlogger_farm.service pmlogger_farm_check.service
-	systemctl start pmlogger_farm.service pmlogger_farm_check.service
-    fi
-    # pmie_farm service inherits the same initial state as pmie service
-    if systemctl is-enabled pmie.service >/dev/null; then
-	systemctl enable pmie_farm.service pmie_farm_check.service
-	systemctl start pmie_farm.service pmie_farm_check.service
-    fi
-
     %systemd_postun_with_restart pmcd.service
     %systemd_post pmcd.service
     %systemd_postun_with_restart pmlogger.service
     %systemd_post pmlogger.service
     %systemd_postun_with_restart pmlogger_farm.service
     %systemd_post pmlogger_farm.service
-    %systemd_post pmlogger_farm_check.service
     %systemd_postun_with_restart pmie.service
     %systemd_post pmie.service
+    %systemd_postun_with_restart pmie_farm.service
     %systemd_post pmie_farm.service
-    %systemd_post pmie_farm_check.service
-    systemctl condrestart pmproxy.service >/dev/null 2>&1
+    %systemd_postun_with_restart pmproxy.service
+    %systemd_post pmproxy.service
+    %systemd_post pmfind.service
 %else
     /sbin/chkconfig --add pmcd >/dev/null 2>&1
     /sbin/service pmcd condrestart

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -2955,11 +2955,13 @@ then
        %systemd_preun pmie.service
        %systemd_preun pmie_farm.service
        %systemd_preun pmproxy.service
+       %systemd_preun pmfind.service
        %systemd_preun pmcd.service
-       %systemd_preun pmie_daily.timer
        %systemd_preun pmlogger_daily.timer
        %systemd_preun pmlogger_check.timer
        %systemd_preun pmlogger_farm_check.timer
+       %systemd_preun pmie_daily.timer
+       %systemd_preun pmie_check.timer
        %systemd_preun pmie_farm_check.timer
 
        systemctl stop pmlogger.service >/dev/null 2>&1
@@ -2967,6 +2969,7 @@ then
        systemctl stop pmie.service >/dev/null 2>&1
        systemctl stop pmie_farm.service >/dev/null 2>&1
        systemctl stop pmproxy.service >/dev/null 2>&1
+       systemctl stop pmfind.service >/dev/null 2>&1
        systemctl stop pmcd.service >/dev/null 2>&1
     %else
        /sbin/service pmlogger stop >/dev/null 2>&1
@@ -3006,25 +3009,17 @@ pmieconf -c enable dmthin
 %if !%{disable_systemd}
     systemctl restart pmcd >/dev/null 2>&1
     systemctl restart pmlogger >/dev/null 2>&1
-    systemctl restart pmlogger_farm >/dev/null 2>&1
     systemctl restart pmie >/dev/null 2>&1
-    systemctl restart pmie_farm >/dev/null 2>&1
     systemctl enable pmcd >/dev/null 2>&1
     systemctl enable pmlogger >/dev/null 2>&1
-    systemctl enable pmlogger_farm >/dev/null 2>&1
     systemctl enable pmie >/dev/null 2>&1
-    systemctl enable pmie_farm >/dev/null 2>&1
 %else
     /sbin/chkconfig --add pmcd >/dev/null 2>&1
     /sbin/chkconfig --add pmlogger >/dev/null 2>&1
-    /sbin/chkconfig --add pmlogger_farm >/dev/null 2>&1
     /sbin/chkconfig --add pmie >/dev/null 2>&1
-    /sbin/chkconfig --add pmie_farm >/dev/null 2>&1
     /sbin/service pmcd condrestart
     /sbin/service pmlogger condrestart
-    /sbin/service pmlogger_farm condrestart
     /sbin/service pmie condrestart
-    /sbin/service pmie_farm condrestart
 %endif
 %endif
 
@@ -3048,30 +3043,19 @@ PCP_LOG_DIR=%{_logsdir}
     # clean up any stale symlinks for deprecated pm*-poll services
     rm -f %{_sysconfdir}/systemd/system/pm*.requires/pm*-poll.* >/dev/null 2>&1 || true
 
-    # pmlogger_farm service inherits the same initial state as pmlogger service
-    if systemctl is-enabled pmlogger.service >/dev/null; then
-	systemctl enable pmlogger_farm.service pmlogger_farm_check.service
-	systemctl start pmlogger_farm.service pmlogger_farm_check.service
-    fi
-    # pmie_farm service inherits the same initial state as pmie service
-    if systemctl is-enabled pmie.service >/dev/null; then
-	systemctl enable pmie_farm.service pmie_farm_check.service
-	systemctl start pmie_farm.service pmie_farm_check.service
-    fi
-
     %systemd_postun_with_restart pmcd.service
     %systemd_post pmcd.service
     %systemd_postun_with_restart pmlogger.service
     %systemd_post pmlogger.service
     %systemd_postun_with_restart pmlogger_farm.service
     %systemd_post pmlogger_farm.service
-    %systemd_post pmlogger_farm_check.service
     %systemd_postun_with_restart pmie.service
     %systemd_post pmie.service
     %systemd_postun_with_restart pmie_farm.service
     %systemd_post pmie_farm.service
-    %systemd_post pmie_farm_check.service
-    systemctl condrestart pmproxy.service >/dev/null 2>&1
+    %systemd_postun_with_restart pmproxy.service
+    %systemd_post pmproxy.service
+    %systemd_post pmfind.service
 %else
     /sbin/chkconfig --add pmcd >/dev/null 2>&1
     /sbin/service pmcd condrestart

--- a/src/pmie/pmie.service.in
+++ b/src/pmie/pmie.service.in
@@ -4,7 +4,7 @@ Documentation=man:pmie(1)
 After=network-online.target pmcd.service
 Before=pmie_check.timer pmie_daily.timer
 BindsTo=pmie_check.timer pmie_daily.timer
-Wants=pmcd.service
+Wants=pmcd.service pmie_farm.service
 
 [Service]
 Type=notify

--- a/src/pmie/pmie_farm.service.in
+++ b/src/pmie/pmie_farm.service.in
@@ -22,6 +22,3 @@ User=@PCP_USER@
 
 [Install]
 WantedBy=multi-user.target
-
-# This dependency will be removed in PCPv6.
-WantedBy=pmie.service

--- a/src/pmlogger/pmlogger.service.in
+++ b/src/pmlogger/pmlogger.service.in
@@ -4,7 +4,7 @@ Documentation=man:pmlogger(1)
 After=network-online.target pmcd.service
 Before=pmlogger_check.timer pmlogger_daily.timer
 BindsTo=pmlogger_check.timer pmlogger_daily.timer
-Wants=pmcd.service
+Wants=pmcd.service pmlogger_farm.service
 
 [Service]
 Type=notify

--- a/src/pmlogger/pmlogger_farm.service.in
+++ b/src/pmlogger/pmlogger_farm.service.in
@@ -22,6 +22,3 @@ User=@PCP_USER@
 
 [Install]
 WantedBy=multi-user.target
-
-# This dependency will be removed in PCPv6.
-WantedBy=pmlogger.service


### PR DESCRIPTION
This change most importantly introduces the Wants= line Mark
(and Jan earlier, indirectly) proposed to make pmlogger_farm
handling function as end-users will expect when manipulating
the pmlogger.service.  Ditto for pmie.

There's also several cleanups of things that are inconsistent
and just plain wrong or missing, particularly in spec files.

This supercedes PR #1492 and PR #1489.
This resolves Red Hat BZ #2027753.