### PR TITLE
Conditional perl builds

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -2996,8 +2996,6 @@ PCP_SA_DIR=@pcp_sa_dir@
 
 %files pmda-dbping -f pcp-pmda-dbping-files.rpm
 
-%files pmda-denki -f pcp-pmda-denki-files.rpm
-
 %files pmda-ds389log -f pcp-pmda-ds389log-files.rpm
 
 %files pmda-ds389 -f pcp-pmda-ds389-files.rpm
@@ -3026,6 +3024,8 @@ PCP_SA_DIR=@pcp_sa_dir@
 
 %files pmda-zimbra -f pcp-pmda-zimbra-files.rpm
 %endif
+
+%files pmda-denki -f pcp-pmda-denki-files.rpm
 
 %files pmda-docker -f pcp-pmda-docker-files.rpm
 

--- a/configure
+++ b/configure
@@ -892,7 +892,6 @@ PMDA_MONGODB
 PMDA_MYSQL
 PMDA_SNMP
 have_perl
-enable_perl
 pcp_perl_prog
 PERL
 PMDA_BPFTRACE
@@ -9415,11 +9414,9 @@ done
 
 
 
-enable_perl=false
 if test "x$do_perl" != "xno"
 then :
 
-    enable_perl=true
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for any perl version" >&5
 printf %s "checking for any perl version... " >&6; }
     if test "$cross_compiling" = "yes"; then
@@ -9436,10 +9433,25 @@ printf %s "checking for any perl version... " >&6; }
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $pcp_perl_prog" >&5
 printf "%s\n" "$pcp_perl_prog" >&6; }
 
+        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if ExtUtils::MakeMaker is installed" >&5
+printf %s "checking if ExtUtils::MakeMaker is installed... " >&6; }
+    if test "$have_perl" = true
+    then
+        $pcp_perl_prog -e "use ExtUtils::MakeMaker" 2>/dev/null
+        if test $? -eq 0
+        then
+	    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result:  yes" >&5
+printf "%s\n" " yes" >&6; }
+        else
+	    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result:  no" >&5
+printf "%s\n" " no" >&6; }
+	    have_perl=false
+        fi
+    fi
+
 else $as_nop
   have_perl=false
 fi
-
 
 
 
@@ -10834,29 +10846,6 @@ fi
 fi
 pod2man=$POD2MAN
 
-
-if test "$enable_perl" != "false"
-then :
-
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if ExtUtils::MakeMaker is installed" >&5
-printf %s "checking if ExtUtils::MakeMaker is installed... " >&6; }
-    perl -e "use ExtUtils::MakeMaker" 2>/dev/null
-    if test $? -eq 0
-    then
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result:  yes" >&5
-printf "%s\n" " yes" >&6; }
-    else
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result:  no" >&5
-printf "%s\n" " no" >&6; }
-	echo
-	echo "FATAL ERROR: Perl ExtUtils::MakeMaker module missing."
-	echo "You can either install this from your distribution, or"
-	echo "download from CPAN (Comprehensive Perl Archive Network)."
-	rm -rf conftest conftest.*
-	exit 1
-    fi
-
-fi
 
 # Extract the first word of "true", so it can be a program name with args.
 set dummy true; ac_word=$2

--- a/configure.ac
+++ b/configure.ac
@@ -1305,9 +1305,7 @@ dnl check if perl available for the build and runtime
 AC_CHECK_PROGS(PERL, perl)
 AC_SUBST(PERL)
 
