### PR TITLE
pmlogger_farm: add default configuration file for farm loggers

### DIFF
--- a/src/pmlogger/GNUmakefile
+++ b/src/pmlogger/GNUmakefile
@@ -45,6 +45,7 @@ install:: $(SUBDIRS)
 
 install:: default
 	$(INSTALL) -m 775 -o $(PCP_USER) -g $(PCP_GROUP) -d $(PCP_VAR_DIR)/config/pmlogger
+	$(INSTALL) -m 644 pmlogger_farm.defaults $(PCP_SYSCONFIG_DIR)/pmlogger_farm
 	$(INSTALL) -m 644 pmlogger.defaults $(PCP_SYSCONFIG_DIR)/pmlogger
 	$(INSTALL) -m 755 -d $(PCP_SHARE_DIR)/zeroconf
 	$(INSTALL) -m 644 pmlogger.zeroconf $(PCP_SHARE_DIR)/zeroconf/pmlogger

--- a/src/pmlogger/pmlogger_check.sh
+++ b/src/pmlogger/pmlogger_check.sh
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Copyright (c) 2013-2016,2018,2020-2021 Red Hat.
+# Copyright (c) 2013-2016,2018,2020-2022 Red Hat.
 # Copyright (c) 1995-2000,2003 Silicon Graphics, Inc.  All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 PMLOGGER="$PCP_BINADM_DIR/pmlogger"
 PMLOGCONF="$PCP_BINADM_DIR/pmlogconf"
 PMLOGGERENVS="$PCP_SYSCONFIG_DIR/pmlogger"
+PMLOGGERFARMENVS="$PCP_SYSCONFIG_DIR/pmlogger_farm"
 PMLOGGERZEROCONFENVS="$PCP_SHARE_DIR/zeroconf/pmlogger"
 
 # error messages should go to stderr, not the GUI notifiers
@@ -1003,8 +1004,8 @@ END				{ print m }'`
 		    continue
 		fi
 	    else
+		envs=`grep -h ^PMLOGGER "$PMLOGGERFARMENVS" 2>/dev/null`
 		args="-h $host $args"
-		envs=""
 		iam=""
 	    fi
 

--- a/src/pmlogger/pmlogger_farm.defaults
+++ b/src/pmlogger/pmlogger_farm.defaults
@@ -1,9 +1,7 @@
-# Environment variables for the primary pmlogger daemon.  See also
-# the pmlogger control file and pmlogconf(1) for additional details.
-# Also see separate pmlogger_farm configuration for the non-primary
-# logger configuration settings, separate to this file.
-# Settings defined in this file will override any settings in the
-# pmlogger zeroconf file (if present).
+# Environment variables for the pmlogger farm daemons.  See also
+# pmlogger control file(s) and pmlogconf(1) for additional details.
+# Also see separate pmlogger configuration for the primary logger
+# configuration settings, separate to this file.
 
 # Behaviour regarding listening on external-facing interfaces;
 # unset PMLOGGER_LOCAL to allow connections from remote hosts.


### PR DESCRIPTION
Provide a mechanism whereby the farm loggers can be configured.
There has been reluctance in the past to sharing configuration
of the local primary logger, so these are now done separately.
Makes sense to me as the primary pmlogger may need to use more
frequent sampling, may not want to allow remote pmlc, etc.

Resolves Red Hat BZ #2101574