### PR TITLE
pmlogger/pmie farms: give up on soft link to pmlogger/pmie

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -2853,41 +2853,37 @@ if [ "$1" -eq 0 ]
 then
     # stop daemons before erasing the package
     %if "@enable_systemd@" == "true"
-        %systemd_preun pmlogger.service
+	%systemd_preun pmlogger.service
+	%systemd_preun pmlogger_check.timer
+	%systemd_preun pmlogger_daily.timer
 	%systemd_preun pmlogger_farm.service
+	%systemd_preun pmlogger_farm_check.service
+	%systemd_preun pmlogger_farm_check.timer
 	%systemd_preun pmie.service
+	%systemd_preun pmie_check.timer
+	%systemd_preun pmie_daily.timer
 	%systemd_preun pmie_farm.service
+	%systemd_preun pmie_farm_check.service
+	%systemd_preun pmie_farm_check.timer
 	%systemd_preun pmproxy.service
 	%systemd_preun pmfind.service
 	%systemd_preun pmcd.service
-	%systemd_preun pmlogger_daily.timer
-	%systemd_preun pmlogger_check.timer
-	%systemd_preun pmlogger_farm_check.timer
-	%systemd_preun pmie_daily.timer
-	%systemd_preun pmie_check.timer
-	%systemd_preun pmie_farm_check.timer
 
 	systemctl stop pmlogger.service >/dev/null 2>&1
-	systemctl stop pmlogger_farm.service >/dev/null 2>&1
 	systemctl stop pmie.service >/dev/null 2>&1
-	systemctl stop pmie_farm.service >/dev/null 2>&1
 	systemctl stop pmproxy.service >/dev/null 2>&1
 	systemctl stop pmfind.service >/dev/null 2>&1
 	systemctl stop pmcd.service >/dev/null 2>&1
     %else
 	/sbin/service pmlogger stop >/dev/null 2>&1
-	/sbin/service pmlogger_farm stop >/dev/null 2>&1
 	/sbin/service pmie stop >/dev/null 2>&1
-	/sbin/service pmie_farm stop >/dev/null 2>&1
 	/sbin/service pmproxy stop >/dev/null 2>&1
 	/sbin/service pmcd stop >/dev/null 2>&1
 
 	/sbin/chkconfig --del pcp >/dev/null 2>&1
 	/sbin/chkconfig --del pmcd >/dev/null 2>&1
 	/sbin/chkconfig --del pmlogger >/dev/null 2>&1
-	/sbin/chkconfig --del pmlogger_farm >/dev/null 2>&1
 	/sbin/chkconfig --del pmie >/dev/null 2>&1
-	/sbin/chkconfig --del pmie_farm >/dev/null 2>&1
 	/sbin/chkconfig --del pmproxy >/dev/null 2>&1
     %endif
     # cleanup namespace state/flag, may still exist
@@ -2910,12 +2906,8 @@ PCP_SA_DIR=@pcp_sa_dir@
     %systemd_post pmcd.service
     %systemd_postun_with_restart pmlogger.service
     %systemd_post pmlogger.service
-    %systemd_postun_with_restart pmlogger_farm.service
-    %systemd_post pmlogger_farm.service
     %systemd_postun_with_restart pmie.service
     %systemd_post pmie.service
-    %systemd_postun_with_restart pmie_farm.service
-    %systemd_post pmie_farm.service
     %systemd_postun_with_restart pmproxy.service
     %systemd_post pmproxy.service
     %systemd_post pmfind.service
@@ -2924,12 +2916,8 @@ PCP_SA_DIR=@pcp_sa_dir@
     /sbin/service pmcd condrestart
     /sbin/chkconfig --add pmlogger >/dev/null 2>&1
     /sbin/service pmlogger condrestart
-    /sbin/chkconfig --add pmlogger_farm >/dev/null 2>&1
-    /sbin/service pmlogger_farm condrestart
     /sbin/chkconfig --add pmie >/dev/null 2>&1
     /sbin/service pmie condrestart
