### PR TITLE
libpcp_web: honour config settings that disable redis completely

### DIFF
--- a/man/man1/pmproxy.1
+++ b/man/man1/pmproxy.1
@@ -1,6 +1,6 @@
 '\"macro stdmacro
 .\"
-.\" Copyright (c) 2013-2015,2018-2019 Red Hat.
+.\" Copyright (c) 2013-2015,2018-2019,2021 Red Hat.
 .\" Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
 .\"
 .\" This program is free software; you can redistribute it and/or modify it
@@ -331,7 +331,7 @@ section can be used to explicitly enable or disable each of the
 different protocols.
 .PP
 The
-.I [pmseries]
+.I [redis]
 section allows connection information for one or more backing
 .B redis-server
 processes to be configured (hostnames and ports).
@@ -344,6 +344,14 @@ Alternatively, it can be a single
 host that will be queried using the "CLUSTER INFO" command to
 automatically configure multiple backing hosts, described at
 .BR https://redis.io/topics/cluster-spec .
+.PP
+In earlier versions of PCP (before 6) an alternative configuration
+setting section was used for this purpose \- Redis
+.I servers
+were specified in the
+.I [pmseries]
+section and this is still accepted as a fallback for backwards
+compatibility.
 .SH STARTING AND STOPPING PMPROXY
 Normally,
 .B pmproxy

--- a/qa/1458
+++ b/qa/1458
@@ -117,10 +117,10 @@ openssl req \
 	-keyout $tmp.key -out $tmp.cert >$seq.full 2>&1
 # creates a self-signed (insecure) certificate, so for testing only
 
+echo "[redis]" >> $tmp.conf
+echo "enabled = false" >> $tmp.conf
 echo "[pmproxy]" >> $tmp.conf
-echo "pcp.enabled = true" >> $tmp.conf
 echo "http.enabled = true" >> $tmp.conf
-echo "redis.enabled = false" >> $tmp.conf
 echo "secure.enabled = false" >> $tmp.conf
 
 port=`_find_free_port`

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -4248,6 +4248,7 @@ series_query_services(void *arg)
     seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     pmSeriesModule	*module = baton->module;
     seriesModuleData	*data = getSeriesModuleData(module);
+    sds			option;
 
     seriesBatonCheckMagic(baton, MAGIC_QUERY, "series_query_services");
     seriesBatonCheckCount(baton, "series_query_services");
@@ -4261,11 +4262,15 @@ series_query_services(void *arg)
 	baton->slots = data->slots;
 	series_query_end_phase(baton);
     } else {
-	baton->slots = data->slots =
-	    redisSlotsConnect(
-		data->config, 1, baton->info,
-		series_query_end_phase, baton->userdata,
-		data->events, (void *)baton);
+	option = pmIniFileLookup(data->config, "redis", "enabled");
+	if (option && strcmp(option, "false") == 0)
+	    baton->error = -ENOTSUP;
+	else
+	    baton->slots = data->slots =
+		redisSlotsConnect(
+		    data->config, 1, baton->info,
+		    series_query_end_phase, baton->userdata,
+		    data->events, (void *)baton);
     }
 }
 
@@ -5258,6 +5263,7 @@ series_lookup_services(void *arg)
     seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     pmSeriesModule	*module = baton->module;
     seriesModuleData	*data = getSeriesModuleData(module);
+    sds			option;
 
     seriesBatonCheckMagic(baton, MAGIC_QUERY, "series_lookup_services");
     seriesBatonReference(baton, "series_lookup_services");
@@ -5269,11 +5275,15 @@ series_lookup_services(void *arg)
 	baton->slots = data->slots;
 	series_query_end_phase(baton);
     } else {
-	baton->slots = data->slots =
-	    redisSlotsConnect(
-		data->config, 1, baton->info,
-		series_query_end_phase, baton->userdata,
-		data->events, (void *)baton);
+	option = pmIniFileLookup(data->config, "redis", "enabled");
+	if (option && strcmp(option, "false") == 0)
+	    baton->error = -ENOTSUP;
+	else
+	    baton->slots = data->slots =
+		redisSlotsConnect(
+		    data->config, 1, baton->info,
+		    series_query_end_phase, baton->userdata,
+		    data->events, (void *)baton);
     }
 }
 

