### PR TITLE
pmproxy: allow request parameters to be sent in the request body

### DIFF
--- a/man/man3/pmwebapi.3
+++ b/man/man3/pmwebapi.3
@@ -175,6 +175,10 @@ parameter.
 The value passed in the request will be sent back in the
 response \- all responses will be in JSON object form in
 this case, with top level "client" and "result" fields.
+.PP
+REST API clients can optionally submit an URL-encoded query string
+in the body of the HTTP request unless otherwise noted.
+In this case the POST method must be used instead of the GET method.
 .SS GET \fI/series/query\fR \- \fBpmSeriesQuery\fR(3)
 .TS
 box;

--- a/qa/1697
+++ b/qa/1697
@@ -1,0 +1,134 @@
+#!/bin/sh
+# PCP QA Test No. 1697
+# Valgrind pmproxy REST API testing.
+# Based on 1601 and 1696
+
+# Copyright (c) 2022 Red Hat.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+. ./common.python
+
+
+_check_valgrind
+_check_series
+_check_redis_server_version_offline
+
+_cleanup()
+{
+    cd $here
+    [ -n "$options" ] && redis-cli $options shutdown
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+username=`id -u -n`
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+# create a pmproxy configuration
+cat <<EOF > $tmp.conf
+[pmproxy]
+pcp.enabled = true
+http.enabled = true
+[pmseries]
+enabled = true
+EOF
+
+_filter_source()
+{
+    sed \
+        -e "s,$here,PATH,g" \
+        -e "s,$hostname,QAHOST,g" \
+    #end
+}
+
+_filter_proxyport()
+{
+    sed \
+	-e "s/ FD $proxyport / FD PORT /g" \
+	-e '/PORT ipv6 /d' \
+    # end
+}
+
+# real QA test starts here
+echo "Start test Redis server ..."
+redisport=`_find_free_port`
+options="-p $redisport"
+redis-server --port $redisport --save "" > $tmp.redis 2>&1 &
+_check_redis_ping $redisport
+_check_redis_server $redisport
+echo
+
+_check_redis_server_version $redisport
+
+# import some well-known test data into Redis
+pmseries $options --load "$here/archives/proc" | _filter_source
+
+# start pmproxy
+mkdir -p $tmp.pmproxy/pmproxy
+export PCP_RUN_DIR=$tmp.pmproxy
+export PCP_TMP_DIR=$tmp.pmproxy
+proxyport=`_find_free_port`
+$_valgrind_clean_assert pmproxy -f -p $proxyport -r $redisport -U $username -l- -c $tmp.conf >$tmp.valout 2>$tmp.valerr &
+pid=$!
+
+# valgrind takes awhile to fire up
+i=0
+while [ $i -lt 40 ]
+do
+    $PCP_BINADM_DIR/telnet-probe -c localhost $proxyport && break
+    sleep 1
+    i=`expr $i + 1`
+done
+if $PCP_BINADM_DIR/telnet-probe -c localhost $proxyport
+then
+    echo "Startup took $i secs" >>$seq.full
+else
+    echo "Arrgh: valgrind failed start pmproxy and get port $proxyport ready after 30 secs"
+    exit
+fi
+
+series1=`pmseries $options disk.all.read`
+[ -z "$series1" ] && _fail "Cannot find any timeseries matching disk.all.read"
+echo "Using series $series1 for disk.all.read"
+
+series2=`pmseries $options disk.dev.read`
+[ -z "$series2" ] && _fail "Cannot find any timeseries matching disk.dev.read"
+echo "Using series $series2 for disk.dev.read"
+
+series3=`pmseries $options kernel.all.uptime`
+[ -z "$series3" ] && _fail "Cannot find any timeseries matching kernel.all.uptime"
+echo "Using series $series3 for kernel.all.uptime"
+
+
+echo "== verify metric descs" | tee -a $seq.full
+curl --silent "http://localhost:$proxyport/series/descs" -d "series=$series1,$series2,$series3" | tee -a $seq.full | pmjson
+
+echo "== verify metric names" | tee -a $seq.full
+curl --silent "http://localhost:$proxyport/series/metrics" -d "series=$series1,$series2,$series3" | tee -a $seq.full | pmjson
+
+echo "== verify metric labels" | tee -a $seq.full
+curl --silent "http://localhost:$proxyport/series/labels" -d "series=$series1,$series3" | tee -a $seq.full | pmjson
+
+echo "== verify metric insts" | tee -a $seq.full
+curl --silent "http://localhost:$proxyport/series/instances" -d "series=$series2" | tee -a $seq.full | pmjson
+
+# valgrind takes awhile to shutdown too
+pmsignal $pid
+pmsleep 3.5
+echo "=== valgrind stdout ===" | tee -a $seq.full
+cat $tmp.valout | _filter_valgrind
+
+echo "=== valgrind stderr ===" | tee -a $seq.full
+cat $tmp.valerr | _filter_pmproxy_log | grep -v "Cannot connect to Redis" | _filter_proxyport
+
+# success, all done
+status=0
+exit

--- a/qa/1697.out
+++ b/qa/1697.out
@@ -1,0 +1,93 @@
+QA output created by 1697
+Start test Redis server ...
+PING
+PONG
+
+pmseries: [Info] processed 5 archive records from PATH/archives/proc
+Using series 1440b8b8bfe69465340eb934e9086ae8212f3cff for disk.all.read
+Using series 605fc77742cd0317597291329561ac4e50c0dd12 for disk.dev.read
+Using series 01d8bc7fa75aaff98a08aa0b1c0f2394368d5183 for kernel.all.uptime
+== verify metric descs
+[
+    {
+        "series": "1440b8b8bfe69465340eb934e9086ae8212f3cff",
+        "source": "2cd6a38f9339f2dd1f0b4775bda89a9e7244def6",
+        "pmid": "60.0.24",
+        "indom": "none",
+        "semantics": "counter",
+        "type": "u64",
+        "units": "count"
+    },
+    {
+        "series": "605fc77742cd0317597291329561ac4e50c0dd12",
+        "source": "2cd6a38f9339f2dd1f0b4775bda89a9e7244def6",
+        "pmid": "60.0.4",
+        "indom": "60.1",
+        "semantics": "counter",
+        "type": "u32",
+        "units": "count"
+    },
+    {
+        "series": "01d8bc7fa75aaff98a08aa0b1c0f2394368d5183",
+        "source": "2cd6a38f9339f2dd1f0b4775bda89a9e7244def6",
+        "pmid": "60.26.0",
+        "indom": "none",
+        "semantics": "instant",
+        "type": "u32",
+        "units": "sec"
+    }
+]
+== verify metric names
+[
+    {
+        "series": "1440b8b8bfe69465340eb934e9086ae8212f3cff",
+        "name": "disk.all.read"
+    },
+    {
+        "series": "605fc77742cd0317597291329561ac4e50c0dd12",
+        "name": "disk.dev.read"
+    },
+    {
+        "series": "01d8bc7fa75aaff98a08aa0b1c0f2394368d5183",
+        "name": "kernel.all.uptime"
+    }
+]
+== verify metric labels
+[
+    {
+        "series": "1440b8b8bfe69465340eb934e9086ae8212f3cff",
+        "labels": {
+            "hostname": "bozo-laptop"
+        }
+    },
+    {
+        "series": "01d8bc7fa75aaff98a08aa0b1c0f2394368d5183",
+        "labels": {
+            "hostname": "bozo-laptop"
+        }
+    }
+]
+== verify metric insts
+[
+    {
+        "series": "605fc77742cd0317597291329561ac4e50c0dd12",
+        "source": "2cd6a38f9339f2dd1f0b4775bda89a9e7244def6",
+        "instance": "c3795d8b757506a2901c6b08b489ba56cae7f0d4",
+        "id": 0,
+        "name": "sda"
+    }
+]
+=== valgrind stdout ===
+=== valgrind stderr ===
+Log for pmproxy on HOST started DATE
+
+pmproxy: PID = PID
+pmproxy request port(s):
+  sts fd   port  family address
+  === ==== ===== ====== =======
+ok FD unix UNIX_DOMAIN_SOCKET
+ok FD PORT inet INADDR_ANY
+[DATE] pmproxy(PID) Info: pmproxy caught SIGTERM
+[DATE] pmproxy(PID) Info: pmproxy Shutdown
+
+Log finished DATE

--- a/qa/group
+++ b/qa/group
@@ -1921,6 +1921,7 @@ x11
 1694 pidstat local python pcp pmlogextract
 1695 pmproxy valgrind local
 1696 pmproxy valgrind local
+1697 pmproxy valgrind local
 1700 pmda.bpftrace local python
 1701 pmda.bpftrace local python
 1702 pmda.bpftrace local python

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -172,6 +172,7 @@ freeSeriesGetLabelMap(seriesGetLabelMap *value)
     sdsfree(value->mapID);
     sdsfree(value->mapKey);
     memset(value, 0, sizeof(seriesGetLabelMap));
+    free(value);
 }
 
 static void
