### PR TITLE
libpcp_web: run pmFetchArchive() in a worker thread

### DIFF
--- a/src/include/pcp/pmapi.h
+++ b/src/include/pcp/pmapi.h
@@ -559,6 +559,7 @@ PCP_CALL extern int pmHighResFetch(int, pmID *, pmHighResResult **);
  * Variant that is used to return a result from an archive.
  */
 PCP_CALL extern int pmFetchArchive(pmResult **);
+PCP_CALL extern int pmFetchArchiveCtx(int, pmResult **);
 PCP_CALL extern int pmFetchHighResArchive(pmHighResResult **);
 
 /*

--- a/src/libpcp/src/exports.in
+++ b/src/libpcp/src/exports.in
@@ -842,4 +842,5 @@ PCP_3.37 {
     __pmFreeLogInDom;
     __pmLogEncodeLabels;
     __pmDumpStackInit;
+    pmFetchArchiveCtx;
 } PCP_3.36;


### PR DESCRIPTION
Run pmFetchArchive() in a worker thread instead of the main thread because it uses blocking (synchronous) I/O calls.

This way the libuv loop does not get blocked, and queued Redis requests can be sent out while the worker thread is reading PCP archives. As a side effect, this also breaks the recursion as mentioned in #1605.

I think this is a better solution than #1605 for the same problem. It wasn't actually much new code, mainly moving existing code around. On my system, with pcp-zeroconf (10s logging interval) it takes about 1:30 minutes to load one archive (i.e. one day of metrics) into Redis (ignoring the proc.* metrics, as done in #1632). Without this commit, it segfaults due to the recursion, as mentioned in #1605 (it does work with archives in the `qa` directory though, afaics they are too small to reproduce the issue).

Overall I think about 1:30 minutes for importing one day of metrics is still a bit much (around 10 minutes for a week of metrics), but it's a start.

fyi: The diff looks a bit convoluted, basically I splitted this code from `server_cache_window()`: https://github.com/performancecopilot/pcp/blob/362ca7bb68bbaddba3d76ddeaca515e87554fd0a/src/libpcp_web/src/load.c#L580-L602 and moved `pmFetchArchive()` to `fetch_archive()` (running on the worker thread) and the conditional to `fetch_archive_done` (running on the main thread). Because `pmFetchArchive()` uses a thread-local variable (the context), I had to create a new function `pmFetchArchiveCtx` which accepts a context handle.