### PR TITLE
pmclient: remove reliance on libpcp.h for timed sleep

### DIFF
--- a/qa/1936
+++ b/qa/1936
@@ -1,0 +1,34 @@
+#!/bin/sh
+# PCP QA Test No. 1936
+# Verify that no use of libpcp.h exists in installed code.
+#
+# Copyright (c) 2022 Red Hat.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=0	# success is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+# real QA test starts here
+echo Silence is golden
+for dir in $PCP_SHARE_DIR $PCP_DEMOS_DIR $PCP_PMDAS_DIR
+do
+    grep -r '^#include .*libpcp.h' $dir 2>/dev/null
+done
+
+# success, all done
+exit

--- a/qa/1936.out
+++ b/qa/1936.out
@@ -1,0 +1,2 @@
+QA output created by 1936
+Silence is golden

--- a/qa/group
+++ b/qa/group
@@ -2030,6 +2030,7 @@ x11
 1914 atop local
 1927 pmda.sockets local
 1931 pmda.bpf local
+1936 other local pmclient
 1937 pmlogrewrite pmda.xfs local pmdumplog
 1955 libpcp pmda pmda.pmcd local
 1956 pmda.linux pmcd local

--- a/src/pmdas/mmv/mmvdump.c
+++ b/src/pmdas/mmv/mmvdump.c
@@ -17,7 +17,6 @@
 #include <pcp/pmapi.h>
 #include <pcp/mmv_stats.h>
 #include <pcp/mmv_dev.h>
-#include <pcp/libpcp.h>
 #include <inttypes.h>
 #include <sys/stat.h>
 #include <strings.h>
@@ -696,7 +695,10 @@ dump(const char *file, void *addr, size_t size)
     return sts;
 }
 
-int 
+/* directly access libpcp internal mmap wrapper for portability */
+extern void *__pmMemoryMap(int, size_t, int);
+
+int
 main(int argc, char **argv)
 {
     int fd;


### PR DESCRIPTION
Since the pmclient implementations are shipped as demo
programs, we shouldn't be making any use of libpcp.h -
this is unavailable via /usr/include/pcp for 3rd party
code.  Providing a local timeval_sleep routine gets us
there as this was the only double-underscore API being
used.