### PR TITLE
libpcp_web: break recursion and let libuv process the I/O queue when …

### DIFF
--- a/src/libpcp_web/src/load.c
+++ b/src/libpcp_web/src/load.c
@@ -553,8 +553,10 @@ server_cache_update_done(void *arg)
     context->count++;
     context->done = NULL;
 
-    /* begin processing of the next record if any */
-    server_cache_window(baton);
+    /* schedule processing of the next record (if any) after 5ms,
+     * to break the recursion and let libuv process pending Redis I/O callbacks
+     */
+    libuv_set_timeout(uv_default_loop(), server_cache_window, baton, 5);
 }
 
 void

--- a/src/libpcp_web/src/util.h
+++ b/src/libpcp_web/src/util.h
@@ -123,4 +123,9 @@ extern void pmwebapi_release_value(int, pmAtomValue *);
 #define moduleinfo(module, level, msg, data)	\
 	((module)->on_info((level), (msg), (data)), sdsfree(msg))
 
+
+/* general purpose libuv utility functions */
+typedef void (*libuv_set_timeout_callback_t)(void *arg);
+extern void libuv_set_timeout(uv_loop_t *, libuv_set_timeout_callback_t, void *, uint64_t);
+
 #endif	/* SERIES_UTIL_H */


### PR DESCRIPTION
…loading archives into Redis

Previously, the following recursion occured when loading archives into
Redis (e.g. using pmseries --load):

    [...]
    server_cache_window
    server_cache_update_done
    doneSeriesGetContext
    series_cache_update
    server_cache_window

The recursion does end when the archive was read entirely, however
the call stack could grew too large, resulting in a segmentation fault.

This commit breaks the recursion by scheduling server_cache_window() to
run on the next libuv loop iteration, after 5ms. 5ms was choosen so that
libuv can process pending (Redis) I/O callbacks.

This change also keeps the memory usage at about 130 MB, where
previously I saw RSS values of 10 GB+ due to queued Redis requests.