### PR TITLE
libpcp: support high resolution interval time parsing

### DIFF
--- a/debian/libpcp3-dev.install
+++ b/debian/libpcp3-dev.install
@@ -187,6 +187,7 @@ usr/share/man/man3/pmParseDebug.3.gz
 usr/share/man/man3/__pmParseDebug.3.gz
 usr/share/man/man3/__pmParseHostAttrsSpec.3.gz
 usr/share/man/man3/__pmParseHostSpec.3.gz
+usr/share/man/man3/pmParseHighResInterval.3.gz
 usr/share/man/man3/pmParseInterval.3.gz
 usr/share/man/man3/pmParseMetricSpec.3.gz
 usr/share/man/man3/__pmParseTime.3.gz

--- a/man/man3/pmparseinterval.3
+++ b/man/man3/pmparseinterval.3
@@ -1,5 +1,6 @@
 '\"macro stdmacro
 .\"
+.\" Copyright (c) 2022 Red Hat.
 .\" Copyright (c) 2000-2004 Silicon Graphics, Inc.  All Rights Reserved.
 .\"
 .\" This program is free software; you can redistribute it and/or modify it
@@ -15,7 +16,8 @@
 .\"
 .TH PMPARSEINTERVAL 3 "PCP" "Performance Co-Pilot"
 .SH NAME
-\f3pmParseInterval\f1 \- convert interval string to \fBtimeval\fR structure
+\f3pmParseInterval\f1,
+\f3pmParseHighResInterval\f1 \- convert interval string to binary time structure
 .SH "C SYNOPSIS"
 .ft 3
 #include <pcp/pmapi.h>
@@ -24,7 +26,10 @@
 .hy 0
 .in +8n
 .ti -8n
-int pmParseInterval(const char *\fIstring\fP, struct timeval *\fIrslt\fP, char\ **\fIerrmsg\fP);
+int pmParseInterval(const char *\fIstring\fP, struct timeval *\fIurslt\fP, char\ **\fIerrmsg\fP);
+.br
+.ti -8n
+int pmParseHighResInterval(const char *\fIstring\fP, struct timespec *\fInrslt\fP, char\ **\fIerrmsg\fP);
 .sp
 .in
 .hy
@@ -44,8 +49,20 @@ specifying an interval of time and fills in the
 and
 .B tv_usec
 components of the
-.I rslt
-structure to represent that interval.
+.I urslt
+structure to represent that interval (microsecond precision).
+.PP
+Similary,
+.B pmParseHighResInterval
+parses the argument
+.I string
+and fills in the
+.B tv_sec
+and
+.B tv_nsec
+components of the
+.I nrslt
+structure to represent that interval (nanosecond precision).
 .PP
 The input
 .I string

--- a/qa/1060
+++ b/qa/1060
@@ -21,16 +21,16 @@ _cleanup()
 {
     if $needclean
     then
+	# ensure cleanup of any pmie just started
+	_service pmie stop >>$here/$seq.full 2>&1
+	$sudo $PCP_BINADM_DIR/pmsignal -a -s TERM pmie >/dev/null 2>&1
+	$sudo rm -f ${PCP_PMIECONTROL_PATH}.d/qa-$seq
+	_wait_pmie_end
 	if $pmie_was_running
 	then
 	    _restore_auto_restart pmie
 	    _service pmie start >>$here/$seq.full 2>&1
-	else
-	    _service pmie stop >>$here/$seq.full 2>&1
-	    $sudo $PCP_BINADM_DIR/pmsignal -a -s TERM pmie >/dev/null 2>&1
-	    _wait_pmie_end
 	fi
-	$sudo rm -f ${PCP_PMIECONTROL_PATH}.d/qa-$seq
 	needclean=false
     fi
     cd $here

--- a/qa/316
+++ b/qa/316
@@ -28,6 +28,36 @@ _args()
     done
 }
 
