### PR TITLE
libpcp_import: support for an archive-append mode

### DIFF
--- a/man/man3/pmistart.3
+++ b/man/man3/pmistart.3
@@ -23,7 +23,7 @@
 .br
 #include <pcp/import.h>
 .sp
-int pmiStart(const char *\fIarchive\fP, int \fIinherit\fP);
+int pmiStart(const char *\fIarchive\fP, int \fIflags\fP);
 .sp
 cc ... \-lpcp_import \-lpcp
 .ft 1
@@ -31,7 +31,7 @@ cc ... \-lpcp_import \-lpcp
 .ft 3
 use PCP::LogImport;
 .sp
-pmiStart($\fIarchive\fP, $\fIinherit\fP);
+pmiStart($\fIarchive\fP, $\fIflags\fP);
 .ft 1
 .SH DESCRIPTION
 As part of the Performance Co-Pilot Log Import API (see
@@ -81,8 +81,19 @@ or
 .BR pmPutValuehandle (3).
 .PP
 If
-.I inherit
-is true, then the new context will inherit any and all
+.I flags
+contains PMI_FLAG_APPEND, then the new context will be created so as to
+append metadata (metrics, instance domains, instances, labels), temporal
+index entries and values to the specified
+.IR archive ,
+if it exists.
+If the
+.I archive
+does not exist then the behaviour is the same as without this flag.
+.PP
+If
+.I flags
+contains PMI_FLAG_INHERIT, then the new context will inherit any and all
 metadata (metrics, instance domains, instances and handles) from the current
 context, otherwise the new context is created with no metadata.
 The basename for the output PCP archive, the source hostname, the
@@ -93,7 +104,7 @@ If this is the first call to
 .B pmiStart
 the metadata will be empty
 independent of the value of
-.IR inherit .
+.IR flags .
 .PP
 Since no physical files for the output PCP archive
 will be created until the first call to

--- a/src/include/pcp/import.h
+++ b/src/include/pcp/import.h
@@ -29,6 +29,9 @@ extern "C" {
 # endif
 #endif
 
+#define PMI_FLAG_INHERIT	0x1	/* pmiStart inherits an existing context */
+#define PMI_FLAG_APPEND		0x2	/* pmiStart appends to existing archive */
+
 /* core libpcp_import API routines */
 PMI_CALL extern int pmiStart(const char *, int);
 PMI_CALL extern int pmiUseContext(int);

--- a/src/libpcp/src/exports.in
+++ b/src/libpcp/src/exports.in
@@ -832,6 +832,7 @@ PCP_3.37 {
     __pmGetTimestamp;
     __pmLogWriteMark;
     __pmLogFeaturesStr;
+    __pmLogLoadIndex;
     __pmLogLoadLabelSet;
     __pmLogPutResult3;
     __pmLogSearchInDom;

--- a/src/libpcp/src/logutil.c
+++ b/src/libpcp/src/logutil.c
@@ -162,7 +162,7 @@ _logpeek(__pmArchCtl *acp, int vol)
     pmsprintf(fname, sizeof(fname), "%s.%d", lcp->name, vol);
     /* need mutual exclusion here to avoid race with a concurrent uncompress */
     PM_LOCK(logutil_lock);
-    if ((f = __pmFopen(fname, "r")) == NULL) {
+    if ((f = __pmFopen(fname, "r+")) == NULL) {
 	PM_UNLOCK(logutil_lock);
 	return f;
     }
@@ -196,7 +196,7 @@ __pmLogChangeVol(__pmArchCtl *acp, int vol)
     pmsprintf(fname, sizeof(fname), "%s.%d", lcp->name, vol);
     /* need mutual exclusion here to avoid race with a concurrent uncompress */
     PM_LOCK(logutil_lock);
-    if ((acp->ac_mfp = __pmFopen(fname, "r")) == NULL) {
+    if ((acp->ac_mfp = __pmFopen(fname, "r+")) == NULL) {
 	PM_UNLOCK(logutil_lock);
 	return -oserror();
     }
@@ -717,14 +717,14 @@ __pmLogFindOpen(__pmArchCtl *acp, const char *name)
 	    tp = &direntp->d_name[blen+1];
 	    if (strcmp(tp, "index") == 0) {
 		exists = 1;
-		if ((lcp->tifp = __pmFopen(filename, "r")) == NULL) {
+		if ((lcp->tifp = __pmFopen(filename, "r+")) == NULL) {
 		    sts = -oserror();
 		    goto cleanup;
 		}
 	    }
 	    else if (strcmp(tp, "meta") == 0) {
 		exists = 1;
-		if ((lcp->mdfp = __pmFopen(filename, "r")) == NULL) {
+		if ((lcp->mdfp = __pmFopen(filename, "r+")) == NULL) {
 		    sts = -oserror();
 		    goto cleanup;
 		}

--- a/src/libpcp_import/src/private.h
+++ b/src/libpcp_import/src/private.h
@@ -71,6 +71,7 @@ typedef struct {
     pmi_label		*label;
     int			last_sts;
     __pmTimestamp	last_stamp;
+    unsigned int	flags;
 } pmi_context;
 
 #define CONTEXT_START	1
@@ -85,6 +86,7 @@ typedef struct {
 
 extern int _pmi_stuff_value(pmi_context *, pmi_handle *, const char *) _PMI_HIDDEN;
 extern int _pmi_put_result(pmi_context *, __pmResult *) _PMI_HIDDEN;
+extern int _pmi_put_mark(pmi_context *, __pmTimestamp *) _PMI_HIDDEN;
 extern int _pmi_put_text(pmi_context *) _PMI_HIDDEN;
 extern int _pmi_put_label(pmi_context *) _PMI_HIDDEN;
 extern int _pmi_end(pmi_context *) _PMI_HIDDEN;


### PR DESCRIPTION
In order to implement sysstat/sar semantics, where an
archive is appended to by short-lived processes - and
not by a long-running process ala pmlogger - we're in
need of an append-mode from the LOGIMPORT(3) API.

This is a prototype of the sorts of changes I believe
we'll need.  I've updated just the one QA test utility
to exercise it at this stage and the rest will follow
once we've settled on appropriate APIs.