-enable_perl=false
 AS_IF([test "x$do_perl" != "xno"], [
-    enable_perl=true
     AC_MSG_CHECKING([for any perl version])
     if test "$cross_compiling" = "yes"; then
         ans=$have_perl
@@ -1321,9 +1319,22 @@ AS_IF([test "x$do_perl" != "xno"], [
         have_perl=false
     fi
     AC_MSG_RESULT($pcp_perl_prog)
+
+    dnl extra check for the Perl MakeMaker package for building modules
+    AC_MSG_CHECKING([if ExtUtils::MakeMaker is installed])
+    if test "$have_perl" = true
+    then
+        $pcp_perl_prog -e "use ExtUtils::MakeMaker" 2>/dev/null
+        if test $? -eq 0
+        then
+	    AC_MSG_RESULT([ yes])
+        else
+	    AC_MSG_RESULT([ no])
+	    have_perl=false
+        fi
+    fi
 ], [have_perl=false])
 AC_SUBST(pcp_perl_prog)
-AC_SUBST(enable_perl)
 AC_SUBST(have_perl)
 
 AC_MSG_CHECKING([if the SNMP PMDA should be included])
@@ -1829,24 +1840,6 @@ if test -z "$POD2MAN"; then
 fi
 pod2man=$POD2MAN
 AC_SUBST(pod2man)
-
-dnl extra check for the Perl MakeMaker package
-AS_IF([test "$enable_perl" != "false"], [
-    AC_MSG_CHECKING([if ExtUtils::MakeMaker is installed])
-    perl -e "use ExtUtils::MakeMaker" 2>/dev/null
-    if test $? -eq 0
-    then
-	AC_MSG_RESULT([ yes])
-    else
-	AC_MSG_RESULT([ no])
-	echo
-	echo "FATAL ERROR: Perl ExtUtils::MakeMaker module missing."
-	echo "You can either install this from your distribution, or"
-	echo "download from CPAN (Comprehensive Perl Archive Network)."
-	rm -rf conftest conftest.*
-	exit 1
-    fi
-])
 
 AC_PATH_PROG(TRUEPROG, true)
 

--- a/src/ganglia2pcp/GNUmakefile
+++ b/src/ganglia2pcp/GNUmakefile
@@ -21,7 +21,9 @@ default:
 include $(BUILDRULES)
 
 install: default
+ifeq "$(HAVE_PERL)" "true"
 	$(INSTALL) -m 755 ganglia2pcp $(PCP_BIN_DIR)/ganglia2pcp
+endif
 
 default_pcp : default
 

--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -266,7 +266,6 @@ ENABLE_AVAHI = @enable_avahi@
 ENABLE_DSTAT = @enable_dstat@
 ENABLE_QT = @enable_qt@
 ENABLE_QT3D = @enable_qt3d@
-ENABLE_PERL = @enable_perl@
 ENABLE_PYTHON2 = @enable_python2@
 ENABLE_PYTHON3 = @enable_python3@
 ENABLE_SYSTEMD = @enable_systemd@

--- a/src/iostat2pcp/GNUmakefile
+++ b/src/iostat2pcp/GNUmakefile
@@ -21,7 +21,9 @@ default:
 include $(BUILDRULES)
 
 install: default
+ifeq "$(HAVE_PERL)" "true"
 	$(INSTALL) -m 755 iostat2pcp $(PCP_BIN_DIR)/iostat2pcp
+endif
 
 default_pcp : default
 

--- a/src/mrtg2pcp/GNUmakefile
+++ b/src/mrtg2pcp/GNUmakefile
@@ -21,7 +21,9 @@ default:
 include $(BUILDRULES)
 
 install: default
+ifeq "$(HAVE_PERL)" "true"
 	$(INSTALL) -m 755 mrtg2pcp $(PCP_BIN_DIR)/mrtg2pcp
+endif
 
 default_pcp : default
 

--- a/src/perl/GNUmakefile
+++ b/src/perl/GNUmakefile
@@ -1,11 +1,12 @@
 #
+# Copyright (c) 2022 Red Hat.
 # Copyright (c) 2008-2009 Aconex.  All Rights Reserved.
-# 
+#
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
@@ -15,7 +16,7 @@
 TOPDIR	= ../..
 include $(TOPDIR)/src/include/builddefs
 
-ifeq "$(ENABLE_PERL)" "true"
+ifeq "$(HAVE_PERL)" "true"
 SUBDIRS	= PMDA LogSummary MMV LogImport
 endif
 

--- a/src/perl/LogImport/GNUmakefile
+++ b/src/perl/LogImport/GNUmakefile
@@ -1,4 +1,3 @@
-#!gmake
 #
 # Copyright (c) 2008 Aconex.  All Rights Reserved.
 # Copyright (c) 2004 Silicon Graphics, Inc.  All Rights Reserved.

--- a/src/perl/LogSummary/GNUmakefile
+++ b/src/perl/LogSummary/GNUmakefile
@@ -1,4 +1,3 @@
-#!gmake
 #
 # Copyright (c) 2008 Aconex.  All Rights Reserved.
 # 

--- a/src/perl/MMV/GNUmakefile
+++ b/src/perl/MMV/GNUmakefile
@@ -1,4 +1,3 @@
-#!gmake
 #
 # Copyright (c) 2009 Aconex.  All Rights Reserved.
 # 

--- a/src/perl/PMDA/GNUmakefile
+++ b/src/perl/PMDA/GNUmakefile
@@ -1,4 +1,3 @@
-#!gmake
 #
 # Copyright (c) 2008-2010 Aconex.  All Rights Reserved.
 # Copyright (c) 2004 Silicon Graphics, Inc.  All Rights Reserved.

--- a/src/pmdas/GNUmakefile
+++ b/src/pmdas/GNUmakefile
@@ -31,14 +31,14 @@ CPMDAS = root pmcd \
 PLPMDAS = bonding netfilter zimbra postgresql \
 	dbping memcache mysql oracle kvm \
 	named news pdns samba dtsrun postfix gpsd \
-	rsyslog snmp nginx nfsclient \
+	rsyslog snmp nginx \
 	ds389 ds389log activemq lustre gpfs slurm \
 	bind2 redis nutcracker
 
 PYPMDAS = bcc gluster zswap unbound mic haproxy \
 	json libvirt lio openmetrics elasticsearch \
 	bpftrace mssql netcheck rabbitmq openvswitch \
-	mongodb
+	nfsclient mongodb
 
 SUBDIRS = $(CPMDAS) $(PLPMDAS) $(PYPMDAS)
 LDIRT = pmcd.conf

--- a/src/pmdas/bonding/GNUmakefile
+++ b/src/pmdas/bonding/GNUmakefile
@@ -26,18 +26,22 @@ MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 
-default: check_domain
+default: build-me check_domain
 
 include $(BUILDRULES)
 
-ifeq "$(TARGET_OS)" "linux"
+ifeq "$(HAVE_PERL)" "true"
+build-me:
 install: default
+ifeq "$(TARGET_OS)" "linux"
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/pmda$(IAM).pl pmda$(IAM).pl $(PMDAADMDIR)/pmda$(IAM).pl
+endif
 	@$(INSTALL_MAN)
 else
+build-me:
 install:
 endif
 

--- a/src/pmdas/dbping/GNUmakefile
+++ b/src/pmdas/dbping/GNUmakefile
@@ -26,16 +26,22 @@ MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION) dbprobe.$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 
-default: check_domain
+default: build-me check_domain
 
 include $(BUILDRULES)
 
+ifeq "$(HAVE_PERL)" "true"
+build-me:
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR) pmda$(IAM).pl dbprobe.pl $(PMDAADMDIR)
 	@$(INSTALL_MAN)
