### PR TITLE
Resolve inconsistencies in new 'farm' systemd timers

### DIFF
--- a/src/pmie/pmie_farm_check.timer
+++ b/src/pmie/pmie_farm_check.timer
@@ -1,10 +1,11 @@
 [Unit]
-Description=5 minute check of pmie farm instances
+Description=Half-hourly check of pmie farm instances
 
 [Timer]
-# if enabled, runs 1m after boot and every 5 mins
+# if enabled, runs 1m after boot and every half hour
 OnBootSec=1min
-OnCalendar=*:00/5
+OnCalendar=*-*-* *:28:10
+OnCalendar=*-*-* *:58:10
 
 [Install]
 WantedBy=timers.target

--- a/src/pmlogger/pmlogger_farm_check.timer
+++ b/src/pmlogger/pmlogger_farm_check.timer
@@ -1,10 +1,11 @@
 [Unit]
-Description=5 minute check of pmlogger farm instances
+Description=Half-hourly check of pmlogger farm instances
 
 [Timer]
-# if enabled, runs 1m after boot and every 5 mins
+# if enabled, runs 1m after boot and every half hour
 OnBootSec=1min
-OnCalendar=*:00/5
+OnCalendar=*-*-* *:25:10
+OnCalendar=*-*-* *:55:10
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
When the farm systemd timers were introduced the check interval
was drastically reduced from half hourly to 5 minutely.  There
wasn't any discussion about rationales for this and its now not
consistent (does not dovetail at all) with the primary pmlogger
and pmie service.  If startup takes a long time (large farms or
slow networks) these will likely overlap constantly, and timing
should be such that we work with the primary services in mind.

Reset to half hourly for these checks, and lets revisit this in
the new year when the other systemd changes are being proposed.

Related to https://github.com/performancecopilot/pcp/pull/1495