-    /sbin/chkconfig --add pmie_farm >/dev/null 2>&1
-    /sbin/service pmie_farm condrestart
     /sbin/chkconfig --add pmproxy >/dev/null 2>&1
     /sbin/service pmproxy condrestart
 %endif

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -2951,40 +2951,36 @@ then
     # stop daemons before erasing the package
     %if !%{disable_systemd}
        %systemd_preun pmlogger.service
+       %systemd_preun pmlogger_check.timer
+       %systemd_preun pmlogger_daily.timer
        %systemd_preun pmlogger_farm.service
+       %systemd_preun pmlogger_farm_check.service
+       %systemd_preun pmlogger_farm_check.timer
        %systemd_preun pmie.service
+       %systemd_preun pmie_check.timer
+       %systemd_preun pmie_daily.timer
        %systemd_preun pmie_farm.service
+       %systemd_preun pmie_farm_check.service
+       %systemd_preun pmie_farm_check.timer
        %systemd_preun pmproxy.service
        %systemd_preun pmfind.service
        %systemd_preun pmcd.service
-       %systemd_preun pmlogger_daily.timer
-       %systemd_preun pmlogger_check.timer
-       %systemd_preun pmlogger_farm_check.timer
-       %systemd_preun pmie_daily.timer
-       %systemd_preun pmie_check.timer
-       %systemd_preun pmie_farm_check.timer
 
        systemctl stop pmlogger.service >/dev/null 2>&1
-       systemctl stop pmlogger_farm.service >/dev/null 2>&1
        systemctl stop pmie.service >/dev/null 2>&1
-       systemctl stop pmie_farm.service >/dev/null 2>&1
        systemctl stop pmproxy.service >/dev/null 2>&1
        systemctl stop pmfind.service >/dev/null 2>&1
        systemctl stop pmcd.service >/dev/null 2>&1
     %else
        /sbin/service pmlogger stop >/dev/null 2>&1
-       /sbin/service pmlogger_farm stop >/dev/null 2>&1
        /sbin/service pmie stop >/dev/null 2>&1
-       /sbin/service pmie_farm stop >/dev/null 2>&1
        /sbin/service pmproxy stop >/dev/null 2>&1
        /sbin/service pmcd stop >/dev/null 2>&1
 
        /sbin/chkconfig --del pcp >/dev/null 2>&1
        /sbin/chkconfig --del pmcd >/dev/null 2>&1
        /sbin/chkconfig --del pmlogger >/dev/null 2>&1
-       /sbin/chkconfig --del pmlogger_farm >/dev/null 2>&1
        /sbin/chkconfig --del pmie >/dev/null 2>&1
-       /sbin/chkconfig --del pmie_farm >/dev/null 2>&1
        /sbin/chkconfig --del pmproxy >/dev/null 2>&1
     %endif
     # cleanup namespace state/flag, may still exist
@@ -3047,12 +3043,8 @@ PCP_LOG_DIR=%{_logsdir}
     %systemd_post pmcd.service
     %systemd_postun_with_restart pmlogger.service
     %systemd_post pmlogger.service
-    %systemd_postun_with_restart pmlogger_farm.service
-    %systemd_post pmlogger_farm.service
     %systemd_postun_with_restart pmie.service
     %systemd_post pmie.service
-    %systemd_postun_with_restart pmie_farm.service
-    %systemd_post pmie_farm.service
     %systemd_postun_with_restart pmproxy.service
     %systemd_post pmproxy.service
     %systemd_post pmfind.service
@@ -3061,12 +3053,8 @@ PCP_LOG_DIR=%{_logsdir}
     /sbin/service pmcd condrestart
     /sbin/chkconfig --add pmlogger >/dev/null 2>&1
     /sbin/service pmlogger condrestart
-    /sbin/chkconfig --add pmlogger_farm >/dev/null 2>&1
-    /sbin/service pmlogger_farm condrestart
     /sbin/chkconfig --add pmie >/dev/null 2>&1
     /sbin/service pmie condrestart
