### PR TITLE
qa: fix indom cache path in qa/1900

### DIFF
--- a/qa/1900.out
+++ b/qa/1900.out
@@ -11,14 +11,14 @@ Check bpf metrics have appeared ... X metrics and X values
 == Running pmdabpf with valgrind
 === std out ===
 
-bpf.disk.all.latency PMID: 157.0.0 [Disk latency]
-    Data Type: 64-bit unsigned int  InDom: 157.2 0x27400002
+bpf.disk.all.latency PMID: 157.1.0 [Disk latency]
+    Data Type: 64-bit unsigned int  InDom: 157.3 0x27400003
     Semantics: counter  Units: microsec
 Help:
 Disk latency histogram across all disks, for both reads and writes.
 
-bpf.runq.latency PMID: 157.1.0 [Run queue latency (ns)]
-    Data Type: 64-bit unsigned int  InDom: 157.3 0x27400003
+bpf.runq.latency PMID: 157.0.0 [Run queue latency (ns)]
+    Data Type: 64-bit unsigned int  InDom: 157.2 0x27400002
     Semantics: counter  Units: nanosec
 Help:
 Run queue latency from task switches,

--- a/qa/common.bpf
+++ b/qa/common.bpf
@@ -56,7 +56,7 @@ _pmdabpf_install()
     cat $tmp.config >> $here/$seq.full
 
     # set aside any pre-existing cluster and indom caches
-    __indomcache="$PCP_VAR_DIR/pmdas/config"
+    __indomcache="$PCP_VAR_DIR/config/pmda"
     [ -f $__indomcache/157.0 ] && \
     $sudo mv $__indomcache/157.0 $__indomcache/157.0.$seq
     [ -f $__indomcache/157.1 ] && \
@@ -175,7 +175,7 @@ _pmdabpf_cleanup()
         $sudo rm -f $PCP_PMDAS_DIR/bpf/bpf.conf
     fi
     # restore any pre-existing cluster and indom caches
-    __indomcache="$PCP_VAR_DIR/pmdas/config"
+    __indomcache="$PCP_VAR_DIR/config/pmda"
     [ -f $__indomcache/157.0.$seq ] && \
     $sudo mv $__indomcache/157.0.$seq $__indomcache/157.0
     [ -f $__indomcache/157.1.$seq ] && \


### PR DESCRIPTION
Note: The order in which bpf PMDA modules get added to the cluster cache
does not depend on the order in bpf.conf, but on the dictGetIterator()
iterator (iterating over the sections in bpf.conf).