+else
+build-me:
+install:
+endif
 
 default_pcp : default
 

--- a/src/pmdas/ds389/GNUmakefile
+++ b/src/pmdas/ds389/GNUmakefile
@@ -29,12 +29,18 @@ default: check_domain
 
 include $(BUILDRULES)
 
+ifeq "$(HAVE_PERL)" "true"
+build-me: $(MAN_PAGES)
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR) pmda$(IAM).pl $(IAM).conf.example $(PMDAADMDIR)
 	@$(INSTALL_MAN)
+else
+build-me:
+install:
+endif
 
 default_pcp : default
 

--- a/src/pmdas/ds389log/GNUmakefile
+++ b/src/pmdas/ds389log/GNUmakefile
@@ -25,16 +25,22 @@ MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 
-default: check_domain
+default: build-me check_domain
 
 include $(BUILDRULES)
 
+ifeq "$(HAVE_PERL)" "true"
+build-me: $(MAN_PAGES)
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/pmda$(IAM).pl pmda$(IAM).pl $(PMDAADMDIR)/pmda$(IAM).pl
 	@$(INSTALL_MAN)
+else
+build-me:
+install:
+endif
 
 default_pcp : default
 

--- a/src/pmdas/gpfs/GNUmakefile
+++ b/src/pmdas/gpfs/GNUmakefile
@@ -24,18 +24,22 @@ MAN_SECTION	= 1
 MAN_PAGES	= pmda$(IAM).$(MAN_SECTION)
 MAN_DEST	= $(PCP_MAN_DIR)/man$(MAN_SECTION)
 