-    /sbin/chkconfig --add pmie_farm >/dev/null 2>&1
-    /sbin/service pmie_farm condrestart
     /sbin/chkconfig --add pmproxy >/dev/null 2>&1
     /sbin/service pmproxy condrestart
 %endif

--- a/src/pmie/GNUmakefile
+++ b/src/pmie/GNUmakefile
@@ -84,7 +84,6 @@ pmie.service : pmie.service.in
 
 pmie_farm.service : pmie_farm.service.in
 	$(SED) <$< >$@ \
-	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
 	    -e 's;@PCP_SYSCONFIG_DIR@;'$(PCP_SYSCONFIG_DIR)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_VAR_DIR@;'$(PCP_VAR_DIR)';' \
@@ -95,6 +94,7 @@ pmie_farm.service : pmie_farm.service.in
 
 pmie_farm_check.service : pmie_farm_check.service.in
 	$(SED) <$< >$@ \
+	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
 	    -e 's;@PCP_BIN_DIR@;'$(PCP_BIN_DIR)';' \
 	    -e 's;@PCP_VAR_DIR@;'$(PCP_VAR_DIR)';' \
 	# END

--- a/src/pmie/pmie.service.in
+++ b/src/pmie/pmie.service.in
@@ -4,7 +4,7 @@ Documentation=man:pmie(1)
 After=network-online.target pmcd.service
 Before=pmie_check.timer pmie_daily.timer
 BindsTo=pmie_check.timer pmie_daily.timer
-Wants=pmcd.service pmie_farm.service
+Wants=pmcd.service
 
 [Service]
 Type=notify

--- a/src/pmie/pmie_farm.service.in
+++ b/src/pmie/pmie_farm.service.in
@@ -1,9 +1,8 @@
 [Unit]
 Description=pmie farm service
-Documentation=man:pmie(1)
-After=network-online.target pmcd.service
-Before=pmie_farm_check.timer pmie_daily.timer
-BindsTo=pmie_farm_check.timer pmie_daily.timer
+Documentation=man:pmie_check(1)
+Before=pmie_farm_check.timer
+BindsTo=pmie_farm_check.timer
 
 [Service]
 Type=@SD_SERVICE_TYPE@
@@ -15,10 +14,9 @@ TimeoutStopSec=120
 Environment="PMIE_CHECK_PARAMS=--skip-primary"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmie_timers
 ExecStart=@PCP_BINADM_DIR@/pmie_farm $PMIE_CHECK_PARAMS
-
 WorkingDirectory=@PCP_VAR_DIR@
 Group=@PCP_GROUP@
 User=@PCP_USER@
 
 [Install]
-WantedBy=multi-user.target
+RequiredBy=pmie.service

--- a/src/pmie/pmie_farm_check.service.in
+++ b/src/pmie/pmie_farm_check.service.in
@@ -1,7 +1,7 @@
 [Unit]
-Description=Check and migrate non-primary pmie instances to pmie_farm
-Documentation=man:pmie_check(1)
-# TODO non-systemd ConditionPathExists=!/etc/cron.d/pcp-pmie
+Description=Check and migrate non-primary pmie farm instances
+Documentation=man:pmiectl(1)
+ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=exec
@@ -10,7 +10,6 @@ TimeoutStartSec=4h
 TimeoutStopSec=120
 ExecStart=@PCP_BIN_DIR@/pmiectl -m check
 WorkingDirectory=@PCP_VAR_DIR@
-
 # root so pmiectl can migrate pmie processes to the pmie_farm service
 Group=root
 User=root

--- a/src/pmlogger/GNUmakefile
+++ b/src/pmlogger/GNUmakefile
@@ -99,7 +99,6 @@ pmlogger.service : pmlogger.service.in
 
 pmlogger_farm.service : pmlogger_farm.service.in
 	$(SED) <$< >$@ \
-	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
 	    -e 's;@PCP_SYSCONFIG_DIR@;'$(PCP_SYSCONFIG_DIR)';' \
 	    -e 's;@PCP_BINADM_DIR@;'$(PCP_BINADM_DIR)';' \
 	    -e 's;@PCP_VAR_DIR@;'$(PCP_VAR_DIR)';' \
