### PR TITLE
Fix of tty metrics on s390x platform

### DIFF
--- a/src/pmdas/linux/pmda.c
+++ b/src/pmdas/linux/pmda.c
@@ -9279,25 +9279,25 @@ linux_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
 		return 0;
 	    switch (item) {
 	    case TTY_TX:
-		atom->ull = ttydev->tx; /* tty.serial.tx */
+		atom->ul = ttydev->tx; /* tty.serial.tx */
 		break;
 	    case TTY_RX:
-		atom->ull = ttydev->rx; /* tty.serial.rx */
+		atom->ul = ttydev->rx; /* tty.serial.rx */
 		break;
 	    case TTY_FRAME:
-		atom->ull = ttydev->frame; /* tty.serial.frame */
+		atom->ul = ttydev->frame; /* tty.serial.frame */
 		break;
 	    case TTY_PARITY:
-		atom->ull = ttydev->parity; /* tty.serial.parity */
+		atom->ul = ttydev->parity; /* tty.serial.parity */
 		break;
 	    case TTY_BRK:
-		atom->ull = ttydev->brk; /* tty.serial.brk */
+		atom->ul = ttydev->brk; /* tty.serial.brk */
 		break;
 	    case TTY_OVERRUN:
-		atom->ull = ttydev->overrun; /* tty.serial.overrun */
+		atom->ul = ttydev->overrun; /* tty.serial.overrun */
 		break;
 	    case TTY_IRQ:
-		atom->ull = ttydev->irq; /* tty.serial.irq */
+		atom->ul = ttydev->irq; /* tty.serial.irq */
 		break;
 
 	    default:


### PR DESCRIPTION
There was a wrong conversion of tty metrics between 32bits and 64bits
values, causing these metrics to be always zero on s390x platform due
to big-endian architecture. This commit fixes the conversion.

Covered by qa/665.