-default: check_domain
+default: build-me check_domain
 
 include $(BUILDRULES)
 
-ifeq "$(TARGET_OS)" "linux"
+ifeq "$(HAVE_PERL)" "true"
+build-me: $(MAN_PAGES)
 install: default
+ifeq "$(TARGET_OS)" "linux"
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/pmda$(IAM).pl pmda$(IAM).pl $(PMDAADMDIR)/pmda$(IAM).pl
 	@$(INSTALL_MAN)
+endif
 else
+build-me:
 install:
 endif
 

--- a/src/pmdas/gpsd/GNUmakefile
+++ b/src/pmdas/gpsd/GNUmakefile
@@ -27,19 +27,25 @@ MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 endif
 
-default: check_domain $(MAN_PAGES)
-
-pmda$(IAM).1: pmda$(IAM).pl
-	$(POD_MAKERULE)
+default: build-me check_domain
 
 include $(BUILDRULES)
 
+ifeq "$(HAVE_PERL)" "true"
+build-me: $(MAN_PAGES)
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/pmda$(IAM).pl pmda$(IAM).pl $(PMDAADMDIR)/pmda$(IAM).pl
 	@$(INSTALL_MAN)
+
+pmda$(IAM).1: pmda$(IAM).pl
+	$(POD_MAKERULE)
+else
+build-me:
+install:
+endif
 
 default_pcp : default
 

--- a/src/pmdas/lustre/GNUmakefile
+++ b/src/pmdas/lustre/GNUmakefile
@@ -25,12 +25,14 @@ MAN_SECTION	= 1
 MAN_PAGES	= pmda$(IAM).$(MAN_SECTION)
 MAN_DEST	= $(PCP_MAN_DIR)/man$(MAN_SECTION)
 
-default: check_domain
+default: build-me check_domain
 
 include $(BUILDRULES)
 
-ifeq "$(TARGET_OS)" "linux"
+ifeq "$(HAVE_PERL)" "true"
+build-me:
 install: default
+ifeq "$(TARGET_OS)" "linux"
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
@@ -38,7 +40,9 @@ install: default
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/lustre.conf lustre.conf $(PMDACONFIG)/lustre.conf
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/pmda$(IAM).pl pmda$(IAM).pl $(PMDAADMDIR)/pmda$(IAM).pl
 	@$(INSTALL_MAN)
+endif
 else
+build-me:
 install:
 endif
 

--- a/src/pmdas/memcache/GNUmakefile
+++ b/src/pmdas/memcache/GNUmakefile
@@ -28,10 +28,12 @@ MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 
-default: check_domain
+default: build-me check_domain
 
 include $(BUILDRULES)
 
+ifeq "$(HAVE_PERL)" "true"
+build-me:
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
@@ -41,6 +43,10 @@ install: default
 	$(INSTALL) -m 755 -d $(LOGCONFVARDIR)
 	$(INSTALL) -m 644 -t $(LOGCONFVARDIR)/summary pmlogconf.summary $(LOGCONFDIR)/summary
 	@$(INSTALL_MAN)
+else
+build-me:
+install:
+endif
 
 default_pcp : default
 

--- a/src/pmdas/named/GNUmakefile
+++ b/src/pmdas/named/GNUmakefile
@@ -28,19 +28,25 @@ MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 endif
 
-default: check_domain $(MAN_PAGES)
-
-pmda$(IAM).1: pmda$(IAM).pl
-	$(POD_MAKERULE)
+default: build-me check_domain
 
 include $(BUILDRULES)
 
+ifeq "$(HAVE_PERL)" "true"
+build-me: $(MAN_PAGES)
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/pmda$(IAM).pl pmda$(IAM).pl $(PMDAADMDIR)/pmda$(IAM).pl
 	@$(INSTALL_MAN)