--- a/src/libpcp_web/src/schema.c
+++ b/src/libpcp_web/src/schema.c
@@ -1685,11 +1685,15 @@ pmSeriesSetup(pmSeriesModule *module, void *arg)
 	module->on_setup(arg);
 	data->shareslots = 1;
     } else {
+	option = pmIniFileLookup(data->config, "redis", "enabled");
+	if (option && strcmp(option, "false") == 0)
+	    return -ENOTSUP;
+
 	/* establish an initial connection to Redis instance(s) */
 	flags = SLOTS_VERSION;
 
 	option = pmIniFileLookup(data->config, "pmsearch", "enabled");
-	if (option && strncmp(option, "true", sdslen(option)) == 0)
+	if (option && strcmp(option, "true") == 0)
 	    flags |= SLOTS_SEARCH;
 
 	data->slots = redisSlotsConnect(
@@ -1966,7 +1970,7 @@ pmDiscoverSetup(pmDiscoverModule *module, pmDiscoverCallBacks *cbs, void *arg)
 
     /* double-check that we are supposed to be in here */
     if ((option = pmIniFileLookup(config, "discover", "enabled"))) {
-	if (strcasecmp(option, "false") == 0)
+	if (strcmp(option, "false") == 0)
 	    return 0;
     }
 

--- a/src/libpcp_web/src/search.c
+++ b/src/libpcp_web/src/search.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Red Hat.
+ * Copyright (c) 2020-2021 Red Hat.
  *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published
@@ -1046,6 +1046,7 @@ int
 pmSearchSetup(pmSearchModule *module, void *arg)
 {
     seriesModuleData	*data = getSeriesModuleData(module);
+    sds			option;
 
     if (data == NULL)
 	return -ENOMEM;
@@ -1058,6 +1059,10 @@ pmSearchSetup(pmSearchModule *module, void *arg)
 	module->on_setup(arg);
 	data->shareslots = 1;
     } else {
+	option = pmIniFileLookup(data->config, "redis", "enabled");
+	if (option && strcmp(option, "false") == 0)
+	    return -ENOTSUP;
+
 	/* establish an initial connection to Redis instance(s) */
 	data->slots = redisSlotsConnect(
 			data->config, SLOTS_SEARCH, module->on_info,

--- a/src/pmproxy/pmproxy.conf
+++ b/src/pmproxy/pmproxy.conf
@@ -34,13 +34,33 @@ redis.enabled = true
 # support SSL/TLS protocol wrapping
 secure.enabled = true
 
+#####################################################################
+## settings related to redis-server connections
+#####################################################################
+[redis]
+
+# allow completely disabling any/all connection attempts across
+# all of the pmproxy functionality (when this is set to false).
+enabled = true
+
+# connection spec(s) - could be any individual cluster host and
+# every host in the cluster will be automatically discovered --
+# alternately use comma-separated hostspecs (non-cluster setup).
+servers = localhost:6379
+
+# authentication with username and password is only supported in
+# Redis 6+ (with ACL support), for versions prior to 6 only the
+# password authentication is supported (leave the username value
+# empty).  Commented or empty values disable authentication.
+#username =
+#password =
 
 #####################################################################
 ## settings related to automatically discovered archives
 #####################################################################
 [discover]
 
-# propogate archives from pmlogger(1) into Redis querying
+# propogate archives from pmlogger(1) into Redis for querying
 enabled = true
 
 # comma-separated metrics name (globs) to skip during discovery
@@ -51,8 +71,8 @@ exclude.indoms = 3.9,3.40,79.7
 
 #####################################################################
 ## settings for metric and indom help text searching via RediSearch
-[pmsearch]
 #####################################################################
+[pmsearch]
 
 # allow REST API queries and indexing of metric and indom help text
 enabled = true
@@ -62,24 +82,11 @@ count = 10
 
 #####################################################################
 ## settings for fast, scalable time series quering via Redis
-[pmseries]
 #####################################################################
+[pmseries]
 
 # allow REST API queries of fast, scalable time series
 enabled = true
-
-# Redis connection spec(s) - could be any individual cluster host,
-# and all hosts in the cluster will be automatically discovered --
-# alternately, use comma-separated hostspecs (non-clustered setup)
-servers = localhost:6379
-
-# Redis Authentication
-# Authentication with username and password is only supported in Redis 6+
-# (Redis ACL), for versions prior to 6 only the password authentication
-# is supported (leave the auth.username setting empty).
-# Commented or empty values disable authentication.
-#auth.username =
-#auth.password =
 
 # number of elements from scan calls (https://redis.io/commands/scan)
 cursor.count = 256

--- a/src/pmproxy/src/pmproxy.c
+++ b/src/pmproxy/src/pmproxy.c
@@ -266,11 +266,11 @@ ParseOptions(int argc, char *argv[], int *nports, int *maxpending)
 	 * Push command line options into the configuration, and ensure
 	 * we have some default for attemping Redis server connections.
 	 */
-	if ((option = pmIniFileLookup(config, "pmseries", "servers")) == NULL ||
+	if ((option = pmIniFileLookup(config, "redis", "servers")) == NULL ||
 	    (redis_host != NULL || redis_port != 6379)) {
 	    option = sdscatfmt(sdsempty(), "%s:%u",
 		    redis_host? redis_host : "localhost", redis_port);
-	    pmIniFileUpdate(config, "pmseries", "servers", option);
+	    pmIniFileUpdate(config, "redis", "servers", option);
 	}
     }
 

--- a/src/pmsearch/pmsearch.c
+++ b/src/pmsearch/pmsearch.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Red Hat.
+ * Copyright (c) 2020-2021 Red Hat.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -428,11 +428,12 @@ main(int argc, char *argv[])
 	    pmIniFileUpdate(config, "pmsearch", "count", option);
 	}
 
-	if ((pmIniFileLookup(config, "pmseries", "servers")) == NULL ||
-	    (redis_host != NULL || redis_port != 6379)) {
+	if ((option = pmIniFileLookup(config, "redis", "servers")) == NULL)
+	    option = pmIniFileLookup(config, "pmseries", "servers");
+	if (option == NULL || redis_host != NULL || redis_port != 6379) {
 	    option = sdscatfmt(sdsempty(), "%s:%u",
 			redis_host? redis_host : "localhost", redis_port);
-	    pmIniFileUpdate(config, "pmseries", "servers", option);
+	    pmIniFileUpdate(config, "redis", "servers", option);
 	}
     }
 

--- a/src/pmseries/pmseries.c
+++ b/src/pmseries/pmseries.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Red Hat.
+ * Copyright (c) 2017-2021 Red Hat.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -1279,11 +1279,12 @@ main(int argc, char *argv[])
 	 * Push command line options into the configuration, and ensure
 	 * we have some default for attemping Redis server connections.
 	 */
-	if ((option = pmIniFileLookup(config, "pmseries", "servers")) == NULL ||
-	    (redis_host != NULL || redis_port != 6379)) {
+	if ((option = pmIniFileLookup(config, "redis", "servers")) == NULL)
+	    option = pmIniFileLookup(config, "pmseries", "servers");
+	if (option == NULL || redis_host != NULL || redis_port != 6379) {
 	    option = sdscatfmt(sdsempty(), "%s:%u",
 			redis_host? redis_host : "localhost", redis_port);
-	    pmIniFileUpdate(config, "pmseries", "servers", option);
+	    pmIniFileUpdate(config, "redis", "servers", option);
 	}
     }
 


### PR DESCRIPTION
Exercised by existing QA test 1458 via CI platforms with no Redis
(test is currently failing there due to this issue).

Related to https://github.com/performancecopilot/pcp/pull/1491