### PR TITLE
pmlogger: zeroconf: Prioritize user configuration over zeroconf

### DIFF
--- a/src/pmlogger/pmlogger.defaults
+++ b/src/pmlogger/pmlogger.defaults
@@ -1,7 +1,7 @@
 # Environment variables for the primary pmlogger daemon.  See also
 # the pmlogger control file and pmlogconf(1) for additional details.
-# Settings defined in this file will be overridden by any settings
-# in the pmlogger zeroconf file (if present).
+# Settings defined in this file will override any settings in the
+# pmlogger zeroconf file (if present).
 
 # Behaviour regarding listening on external-facing interfaces;
 # unset PMLOGGER_LOCAL to allow connections from remote hosts.

--- a/src/pmlogger/pmlogger.zeroconf
+++ b/src/pmlogger/pmlogger.zeroconf
@@ -1,6 +1,6 @@
 #
-# PMLOGGER environment variables defined in this file take precedence over
-# the same variables defined in the standard pmlogger config file.
+# PMLOGGER environment variables defined in the standard pmlogger config file
+# take precedence over the same variables defined in this file.
 #
 # The PMLOGGER_INTERVAL setting affects the default primary pmlogger recording
 # frequency. This only affects the *default* interval setting when specified

--- a/src/pmlogger/pmlogger_check.sh
+++ b/src/pmlogger/pmlogger_check.sh
@@ -983,8 +983,8 @@ END				{ print m }'`
 	then
 	    if [ "X$primary" = Xy ]
 	    then
-		# pcp-zeroconf environment variables (if present) take precedence
-		envs=`grep -h ^PMLOGGER "$PMLOGGERENVS" "$PMLOGGERZEROCONFENVS" 2>/dev/null`
+		# User configuration takes precedence over pcp-zeroconf
+		envs=`grep -h ^PMLOGGER "$PMLOGGERZEROCONFENVS" "$PMLOGGERENVS" 2>/dev/null`
 		args="-P $args"
 		iam=" primary"
 		# clean up port-map, just in case


### PR DESCRIPTION
In 2c17ba0cc16f58de511dff1e3122096d60c50bb0, zeroconf provided
defaults (/usr/share/pcp/zeroconf/pmlogger, which was actually
/etc/sysconf/pmlogger_zeroconf at the time of the change) were prioritized over
user configuration (/etc/sysconf/pmlogger). This lead to regression in clients
which edited the user configuration and expected the changes to be given
priority over zeroconf configuration. This was identified at least in
ansible-pcp[1].

Undo the changes in this commit so that the final priority is as follows:

User configuration (/etc/sysconfig/pmlogger)
  (priority over)
Zeroconf defaults (/usr/share/pcp/zeroconf/pmlogger)
  (priority over)
Code defaults (pmlogger.c)

Links:

1) https://github.com/performancecopilot/pcp/pull/1462#issuecomment-1022714960

Tests:

- Install pcp. Ensure pmlogger is running. Notice that there is no
PMLOGGER_INTERVAL set in the pmlogger daemon's environment.

- Install pcp-zeroconf. Restart pmlogger. Notice that PMLOGGER_INTERVAL
environment is set in the pmlogger daemon's environment. The value is 10.

- Edit /etc/sysconfig/pmlogger and set the value of PMLOGGER_INTERVAL to 15.
Restart pmlogger and notice that PMLOGGER_INTERVAL is set to 15 in pmlogger
daemon's environment.

Signed-off-by: Sunil Mohan Adapa <sunil@medhas.org>
Tested-by: Sunil Mohan Adapa <sunil@medhas.org>