### PR TITLE
systemd units: pmlogger and pmie farm conditional use of type=exec

### DIFF
--- a/src/pmie/GNUmakefile
+++ b/src/pmie/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2015,2020-2021 Red Hat.
+# Copyright (c) 2013-2015,2020-2022 Red Hat.
 # Copyright (c) 2000,2004 Silicon Graphics, Inc.  All Rights Reserved.
 # 
 # This program is free software; you can redistribute it and/or modify it
@@ -97,6 +97,7 @@ pmie_farm_check.service : pmie_farm_check.service.in
 	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
 	    -e 's;@PCP_BIN_DIR@;'$(PCP_BIN_DIR)';' \
 	    -e 's;@PCP_VAR_DIR@;'$(PCP_VAR_DIR)';' \
+	    -e 's;@SD_SERVICE_TYPE@;'$(SD_SERVICE_TYPE)';' \
 	# END
 
 pmie_check.service : pmie_check.service.in

--- a/src/pmie/pmie_farm_check.service.in
+++ b/src/pmie/pmie_farm_check.service.in
@@ -4,7 +4,7 @@ Documentation=man:pmiectl(1)
 ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
-Type=exec
+Type=@SD_SERVICE_TYPE@
 Restart=no
 TimeoutStartSec=4h
 TimeoutStopSec=120

--- a/src/pmlogger/GNUmakefile
+++ b/src/pmlogger/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2021 Red Hat.
+# Copyright (c) 2013-2022 Red Hat.
 # Copyright (c) 2000,2004 Silicon Graphics, Inc.  All Rights Reserved.
 # 
 # This program is free software; you can redistribute it and/or modify it
@@ -112,6 +112,7 @@ pmlogger_farm_check.service : pmlogger_farm_check.service.in
 	    -e 's;@CRONTAB_PATH@;'$(CRONTAB_PATH)';' \
 	    -e 's;@PCP_BIN_DIR@;'$(PCP_BIN_DIR)';' \
 	    -e 's;@PCP_VAR_DIR@;'$(PCP_VAR_DIR)';' \
+	    -e 's;@SD_SERVICE_TYPE@;'$(SD_SERVICE_TYPE)';' \
 	# END
 
 pmlogger_daily.service : pmlogger_daily.service.in

--- a/src/pmlogger/pmlogger_farm_check.service.in
+++ b/src/pmlogger/pmlogger_farm_check.service.in
@@ -4,7 +4,7 @@ Documentation=man:pmlogctl(1)
 ConditionPathExists=!@CRONTAB_PATH@
 
 [Service]
-Type=exec
+Type=@SD_SERVICE_TYPE@
 Restart=no
 TimeoutStartSec=4h
 TimeoutStopSec=120


### PR DESCRIPTION
Older versions of systemd do not support type=exec but the pmie
and pmlogger farm check services were using it unconditionally.
Update these to use the technique used by the non-farm service
variants.

Related to https://github.com/performancecopilot/pcp/issues/1514