+do_nsec()
+{
+    arg=""
+    for a
+    do
+	_args "$a" nanosecond nanoseconds nsec nsecs
+    done
+    # sed needed for arithmetic precision and rounding differences between machines
+    #
+    eval src/parsehighresinterval $arg \
+    | sed \
+	-e 's/0.122999999 sec/0.123000000 sec/' \
+	-e 's/0.007999999 sec/0.008000000 sec/'
+}
+
+do_usec()
+{
+    arg=""
+    for a
+    do
+	_args "$a" microsecond microseconds usec usecs
+    done
+    # sed needed for arithmetic precision and rounding differences between machines
+    #
+    eval src/parsehighresinterval $arg \
+    | sed \
+	-e 's/0.122999999 sec/0.123000000 sec/' \
+	-e 's/0.007999999 sec/0.008000000 sec/'
+}
+
 do_msec()
 {
     arg=""
@@ -91,6 +121,14 @@ do_day()
 # real QA test starts here
 
 echo
+echo "nanoseconds ..."
+do_nsec 123 45.67 8. "   9.123   "
+
+echo
+echo "microseconds ..."
+do_usec 123 45.67 8. "   9.123   "
+
+echo
 echo "milliseconds ..."
 do_msec 123 45.67 8. "   9.123   "
 
@@ -115,7 +153,7 @@ echo "some hybrids ..."
 src/parseinterval 1min30sec 1d1h1m1s1msec "1.5 hr 10 min 15 sec" \
 | sed \
     -e 's/90061.000999 sec/90061.001000 sec/'
-src/parseinterval "1 2 3 4 5 6 7 8 9 10" 55seconds
+src/parsehighresinterval "1 2 3 4 5 6 7 8 9 10" 55seconds
 
 echo
 echo "some errors ..."

--- a/qa/316.out
+++ b/qa/316.out
@@ -1,5 +1,73 @@
 QA output created by 316
 
+nanoseconds ...
+"123nanosecond" Time: 0.000000123 sec
+"123NANOSECOND" Time: 0.000000123 sec
+"123nanoseconds" Time: 0.000000123 sec
+"123NANOSECONDS" Time: 0.000000123 sec
+"123nsec" Time: 0.000000123 sec
+"123NSEC" Time: 0.000000123 sec
+"123nsecs" Time: 0.000000123 sec
+"123NSECS" Time: 0.000000123 sec
+"45.67nanosecond" Time: 0.000000046 sec
+"45.67NANOSECOND" Time: 0.000000046 sec
+"45.67nanoseconds" Time: 0.000000046 sec
+"45.67NANOSECONDS" Time: 0.000000046 sec
+"45.67nsec" Time: 0.000000046 sec
+"45.67NSEC" Time: 0.000000046 sec
+"45.67nsecs" Time: 0.000000046 sec
+"45.67NSECS" Time: 0.000000046 sec
+"8.nanosecond" Time: 0.000000008 sec
+"8.NANOSECOND" Time: 0.000000008 sec
+"8.nanoseconds" Time: 0.000000008 sec
+"8.NANOSECONDS" Time: 0.000000008 sec
+"8.nsec" Time: 0.000000008 sec
+"8.NSEC" Time: 0.000000008 sec
+"8.nsecs" Time: 0.000000008 sec
+"8.NSECS" Time: 0.000000008 sec
+"   9.123   nanosecond" Time: 0.000000009 sec
+"   9.123   NANOSECOND" Time: 0.000000009 sec
+"   9.123   nanoseconds" Time: 0.000000009 sec
+"   9.123   NANOSECONDS" Time: 0.000000009 sec
+"   9.123   nsec" Time: 0.000000009 sec
+"   9.123   NSEC" Time: 0.000000009 sec
+"   9.123   nsecs" Time: 0.000000009 sec
+"   9.123   NSECS" Time: 0.000000009 sec
+
+microseconds ...
+"123microsecond" Time: 0.000123000 sec
+"123MICROSECOND" Time: 0.000123000 sec
+"123microseconds" Time: 0.000123000 sec
+"123MICROSECONDS" Time: 0.000123000 sec
+"123usec" Time: 0.000123000 sec
+"123USEC" Time: 0.000123000 sec
+"123usecs" Time: 0.000123000 sec
+"123USECS" Time: 0.000123000 sec
+"45.67microsecond" Time: 0.000045670 sec
+"45.67MICROSECOND" Time: 0.000045670 sec
+"45.67microseconds" Time: 0.000045670 sec
+"45.67MICROSECONDS" Time: 0.000045670 sec
+"45.67usec" Time: 0.000045670 sec
+"45.67USEC" Time: 0.000045670 sec
+"45.67usecs" Time: 0.000045670 sec
+"45.67USECS" Time: 0.000045670 sec
+"8.microsecond" Time: 0.000008000 sec
+"8.MICROSECOND" Time: 0.000008000 sec
+"8.microseconds" Time: 0.000008000 sec
+"8.MICROSECONDS" Time: 0.000008000 sec
+"8.usec" Time: 0.000008000 sec
+"8.USEC" Time: 0.000008000 sec
+"8.usecs" Time: 0.000008000 sec
+"8.USECS" Time: 0.000008000 sec
+"   9.123   microsecond" Time: 0.000009123 sec
+"   9.123   MICROSECOND" Time: 0.000009123 sec
+"   9.123   microseconds" Time: 0.000009123 sec
+"   9.123   MICROSECONDS" Time: 0.000009123 sec
+"   9.123   usec" Time: 0.000009123 sec
+"   9.123   USEC" Time: 0.000009123 sec
+"   9.123   usecs" Time: 0.000009123 sec
+"   9.123   USECS" Time: 0.000009123 sec
+
 milliseconds ...
 "123millisecond" Time: 0.123000 sec
 "123MILLISECOND" Time: 0.123000 sec
@@ -186,8 +254,8 @@ some hybrids ...
 "1min30sec" Time: 90.000000 sec
 "1d1h1m1s1msec" Time: 90061.001000 sec
 "1.5 hr 10 min 15 sec" Time: 6015.000000 sec
-"1 2 3 4 5 6 7 8 9 10" Time: 55.000000 sec
-"55seconds" Time: 55.000000 sec
+"1 2 3 4 5 6 7 8 9 10" Time: 55.000000000 sec
+"55seconds" Time: 55.000000000 sec
 
 some errors ...
 "123+sec" Error:

--- a/qa/src/.gitignore
+++ b/qa/src/.gitignore
@@ -174,6 +174,7 @@ obs
 parsehostattrs
 parsehostspec
 parseinterval
+parsehighresinterval
 parsemetricspec
 permslist.old
 pcp_lite_crash

--- a/qa/src/GNUlocaldefs
+++ b/qa/src/GNUlocaldefs
@@ -22,9 +22,9 @@ CFILES = disk_test.c exercise.c context_test.c chkoptfetch.c \
 	pcp_lite_crash.c compare.c mkfiles.c nameall.c nullinst.c \
 	storepdu.c fetchpdu.c badloglabel.c interp_bug2.c interp_bug.c \
 	xmktime.c descreqX2.c recon.c torture_indom.c \
-	fetchrate.c stripmark.c pmnsinarchives.c \
+	fetchrate.c stripmark.c pmnsinarchives.c pmnsunload.c \
 	endian.c chk_memleak.c chk_metric_types.c mark-bug.c \
-	pmnsunload.c parsemetricspec.c parseinterval.c \
+	parsemetricspec.c parseinterval.c parsehighresinterval.c \
 	pducheck.c pducrash.c pdu-server.c \
 	pmprintf.c pmsprintf.c pmsocks_objstyle.c numberstr.c \
 	read-bf.c write-bf.c slow_af.c indom.c tztest.c \

--- a/qa/src/parsehighresinterval.c
+++ b/qa/src/parsehighresinterval.c
@@ -5,18 +5,18 @@ main(int argc, char *argv[])
 {
     int			sts;
     char		*err;
-    struct timeval	time;
+    struct timespec	time;
 
     while (argc > 1) {
 	printf("\"%s\"", argv[1]);
-	sts = pmParseInterval(argv[1], &time, &err);
+	sts = pmParseHighResInterval(argv[1], &time, &err);
 	if (sts == -1) {
 	    printf(" Error:\n%s", err);
 	    free(err);
 	}
 	else if (sts == 0) {
-	    printf(" Time: %lld.%06ld sec\n",
-			(long long)time.tv_sec, (long)time.tv_usec);
+	    printf(" Time: %lld.%09ld sec\n",
+			(long long)time.tv_sec, (long)time.tv_nsec);
 	}
 	else {
 	    printf(" Bogus return value: %d\n", sts);

--- a/src/include/pcp/pmapi.h
+++ b/src/include/pcp/pmapi.h
@@ -755,6 +755,7 @@ PCP_CALL extern char *pmEventFlagsStr_r(int, char *, int);
 
 /* Parse -t, -S, -T, -A and -O options */
 PCP_CALL extern int pmParseInterval(const char *, struct timeval *, char **);
+PCP_CALL extern int pmParseHighResInterval(const char *, struct timespec *, char **);
 PCP_CALL extern int pmParseTimeWindow(
       const char *, const char *, const char *, const char *,
       const struct timeval *, const struct timeval *,
@@ -1303,6 +1304,7 @@ PCP_CALL extern int pmtimespecNow(struct timespec *);
 PCP_CALL extern void pmtimespecDec(struct timespec *, const struct timespec *);
 PCP_CALL extern double pmtimespecSub(const struct timespec *, const struct timespec *);
 PCP_CALL extern double pmtimespecToReal(const struct timespec *);
+PCP_CALL extern void pmtimespecFromReal(double, struct timespec *);
 PCP_CALL extern void pmPrintHighResStamp(FILE *, const struct timespec *);
 
 /* filesystem path name separator */

--- a/src/libpcp/src/exports.in
+++ b/src/libpcp/src/exports.in
@@ -796,10 +796,13 @@ PCP_3.36 {
 
 PCP_3.37 {
   global:
+    pmtimespecToReal;
+    pmtimespecFromReal;
     pmExtendFetchGroup_timespec;
     pmExtendFetchGroup_timeval;
     pmHighResFetchArchive;
     pmHighResSortInstances;
+    pmParseHighResInterval;
     __pmDecodeHighResResult_ctx;
     __pmEncodeHighResResult;
     __pmDecodeResult_ctx;

--- a/src/libpcp/src/tv.c
+++ b/src/libpcp/src/tv.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1995 Silicon Graphics, Inc.  All Rights Reserved.
- * Copyright (c) 2021 Red Hat.
+ * Copyright (c) 2021-2022 Red Hat.
  *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published
@@ -103,6 +103,13 @@ pmtimevalFromReal(double secs, struct timeval *val)
 {
     val->tv_sec = (time_t)secs;
     val->tv_usec = (long)((long double)(secs - val->tv_sec) * (long double)1000000 + (long double)0.5);
+}
+
+void
+pmtimespecFromReal(double secs, struct timespec *val)
+{
+    val->tv_sec = (time_t)secs;
+    val->tv_nsec = (long)((long double)(secs - val->tv_sec) * (long double)1000000000 + (long double)0.5);
 }
 
 /*


### PR DESCRIPTION
Add a new pmParseHighResInterval(3) interface into libpcp.

Resolves https://github.com/performancecopilot/pcp/issues/1375