### PR TITLE
pmseries: fix assumption that any 40-character string is a SID

### DIFF
--- a/qa/1211
+++ b/qa/1211
@@ -2,7 +2,7 @@
 # PCP QA Test No. 1211
 # Exercise basic pmseries loading and querying.
 #
-# Copyright (c) 2018-2019 Red Hat.
+# Copyright (c) 2018-2019,2022 Red Hat.
 #
 
 seq=`basename $0`
@@ -127,6 +127,10 @@ echo
 
 echo "Perform simple label-based query ..."
 pmseries $options 'kernel.all.load{hostname:"bozo-laptop"}' | LC_COLLATE=POSIX sort
+echo
+
+echo "Perform 40-character non-SeriesID query ..."
+pmseries $options 'kernel.all.load{hostname: "bozo-laptop"}' | LC_COLLATE=POSIX sort
 echo
 
 echo "Perform simple instance-based query ..."

--- a/qa/1211.out
+++ b/qa/1211.out
@@ -303,6 +303,9 @@ d51624d12da45900bfee2fd73f1e23f3ccabb784
 Perform simple label-based query ...
 fecd5a4b4c6e1273eaa001287a6dd57b7bbd19f7
 
+Perform 40-character non-SeriesID query ...
+fecd5a4b4c6e1273eaa001287a6dd57b7bbd19f7
+
 Perform simple instance-based query ...
 fecd5a4b4c6e1273eaa001287a6dd57b7bbd19f7
 

--- a/src/pmseries/pmseries.c
+++ b/src/pmseries/pmseries.c
@@ -13,6 +13,7 @@
  */
 
 #include "pmwebapi.h"
+#include <ctype.h>
 #include <uv.h>
 
 typedef enum series_flags {
@@ -1126,6 +1127,22 @@ pmseries_overrides(int opt, pmOptions *opts)
     return 0;
 }
 
+static int
+issid(const char *string)
+{
+    const char *s;
+
+    if (strlen(string) != 40)
+	return 0;
+
+    for (s = string; *s != '\0'; s++) {
+	if (isdigit(*s) || (*s >= 'a' && *s <= 'f'))
+	    continue;
+	return 0;
+    }
+    return 1;
+}
+
 static pmLongOptions longopts[] = {
     PMAPI_OPTIONS_HEADER("Connection Options"),
     { "config", 1, 'c', "FILE", "configuration file path"},
@@ -1344,7 +1361,7 @@ main(int argc, char *argv[])
         !(flags & (PMSERIES_OPT_SOURCE | PMSERIES_OPT_VALUES)) &&
 	!(flags & (PMSERIES_NEED_DESCS | PMSERIES_NEED_INSTS))) {
 	for (c = opts.optind; c < argc; c++) {
-	    if (strlen(argv[c]) != 40)
+	    if (!issid(argv[c]))
 		break;
 	}
 	if (c != argc || opts.optind == argc)


### PR DESCRIPTION
Tighten the checks around what makes up a series identifier,
so that we don't misclassify legitimate queries as SIDs.

Related to https://github.com/performancecopilot/pcp/pull/1638