### PR TITLE
Remove "lockdown" selinux class

### DIFF
--- a/configure
+++ b/configure
@@ -738,7 +738,6 @@ pcp_selinux_security
 pcp_selinux_sudo_exec
 pcp_selinux_initrc_tmp
 pcp_selinux_glusterd_log
-pcp_selinux_lockdown_class
 pcp_selinux_icmp_socket_class
 pcp_selinux_capability2_bpf
 pcp_selinux_capability2_syslog
@@ -12513,11 +12512,6 @@ if test "x$enable_selinux" != "xfalse"; then :
     seinfo -x --class=icmp_socket $seinfo_common_flag 2>/dev/null \
     | egrep '^[ 	][ 	]*(class |)icmp_socket$' >/dev/null \
     && pcp_selinux_icmp_socket_class=true
-
-    seinfo -x --class=lockdown $seinfo_common_flag 2>/dev/null \
-    | egrep '^[ 	][ 	]*(class |)lockdown$' >/dev/null \
-    && pcp_selinux_lockdown_class=true
-
 
     seinfo -x --class=netlink_selinux_socket $seinfo_common_flag 2>/dev/null \
     | egrep '^[ 	][ 	]*(class |)netlink_selinux_socket$' >/dev/null \

--- a/configure.ac
+++ b/configure.ac
@@ -2324,10 +2324,6 @@ AS_IF([test "x$enable_selinux" != "xfalse"], [
     | egrep '^[[ 	]][[ 	]]*(class |)icmp_socket$' >/dev/null \
     && pcp_selinux_icmp_socket_class=true
 
-    seinfo -x --class=lockdown $seinfo_common_flag 2>/dev/null \
-    | egrep '^[[ 	]][[ 	]]*(class |)lockdown$' >/dev/null \
-    && pcp_selinux_lockdown_class=true
-
     dnl these ones are for pcpqa.te
 
     seinfo -x --class=netlink_selinux_socket $seinfo_common_flag 2>/dev/null \
@@ -2387,7 +2383,6 @@ AC_SUBST(pcp_selinux_sbd_exec)
 AC_SUBST(pcp_selinux_capability2_syslog)
 AC_SUBST(pcp_selinux_capability2_bpf)
 AC_SUBST(pcp_selinux_icmp_socket_class)
-AC_SUBST(pcp_selinux_lockdown_class)
 AC_SUBST(pcp_selinux_glusterd_log)
 
 dnl for pcpqa.te

--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -298,7 +298,6 @@ PCP_SELINUX_LOGGING_WATCH_ALL_LOG_DIRS_PATH = @pcp_selinux_logging_watch_all_log
 PCP_SELINUX_CAPABILITY2_SYSLOG = @pcp_selinux_capability2_syslog@
 PCP_SELINUX_CAPABILITY2_BPF = @pcp_selinux_capability2_bpf@
 PCP_SELINUX_ICMP_SOCKET_CLASS = @pcp_selinux_icmp_socket_class@
-PCP_SELINUX_LOCKDOWN_CLASS = @pcp_selinux_lockdown_class@
 PCP_SELINUX_GLUSTERD_LOG = @pcp_selinux_glusterd_log@
 # pcpqa.te
 PCP_SELINUX_INITRC_TMP = @pcp_selinux_initrc_tmp@

--- a/src/selinux/GNUlocaldefs
+++ b/src/selinux/GNUlocaldefs
@@ -146,11 +146,6 @@ PCP_NETLINK_TCPDIAG_SOCKET_CLASS="class netlink_tcpdiag_socket { bind create get
 PCP_NETLINK_TCPDIAG_SOCKET_RULE="allow pcp_pmcd_t self:netlink_tcpdiag_socket { bind create getattr nlmsg_read setopt };"
 endif
 
-ifeq "$(PCP_SELINUX_LOCKDOWN_CLASS)" "true"
-PCP_LOCKDOWN_CLASS="class lockdown { integrity }; \# pmda.kvm"
-PCP_LOCKDOWN_RULE="allow pcp_pmcd_t self:lockdown integrity;"
-endif
-
 ifeq "$(PCP_SELINUX_KMOD_EXEC)" "true"
 PCP_KMOD_EXEC_T="type kmod_exec_t;"
 PCP_KMOD_EXEC_RULE="allow pcp_pmcd_t kmod_exec_t:file { execute execute_no_trans };"

--- a/src/selinux/pcpupstream.te.in
+++ b/src/selinux/pcpupstream.te.in
@@ -209,8 +209,6 @@ allow pcp_pmcd_t hostname_exec_t:file { getattr execute read open execute_no_tra
 # pmda.kvm
 #type=AVC msg=audit(YYY.88): avc:  denied  { read } for  pid=2023 comm="pmdakvm" name="kvm" dev="tracefs" ino=18541 scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:object_r:tracefs_t:s0 tclass=dir permissive=0
 @PCP_TRACEFS_DIR_RULE@
-#type=AVC msg=audit(YYY.101): avc:  denied  { integrity } for  pid=1606 comm="pmdakvm" lockdown_reason="debugfs access" scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:system_r:pcp_pmcd_t:s0 tclass=lockdown permissive=0
-@PCP_LOCKDOWN_RULE@
 
 #type=AVC msg=audit(YYY.37): avc:  denied  { getattr } for  pid=YYYY comm="pmdaproc" path="/dev/gpmctl" dev="devtmpfs" ino=19750 scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:object_r:gpmctl_t:s0 tclass=sock_file permissive=1
 allow pcp_pmcd_t gpmctl_t:sock_file getattr;


### PR DESCRIPTION
With newer kernel, this class doesn't exist at all; selinux-policy also
removed it lately. Keeping this lockdown call makes the package
impossible to install on newer systems such as centos-9 or rhel-9, and
this further breaks other selinux related packages in such a way we
can't easily recover.