### PR TITLE
ci: fix pylint and mandoc linter warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -149,11 +149,17 @@ disable=print-statement,
         bad-option-value, # older pylint versions don't recognize options from newer pylint versions
         no-else-continue,
         wrong-import-order,
-	consider-using-with, # Python 2 doesn't support this
-        super-with-arguments, # Python 2 doesn't support this
-        raise-missing-from, # Python 2 doesn't support this
         relative-beyond-top-level,
-        unsubscriptable-object # https://github.com/PyCQA/pylint/issues/3882
+        unsubscriptable-object, # https://github.com/PyCQA/pylint/issues/3882
+        use-implicit-booleaness-not-comparison,
+
+        # Python 2 doesn't support the following code changes
+        # remove these once PCP drops support for Python 2
+        consider-using-with,
+        super-with-arguments,
+        raise-missing-from,
+        consider-using-f-string,
+        unspecified-encoding
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/scripts/man-lint
+++ b/scripts/man-lint
@@ -19,6 +19,7 @@ mandoc -T lint "$@" \
     | grep -v ' UNSUPP: ' \
     | grep -v ' WARNING: missing date' \
     | grep -v ' WARNING: cannot parse date' \
+    | grep -v ' STYLE: input text line longer than 80 bytes' \
 > $tmp/mandoc 2>&1
 
 if test -s $tmp/mandoc

--- a/src/pcp/atop/pcp-atop.1
+++ b/src/pcp/atop/pcp-atop.1
@@ -215,7 +215,8 @@ When
 notices that the daemon is active, it reads these GPU utilization
 counters with every interval.
 .PP
-Find a description about the utilization counters in the section OUTPUT DESCRIPTION.
+Find a description about the utilization counters in the section
+OUTPUT DESCRIPTION.
 .SH INTERACTIVE COMMANDS
 When running
 .B pcp-atop
@@ -712,8 +713,8 @@ A PCP archive can be read and visualized again with the
 .B \-r
 option.
 The argument is a comma-separated list of names, each