+
+pmda$(IAM).1: pmda$(IAM).pl
+	$(POD_MAKERULE)
+else
+build-me:
+install:
+endif
 
 default_pcp : default
 

--- a/src/pmdas/netfilter/GNUmakefile
+++ b/src/pmdas/netfilter/GNUmakefile
@@ -28,12 +28,14 @@ MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 
-default: check_domain
+default: build-me check_domain
 
 include $(BUILDRULES)
 
-ifeq "$(TARGET_OS)" "linux"
+ifeq "$(HAVE_PERL)" "true"
+build-me:
 install: default
+ifeq "$(TARGET_OS)" "linux"
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
@@ -43,7 +45,9 @@ install: default
 	$(INSTALL) -m 755 -d $(LOGCONFVARDIR)
 	$(INSTALL) -m 644 -t $(LOGCONFVARDIR)/summary pmlogconf.summary $(LOGCONFDIR)/summary
 	$(INSTALL) -m 644 -t $(LOGCONFVARDIR)/config pmlogconf.config $(LOGCONFDIR)/config
+endif
 else
+build-me:
 install:
 endif
 

--- a/src/pmdas/news/GNUmakefile
+++ b/src/pmdas/news/GNUmakefile
@@ -27,13 +27,12 @@ MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 endif
 
-default: check_domain $(MAN_PAGES)
-
-pmda$(IAM).1: pmda$(IAM).pl
-	$(POD_MAKERULE)
+default: build-me check_domain
 
 include $(BUILDRULES)
 
+ifeq "$(HAVE_PERL)" "true"
+build-me: $(MAN_PAGES)
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
@@ -41,6 +40,13 @@ install: default
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/pmda$(IAM).pl pmda$(IAM).pl $(PMDAADMDIR)/pmda$(IAM).pl
 	$(INSTALL) -m 644 -t $(PMDATMPDIR) README active $(PMDAADMDIR)
 	@$(INSTALL_MAN)
+
+pmda$(IAM).1: pmda$(IAM).pl
+	$(POD_MAKERULE)
+else
+build-me:
+install:
+endif
 
 default_pcp : default
 

--- a/src/pmdas/pdns/GNUmakefile
+++ b/src/pmdas/pdns/GNUmakefile
@@ -28,19 +28,25 @@ MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 endif
 
-default: check_domain $(MAN_PAGES)
-
-pmda$(IAM).1: pmda$(IAM).pl
-	$(POD_MAKERULE)
+default: build-me check_domain
 
 include $(BUILDRULES)
 
+ifeq "$(HAVE_PERL)" "true"
+build-me: $(MAN_PAGES)
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/pmda$(IAM).pl pmda$(IAM).pl $(PMDAADMDIR)/pmda$(IAM).pl
 	@$(INSTALL_MAN)
+
+pmda$(IAM).1: pmda$(IAM).pl
+	$(POD_MAKERULE)
+else
+build-me:
+install:
+endif
 
 default_pcp : default
 

--- a/src/pmdas/redis/GNUmakefile
+++ b/src/pmdas/redis/GNUmakefile
@@ -30,10 +30,12 @@ MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 
-default: check_domain
+default: build-me check_domain
 
 include $(BUILDRULES)
 
+ifeq "$(HAVE_PERL)" "true"
+build-me: $(MAN_PAGES)
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
@@ -42,6 +44,10 @@ install: default
 	$(INSTALL) -m 755 -d $(PMDACONFIG)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/redis.conf redis.conf $(PMDACONFIG)/redis.conf
 	@$(INSTALL_MAN)
+else
+build-me:
+install:
+endif
 
 default_pcp : default
 

--- a/src/pmdas/rsyslog/GNUmakefile
+++ b/src/pmdas/rsyslog/GNUmakefile
@@ -28,10 +28,14 @@ MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 
-default: check_domain
+include $(BUILDRULES)
+
+default: build-me check_domain
 
 include $(BUILDRULES)
 
