### PR TITLE
pmdabpf: fix persistence of indom and cluster identifiers

### DIFF
--- a/qa/1900.out
+++ b/qa/1900.out
@@ -11,14 +11,14 @@ Check bpf metrics have appeared ... X metrics and X values
 == Running pmdabpf with valgrind
 === std out ===
 
-bpf.disk.all.latency PMID: 157.0.0 [Disk latency]
-    Data Type: 64-bit unsigned int  InDom: 157.0 0x27400000
+bpf.disk.all.latency PMID: 157.1.0 [Disk latency]
+    Data Type: 64-bit unsigned int  InDom: 157.3 0x27400003
     Semantics: counter  Units: microsec
 Help:
 Disk latency histogram across all disks, for both reads and writes.
 
-bpf.runq.latency PMID: 157.1.0 [Run queue latency (ns)]
-    Data Type: 64-bit unsigned int  InDom: 157.1 0x27400001
+bpf.runq.latency PMID: 157.0.0 [Run queue latency (ns)]
+    Data Type: 64-bit unsigned int  InDom: 157.2 0x27400002
     Semantics: counter  Units: nanosec
 Help:
 Run queue latency from task switches,

--- a/qa/common.bpf
+++ b/qa/common.bpf
@@ -55,6 +55,13 @@ _pmdabpf_install()
     echo "pmdabpf config:" >> $here/$seq.full
     cat $tmp.config >> $here/$seq.full
 
+    # set aside any pre-existing cluster and indom caches
+    __indomcache="$PCP_VAR_DIR/pmdas/config"
+    [ -f $__indomcache/157.0 ] && \
+    $sudo mv $__indomcache/157.0 $__indomcache/157.0.$seq
+    [ -f $__indomcache/157.1 ] && \
+    $sudo mv $__indomcache/157.1 $__indomcache/157.1.$seq
+
     [ -f $PCP_PMDAS_DIR/bpf/bpf.conf ] && \
     $sudo cp $PCP_PMDAS_DIR/bpf/bpf.conf $PCP_PMDAS_DIR/bpf/bpf.conf.$seq
     $sudo cp $tmp.config $PCP_PMDAS_DIR/bpf/bpf.conf
@@ -160,12 +167,19 @@ _pmdabpf_remove()
 _pmdabpf_cleanup()
 {
     cat $PCP_LOG_DIR/pmcd/bpf.log >> $here/$seq.full
+    # restore any pre-existing BPF configuration file
     if [ -f $PCP_PMDAS_DIR/bpf/bpf.conf.$seq ]; then
         $sudo cp $PCP_PMDAS_DIR/bpf/bpf.conf.$seq $PCP_PMDAS_DIR/bpf/bpf.conf
         $sudo rm $PCP_PMDAS_DIR/bpf/bpf.conf.$seq
     else
         $sudo rm -f $PCP_PMDAS_DIR/bpf/bpf.conf
     fi
+    # restore any pre-existing cluster and indom caches
+    __indomcache="$PCP_VAR_DIR/pmdas/config"
+    [ -f $__indomcache/157.0.$seq ] && \
+    $sudo mv $__indomcache/157.0.$seq $__indomcache/157.0
+    [ -f $__indomcache/157.1.$seq ] && \
+    $sudo mv $__indomcache/157.1.$seq $__indomcache/157.1
     # note: _restore_auto_restart pmcd done in _cleanup_pmda()
     _cleanup_pmda bpf
 }


### PR DESCRIPTION
Resolves problems in the way the cluster and indom cache
(pmdaCache) operations were being used.  Firstly, due to
a mix up in the first parameter passed to the interfaces
used for persistence we were not actually persisting the
cluster/indom identifiers, despite best intentions to do
so.

Second, we must reserve the first two indom identifiers
(0 and 1) for the internal cache indoms - guarantee this
now through force-setting this before loading anything.

Finally, the QA tests were susceptible to indeterminism
in the situation where an existing setup has persisted
different BPF script identifiers to those used by tests.