### PR TITLE
selinux: switch to conditional dependency

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -224,7 +224,16 @@ fi
 }
 
 %if "@enable_selinux@" == "true"
+
+# rpm boolean dependencies are supported since RHEL 8
+%if 0%{?fedora} >= 35 || 0%{?rhel} >= 8
+# This ensures that the pcp-selinux package and all it's dependencies are not pulled
+# into containers and other systems that do not use SELinux
+Requires: (pcp-selinux = @package_version@ if selinux-policy-targeted)
+%else
 Requires: pcp-selinux = @package_version@
+%endif
+
 %endif
 
 Requires: pcp-libs = @package_version@

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -290,7 +290,16 @@ BuildRequires: qt5-qtsvg-devel
 Requires: bash xz gawk sed grep findutils which %{_hostname_executable}
 Requires: pcp-libs = %{version}-%{release}
 %if !%{disable_selinux}
+
+# rpm boolean dependencies are supported since RHEL 8
+%if 0%{?fedora} >= 35 || 0%{?rhel} >= 8
+# This ensures that the pcp-selinux package and all it's dependencies are not pulled
+# into containers and other systems that do not use SELinux
+Requires: (pcp-selinux = %{version}-%{release} if selinux-policy-targeted)
+%else
 Requires: pcp-selinux = %{version}-%{release}
+%endif
+
 %endif
 
 %global _confdir        %{_sysconfdir}/pcp


### PR DESCRIPTION
This ensures that the pcp-selinux package and all it's dependencies are
not pulled into containers and other systems that do not use SELinux.
https://fedoraproject.org/wiki/SELinux/IndependentPolicy#Adding_dependency_to_the_spec_file_of_corresponding_package

This rpm syntax is called "boolean dependencies" and is supported since rpm 4.13 (>= RHEL 8).
https://rpm-software-management.github.io/rpm/manual/boolean_dependencies.html

Co-authored-by: Vit Mojzis <vmojzis@redhat.com>
Resolves: rhbz#2050838