### PR TITLE
pmdabpf: resolve memory leaks, destroy bpf skeleton object at shutdown

### DIFF
--- a/src/pmdas/bpf/.gitignore
+++ b/src/pmdas/bpf/.gitignore
@@ -2,6 +2,7 @@ domain.h
 exports
 pmdabpf
 pmda_bpf.so
+modules/*.skel.h
 modules/*.so
 modules/vmlinux.h
 

--- a/src/pmdas/bpf/modules/biolatency.c
+++ b/src/pmdas/bpf/modules/biolatency.c
@@ -7,6 +7,7 @@
 #define NUM_LATENCY_SLOTS 63
 pmdaInstid biolatency_instances[NUM_LATENCY_SLOTS];
 
+struct biolatency_bpf *bpf_obj;
 int biolatency_fd = -1;
 #define INDOM_COUNT 1
 #define BIOLATENCY_INDOM 0
@@ -81,7 +82,6 @@ void biolatency_register(unsigned int cluster_id, pmdaMetric *metrics, pmdaIndom
 
 int biolatency_init(dict *cfg, char *module_name)
 {
-    struct biolatency_bpf *bpf_obj;
     char errorstring[1024];
     int ret;
 
@@ -120,6 +120,9 @@ void biolatency_shutdown()
     if (biolatency_fd != 0) {
         close(biolatency_fd);
         biolatency_fd = -1;
+    }
+    if (bpf_obj) {
+        biolatency_bpf__destroy(bpf_obj);
     }
 }
 

--- a/src/pmdas/bpf/modules/runqlat.c
+++ b/src/pmdas/bpf/modules/runqlat.c
@@ -7,6 +7,7 @@
 #define NUM_LATENCY_SLOTS 63
 pmdaInstid runqlat_instances[NUM_LATENCY_SLOTS];
 
+struct runqlat_bpf *bpf_obj;
 int runqlat_fd = -1;
 #define INDOM_COUNT 1
 #define RUNQLAT_INDOM 0
@@ -81,7 +82,6 @@ void runqlat_register(unsigned int cluster_id, pmdaMetric *metrics, pmdaIndom *i
 
 int runqlat_init(dict *cfg, char *module_name)
 {
-    struct runqlat_bpf *bpf_obj;
     char errorstring[1024];
     int ret;
 
@@ -120,6 +120,9 @@ void runqlat_shutdown()
     if (runqlat_fd != 0) {
         close(runqlat_fd);
         runqlat_fd = -1;
+    }
+    if (bpf_obj) {
+        runqlat_bpf__destroy(bpf_obj);
     }
 }
 


### PR DESCRIPTION
Every bpf PMDA module gets two parameters passed in the init function: `init(dict *cfg, char *module_name)`
`cfg` is the global configuration object (with contents of `bpf.conf`) and `module_name` is for example `biolatency.so`.

This PR `free`s the configuration object at shutdown, and the `module_name` after calling `init()` of the module.

imho that's inconsistent, and I'm now very happy with it - however, what's an elegant way to keep references to the `module_name` of each module and `free` it in `bpf_shutdown`? One option would be to create a linked list of these pointers, but I'm sure there is a better option ... Maybe just pass the memory allocated by `pmdaCacheStore` to the `init()` function? Doesn't seem very neat either.