### PR TITLE
libpcp: time_t sentinel fix, add time parsers using timespecs

### DIFF
--- a/debian/libpcp3-dev.install
+++ b/debian/libpcp3-dev.install
@@ -193,6 +193,7 @@ usr/share/man/man3/pmParseInterval.3.gz
 usr/share/man/man3/pmParseMetricSpec.3.gz
 usr/share/man/man3/__pmParseHighResTime.3.gz
 usr/share/man/man3/__pmParseTime.3.gz
+usr/share/man/man3/pmParseHighResTimeWindow.3.gz
 usr/share/man/man3/pmParseTimeWindow.3.gz
 usr/share/man/man3/pmParseUnitsStr.3.gz
 usr/share/man/man3/pmPathSeparator.3.gz

--- a/debian/libpcp3-dev.install
+++ b/debian/libpcp3-dev.install
@@ -39,6 +39,7 @@ usr/share/man/man3/pmClearDebug.3.gz
 usr/share/man/man3/pmClearFetchGroup.3.gz
 usr/share/man/man3/__pmConnectLogger.3.gz
 usr/share/man/man3/__pmControlLog.3.gz
+usr/share/man/man3/__pmConvertHighResTime.3.gz
 usr/share/man/man3/__pmConvertTime.3.gz
 usr/share/man/man3/pmConvScale.3.gz
 usr/share/man/man3/pmCreateFetchGroup.3.gz
@@ -190,6 +191,7 @@ usr/share/man/man3/__pmParseHostSpec.3.gz
 usr/share/man/man3/pmParseHighResInterval.3.gz
 usr/share/man/man3/pmParseInterval.3.gz
 usr/share/man/man3/pmParseMetricSpec.3.gz
+usr/share/man/man3/__pmParseHighResTime.3.gz
 usr/share/man/man3/__pmParseTime.3.gz
 usr/share/man/man3/pmParseTimeWindow.3.gz
 usr/share/man/man3/pmParseUnitsStr.3.gz

--- a/man/man3/pmparsetimewindow.3
+++ b/man/man3/pmparsetimewindow.3
@@ -1,6 +1,6 @@
 '\"macro stdmacro
 .\"
-.\" Copyright (c) 2016 Red Hat.
+.\" Copyright (c) 2016,2022 Red Hat.
 .\" Copyright (c) 2000-2004 Silicon Graphics, Inc.  All Rights Reserved.
 .\"
 .\" This program is free software; you can redistribute it and/or modify it
@@ -102,7 +102,7 @@ for example), while
 should have its
 .I tv_sec
 component set to
-.BR INT_MAX .
+.BR PM_MAX_TIME_T .
 .P
 The
 .BR rsltStart ,

--- a/man/man3/pmparsetimewindow.3
+++ b/man/man3/pmparsetimewindow.3
@@ -16,7 +16,8 @@
 .\"
 .TH PMPARSETIMEWINDOW 3 "PCP" "Performance Co-Pilot"
 .SH NAME
-\f3pmParseTimeWindow\f1 \- parse time window command line arguments
+\f3pmParseTimeWindow\f1,
+\f3pmParseHighResTimeWindow\f1 \- parse time window command line arguments
 .SH "C SYNOPSIS"
 .ft 3
 #include <pcp/pmapi.h>
@@ -26,6 +27,9 @@
 .in +8n
 .ti -8n
 int pmParseTimeWindow(const char *\fIswStart\fP, const\ char\ *\fIswEnd\fP, const\ char\ *\fIswAlign\fP, const\ char\ *\fIswOffset\fP, const\ struct\ timeval\ *\fIlogStart\fP, const\ struct\ timeval\ *\fIlogEnd\fP, struct\ timeval\ *\fIrsltStart\fP, struct\ timeval\ *\fIrsltEnd\fP, struct\ timeval\ *\fIrsltOffset\fP, char\ **\fIerrMsg\fP);
