### PR TITLE
libpcp: high resolution log label and time window APIs

### DIFF
--- a/man/man1/pmval.1
+++ b/man/man1/pmval.1
@@ -1,7 +1,7 @@
 '\"! tbl | mmdoc
 '\"macro stdmacro
 .\"
-.\" Copyright (c) 2015-2018 Red Hat.
+.\" Copyright (c) 2015-2018,2022 Red Hat.
 .\" Copyright (c) 2000 Silicon Graphics, Inc.  All Rights Reserved.
 .\"
 .\" This program is free software; you can redistribute it and/or modify it
@@ -422,8 +422,9 @@ Use . (dot) for a \(lqmatch all\(rq
 .TP
 \fB\-X\fR, \fB\-\-timestamp\fR
 When replaying from an archive, this option requests that the
-timestamp be reported with additional date information and microsecond
-precision, for example
+timestamp be reported with additional date information and increased
+precision (microseconds with a single \fB\-X\fR, nanoseconds with an
+additional \fB\-X\fR), for example
 .B "Sat\ May\ 22\ 20:32:20.971633\ 2021"
 instead of the default format, for example
 .BR "20:32:20.971" .

--- a/qa/443.out
+++ b/qa/443.out
@@ -30,7 +30,7 @@ Usage: pmevent [options] metricname
 pmevent: -s requires a positive numeric argument
 Usage: pmevent [options] metricname
 === -t 10foobars ===
-pmevent: -t argument not in pmParseInterval(3) format:
+pmevent: -t argument not in pmParseHighResInterval(3) format:
 10foobars
   ^ -- unexpected value
 

--- a/qa/src/exertz.c
+++ b/qa/src/exertz.c
@@ -182,15 +182,15 @@ Options\n\
 
     if (tzhost != (char *)0) {
 	if (type == PM_CONTEXT_ARCHIVE) {
-	    pmLogLabel	label;
-	    if ((sts = pmGetArchiveLabel(&label)) < 0) {
+	    pmHighResLogLabel	label;
+	    if ((sts = pmGetHighResArchiveLabel(&label)) < 0) {
 		fprintf(stderr, "%s: Cannot get archive label record: %s\n",
 		    pmGetProgname(), pmErrStr(sts));
 		exit(1);
 	    }
-	    if (strcmp(tzhost, label.ll_hostname) != 0) {
+	    if (strcmp(tzhost, label.hostname) != 0) {
 		fprintf(stderr, "%s: mismatched host name between -z (%s) and archive (%s)\n",
-		    pmGetProgname(), tzhost, label.ll_hostname);
+		    pmGetProgname(), tzhost, label.hostname);
 		exit(1);
 	    }
 	}

--- a/src/dbpmda/src/dso.c
+++ b/src/dbpmda/src/dso.c
@@ -71,7 +71,7 @@ opendso(char *dso, char *init, int domain)
 	    challenge = 0xff;
 	    dispatch.comm.pmda_interface = challenge;
 	    /* set in 2 steps to avoid int to bitfield truncation warnings */
-	    dispatch.comm.pmapi_version = PMAPI_VERSION;
+	    dispatch.comm.pmapi_version = PMAPI_VERSION_2;   /* use oldest */
 	    dispatch.comm.pmapi_version = ~dispatch.comm.pmapi_version;
 	    dispatch.comm.flags = 0;
 	    dispatch.status = 0;
@@ -99,7 +99,8 @@ opendso(char *dso, char *init, int domain)
 		    dispatch.status = -1;
 		    dlclose(handle);
 		}
-		if (dispatch.comm.pmapi_version != PMAPI_VERSION_2) {
+		if (dispatch.comm.pmapi_version != PMAPI_VERSION_2 &&
+		    dispatch.comm.pmapi_version != PMAPI_VERSION_3) {
 		    printf("Error: Unsupported PMAPI version %d returned by DSO \"%s\"\n",
 			   dispatch.comm.pmapi_version, dso);
 		    dispatch.status = -1;

--- a/src/include/pcp/libpcp.h
+++ b/src/include/pcp/libpcp.h
@@ -1309,7 +1309,9 @@ PCP_CALL extern char *__pmZoneinfo(void);
 /* string conversion to value of given type, suitable for pmStore */
 PCP_CALL extern int __pmStringValue(const char *, pmAtomValue *, int);
 
-/* timeval-based delays */
+/* time-based delays */
+PCP_CALL extern void __pmtimespecSleep(struct timespec);
+PCP_CALL extern void __pmtimespecPause(struct timespec);
 PCP_CALL extern void __pmtimevalSleep(struct timeval);
 PCP_CALL extern void __pmtimevalPause(struct timeval);
 

--- a/src/include/pcp/pmapi.h
+++ b/src/include/pcp/pmapi.h
@@ -54,8 +54,11 @@
 extern "C" {
 #endif
 
-#define PMAPI_VERSION_2	2
-#define PMAPI_VERSION	PMAPI_VERSION_2
+#define PMAPI_VERSION_2	2	/* traditional PMAPI */
+#define PMAPI_VERSION_3	3	/* nanosec precision */
+#ifndef PMAPI_VERSION
+#define PMAPI_VERSION	PMAPI_VERSION_2   /* default */
+#endif
 
 /*
  * -------- Naming Services --------
@@ -1030,10 +1033,14 @@ typedef struct pmOptions {
     int			narchives;
     char **		hosts;
     char **		archives;
+#if PMAPI_VERSION == PMAPI_VERSION_3
+    struct timeval	unused[4];
+#else
     struct timeval	start;
     struct timeval	finish;
     struct timeval	origin;
     struct timeval	interval;
+#endif
     char *		align_optarg;
     char *		start_optarg;
     char *		finish_optarg;
@@ -1048,6 +1055,12 @@ typedef struct pmOptions {
     unsigned int	nsflag  : 1;
     unsigned int	Lflag   : 1;
     unsigned int	zeroes  : 28;
+#if PMAPI_VERSION == PMAPI_VERSION_3
+    struct timespec	start;
+    struct timespec	finish;
+    struct timespec	origin;
+    struct timespec	interval;
+#endif
 } pmOptions;
 
 PCP_CALL extern int pmgetopt_r(int, char *const *, pmOptions *);

--- a/src/libpcp/src/GNUmakefile
+++ b/src/libpcp/src/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2021 Red Hat.
+# Copyright (c) 2012-2022 Red Hat.
 # Copyright (c) 2008 Aconex.  All Rights Reserved.
 # Copyright (c) 2000,2003,2004 Silicon Graphics, Inc.  All Rights Reserved.
 #
@@ -38,8 +38,9 @@ CFILES = connect.c context.c desc.c err.c fetch.c fetchgroup.c result.c \
 	stuffvalue.c endian.c config.c auxconnect.c auxserver.c discovery.c \
 	p_lcontrol.c p_lrequest.c p_lstatus.c logconnect.c logcontrol.c \
 	connectlocal.c derive_fetch.c events.c lock.c hash.c \
-	fault.c access.c getopt.c io.c io_stdio.c exec.c sha256.c \
-	shellprobe.c subnetprobe.c strings.c deprecated.c \
+	fault.c access.c getopt.c getopt2.c getopt3.c \
+	io.c io_stdio.c exec.c sha256.c strings.c \
+	shellprobe.c subnetprobe.c deprecated.c \
 	e_loglabel.c e_index.c e_indom.c e_labels.c \
 	$(JSONSL_CFILES)
 HFILES = derive.h internal.h compiler.h pmdbg.h sha256.h sort_r.h \

--- a/src/libpcp/src/check-statics
+++ b/src/libpcp/src/check-statics
@@ -315,6 +315,8 @@ getdate.tab.o
 getopt.o
     ?paths                	# const, may be optimized away
     ?fallback                	# const, may be optimized away
+getopt2.o
+getopt3.o
 hash.o
 help.o
 instance.o

--- a/src/libpcp/src/config.c
+++ b/src/libpcp/src/config.c
@@ -451,7 +451,7 @@ static const char *disabled(void) { return "false"; }
 
 #define STRINGIFY(s)		#s
 #define TO_STRING(s)		STRINGIFY(s)
-static const char *pmapi_version(void) { return TO_STRING(PMAPI_VERSION); }
+static const char *pmapi_version(void) { return TO_STRING(PMAPI_VERSION_3); }
 static const char *pcp_version(void) { return PCP_VERSION; }
 #if defined(HAVE_SECURE_SOCKETS)
 #include "nss.h"

--- a/src/libpcp/src/connectlocal.c
+++ b/src/libpcp/src/connectlocal.c
@@ -432,11 +432,11 @@ __pmConnectLocal(__pmHashCtl *attrs)
 	/*
 	 * the PMDA interface / PMAPI version discovery as a "challenge" ...
 	 * for pmda_interface it is all the bits being set,
-	 * for pmapi_version it is the complement of the one you are using now
+	 * for pmapi_version it is the complement of the oldest supported.
 	 */
 	challenge = 0xff;
 	dp->dispatch.comm.pmda_interface = challenge;
-	dp->dispatch.comm.pmapi_version = (~PMAPI_VERSION) & 0xff;
+	dp->dispatch.comm.pmapi_version = PMAPI_VERSION_2 & 0xff;
 	dp->dispatch.comm.flags = 0;
 	dp->dispatch.status = 0;
 
@@ -463,7 +463,8 @@ connected:
 		dlclose(dp->handle);
 		dp->domain = -1;
 	    }
-	    else if (dp->dispatch.comm.pmapi_version != PMAPI_VERSION_2) {
+	    else if (dp->dispatch.comm.pmapi_version != PMAPI_VERSION_2 &&
+		     dp->dispatch.comm.pmapi_version != PMAPI_VERSION_3) {
 		pmprintf("__pmConnectLocal: Error: Unknown PMAPI version %d "
 			 "in \"%s\" DSO\n",
 			 dp->dispatch.comm.pmapi_version, dp->name);

--- a/src/libpcp/src/exports.in
+++ b/src/libpcp/src/exports.in
@@ -800,10 +800,14 @@ PCP_3.37 {
     pmtimespecFromReal;
     pmExtendFetchGroup_timespec;
     pmExtendFetchGroup_timeval;
+    pmGetHighResArchiveLabel;
+    pmGetHighResArchiveEnd;
     pmHighResFetchArchive;
     pmHighResSortInstances;
     pmParseHighResInterval;
     pmParseHighResTimeWindow;
+    __pmtimespecPause;
+    __pmtimespecSleep;
     __pmConvertHighResTime;
     __pmParseHighResTime;
     __pmDecodeHighResResult_ctx;

--- a/src/libpcp/src/getopt2.c
+++ b/src/libpcp/src/getopt2.c
@@ -1,0 +1,59 @@
+/*
+ * PMAPI v2 argument parsing for all PMAPI client tools.
+ *
+ * Copyright (c) 2014-2018,2020-2022 Red Hat.
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ */
+
+#undef PMAPI_VERSION
+#define PMAPI_VERSION 2		/* pmOptions with struct timeval */
+#include "pmapi.h"
+#include "libpcp.h"
+#include "internal.h"
+
+void
+__pmParseTimeWindow2(pmOptions *opts,
+	struct timespec *first_boundary, struct timespec *last_boundary)
+{
+    struct timeval first, last;
+    char *msg = NULL;
+
+    first.tv_sec = first_boundary->tv_sec;
+    first.tv_usec = first_boundary->tv_nsec / 1000;
+    last.tv_sec = last_boundary->tv_sec;
+    last.tv_usec = last_boundary->tv_nsec / 1000;
+
+    if (pmParseTimeWindow(
+			opts->start_optarg, opts->finish_optarg,
+			opts->align_optarg, opts->origin_optarg, &first, &last,
+			&opts->start, &opts->finish, &opts->origin, &msg) < 0) {
+	pmprintf("%s: invalid time window.\n%s\n", pmGetProgname(), msg);
+	opts->errors++;
+    }
+    if (msg)
+	free(msg);
+}
+
+void
+__pmSetSampleInterval2(pmOptions *opts, char *arg)
+{
+    char *endnum;
+    int sts;
+
+    if ((sts = pmParseInterval(arg, &opts->interval, &endnum)) < 0) {
+	pmprintf("%s: -t argument not in %s(3) format:\n",
+		pmGetProgname(), "pmParseInterval");
+	pmprintf("%s\n", endnum);
+	opts->errors++;
+	free(endnum);
+    }
+}

--- a/src/libpcp/src/getopt3.c
+++ b/src/libpcp/src/getopt3.c
@@ -1,0 +1,54 @@
+/*
+ * PMAPI v3 argument parsing for all PMAPI client tools.
+ *
+ * Copyright (c) 2014-2018,2020-2022 Red Hat.
+ *
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ */
+
+#undef PMAPI_VERSION
+#define PMAPI_VERSION 3		/* pmOptions with struct timespec */
+#include "pmapi.h"
+#include "libpcp.h"
+#include "internal.h"
+
+void
+__pmParseTimeWindow3(pmOptions *opts,
+	struct timespec *first_boundary, struct timespec *last_boundary)
+{
+    char *msg = NULL;
+
+    if (pmParseHighResTimeWindow(
+			opts->start_optarg, opts->finish_optarg,
+			opts->align_optarg, opts->origin_optarg,
+			first_boundary, last_boundary,
+			&opts->start, &opts->finish, &opts->origin, &msg) < 0) {
+	pmprintf("%s: invalid time window.\n%s\n", pmGetProgname(), msg);
+	opts->errors++;
+    }
+    if (msg)
+	free(msg);
+}
+
+void
+__pmSetSampleInterval3(pmOptions *opts, char *arg)
+{
+    char *endnum;
+    int sts;
+
+    if ((sts = pmParseHighResInterval(arg, &opts->interval, &endnum)) < 0) {
+	pmprintf("%s: -t argument not in %s(3) format:\n",
+		pmGetProgname(), "pmParseHighResInterval");
+	pmprintf("%s\n", endnum);
+	opts->errors++;
+	free(endnum);
+    }
+}

--- a/src/libpcp/src/internal.h
+++ b/src/libpcp/src/internal.h
@@ -408,7 +408,6 @@ extern const char *__pmLogName_r(const char *, int, char *, int) _PCP_HIDDEN;
 extern const char *__pmLogName(const char *, int) _PCP_HIDDEN;	/* NOT thread-safe */
 extern int __pmLogGenerateMark(__pmLogCtl *, int, __pmResult **) _PCP_HIDDEN;
 extern int __pmLogFetchInterp(__pmContext *, int, pmID *, __pmResult **) _PCP_HIDDEN;
-extern int __pmGetArchiveLabel(__pmLogCtl *, pmLogLabel *) _PCP_HIDDEN;
 extern __pmTimestamp *__pmLogStartTime(__pmArchCtl *) _PCP_HIDDEN;
 extern int __pmLogSetTime(__pmContext *) _PCP_HIDDEN;
 extern void __pmLogResetInterp(__pmContext *) _PCP_HIDDEN;
@@ -449,5 +448,13 @@ extern char *__pmLabelFlagString(int, char *, int) _PCP_HIDDEN;
 /* logmeta.c hooks */
 extern int addindom(__pmLogCtl *, int, const __pmLogInDom_io *, __int32_t *, int) _PCP_HIDDEN;
 extern int addlabel(__pmArchCtl *, unsigned int, unsigned int, int, pmLabelSet *, const __pmTimestamp *) _PCP_HIDDEN;
+
+/* getopt.c ABI-version-specific details */
+extern void __pmParseTimeWindow2(pmOptions *,
+			struct timespec *, struct timespec *) _PCP_HIDDEN;
+extern void __pmParseTimeWindow3(pmOptions *,
+			struct timespec *, struct timespec *) _PCP_HIDDEN;
+extern void __pmSetSampleInterval2(pmOptions *, char *) _PCP_HIDDEN;
+extern void __pmSetSampleInterval3(pmOptions *, char *) _PCP_HIDDEN;
 
 #endif /* _LIBPCP_INTERNAL_H */

--- a/src/libpcp_fault/src/GNUmakefile
+++ b/src/libpcp_fault/src/GNUmakefile
@@ -34,8 +34,9 @@ CFILES = connect.c context.c desc.c err.c fetch.c fetchgroup.c result.c \
 	stuffvalue.c endian.c config.c auxconnect.c auxserver.c discovery.c \
 	p_lcontrol.c p_lrequest.c p_lstatus.c logconnect.c logcontrol.c \
 	connectlocal.c derive_fetch.c events.c lock.c hash.c \
-	fault.c access.c getopt.c io.c io_stdio.c exec.c sha256.c \
-	shellprobe.c subnetprobe.c strings.c deprecated.c \
+	fault.c access.c getopt.c getopt2.c getopt3.c \
+	io.c io_stdio.c exec.c sha256.c strings.c \
+	shellprobe.c subnetprobe.c deprecated.c \
 	e_loglabel.c e_index.c e_indom.c e_labels.c \
 	$(JSONSL_CFILES)
 HFILES = derive.h internal.h compiler.h pmdbg.h sha256.h sort_r.h \

--- a/src/libpcp_static/src/GNUmakefile
+++ b/src/libpcp_static/src/GNUmakefile
@@ -34,8 +34,9 @@ CFILES = connect.c context.c desc.c err.c fetch.c fetchgroup.c result.c \
 	stuffvalue.c endian.c config.c auxconnect.c auxserver.c discovery.c \
 	p_lcontrol.c p_lrequest.c p_lstatus.c logconnect.c logcontrol.c \
 	connectlocal.c derive_fetch.c events.c lock.c hash.c \
-	fault.c access.c getopt.c io.c io_stdio.c exec.c sha256.c \
-	shellprobe.c subnetprobe.c strings.c deprecated.c \
+	fault.c access.c getopt.c getopt2.c getopt3.c \
+	io.c io_stdio.c exec.c sha256.c strings.c \
+	shellprobe.c subnetprobe.c deprecated.c \
 	e_loglabel.c e_index.c e_indom.c e_labels.c \
 	$(JSONSL_CFILES)
 HFILES = derive.h internal.h compiler.h pmdbg.h sha256.h sort_r.h \

--- a/src/pmcd/src/config.c
+++ b/src/pmcd/src/config.c
@@ -2048,7 +2048,7 @@ GetAgentDso(AgentInfo *aPtr)
     challenge = 0xff;
     dso->dispatch.comm.pmda_interface = challenge;
     /* set in 2 steps to avoid int to bitfield truncation warnings */
-    dso->dispatch.comm.pmapi_version = PMAPI_VERSION;
+    dso->dispatch.comm.pmapi_version = PMAPI_VERSION_2; /* oldest supported */
     dso->dispatch.comm.pmapi_version = ~dso->dispatch.comm.pmapi_version;
 
     dso->dispatch.comm.flags = 0;

--- a/src/pmval/pmval.c
+++ b/src/pmval/pmval.c
@@ -39,6 +39,7 @@ static pmLongOptions longopts[] = {
 
 static int override(int, pmOptions *);
 static pmOptions opts = {
+    .version = PMAPI_VERSION_3,
     .flags = PM_OPTFLAG_DONE | PM_OPTFLAG_BOUNDARIES | PM_OPTFLAG_STDOUT_TZ,
     .short_options = PMAPI_OPTIONS "df:i:K:LrU:vw:x:X",
     .long_options = longopts,
@@ -232,45 +233,51 @@ initapi(Context *x, pmMetricSpec *msp, int argc, char **argv)
 
 /* print the timestamp (various precisions) for archives */
 static void
-mytimestamp(struct timeval *stamp)
+mytimestamp(struct timespec *stamp)
 {
-    if (Xflag) {
+    time_t		sec = stamp->tv_sec;
+    struct tm		tmp;
+
+    pmLocaltime(&sec, &tmp);
+    if (!Xflag) {
+	printf("%02d:%02d:%02d.%03d",
+			tmp.tm_hour, tmp.tm_min, tmp.tm_sec,
+			(int)stamp->tv_nsec / 1000000);
+    } else {
 	char		timebuf[32];	/* for pmCtime result + .xxx */
 	char	       *ddmm;
 	char	       *yr;
-	time_t		time;
-	pmTimeval	pmtv;
 
-	time = stamp->tv_sec;
-	ddmm = pmCtime(&time, timebuf);
+	ddmm = pmCtime(&sec, timebuf);
 	ddmm[10] = '\0';
 	yr = &ddmm[20];
-	printf("%s ", ddmm);
-	pmtv.tv_sec = stamp->tv_sec;
-	pmtv.tv_usec = stamp->tv_usec;
-	__pmPrintTimeval(stdout, &pmtv);
-	printf(" %4.4s", yr);
+	if (Xflag == 1)
+	    printf("%s %02d:%02d:%02d.%06d %4.4s", ddmm,
+			tmp.tm_hour, tmp.tm_min, tmp.tm_sec,
+			(int)stamp->tv_nsec / 1000, yr);
+	else /* -XX highest resolution - nanoseconds */
+	    printf("%s %02d:%02d:%02d.%09d %4.4s", ddmm,
+			tmp.tm_hour, tmp.tm_min, tmp.tm_sec,
+			(int)stamp->tv_nsec, yr);
     }
-    else
-	pmPrintStamp(stdout, stamp);
 }
 
 /* Fetch metric values. */
 static int
 getvals(Context *x,		/* in - full pm description */
-        pmResult **vs)		/* alloc - pm values */
+        pmHighResResult **vs)		/* alloc - pm values */
 {
-    pmResult	*r;
-    int		e;
-    int		i;
+    pmHighResResult	*r;
+    int			e;
+    int			i;
 
     if (rawArchive) {
 	/*
-	 * for -U mode, read until we find either a pmResult with the
+	 * for -U mode, read until we find either a pmHighResResult with the
 	 * pmid we are after, or a mark record
 	 */
 	for ( ; ; ) {
-	    e = pmFetchArchive(&r);
+	    e = pmHighResFetchArchive(&r);
 	    if (e < 0)
 		break;
 
@@ -279,7 +286,7 @@ getvals(Context *x,		/* in - full pm description */
 		    mytimestamp(&r->timestamp);
 		printf("  Archive logging suspended\n");
 		reporting = 0;
-		pmFreeResult(r);
+		pmFreeHighResResult(r);
 		return -1;
 	    }
 
@@ -289,11 +296,11 @@ getvals(Context *x,		/* in - full pm description */
 	    }
 	    if (i != r->numpmid)
 		break;
-	    pmFreeResult(r);
+	    pmFreeHighResResult(r);
 	}
     }
     else {
-	e = pmFetch(1, &(x->pmid), &r);
+	e = pmHighResFetch(1, &(x->pmid), &r);
 	i = 0;
     }
 
@@ -315,8 +322,8 @@ getvals(Context *x,		/* in - full pm description */
     if (opts.guiflag)
 	pmTimeStateAck(&controls, pmtime);
 
-    if (pmtimevalToReal(&r->timestamp) > pmtimevalToReal(&opts.finish)) {
-	pmFreeResult(r);
+    if (pmtimespecToReal(&r->timestamp) > pmtimespecToReal(&opts.finish)) {
+	pmFreeHighResResult(r);
 	return -2;
     }
 
@@ -330,12 +337,12 @@ getvals(Context *x,		/* in - full pm description */
 	    printf("No values available\n");
 	else if (rawEvents && verbose)
 	    printf("%s: No values available\n", x->metric);
-	pmFreeResult(r);
+	pmFreeHighResResult(r);
 	return -1;
     }
     else if (e < 0) {
 	if (rawEvents && e == PM_ERR_NOTCONN) {
-	    pmFreeResult(r);
+	    pmFreeHighResResult(r);
 	    exit(EXIT_SUCCESS);
 	}
 	else if (rawArchive) {
@@ -345,7 +352,7 @@ getvals(Context *x,		/* in - full pm description */
 	    fprintf(stderr, "\n%s: pmFetch: %s\n",
 			pmGetProgname(), pmErrStr(r->vset[i]->numval));
 	}
-	pmFreeResult(r);
+	pmFreeHighResResult(r);
 	return -1;
     }
 
@@ -455,7 +462,7 @@ footer:
     else printf("samples:   %d\n", opts.samples);
     if ((opts.samples > 1) &&
 	(opts.context != PM_CONTEXT_ARCHIVE || amode == PM_MODE_INTERP))
-	printf("interval:  %1.2f sec\n", pmtimevalToReal(&opts.interval));
+	printf("interval:  %1.2f sec\n", pmtimespecToReal(&opts.interval));
 }
 
 /* Print instance identifier names as column labels. */
@@ -494,10 +501,12 @@ printlabels(Context *x)
     putchar('\n');
     for (i = 0; i < n; i++) {
 	if ((opts.guiflag || opts.context == PM_CONTEXT_ARCHIVE) && i == 0) {
-	    if (Xflag)
-		printf("                               ");
+	    if (Xflag > 1)
+		printf("%*c", 34, ' ');
+	    else if (Xflag == 1)
+		printf("%*c", 31, ' ');
 	    else
-		printf("            ");
+		printf("%*c", 12, ' ');
 	}
 	if (rawCounter || (x->desc.sem != PM_SEM_COUNTER) || style != 0)
 	    printf("%*.*s ", cols, cols, pairs->name);
@@ -706,15 +715,15 @@ printrate(int     valfmt,	/* from pmValueSet */
 /* Print performance metric rates */
 static void
 printrates(Context *x,
-	   pmValueSet *vset1, struct timeval stamp1,	/* current values */
-	   pmValueSet *vset2, struct timeval stamp2)	/* previous values */
+	   pmValueSet *vset1, struct timespec stamp1,	/* current values */
+	   pmValueSet *vset2, struct timespec stamp2)	/* previous values */
 {
     int     i, j, k;
     double  delta;
 
     /* compute delta from timestamps and convert units */
     delta = x->scale *
-	    (pmtimevalToReal(&stamp1) - pmtimevalToReal(&stamp2));
+	    (pmtimespecToReal(&stamp1) - pmtimespecToReal(&stamp2));
 
     /* null instance domain */
     if (x->desc.indom == PM_INDOM_NULL) {
@@ -766,13 +775,13 @@ printrates(Context *x,
 }
 
 static void
-printtime(struct timeval *tv)
+printtime(struct timespec *ts)
 {
     char	tbfr[26];
     char	*tp;
     time_t	time;
 
-    time = tv->tv_sec;
+    time = ts->tv_sec;
     tp = pmCtime(&time, tbfr);
     /*
      * tp -> Ddd Mmm DD HH:MM:SS YYYY\n
@@ -933,6 +942,13 @@ initfilters(Context *x, int conntype)
     pmFreeResult(result);
 }
 
+static inline void
+timespec2val(struct timespec *in, struct timeval *out)
+{
+    out->tv_sec = in->tv_sec;
+    out->tv_usec = in->tv_nsec / 1000;
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -948,8 +964,8 @@ main(int argc, char *argv[])
     char        *endnum;
     char        *errmsg;
     pmMetricSpec *msp = NULL;
-    pmResult    *rslt1;		/* current values */
-    pmResult    *rslt2 = NULL;	/* previous values */
+    pmHighResResult *rslt1;		/* current values */
+    pmHighResResult *rslt2 = NULL;	/* previous values */
 
     setlinebuf(stdout);
     context.iall = 1;
@@ -1012,7 +1028,7 @@ main(int argc, char *argv[])
 	    break;
 
 	case 'X':	/* report Ddd Mmm DD <timestamp> YYYY */
-	    Xflag = 1;
+	    Xflag++;
 	    break;
 
 	default:
@@ -1144,7 +1160,7 @@ main(int argc, char *argv[])
 	opts.guiport = -1;
     if (!opts.finish.tv_sec)
 	opts.finish.tv_sec = PM_MAX_TIME_T;
-    if (opts.interval.tv_sec == 0 && opts.interval.tv_usec == 0)
+    if (opts.interval.tv_sec == 0 && opts.interval.tv_nsec == 0)
 	opts.interval.tv_sec = 1;
 
     initapi(&context, msp, argc, argv);
@@ -1157,10 +1173,10 @@ main(int argc, char *argv[])
 	amode != PM_MODE_FORW) {
 	double start, finish, origin, delta;
 
-	start  = pmtimevalToReal(&opts.start);
-	finish = pmtimevalToReal(&opts.finish);
-	origin = pmtimevalToReal(&opts.origin);
-	delta  = pmtimevalToReal(&opts.interval);
+	start  = pmtimespecToReal(&opts.start);
+	finish = pmtimespecToReal(&opts.finish);
+	origin = pmtimespecToReal(&opts.origin);
+	delta  = pmtimespecToReal(&opts.interval);
 
 	opts.samples = (int) ((finish - origin) / delta);
 	if (opts.samples < 0)
@@ -1203,16 +1219,29 @@ main(int argc, char *argv[])
     }
 
     if (opts.guiflag || opts.guiport != -1) {
+	struct timeval interval, origin, start, finish;
+
+	timespec2val(&opts.interval, &interval);
+	timespec2val(&opts.origin, &origin);
+	timespec2val(&opts.start, &start);
+	timespec2val(&opts.finish, &finish);
+
 	/* set up pmtime control */
 	pmWhichZone(&opts.timezone);
-	pmtime = pmTimeStateSetup(&controls, opts.context, opts.guiport,
-				  opts.interval, opts.origin, opts.start,
-				  opts.finish, opts.timezone, tzlabel);
+	pmtime = pmTimeStateSetup(&controls,
+				  opts.context, opts.guiport,
+				  interval, origin, start, finish,
+				  opts.timezone, tzlabel);
 	controls.stepped = timestep;
 	opts.guiflag = 1;	/* we're using pmtime control from here on */
     }
-    else if (opts.context == PM_CONTEXT_ARCHIVE) /* no time control, go it alone */
-	pmTimeStateMode(amode, opts.interval, &opts.origin);
+    else if (opts.context == PM_CONTEXT_ARCHIVE) { /* no time control, go it alone */
+	struct timeval interval, origin;
+
+	timespec2val(&opts.interval, &interval);
+	timespec2val(&opts.origin, &origin);
+	pmTimeStateMode(amode, interval, &origin);
+    }
 
     forever = (opts.samples < 0 || opts.guiflag);
 
@@ -1229,7 +1258,7 @@ main(int argc, char *argv[])
 
     /* wait till time for first sample */
     if (opts.context != PM_CONTEXT_ARCHIVE)
-	__pmtimevalPause(opts.start);
+	__pmtimespecPause(opts.start);
 
     /* main loop fetching and printing sample values */
     while (forever || (opts.samples-- > 0)) {
@@ -1285,7 +1314,7 @@ main(int argc, char *argv[])
 
 	/* wait till time for sample */
 	if (!opts.guiflag && (pauseFlag || opts.context != PM_CONTEXT_ARCHIVE))
-	    __pmtimevalSleep(opts.interval);
+	    __pmtimespecSleep(opts.interval);
 
 	if (havePrev == 0)
 	    continue;	/* keep trying to get the previous sample */
@@ -1333,14 +1362,14 @@ main(int argc, char *argv[])
 	 * discard previous and save current result, so this value
 	 * becomes the previous value at the next iteration
 	 */
-	pmFreeResult(rslt2);
+	pmFreeHighResResult(rslt2);
 	rslt2 = rslt1;
 	idx2 = idx1;
     }
 
     /* make valgrind happy */
     if (rslt2 != NULL)
-	pmFreeResult(rslt2);
+	pmFreeHighResResult(rslt2);
     if (msp != NULL)
 	pmFreeMetricSpec(msp);
 

--- a/src/pmval/pmval.h
+++ b/src/pmval/pmval.h
@@ -1,15 +1,15 @@
 /*
  * pmval - simple performance metrics value dumper
  *
- * Copyright (c) 2014-2015 Red Hat.
+ * Copyright (c) 2014-2015,2022 Red Hat.
  * Copyright (c) 2008-2009 Aconex.  All Rights Reserved.
  * Copyright (c) 1995-2001 Silicon Graphics, Inc.  All Rights Reserved.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation; either version 2 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
  * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
@@ -18,6 +18,7 @@
 #ifndef PMVAL_H
 #define PMVAL_H
 
+#define PMAPI_VERSION 3
 #include "pmapi.h"
 #include "libpcp.h"
 #include "pmtime.h"

--- a/src/python/pmapi.c
+++ b/src/python/pmapi.c
@@ -1494,6 +1494,7 @@ MOD_INIT(cpmapi)
     PyModule_AddObject(module, "pmErrSymDict", edict);
 
     dict_add(dict, "PMAPI_VERSION_2", PMAPI_VERSION_2);
+    dict_add(dict, "PMAPI_VERSION_3", PMAPI_VERSION_3);
     dict_add(dict, "PMAPI_VERSION", PMAPI_VERSION);
 
     dict_add_unsigned(dict, "PM_ID_NULL", PM_ID_NULL);


### PR DESCRIPTION
Provide new APIs to access the v3 log labels start timestamp
in high resolution form, as well as optional zoneinfo field,
in the form of pmGetHighResArchiveLabel(3).  The context end
of archive timestamp is made available in high resolution too
via a new pmGetHighResArchiveEnd routine.

Update the pmGetOptions routine to support a v3 ABI such that
PMAPI client tools can opt-in to working with nanosecond time
throughout.  pmval is converted as a proof of concept.

Resolves https://github.com/performancecopilot/pcp/issues/1372
Resolves https://github.com/performancecopilot/pcp/issues/1374
Resolves https://github.com/performancecopilot/pcp/issues/1377