-of which may be the base name of an archive or the name of a directory containing
-one or more archives.
+of which may be the base name of an archive or the name of a directory
+containing one or more archives.
 If no argument is specified, the file
 .BI $PCP_LOG_DIR/pmlogger/HOST/YYYYMMDD
 is opened for input (where
@@ -1262,7 +1263,8 @@ When the comma-separated list exceeds
 the width of the column, a hexadecimal value is shown.
 .TP 9
 .B LOCKSZ
-The virtual amount of memory being locked (i.e. non-swappable) by this process (or user).
+The virtual amount of memory being locked (i.e. non-swappable) by this process
+(or user).
 .TP 9
 .B MAJFLT
 The number of page faults issued by this process that have been solved
@@ -2018,8 +2020,8 @@ for further details on activating these metrics.
 .PP
 The semantics of the per-process network statistics deviate slightly from the
 .BR atop (1)
-tool: instead of the number of TCP/UDP packets sent/received (which may be inaccurate
-due to TCP segmentation offload),
+tool: instead of the number of TCP/UDP packets sent/received (which may be
+inaccurate due to TCP segmentation offload),
 .BR pcp-atop
 shows the number of tcp_sendmsg()/udp_sendmsg()/etc. kernel calls per process.
 .SH FILES

--- a/src/pcp/dstat/pcp-dstat.py
+++ b/src/pcp/dstat/pcp-dstat.py
@@ -592,7 +592,7 @@ class DstatTool(object):
         except ConfigParser.Error as cfgerr:
             sys.stderr.write("Config parse failure: %s\n" % cfgerr.message())
             sys.exit(1)
-        except Exception as cfgerr:
+        except Exception:
             sys.stderr.write("Cannot parse configs in %s\n" % paths)
             sys.exit(1)
 

--- a/src/pcp/mpstat/pcp-mpstat.py
+++ b/src/pcp/mpstat/pcp-mpstat.py
@@ -413,7 +413,7 @@ class CpuUtilReporter:
         if self.header_print:
             self.printer("\n%-10s\t%-3s\t%-5s\t%-6s\t%-5s\t%-8s\t%-5s\t%-6s\t%-7s\t%-7s\t%-6s\t%-6s"%("Timestamp","CPU","%usr","%nice","%sys","%iowait","%irq","%soft","%steal","%guest","%nice","%idle"))
             self.header_print = False
-        if self.mpstat_options.cpu_list == "ALL" or self.mpstat_options.cpu_list == "ON":
+        if self.mpstat_options.cpu_list in ("ALL", "ON"):
             self.header_print = True
         if not isinstance(self.mpstat_options.cpu_list, list):
             cpu_util = cpu_utils.get_totalcpu_util()
@@ -555,13 +555,13 @@ class DisplayOptions:
         return self.mpstatoptions.no_options or (self.mpstatoptions.cpu_filter and not self.mpstatoptions.interrupts_filter)
 
     def display_total_cpu_usage(self):
-        return self.mpstatoptions.interrupts_filter and (self.mpstatoptions.interrupt_type == "SUM" or self.mpstatoptions.interrupt_type == "ALL")
+        return self.mpstatoptions.interrupts_filter and self.mpstatoptions.interrupt_type in ("SUM", "ALL")
 
     def display_hard_interrupt_usage(self):
-        return self.mpstatoptions.interrupts_filter and (self.mpstatoptions.interrupt_type == "CPU" or self.mpstatoptions.interrupt_type == "ALL")
+        return self.mpstatoptions.interrupts_filter and self.mpstatoptions.interrupt_type in ("CPU", "ALL")
 
     def display_soft_interrupt_usage(self):
-        return self.mpstatoptions.interrupts_filter and (self.mpstatoptions.interrupt_type == "SCPU" or self.mpstatoptions.interrupt_type == "ALL")
+        return self.mpstatoptions.interrupts_filter and self.mpstatoptions.interrupt_type in ("SCPU", "ALL")
 
 class MpstatReport(pmcc.MetricGroupPrinter):
     Machine_info_count = 0

--- a/src/pcp2influxdb/pcp2influxdb.py
+++ b/src/pcp2influxdb/pcp2influxdb.py
@@ -69,7 +69,7 @@ class Metric(object):
 
     def __init__(self, name):
         self.name = self.sanitize_name(name)
-        self.fields = dict()
+        self.fields = {}
         self.tags = None
         self.ts = None
 

--- a/src/pcp2zabbix/pcp2zabbix.py
+++ b/src/pcp2zabbix/pcp2zabbix.py
@@ -515,7 +515,7 @@ class PCP2Zabbix(object):
         except socket.timeout as err:
             sys.stderr.write("Zabbix connection timed out: %s\n" % str(err))
             return False
-        except KeyboardInterrupt as err:
+        except KeyboardInterrupt:
             sys.exit(1)
         finally:
             zabbix.close()

--- a/src/pmdas/bcc/modules/biotop.python
+++ b/src/pmdas/bcc/modules/biotop.python
@@ -80,7 +80,7 @@ class PCPBCCModule(PCPBCCBase):
         if sort_key[0] == "-":
             sort_key = sort_key[1:]
             self.sort_reversed = True
-        if sort_key not in self.sort_fns.keys():
+        if sort_key not in self.sort_fns:
             raise RuntimeError("Sort key must be one of %s." % ", ".join(self.sort_fns.keys()))
         self.sort_fn = self.sort_fns[sort_key]
 

--- a/src/pmdas/bcc/modules/ucalls.python
+++ b/src/pmdas/bcc/modules/ucalls.python
@@ -89,7 +89,7 @@ class PCPBCCModule(PCPBCCBase):
                 raise RuntimeError("Language must be set when no process found on startup!")
             self.lang = utils.detect_language(self.methods.keys(), self.pid)
             self.log("Language not set, detected: %s." % str(self.lang))
-        if self.lang not in self.methods.keys():
+        if self.lang not in self.methods:
             raise RuntimeError("Language must be one of: %s." % str(self.methods.keys()))
 
         self.log("Initialized.")

--- a/src/pmdas/bcc/modules/ustat.python
+++ b/src/pmdas/bcc/modules/ustat.python
@@ -171,7 +171,7 @@ class PCPBCCModule(PCPBCCBase):
                 raise RuntimeError("Language must be set when no process found on startup!")
             self.lang = utils.detect_language(self.langs.keys(), self.pids[0])
             self.log("Language not set, detected: %s." % str(self.lang))
-        if self.lang not in self.langs.keys():
+        if self.lang not in self.langs:
             raise RuntimeError("Language must be one of: %s." % str(self.langs.keys()))
 
         self.log("Initialized.")

--- a/src/pmdas/lmsensors/pmdalmsensors.python
+++ b/src/pmdas/lmsensors/pmdalmsensors.python
@@ -30,8 +30,8 @@ from pcp.pmda import PMDA, pmdaMetric
 from pcp.pmapi import pmUnits, pmContext as PCP
 import cpmapi as c_api
 
-sensorvalues = dict()   # lookup sensorname -> sensorvalue (temp/fan)
-sensornames = dict()    # lookup sensornumber -> sensorname
+sensorvalues = {}   # lookup sensorname -> sensorvalue (temp/fan)
+sensornames = {}    # lookup sensornumber -> sensorname
 basename = "lmsensors"
 
 def lmsensors_get():

--- a/src/pmdas/mssql/pmdamssql.python
+++ b/src/pmdas/mssql/pmdamssql.python
@@ -1110,16 +1110,16 @@ class MSSQLPMDA(PMDA):
         #self.debug("mssql_refresh", "cluster %d started" % cluster)
         if cluster < 100:   # reserved for os_perf_counter clusters
             self.mssql_refresh_dm_os_perf(cluster)
-        elif cluster in self.dm_io_vfiles_clusters.keys():
+        elif cluster in self.dm_io_vfiles_clusters:
             self.mssql_refresh_dm_values(cluster,
                     self.dm_io_vfiles_clusters, self.dm_io_vfiles_items)
-        elif cluster in self.dm_os_execreq_clusters.keys():
+        elif cluster in self.dm_os_execreq_clusters:
             self.mssql_refresh_dm_values(cluster,
                     self.dm_os_execreq_clusters, self.dm_os_execreq_items)
-        elif cluster in self.dm_os_workers_clusters.keys():
+        elif cluster in self.dm_os_workers_clusters:
             self.mssql_refresh_dm_values(cluster,
                     self.dm_os_workers_clusters, self.dm_os_workers_items)
-        elif cluster in self.dm_os_wait_stats_clusters.keys():
+        elif cluster in self.dm_os_wait_stats_clusters:
             self.mssql_refresh_dm_values(cluster,
                     self.dm_os_wait_stats_clusters, self.dm_os_wait_stats_items)
         #self.debug("mssql_refresh", "cluster %d finished" % cluster)

--- a/src/pmdas/openmetrics/pmdaopenmetrics.python
+++ b/src/pmdas/openmetrics/pmdaopenmetrics.python
@@ -240,7 +240,7 @@ class Metric(object):
             else:
                 self.msem = c_api.PM_SEM_INSTANT
 
-            if ((self.typeline == 'histogram' or self.typeline == 'summary')
+            if (self.typeline in ('histogram', 'summary')
                 and 'count' in pieces): # regardless of UNIT; *_sum peer has proper type
                 self.munits = pmUnits(0, 0, 1, 0, 0, 0) # simple count
             elif self.typeline == 'histogram' and 'bucket' in pieces: # ditto
@@ -1068,7 +1068,7 @@ class OpenMetricsPMDA(PMDA):
 
     def lookup_regex(self, pat):
         ''' cache of compiled regex '''
-        if pat not in self.regex_cache.keys():
+        if pat not in self.regex_cache:
             self.regex_cache[pat] = re.compile(r"%s" % pat)
             self.debug("lookup_regex: added '%s'" % pat) if self.dbg else None
         return self.regex_cache[pat]

--- a/src/pmdas/openvswitch/pmdaopenvswitch.python
+++ b/src/pmdas/openvswitch/pmdaopenvswitch.python
@@ -38,9 +38,9 @@ class OpenvswitchPMDA(PMDA):
         """ (Constructor) Initialisation - register metrics, callbacks, drop privileges """
         PMDA.__init__(self, name, domain)
         self.verbose = False # True for debugging diagnostics
-        self.switch_info_json = dict()
-        self.port_info_json = dict()
-        self.flow_json = dict()
+        self.switch_info_json = {}
+        self.port_info_json = {}
+        self.flow_json = {}
         self.switch_names = []
         self.port_info_names = []
         self.flow_names = []
@@ -141,7 +141,7 @@ class OpenvswitchPMDA(PMDA):
     def get_switch_info_json(self):
         """ Convert the commandline output to json """
         query = ["ovs-vsctl", "--format=json", "list", "bridge"]
-        self.switch_info_json = dict()
+        self.switch_info_json = {}
         self.switch_names = []
 
         try:
@@ -174,7 +174,7 @@ class OpenvswitchPMDA(PMDA):
 
     def get_port_info_json(self):
         """ Convert the commandline output to json """
-        self.port_info_json = dict()
+        self.port_info_json = {}
         self.port_info_names = []
 
         for val in self.switch_names:
@@ -215,7 +215,7 @@ class OpenvswitchPMDA(PMDA):
 
     def get_flow_json(self):
         """ Convert the commandline output to json """
-        self.flow_json = dict()
+        self.flow_json = {}
         self.flow_names = []
 
         for val in self.switch_names:

--- a/src/pmdas/rabbitmq/pmdarabbitmq.python
+++ b/src/pmdas/rabbitmq/pmdarabbitmq.python
@@ -49,7 +49,7 @@ class RabbitmqPMDA(PMDA):
         self.port = DEFAULT_PORT
         self.url = None
         self.queue_names = []
-        self.stats = dict()
+        self.stats = {}
         self.read_config()
         self.build_url()
         self.rabbit_fetch()
@@ -156,7 +156,7 @@ class RabbitmqPMDA(PMDA):
 
     def rabbit_fetch(self):
         """ fetches result from HTTP GET request """
-        self.stats = dict()
+        self.stats = {}
         self.queue_names = []
 
         try:

--- a/src/python/pcp/pmapi.py
+++ b/src/python/pcp/pmapi.py
@@ -2819,6 +2819,7 @@ class fetchgroup(object):
                 vv.append((self.icodes[i],
                            self.inames[i].decode('utf-8') if self.inames[i] else None,
                            # nested lambda for proper i capture
+                           # pylint: disable=cell-var-from-loop
                            (lambda i: (lambda: decode_one(self, i)))(i)))
             return vv
 
@@ -2863,6 +2864,7 @@ class fetchgroup(object):
                 dt = datetime.datetime(ts.tm_year+1900, ts.tm_mon+1, ts.tm_mday,
                                        ts.tm_hour, ts.tm_min, ts.tm_sec, us, None)
                 # nested lambda for proper i capture
+                # pylint: disable=cell-var-from-loop
                 vv.append((dt,
                            (lambda i: (lambda: decode_one(self, i)))(i)))
             return vv

--- a/src/python/pcp/pmconfig.py
+++ b/src/python/pcp/pmconfig.py
@@ -572,13 +572,13 @@ class pmConfig(object):
                 if not inst[0]:
                     inst = ([pmapi.c_api.PM_IN_NULL], [None]) # pmcd.pmie.logfile
             # Reject unsupported types
-            if not (desc.contents.type == pmapi.c_api.PM_TYPE_32 or
-                    desc.contents.type == pmapi.c_api.PM_TYPE_U32 or
-                    desc.contents.type == pmapi.c_api.PM_TYPE_64 or
-                    desc.contents.type == pmapi.c_api.PM_TYPE_U64 or
-                    desc.contents.type == pmapi.c_api.PM_TYPE_FLOAT or
-                    desc.contents.type == pmapi.c_api.PM_TYPE_DOUBLE or
-                    desc.contents.type == pmapi.c_api.PM_TYPE_STRING):
+            if desc.contents.type not in (pmapi.c_api.PM_TYPE_32,
+                                          pmapi.c_api.PM_TYPE_U32,
+                                          pmapi.c_api.PM_TYPE_64,
+                                          pmapi.c_api.PM_TYPE_U64,
+                                          pmapi.c_api.PM_TYPE_FLOAT,
+                                          pmapi.c_api.PM_TYPE_DOUBLE,
+                                          pmapi.c_api.PM_TYPE_STRING):
                 raise pmapi.pmErr(pmapi.c_api.PM_ERR_TYPE)
             instances = self.util.instances if not self._tmp else self._tmp
             if hasattr(self.util, 'omit_flat') and self.util.omit_flat and not inst[1][0]:


### PR DESCRIPTION
Contains a few syntax updates to make the Python code more 'pythonic', otherwise no functional change.