+.br
+.ti -8n
+int pmParseHighResTimeWindow(const char *\fIswStart\fP, const\ char\ *\fIswEnd\fP, const\ char\ *\fIswAlign\fP, const\ char\ *\fIswOffset\fP, const\ struct\ timespec\ *\fIlogStart\fP, const\ struct\ timespec\ *\fIlogEnd\fP, struct\ timespec\ *\fIrsltStart\fP, struct\ timespec\ *\fIrsltEnd\fP, struct\ timespec\ *\fIrsltOffset\fP, char\ **\fIerrMsg\fP);
 .sp
 .in
 .hy
@@ -34,7 +38,9 @@ cc ... \-lpcp
 .ft 1
 .SH DESCRIPTION
 .B pmParseTimeWindow
-is designed to encapsulate the interpretation of the
+and
+.B pmParseHighResTimeWindow
+are designed to encapsulate the interpretation of the
 .BR \-S ,
 .BR \-T ,
 .B \-A
@@ -44,7 +50,8 @@ command line options used by Performance Co-Pilot (PCP) applications
 to define a time window of interest.
 The time window is defined by a start time and an end time that constrains
 the time interval during which the PCP application will retrieve and
-display performance metrics.  In the absence of the
+display performance metrics.
+In the absence of the
 .B \-O
 and
 .B \-A
@@ -57,7 +64,9 @@ is described in
 .BR PCPIntro (1).
 .SH USAGE
 .B pmParseTimeWindow
-expects to be called with the argument of the
+and
+.B pmParseHighResTimeWindow
+expect to be called with the argument of the
 .B \-S
 option as
 .BR swStart ,
@@ -110,22 +119,25 @@ The
 and
 .B rsltOffset
 structures must be allocated before calling
-.BR pmParseTimeWindow .
+.B pmParseTimeWindow
+or
+.BR pmParseTimeHighResWindow .
 .P
 You also need to set the current PCP reporting time zone to correctly
 reflect the
 .B \-z
 and
 .B \-Z
-command line parameters before calling
-.BR pmParseTimeWindow .
+command line parameters before calling these routines.
 See
 .BR pmUseZone (3)
 and friends for information on how this is done.
 .SH DIAGNOSTICS
 If the conversion is successful,
 .B pmParseTimeWindow
-returns 1 and fills in
+and
+.B pmParseHighResTimeWindow
+return 1 and fill in
 .BR rsltStart ,
 .B rsltEnd
 and
@@ -134,8 +146,10 @@ with the start, end, and offset times for the time window defined by the input
 parameters.
 The
 .B errMsg
-parameter is not changed when
+parameter is not changed when either
 .BR pmParseTimeWindow
+or
+.BR pmParseHighResTimeWindow
 returns 1.
 .P
 If the conversion is successful, but the requested alignment could not be
@@ -147,7 +161,9 @@ and
 .B rsltOffset
 are filled in and
 .BR pmParseTimeWindow
-returns 0.
+and
+.BR pmParseHighResTimeWindow
+return 0.
 In this case,
 .B errMsg
 will point to a warning message in a dynamically allocated buffer.
@@ -156,7 +172,9 @@ The caller is responsible for releasing the buffer by calling
 .P
 If the argument strings could not be parsed,
 .B pmParseTimeWindow
-returns \-1.
+and
+.B pmParseHighResTimeWindow
+return \-1.
 In this case,
 .BR errMsg
 will point to an error message

--- a/man/man3i/__pmconverttime.3
+++ b/man/man3i/__pmconverttime.3
@@ -16,7 +16,8 @@
 .\"
 .TH PMCONVERTTIME 3 "PCP" "Performance Co-Pilot"
 .SH NAME
-\f3__pmConvertTime\f1 \- convert \fBtm\fR structure to \fBtimeval\fR structure
+\f3__pmConvertTime\f1,
+\f3__pmConvertHighResTime\f1 \- convert \fBtm\fR structure into seconds
 .SH "C SYNOPSIS"
 .ft 3
 #include "pmapi.h"
@@ -28,6 +29,9 @@
 .in +8n
 .ti -8n
 int __pmConvertTime(struct tm *\fItmin\fP, struct timeval *\fIorigin\fP, struct\ timeval\ *\fIrslt\fP);
+.br
+.ti -8n
+int __pmConvertHighResTime(struct tm *\fItmin\fP, struct timespec *\fIorigin\fP, struct\ timespec\ *\fIrslt\fP);
 .sp
 .in
 .hy
