### PR TITLE
pmdabpf: check libbpf version before running any qa

### DIFF
--- a/qa/1931
+++ b/qa/1931
@@ -12,6 +12,7 @@ echo "QA output created by $seq"
 
 _pmdabpf_check
 _pmdabpf_require_kernel_version 5 0
+_pmdabpf_require_libbpf_version 0 7
 
 status=1       # failure is the default!
 signal=$PCP_BINADM_DIR/pmsignal

--- a/qa/common.bpf
+++ b/qa/common.bpf
@@ -23,6 +23,16 @@ _pmdabpf_require_kernel_version()
     _notrun "this test requires kernel $1.$2+"
 }
 
+_pmdabpf_require_libbpf_version()
+{
+    LIBBPF_VERSION=false
+    eval `sed -n <$PCP_INC_DIR/builddefs -e '/LIBBPF_VERSION/s/ //gp'`
+
+    echo $LIBBPF_VERSION \
+    | awk -F. -v major=$1 -v minor=$2 '$1 < major || ($1 == major && $2 < minor) {exit 1}' || \
+    _notrun "this test requires libbpf $1.$2+"
+}
+
 _pmdabpf_install_filter()
 {
     # ignore warnings because PMDA might not be ready yet


### PR DESCRIPTION
Fixes: 2d9476cb0 ("qa/1931: pmdabpf: execsnoop")