### PR TITLE
Fix macosx autoconfig setup

### DIFF
--- a/configure
+++ b/configure
@@ -3315,18 +3315,22 @@ $as_echo "#define IS_DARWIN 1" >>confdefs.h
 
     target_distro=macosx
     version=`sw_vers -productVersion`
-    CFLAGS="-fPIC -no-cpp-precomp -fno-strict-aliasing"
+    CFLAGS="-fPIC -fno-strict-aliasing"
     case "$version"
     in
 	10.0-5.*)
-	    	    ;;
+	    CFLAGS="$CFLAGS -no-cpp-precomp"
+	    ;;
 	10.6-9.*|10.10-3.*)
 	    target_distro=cocoa
-	    CFLAGS="$CFLAGS -arch i386 -arch x86_64"
+	    CFLAGS="$CFLAGS -no-cpp-precomp -arch i386 -arch x86_64"
+	    ;;
+	11.*|12.*)
+	    target_distro=cocoa
 	    ;;
 	*)
-	    	    target_distro=cocoa
-	    CFLAGS="$CFLAGS -arch x86_64"
+	    target_distro=cocoa
+	    CFLAGS="$CFLAGS -no-cpp-precomp -arch x86_64"
 	    ;;
     esac
     export CFLAGS


### PR DESCRIPTION
- introduces extra handling for macosx 11.* and 12.*.  Old configure script has a setting which assumes x86 for all systems and uses "-arch x86_64" for the compiler - that's no longer true as 11.* and later also support aarch64/Apple silicon
- Current gcc from brew (the most common mac os x package system for opensource soft) has a GCC-11 build which does not know "-no-cpp-precomp", so with this fix we do not use -no-cpp-precomp on 11.* and 12.*

Note: this is not fixing PCP build on current Mac OS X/apple silicon completely, but it's a required piece in the right direction.