### PR TITLE
ci: unset XDG_RUNTIME_DIR when invoking podman

### DIFF
--- a/build/ci/ci-run.py
+++ b/build/ci/ci-run.py
@@ -122,7 +122,7 @@ class ContainerRunner:
                 k, v = line.rstrip().split("=")
                 if k == "NAME":
                     if v == '"Ubuntu"':
-                        self.sudo = ["sudo", "-E"]
+                        self.sudo = ["sudo", "-E", "XDG_RUNTIME_DIR="]
                         self.security_opts = ["--security-opt", "label=disable"]
                     break
 


### PR DESCRIPTION
Fixes the following error in the GitHub Action VM:

    error running container: error from /usr/bin/crun creating container for [/bin/sh -c dnf install -y systemd sudo glibc-langpack-en]: sd-bus call: Connection reset by peer

https://github.community/t/error-running-container-error-from-usr-bin-crun-creating-container-for-bin-sh-c-dnf-update-y-nobest-sd-bus-call-connection-reset-by-peer-1994/261522
https://github.com/containers/buildah/issues/3887