+ifeq "$(HAVE_PERL)" "true"
+build-me: $(MAN_PAGES)
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
@@ -41,6 +45,10 @@ install: default
 	$(INSTALL) -m 755 -d $(LOGCONFVARDIR)
 	$(INSTALL) -m 644 -t $(LOGCONFVARDIR)/summary pmlogconf.summary $(LOGCONFDIR)/summary
 	@$(INSTALL_MAN)
+else
+build-me:
+install:
+endif
 
 default_pcp : default
 

--- a/src/pmdas/samba/GNUmakefile
+++ b/src/pmdas/samba/GNUmakefile
@@ -28,21 +28,23 @@ MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 endif
 
-default: check_domain $(MAN_PAGES)
-
-pmda$(IAM).1: pmda$(IAM).pl
-	$(POD_MAKERULE)
+default: build-me check_domain
 
 include $(BUILDRULES)
 
-ifneq "$(TARGET_OS)" "mingw"
+ifeq "$(HAVE_PERL)" "true"
+build-me: $(MAN_PAGES)
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/pmda$(IAM).pl pmda$(IAM).pl $(PMDAADMDIR)/pmda$(IAM).pl
 	@$(INSTALL_MAN)
+
+pmda$(IAM).1: pmda$(IAM).pl
+	$(POD_MAKERULE)
 else
+build-me:
 install:
 endif
 

--- a/src/pmdas/slurm/GNUmakefile
+++ b/src/pmdas/slurm/GNUmakefile
@@ -25,18 +25,22 @@ MAN_SECTION	= 1
 MAN_PAGES	= pmda$(IAM).$(MAN_SECTION)
 MAN_DEST	= $(PCP_MAN_DIR)/man$(MAN_SECTION)
 
-default: check_domain
+default: build-me check_domain
 
 include $(BUILDRULES)
 
-ifeq "$(TARGET_OS)" "linux"
+ifeq "$(HAVE_PERL)" "true"
+build-me: $(MAN_PAGES)
 install: default
+ifeq "$(TARGET_OS)" "linux"
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/pmda$(IAM).pl pmda$(IAM).pl $(PMDAADMDIR)/pmda$(IAM).pl
 	@$(INSTALL_MAN)
+endif
 else
+build-me:
 install:
 endif
 

--- a/src/pmdas/zimbra/GNUmakefile
+++ b/src/pmdas/zimbra/GNUmakefile
@@ -28,10 +28,12 @@ MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 
-default: check_domain
+default: build-me check_domain
 
 include $(BUILDRULES)
 
+ifeq "$(HAVE_PERL)" "true"
+build-me:
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
@@ -42,6 +44,10 @@ install: default
 	$(INSTALL) -m 755 -d $(LOGCONFDIR)
 	$(INSTALL) -m 755 -d $(LOGCONFVARDIR)
 	$(INSTALL) -m 644 -t $(LOGCONFVARDIR)/all pmlogconf.all $(LOGCONFDIR)/all
+else
+build-me:
+install:
+endif
 
 default_pcp : default
 

--- a/src/sar2pcp/GNUmakefile
+++ b/src/sar2pcp/GNUmakefile
@@ -21,7 +21,9 @@ default:
 include $(BUILDRULES)
 
 install: default
+ifeq "$(HAVE_PERL)" "true"
 	$(INSTALL) -m 755 sar2pcp $(PCP_BIN_DIR)/sar2pcp
+endif
 
 default_pcp : default
 

--- a/src/sheet2pcp/GNUmakefile
+++ b/src/sheet2pcp/GNUmakefile
@@ -23,7 +23,9 @@ default:
 include $(BUILDRULES)
 
 install: default
+ifeq "$(HAVE_PERL)" "true"
 	$(INSTALL) -m 755 sheet2pcp $(PCP_BIN_DIR)/sheet2pcp
+endif
 
 default_pcp : default
 


### PR DESCRIPTION
    build: make perl truly conditional in the PCP build
    
    If Make::Maker is not installed we could not build PCP,
    even when configure'd with --disable-perl.  That makes
    no sense and also raises the barrier to entry on some
    systems - as Veda observed earlier this week preparing
    python updates to openvswitch metrics on RHEL-8.