@@ -4341,6 +4342,7 @@ reverse_map(seriesQueryBaton *baton, redisMap *map, int nkeys, redisReply **elem
 		key = sdsnewlen(hash->str, hash->len);
 		val = sdsnewlen(name->str, name->len);
 		redisMapInsert(map, key, val);
+		sdsfree(key); // map has keyDup set
 	    } else {
 		infofmt(msg, "expected string key for hashmap (type=%s)",
 			redis_reply_type(hash));

--- a/src/pmproxy/src/http.c
+++ b/src/pmproxy/src/http.c
@@ -581,7 +581,7 @@ http_add_parameter(dict *parameters,
     return 0;
 }
 
-static int
+int
 http_parameters(const char *url, size_t length, dict **parameters)
 {
     const char		*end = url + length;

--- a/src/pmproxy/src/http.h
+++ b/src/pmproxy/src/http.h
@@ -64,6 +64,7 @@ extern void http_transfer(struct client *);
 extern void http_reply(struct client *, sds, http_code_t, http_flags_t, http_options_t);
 extern void http_error(struct client *, http_code_t, const char *);
 
+extern int http_parameters(const char *, size_t, dict **);
 extern int http_decode(const char *, size_t, sds);
 extern const char *http_status_mapping(http_code_t);
 extern const char *http_content_type(http_flags_t);


### PR DESCRIPTION
Most pmseries REST API methods accept a comma-separated list of series
ids. Each series id is 40 bytes, therefore requesting data for many
series at once can generate a query string which exceeds the maximum
size of an URL.

This commit allows to optionally submit the request parameters in the
body of the HTTP request.

Breaking change warning: Previously it was possible to submit the `expr` parameter for `/series/load` and `/series/query` in the response body, and the `series` parameter as a newline-separated list of series ids. This functionality wasn't documented (correct me if I'm wrong), so afaics it should be fine to replace it with accepting the request body for all current REST API methods in the standardized urlencoding format.

fyi, corresponding grafana-pcp PR: https://github.com/performancecopilot/grafana-pcp/pull/116

Note: I'm currently seeing the following memleaks in the new QA test, which are afaics unrelated to this PR (all originate from memory allocated in `query.c`):
```
44 bytes in 1 blocks are definitely lost in loss record 20 of 48
at 0x484486F: malloc (vg_replace_malloc.c:381)
by 0x4C4C616: hi_malloc (alloc.h:58)
by 0x4C4C771: sdsnewlen (sds.c:93)
by 0x4C4C999: sdsdup (sds.c:153)
by 0x4C27B6F: series_instances_reply (query.c:5006)
by 0x4C27FA7: series_lookup_instances_callback (query.c:5078)
by 0x4C3B341: redisSlotsReplyCallback (slots.c:515)
by 0x4C5C7EF: redisClusterAsyncCallback (hircluster.c:3908)
by 0x4C46387: __redisRunCallback (async.c:287)
by 0x4C46EAA: redisProcessCallbacks (async.c:572)
by 0x4C470D7: redisAsyncRead (async.c:635)
by 0x4C47134: redisAsyncHandleRead (async.c:654)
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   fun:hi_malloc
   fun:sdsnewlen
   fun:sdsdup
   fun:series_instances_reply
   fun:series_lookup_instances_callback
   fun:redisSlotsReplyCallback
   fun:redisClusterAsyncCallback
   fun:__redisRunCallback
   fun:redisProcessCallbacks
   fun:redisAsyncRead
   fun:redisAsyncHandleRead
}
44 bytes in 2 blocks are definitely lost in loss record 21 of 48
at 0x484486F: malloc (vg_replace_malloc.c:381)
by 0x4C4C616: hi_malloc (alloc.h:58)
by 0x4C4C771: sdsnewlen (sds.c:93)
by 0x4C25525: reverse_map (query.c:4340)
by 0x4C25FBB: series_label_value_reply (query.c:4526)
by 0x4C3B341: redisSlotsReplyCallback (slots.c:515)
by 0x4C5C7EF: redisClusterAsyncCallback (hircluster.c:3908)
by 0x4C46387: __redisRunCallback (async.c:287)
by 0x4C46EAA: redisProcessCallbacks (async.c:572)
by 0x4C470D7: redisAsyncRead (async.c:635)
by 0x4C47134: redisAsyncHandleRead (async.c:654)
by 0x4C39A8F: redisLibuvPoll (libuv.h:21)
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   fun:hi_malloc
   fun:sdsnewlen
   fun:reverse_map
   fun:series_label_value_reply
   fun:redisSlotsReplyCallback
   fun:redisClusterAsyncCallback
   fun:__redisRunCallback
   fun:redisProcessCallbacks
   fun:redisAsyncRead
   fun:redisAsyncHandleRead
   fun:redisLibuvPoll
}
112 bytes in 2 blocks are definitely lost in loss record 27 of 48
at 0x4849464: calloc (vg_replace_malloc.c:1328)
by 0x4C264E4: series_label_reply (query.c:4607)
by 0x4C2687F: series_lookup_labels_callback (query.c:4659)
by 0x4C3B341: redisSlotsReplyCallback (slots.c:515)
by 0x4C5C7EF: redisClusterAsyncCallback (hircluster.c:3908)
by 0x4C46387: __redisRunCallback (async.c:287)
by 0x4C46EAA: redisProcessCallbacks (async.c:572)
by 0x4C470D7: redisAsyncRead (async.c:635)
by 0x4C47134: redisAsyncHandleRead (async.c:654)
by 0x4C39A8F: redisLibuvPoll (libuv.h:21)
by 0x4CB4A7D: ??? (in /usr/lib64/libuv.so.1.0.0)
by 0x4C9E617: uv_run (in /usr/lib64/libuv.so.1.0.0)
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:calloc
   fun:series_label_reply
   fun:series_lookup_labels_callback
   fun:redisSlotsReplyCallback
   fun:redisClusterAsyncCallback
   fun:__redisRunCallback
   fun:redisProcessCallbacks
   fun:redisAsyncRead
   fun:redisAsyncHandleRead
   fun:redisLibuvPoll
   obj:/usr/lib64/libuv.so.1.0.0
   fun:uv_run
}
4,972 bytes in 226 blocks are definitely lost in loss record 47 of 48
at 0x484486F: malloc (vg_replace_malloc.c:381)
by 0x4C4C616: hi_malloc (alloc.h:58)
by 0x4C4C771: sdsnewlen (sds.c:93)
by 0x4C25525: reverse_map (query.c:4340)
by 0x4C2858B: redis_lookup_mapping_callback (query.c:5177)
by 0x4C3B341: redisSlotsReplyCallback (slots.c:515)
by 0x4C5C7EF: redisClusterAsyncCallback (hircluster.c:3908)
by 0x4C46387: __redisRunCallback (async.c:287)
by 0x4C46EAA: redisProcessCallbacks (async.c:572)
by 0x4C470D7: redisAsyncRead (async.c:635)
by 0x4C47134: redisAsyncHandleRead (async.c:654)
by 0x4C39A8F: redisLibuvPoll (libuv.h:21)
{
   <insert_a_suppression_name_here>
   Memcheck:Leak
   match-leak-kinds: definite
   fun:malloc
   fun:hi_malloc
   fun:sdsnewlen
   fun:reverse_map
   fun:redis_lookup_mapping_callback
   fun:redisSlotsReplyCallback
   fun:redisClusterAsyncCallback
   fun:__redisRunCallback
   fun:redisProcessCallbacks
   fun:redisAsyncRead
   fun:redisAsyncHandleRead
   fun:redisLibuvPoll
}
```