@@ -43,7 +47,9 @@ remain fixed across releases, and they may not work, or may provide
 different semantics at some point in the future.
 .SH DESCRIPTION
 .B __pmConvertTime
-accepts a
+and
+.B __pmConvertHighResTime
+accept a
 .B tm
 structure that has been filled in by
 .BR __pmParseCtime (3)
@@ -51,7 +57,7 @@ and a reference time point
 .BR origin ,
 and fills in the given
 .B rslt
-structure with the time the user meant when he specified a partial
+structure with the time the user meant when specifying a partial
 .B ctime
 or positive or negative time
 .BR interval .
@@ -65,8 +71,10 @@ offset, in which case it is the end
 time of the log.
 .PP
 .B __pmConvertTime
-returns 0 if successful.
-It returns \-1 and writes an error message to
+and
+.B __pmConvertHighResTime
+return 0 if successful.
+They return \-1 and write an error message to
 .BR stderr ,
 if an error is detected.
 .PP

--- a/man/man3i/__pmparsetime.3
+++ b/man/man3i/__pmparsetime.3
@@ -1,5 +1,6 @@
 '\"macro stdmacro
 .\"
+.\" Copyright (c) 2022 Red Hat.
 .\" Copyright (c) 2000-2004 Silicon Graphics, Inc.  All Rights Reserved.
 .\"
 .\" This program is free software; you can redistribute it and/or modify it
@@ -15,7 +16,8 @@
 .\"
 .TH PMPARSETIME 3 "PCP" "Performance Co-Pilot"
 .SH NAME
-\f3__pmParseTime\f1 \- parse time point specification
+\f3__pmParseTime\f1,
+\f3__pmParseHighResTime\f1 \- parse time point specification
 .SH "C SYNOPSIS"
 .ft 3
 #include "pmapi.h"
@@ -27,6 +29,9 @@
 .in +8n
 .ti -8n
 int __pmParseTime(const char *\fIstring\fP, struct timeval *\fIlogStart\fP, struct\ timeval\ *\fIlogEnd\fP, struct\ timeval\ *\fIrslt\fP, char\ **\fIerrMsg\fP);
+.br
+.ti -8n
+int __pmParseHighResTime(const char *\fIstring\fP, struct timespec *\fIlogStart\fP, struct\ timespec\ *\fIlogEnd\fP, struct\ timespec\ *\fIrslt\fP, char\ **\fIerrMsg\fP);
 .sp
 .in
 .hy
@@ -42,10 +47,12 @@ remain fixed across releases, and they may not work, or may provide
 different semantics at some point in the future.
 .SH DESCRIPTION
 .B __pmParseTime
-is designed to encapsulate the interpretation of a time point specification in
-command line switches for use by the PCP client tools.
+and
+.B __PmParseHighResTime
+are designed to encapsulate the interpretation of a time point specification
+in command line switches for use by the PCP client tools.
 .P
-This function expects to be called with the time point specification as
+These functions expects to be called with the time point specification as
 .BR string .
 If the tool is running against PCP archive(s), you also
 need to supply the start time of the first (only) archive as
@@ -62,26 +69,32 @@ If the tool is running against a live feed of performance data,
 should be the current time (but could be aligned on the next second
 for example), while
 .B logEnd
-should have its tv_sec component set to INT_MAX.
+should have its tv_sec component set to PM_MAX_TIME_T.
 .P
 The
 .B rslt
-structure must be allocated before calling
-.BR __pmParseTime .
+structure must be allocated before either calling
+.B __pmParseTime
+or
+.BR __pmParseHighResTime .
 .P
 You also need to set the current PCP reporting time zone to correctly
 reflect the \-z and \-Z command line parameters before calling
-.BR __pmParseTime .
+.B __pmParseTime
+or
+.BR __pmParseHighResTime .
 See
 .BR pmUseZone (3)
 and friends for information on how this is done.
 .P
-If the conversion is successful,
+If the conversion is successful, both
 .B __pmParseTime
-returns 0, and fills in
+and
+.B __pmParseHighResTime
+return 0, and fill in
 .B rslt