@@ -110,6 +109,7 @@ pmlogger_farm.service : pmlogger_farm.service.in
 
 pmlogger_farm_check.service : pmlogger_farm_check.service.in
 	$(SED) <$< >$@ \
+	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
 	    -e 's;@PCP_BIN_DIR@;'$(PCP_BIN_DIR)';' \
 	    -e 's;@PCP_VAR_DIR@;'$(PCP_VAR_DIR)';' \
 	# END

--- a/src/pmlogger/pmlogger.service.in
+++ b/src/pmlogger/pmlogger.service.in
@@ -4,7 +4,7 @@ Documentation=man:pmlogger(1)
 After=network-online.target pmcd.service
 Before=pmlogger_check.timer pmlogger_daily.timer
 BindsTo=pmlogger_check.timer pmlogger_daily.timer
-Wants=pmcd.service pmlogger_farm.service
+Wants=pmcd.service
 
 [Service]
 Type=notify

--- a/src/pmlogger/pmlogger_farm.service.in
+++ b/src/pmlogger/pmlogger_farm.service.in
@@ -1,9 +1,8 @@
 [Unit]
 Description=pmlogger farm service
-Documentation=man:pmlogger(1)
-After=network-online.target pmcd.service
-Before=pmlogger_farm_check.timer pmlogger_daily.timer
-BindsTo=pmlogger_farm_check.timer pmlogger_daily.timer
+Documentation=man:pmlogger_check(1)
+Before=pmlogger_farm_check.timer
+BindsTo=pmlogger_farm_check.timer
 
 [Service]
 Type=@SD_SERVICE_TYPE@
@@ -15,10 +14,9 @@ TimeoutStopSec=120
 Environment="PMLOGGER_CHECK_PARAMS=--skip-primary"
 EnvironmentFile=-@PCP_SYSCONFIG_DIR@/pmlogger_timers
 ExecStart=@PCP_BINADM_DIR@/pmlogger_farm $PMLOGGER_CHECK_PARAMS
-
 WorkingDirectory=@PCP_VAR_DIR@
 Group=@PCP_GROUP@
 User=@PCP_USER@
 
 [Install]
-WantedBy=multi-user.target
+RequiredBy=pmlogger.service

--- a/src/pmlogger/pmlogger_farm_check.service.in
+++ b/src/pmlogger/pmlogger_farm_check.service.in
@@ -1,7 +1,7 @@
 [Unit]
-Description=Check and migrate non-primary pmlogger instances to pmlogger_farm
-Documentation=man:pmlogger_check(1)
-# TODO non-systemd ConditionPathExists=!/etc/cron.d/pcp-pmlogger
+Description=Check and migrate non-primary pmlogger farm instances
+Documentation=man:pmlogctl(1)
+ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
 Type=exec
@@ -10,8 +10,7 @@ TimeoutStartSec=4h
 TimeoutStopSec=120
 ExecStart=@PCP_BIN_DIR@/pmlogctl -m check
 WorkingDirectory=@PCP_VAR_DIR@
-
-# root so pmlogctl can migrate pmloggers to the pmlogger_farm service
+# root so pmlogctl can migrate pmlogger processes to the pmlogger_farm service
 Group=root
 User=root
 


### PR DESCRIPTION
Several attempts to allow the pmlogger and new pmlogger_farm
services to exist both dependently and independently haven't
been able to solve the problem of the pmlogger_farm services
and timers starting reliably when we need them to.  This has
caused various backwards-compatibility regressions not least
of which is ansible-pcp and the metrics role.

Simplify things by enforcing a hard link between these now -
when pmlogger is enabled/started so is pmlogger_farm.  Using
the same systemd mechanisms we have used reliably to ensure
pmlogger_check and pmlogger_daily are linked to pmlogger, we
now have reliable farm services once more.  The farm-versus-
primary cgroup separation is still maintained however.

While here, I saw the TODO note re lacking cron-back-compat
support - I've implemented that correctly now (trivial) but
its unlikely to affect anyone nowadays.

Resolves Red Hat BZ #2027753.