### PR TITLE
chore: fix pylint errors

### DIFF
--- a/src/pcp/dstat/pcp-dstat.py
+++ b/src/pcp/dstat/pcp-dstat.py
@@ -535,11 +535,11 @@ class DstatTool(object):
 
         ### Empty ansi and theme databases when colors not in use
         if not self.color:
-            for key in COLOR:
+            for key in list(COLOR.keys()):
                 COLOR[key] = ''
-            for key in THEME:
+            for key in list(THEME.keys()):
                 THEME[key] = ''
-            for key in ANSI:
+            for key in list(ANSI.keys()):
                 ANSI[key] = ''
             THEME['colors_hi'] = (ANSI['default'],)
             THEME['colors_lo'] = (ANSI['default'],)

--- a/src/pmdas/elasticsearch/pmdaelasticsearch.python
+++ b/src/pmdas/elasticsearch/pmdaelasticsearch.python
@@ -96,13 +96,12 @@ class ElasticsearchPMDA(PMDA):
 
         if not _is_pmda_setup():
             try:
-                connection = self.baseurl
                 self.request = _setup_urllib(self.baseurl, self.auth, self.password)
                 request = self.request.urlopen(self.baseurl)
                 request.read()
                 request.close()
             except (BaseException, Exception):
-                self.log(f"Failed Elasticsearch connection attempt at {connection}")
+                self.log(f"Failed Elasticsearch connection attempt at {self.baseurl}")
 
         # metrics setup
         self.cluster_indom = PM_INDOM_NULL

--- a/src/pmdas/haproxy/pmdahaproxy.python
+++ b/src/pmdas/haproxy/pmdahaproxy.python
@@ -68,6 +68,7 @@ class HAProxyPMDA(PMDA):
         self.set_user(self.user)
 
         self.connect_pmcd()
+        conn = ""
         try:
             if not self.url:
                 conn = self.skt
@@ -307,6 +308,7 @@ class HAProxyPMDA(PMDA):
 
     def haproxy_refresh(self, cluster):
         """ Refresh """
+        conn = ""
         try:
             if not self.url:
                 conn = self.skt

--- a/src/python/pcp/pmconfig.py
+++ b/src/python/pcp/pmconfig.py
@@ -587,6 +587,7 @@ class pmConfig(object):
                 found = [[], []]
                 for r in instances:
                     hit = False
+                    msg = ""
                     try:
                         if r.isdigit():
                             msg = "Invalid instance"
@@ -685,9 +686,9 @@ class pmConfig(object):
 
     def validate_common_options(self):
         """ Validate common utility options """
+        err = "Integer expected"
+        attr = "unknown"
         try:
-            err = "Integer expected"
-            attr = "unknown"
             if hasattr(self.util, 'rank') and self.util.rank:
                 attr = 'rank'
                 self.util.rank = int(self.util.rank)
@@ -751,6 +752,7 @@ class pmConfig(object):
                         sys.exit(1)
                 else:
                     err = ""
+                    expr = ""
                     try:
                         name, expr = derived.split("=", 1)
                         self.util.context.pmLookupName(name.strip())
@@ -761,8 +763,8 @@ class pmConfig(object):
                             try:
                                 self.util.context.pmRegisterDerived(name.strip(), expr.strip())
                                 continue
-                            except pmapi.pmErr as error:
-                                err = error.message()
+                            except pmapi.pmErr as error2:
+                                err = error2.message()
                     except ValueError as error:
                         err = "Invalid syntax (expected metric=expression)"
                     except Exception as error:
@@ -797,8 +799,8 @@ class pmConfig(object):
                     ignore = False
                     try:
                         self.util.context.pmLookupName(metric)
-                    except pmapi.pmErr as error:
-                        if error.args[0] != pmapi.c_api.PM_ERR_NAME:
+                    except pmapi.pmErr as error2:
+                        if error2.args[0] != pmapi.c_api.PM_ERR_NAME:
                             raise
                         if self.ignore_unknown_metrics() and metric in self._conf_metrics:
                             ignore = True


### PR DESCRIPTION
a couple of minor Python fixes:

* don't modify the dict while iterating over it
* variables should be declared before the try/except block; in the `except` block, don't access variables declared in the `try` block
* don't shadow the `error` variable when nesting try/except blocks