-with the time value defined by the input
-parameters.  If the argument strings could not be parsed, it returns \-1
+with the time value defined by the input parameters.
+If the argument strings could not be parsed, it returns \-1
 and a dynamically allocated error message string in
 .BR errMsg .
 Be sure to

--- a/qa/src/churnctx.c
+++ b/qa/src/churnctx.c
@@ -364,7 +364,7 @@ Options:\n\
 	}
   	startTime = label.ll_start;
 	if ((sts = pmGetArchiveEnd(&endTime)) < 0) {
-	    endTime.tv_sec = INT_MAX;
+	    endTime.tv_sec = PM_MAX_TIME_T;
 	    endTime.tv_usec = 0;
 	    fflush(stdout);
 	    fprintf(stderr, "%s: Cannot locate end of archive: %s\n",
@@ -376,7 +376,7 @@ Options:\n\
     }
     else {
 	gettimeofday(&startTime, NULL);
-	endTime.tv_sec = INT_MAX;
+	endTime.tv_sec = PM_MAX_TIME_T;
 	endTime.tv_usec = 0;
     }
 

--- a/qa/src/mark-bug.c
+++ b/qa/src/mark-bug.c
@@ -258,7 +258,7 @@ Options\n\
     }
     else {
 	gettimeofday(&startTime, NULL);
-	endTime.tv_sec = INT_MAX;
+	endTime.tv_sec = PM_MAX_TIME_T;
     }
 
     if (zflag) {

--- a/qa/src/pmsocks_objstyle.c
+++ b/qa/src/pmsocks_objstyle.c
@@ -129,7 +129,7 @@ Options\n\
     }
     else {
 	gettimeofday(&startTime, NULL);
-	endTime.tv_sec = INT_MAX;
+	endTime.tv_sec = PM_MAX_TIME_T;
     }
 
     if (zflag) {

--- a/qa/src/timeshift.c
+++ b/qa/src/timeshift.c
@@ -44,8 +44,8 @@ main(int argc, char **argv)
     time_t		t;
     struct tm		old;
     struct tm		new;
-    struct timeval	epoch = { 0, 0 };
-    struct timeval	tv;
+    struct timespec	epoch = { 0, 0 };
+    struct timespec	tspec;
     char		*errmsg;
     int			delta;
 
@@ -164,13 +164,13 @@ main(int argc, char **argv)
     if (dflag)
 	new.tm_isdst = 1;
 
-    __pmConvertTime(&new, &epoch, &tv);
+    __pmConvertHighResTime(&new, &epoch, &tspec);
 
     if (vflag)
-	fprintf(stderr, "want: %ld %04d-%02d-%02d %02d:%02d:%02d dst=%d\n", 
-	    (long)tv.tv_sec, new.tm_year+1900, new.tm_mon+1, new.tm_mday, new.tm_hour, new.tm_min, new.tm_sec, new.tm_isdst);
+	fprintf(stderr, "want: %lld %04d-%02d-%02d %02d:%02d:%02d dst=%d\n", 
+	    (long long)tspec.tv_sec, new.tm_year+1900, new.tm_mon+1, new.tm_mday, new.tm_hour, new.tm_min, new.tm_sec, new.tm_isdst);
 
-    delta = tv.tv_sec - t;
+    delta = tspec.tv_sec - t;
 
     if (delta < 0) {
 	printf("-");

--- a/src/include/pcp/libpcp.h
+++ b/src/include/pcp/libpcp.h
@@ -1323,9 +1323,14 @@ PCP_CALL extern int __pmTimestampCmp(const __pmTimestamp *, const __pmTimestamp 
 
 /* reverse ctime, time interval parsing, time conversions */
 PCP_CALL extern int __pmParseCtime(const char *, struct tm *, char **);
-PCP_CALL extern int __pmParseTime(const char *, struct timeval *, struct timeval *,
-			 struct timeval *, char **);
-PCP_CALL extern int __pmConvertTime(struct tm *, struct timeval *, struct timeval *);
+PCP_CALL extern int __pmParseTime(const char *, struct timeval *,
+				struct timeval *, struct timeval *, char **);
+PCP_CALL extern int __pmParseHighResTime(const char *, struct timespec *,
+				struct timespec *, struct timespec *, char **);
+PCP_CALL extern int __pmConvertTime(struct tm *, struct timeval *,
+				struct timeval *);
+PCP_CALL extern int __pmConvertHighResTime(struct tm *, struct timespec *,
+				struct timespec *);
 PCP_CALL extern time_t __pmMktime(struct tm *);
 
 /* Query server features - used for expressing protocol capabilities */

--- a/src/include/pcp/pmapi.h
+++ b/src/include/pcp/pmapi.h
@@ -761,6 +761,13 @@ PCP_CALL extern int pmParseTimeWindow(
       const struct timeval *, const struct timeval *,
       struct timeval *, struct timeval *, struct timeval *, char **);
 
+/* Sentinel value for end-time parameters in time window parsing */
+#if PM_SIZEOF_TIME_T == 8
+#define PM_MAX_TIME_T	LONGLONG_MAX
+#else
+#define PM_MAX_TIME_T	INT_MAX
+#endif
+
 /* Reporting timezone */
 PCP_CALL extern int pmUseZone(const int);
 PCP_CALL extern int pmNewZone(const char *);

--- a/src/include/pcp/pmapi.h
+++ b/src/include/pcp/pmapi.h
@@ -760,6 +760,10 @@ PCP_CALL extern int pmParseTimeWindow(
       const char *, const char *, const char *, const char *,
       const struct timeval *, const struct timeval *,
       struct timeval *, struct timeval *, struct timeval *, char **);
+PCP_CALL extern int pmParseHighResTimeWindow(
+      const char *, const char *, const char *, const char *,
+      const struct timespec *, const struct timespec *,
+      struct timespec *, struct timespec *, struct timespec *, char **);
 
 /* Sentinel value for end-time parameters in time window parsing */
 #if PM_SIZEOF_TIME_T == 8

--- a/src/libpcp/src/exports.in
+++ b/src/libpcp/src/exports.in
@@ -803,6 +803,7 @@ PCP_3.37 {
     pmHighResFetchArchive;
     pmHighResSortInstances;
     pmParseHighResInterval;
+    pmParseHighResTimeWindow;
     __pmConvertHighResTime;
     __pmParseHighResTime;
     __pmDecodeHighResResult_ctx;

--- a/src/libpcp/src/exports.in
+++ b/src/libpcp/src/exports.in
@@ -803,6 +803,8 @@ PCP_3.37 {
     pmHighResFetchArchive;
     pmHighResSortInstances;
     pmParseHighResInterval;
+    __pmConvertHighResTime;
+    __pmParseHighResTime;
     __pmDecodeHighResResult_ctx;
     __pmEncodeHighResResult;
     __pmDecodeResult_ctx;

--- a/src/libpcp/src/getopt.c
+++ b/src/libpcp/src/getopt.c
@@ -1,7 +1,7 @@
 /*
  * Common argument parsing for all PMAPI client tools.
  *
- * Copyright (c) 2014-2018,2020-2021 Red Hat.
+ * Copyright (c) 2014-2018,2020-2022 Red Hat.
  * Copyright (C) 1987-2014 Free Software Foundation, Inc.
  *
  * This library is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ __pmUpdateBounds(pmOptions *opts, int index, struct timeval *begin, struct timev
 	return sts;
     }
     if ((sts = pmGetArchiveEnd(&logend)) < 0) {
-	logend.tv_sec = INT_MAX;
+	logend.tv_sec = PM_MAX_TIME_T;
 	logend.tv_usec = 0;
 	fflush(stdout);
 	fprintf(stderr, "%s: Cannot locate end of archive %s: %s\n",
@@ -89,7 +89,7 @@ __pmBoundaryOptions(pmOptions *opts, struct timeval *begin, struct timeval *end)
     if (opts->context != PM_CONTEXT_ARCHIVE) {
 	/* live/local context, open ended - start now, never end */
 	pmtimevalNow(begin);
-	end->tv_sec = INT_MAX;
+	end->tv_sec = PM_MAX_TIME_T;
 	end->tv_usec = 0;
     } else if (opts->narchives == 1) {
 	/* Singular archive context, which may contain more than one archive. */

--- a/src/libpcp/src/logutil.c
+++ b/src/libpcp/src/logutil.c
@@ -2476,7 +2476,7 @@ __pmGetArchiveEnd_ctx(__pmContext *ctxp, __pmTimestamp *tsp)
     /*
      * default, when all else fails ...
      */
-    tsp->sec = INT_MAX;
+    tsp->sec = PM_MAX_TIME_T;
     tsp->nsec = 0;
 
     /*

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2021 Red Hat.
+ * Copyright (c) 2017-2022 Red Hat.
  * Copyright (c) 2020 Yushan ZHANG.
  *
  * This library is free software; you can redistribute it and/or modify it
@@ -5445,7 +5445,7 @@ static void
 parsetime(seriesQueryBaton *baton, sds string, struct timeval *result, const char *source)
 {
     struct timeval	start = { 0, 0 };
-    struct timeval	end = { INT_MAX, 0 };
+    struct timeval	end = { PM_MAX_TIME_T, 0 };
     char		*error;
     sds			msg;
     int			sts;
@@ -5551,7 +5551,7 @@ initSeriesGetValues(seriesQueryBaton *baton, int nseries, sds *series,
 	gettimeofday(&offset, NULL);
 	tsub(&offset, &timing->start);
 	timing->start = offset;
-	timing->end.tv_sec = INT_MAX;
+	timing->end.tv_sec = PM_MAX_TIME_T;
     }
     if (window->count)
 	parseuint(baton, window->count, &timing->count, "count");

--- a/src/libpcp_web/src/query_parser.y
+++ b/src/libpcp_web/src/query_parser.y
@@ -2,7 +2,7 @@
 /*
  * query_parser.y - yacc/bison grammar for the PCP time series language
  *
- * Copyright (c) 2017-2021 Red Hat.
+ * Copyright (c) 2017-2022 Red Hat.
  * Copyright (c) 2020 Yushan ZHANG.
  *
  * This library is free software; you can redistribute it and/or modify it
@@ -1157,7 +1157,7 @@ static void
 parsetime(PARSER *lp, struct timeval *result, const char *string)
 {
     struct timeval start = { 0, 0 };
-    struct timeval end = { INT_MAX, 0 };
+    struct timeval end = { PM_MAX_TIME_T, 0 };
     char	*error;
     int		sts;
 
@@ -1219,7 +1219,7 @@ newrange(PARSER *lp, const char *string)
 	gettimeofday(&offset, NULL);
 	tsub(&offset, &tp->start);
 	tp->start = offset;
-	tp->end.tv_sec = INT_MAX;
+	tp->end.tv_sec = PM_MAX_TIME_T;
 	tp->window.range = sdsnew(string);
     }
 }

--- a/src/pmchart/main.cpp
+++ b/src/pmchart/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014,2016,2021 Red Hat.
+ * Copyright (c) 2014,2016,2021-2022 Red Hat.
  * Copyright (c) 2006, Ken McDonell.  All Rights Reserved.
  * Copyright (c) 2007-2009, Aconex.  All Rights Reserved.
  * 
@@ -688,7 +688,8 @@ main(int argc, char ** argv)
     else if (liveGroup->numContexts() > 0) {
 	liveGroup->defaultTZ(tzLabel, tzString);
 	pmtimevalNow(&logStartTime);
-	logEndTime.tv_sec = logEndTime.tv_usec = INT_MAX;
+	logEndTime.tv_sec = logEndTime.tv_usec = PM_MAX_TIME_T;
+	logEndTime.tv_usec = 0;
 	if ((sts = pmParseTimeWindow(opts.start_optarg, opts.finish_optarg,
 					opts.align_optarg, opts.origin_optarg,
 					&logStartTime, &logEndTime, &opts.start,

--- a/src/pmchart/recorddialog.cpp
+++ b/src/pmchart/recorddialog.cpp
@@ -349,8 +349,8 @@ void RecordDialog::startLoggers()
 	control << "V0\n";
 	control << "F" << my.folio << "\n";
 	control << "Ppmchart\n" << "R\n";
-	for (int i = 0; i < control.size(); i++)
-	    process->write(control.at(i).toLatin1());
+	for (int j = 0; j < control.size(); j++)
+	    process->write(control.at(j).toLatin1());
     }
 }
 

--- a/src/pmdumptext/pmdumptext.cpp
+++ b/src/pmdumptext/pmdumptext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat.
+ * Copyright (c) 2014,2022 Red Hat.
  * Copyright (c) 1997,2004-2006 Silicon Graphics, Inc.  All Rights Reserved.
  * Copyright (c) 2007 Aconex.  All Rights Reserved.
  * 
@@ -1081,8 +1081,8 @@ main(int argc, char *argv[])
 
     if (isLive) {
 	pmtimevalNow(&logStartTime);
-	logEndTime.tv_sec = INT_MAX;
-	logEndTime.tv_usec = INT_MAX;
+	logEndTime.tv_sec = PM_MAX_TIME_T;
+	logEndTime.tv_usec = 0;
     }
     else {
 	group->updateBounds();
@@ -1090,8 +1090,8 @@ main(int argc, char *argv[])
 	logStartTime = group->logStart();
 	logEndTime = group->logEnd();
 	if (pmtimevalToReal(&logEndTime) <= pmtimevalToReal(&logStartTime)) {
-	    logEndTime.tv_sec = INT_MAX;
-	    logEndTime.tv_usec = INT_MAX;	
+	    logEndTime.tv_sec = PM_MAX_TIME_T;
+	    logEndTime.tv_usec = 0;
 	}
     }
 

--- a/src/pmie/src/pmie.c
+++ b/src/pmie/src/pmie.c
@@ -2,7 +2,7 @@
  * pmie.c - performance inference engine
  ***********************************************************************
  *
- * Copyright (c) 2013-2015,2017,2020 Red Hat.
+ * Copyright (c) 2013-2015,2017,2020,2022 Red Hat.
  * Copyright (c) 1995-2003 Silicon Graphics, Inc.  All Rights Reserved.
  * 
  * This program is free software; you can redistribute it and/or modify it
@@ -760,7 +760,7 @@ getargs(int argc, char *argv[])
     if (archives) {
 	pmtimevalFromReal(last, &tv2);
     } else {
-	tv2.tv_sec = INT_MAX;		/* sizeof(time_t) == sizeof(int) */
+	tv2.tv_sec = PM_MAX_TIME_T;
 	tv2.tv_usec = 0;
     }
     if (pmParseTimeWindow(opts.start_optarg, opts.finish_optarg,
@@ -815,7 +815,7 @@ getargs(int argc, char *argv[])
     if (archives) {
 	pmtimevalFromReal(last, &tv2);
     } else {
-	tv2.tv_sec = INT_MAX;
+	tv2.tv_sec = PM_MAX_TIME_T;
 	tv2.tv_usec = 0;
     }
     if (pmParseTimeWindow(opts.start_optarg, opts.finish_optarg,
@@ -904,7 +904,7 @@ interact(void)
 		if (archives) {
 		    pmtimevalFromReal(last, &tv2);
 		} else {
-		    tv2.tv_sec = INT_MAX;
+		    tv2.tv_sec = PM_MAX_TIME_T;
 		    tv2.tv_usec = 0;
 		}
 		if (__pmParseTime(token, &tv1, &tv2, &tv1, &msg) < 0) {

--- a/src/pmlogcheck/pmlogcheck.c
+++ b/src/pmlogcheck/pmlogcheck.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Red Hat.
+ * Copyright (c) 2014,2022 Red Hat.
  * Copyright (c) 1995-2003 Silicon Graphics, Inc.  All Rights Reserved.
  * Copyright (c) 2017 Ken McDonell.  All Rights Reserved.
  * 
@@ -83,7 +83,7 @@ dumpLabel(void)
     pmPrintStamp(stderr, &label.ll_start);
     fprintf(stderr, " %4.4s\n", yr);
 
-    if (opts.finish.tv_sec == INT_MAX) {
+    if (opts.finish.tv_sec == PM_MAX_TIME_T) {
         /* pmGetArchiveEnd() failed! */
         fprintf(stderr, "  ending     UNKNOWN\n");
     }

--- a/src/pmlogger/src/pmlogger.c
+++ b/src/pmlogger/src/pmlogger.c
@@ -1480,8 +1480,8 @@ main(int argc, char **argv)
         now_tv.tv_usec = 0; 
 
         start = now_tv;
-        end.tv_sec = INT_MAX;
-        end.tv_usec = INT_MAX;
+        end.tv_sec = PM_MAX_TIME_T;
+        end.tv_usec = 0;
         sts = __pmParseTime(runtime, &start, &end, &res_end, &err_msg);
         if (sts < 0) {
 	    fprintf(stderr, "%s: illegal -T argument\n%s", pmGetProgname(), err_msg);

--- a/src/pmlogsummary/pmlogsummary.c
+++ b/src/pmlogsummary/pmlogsummary.c
@@ -207,7 +207,7 @@ printlabel(void)
     pmPrintStamp(stdout, &opts.start);
     printf(" %4.4s\n", yr);
 
-    if (opts.finish.tv_sec == INT_MAX) {
+    if (opts.finish.tv_sec == PM_MAX_TIME_T) {
 	/* pmGetArchiveEnd() failed! */
 	printf("  ending     UNKNOWN\n");
     }

--- a/src/pmval/pmval.c
+++ b/src/pmval/pmval.c
@@ -1,15 +1,15 @@
 /*
  * pmval - simple performance metrics value dumper
  *
- * Copyright (c) 2014-2015 Red Hat.
+ * Copyright (c) 2014-2015,2022 Red Hat.
  * Copyright (c) 2008-2009 Aconex.  All Rights Reserved.
  * Copyright (c) 1995-2001 Silicon Graphics, Inc.  All Rights Reserved.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation; either version 2 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
  * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
@@ -407,7 +407,7 @@ printhdr(Context *x)
 	printf("host:      %s\n", x->hostname);
 	time = opts.origin.tv_sec;
 	printf("start:     %s", pmCtime(&time, tbfr));
-	if (opts.finish.tv_sec != INT_MAX) {
+	if (opts.finish.tv_sec != PM_MAX_TIME_T) {
 	    time = opts.finish.tv_sec;
 	    printf("end:       %s", pmCtime(&time, tbfr));
 	}
@@ -1143,7 +1143,7 @@ main(int argc, char *argv[])
     if (!opts.guiport)
 	opts.guiport = -1;
     if (!opts.finish.tv_sec)
-	opts.finish.tv_sec = INT_MAX;
+	opts.finish.tv_sec = PM_MAX_TIME_T;
     if (opts.interval.tv_sec == 0 && opts.interval.tv_usec == 0)
 	opts.interval.tv_sec = 1;
 
@@ -1153,7 +1153,7 @@ main(int argc, char *argv[])
 
     if (!(opts.guiflag || opts.guiport != -1) &&
 	opts.samples < 0 &&
-	opts.finish.tv_sec != INT_MAX &&
+	opts.finish.tv_sec != PM_MAX_TIME_T &&
 	amode != PM_MODE_FORW) {
 	double start, finish, origin, delta;
 

--- a/src/pmview/main.cpp
+++ b/src/pmview/main.cpp
@@ -432,7 +432,8 @@ main(int argc, char **argv)
 	activeGroup = liveGroup;
 	liveGroup->defaultTZ(a.my.tzLabel, a.my.tzString);
 	gettimeofday(&a.my.logStartTime, NULL);
-	a.my.logEndTime.tv_sec = a.my.logEndTime.tv_usec = INT_MAX;
+	a.my.logEndTime.tv_sec = PM_MAX_TIME_T;
+	a.my.logEndTime.tv_usec = 0;
 	if ((sts = pmParseTimeWindow(a.my.Sflag, a.my.Tflag,
 					a.my.Aflag, a.my.Oflag,
 					&a.my.logStartTime, &a.my.logEndTime,


### PR DESCRIPTION
Fix the sentinel time_t value used in several places to denote
end of time using sizeof(time_t) from configure.ac - no longer
assuming it is fixed at sizeof(int).  A new macro is added for
convenience (PM_MAX_TIME_T).
    
__pmParseTime and __pmConvertTime gain high resolution variants
which are used internally within the lower resolution versions.
This is a general pattern that seems to work best for all these
time conversions.