### PR TITLE
libpcp_web: ensure a valid baton is passed to query functions

### DIFF
--- a/qa/1214
+++ b/qa/1214
@@ -16,11 +16,6 @@ echo "QA output created by $seq"
 _check_valgrind
 _check_series
 
-#
-# pmproxy: redis.c:1868: redisProcessCallBacks: Assertion `(c->flags & REDIS_SUBSCRIBED || c->flags & REDIS_MONITORING)'
-# Request callback, reply is NOT NULL and we are still connected but not subscribed or monitoring.
-_notrun "pmseries querying redis via pmproxy trips assert and pmproxy aborts. query redis directly is OK"
-
 _cleanup()
 {
     echo

--- a/qa/1360
+++ b/qa/1360
@@ -22,9 +22,9 @@ _check_valgrind
 _check_series
 
 # need older redis version for this test ...
-#
-redis_version=`redis-server --version | sed -E 's/.*v=([0-9]).*/\1/g'`
-[ $redis_version -ge 5 ] && _notrun "Redis version $redis_version not old enough"
+version=`redis-server --version | sed -E 's/.*v=([0-9]).*/\1/g'`
+[ $version -ge 5 ] && \
+    _notrun "Redis version $version needs no backward compatibility testing"
 
 _cleanup()
 {

--- a/qa/triaged
+++ b/qa/triaged
@@ -42,6 +42,9 @@
 		errors in the sample time calculation (that's a guess)
 1210	vm[0-9][0-9]	may collide with pmlogger_check and (correctly)
 			detects presence of /etc/pcp/pmlogger/lock
+1214    .*      known proxy mishandling of Redis protocol pass-through;
+                hiredis buffering code needs to be more deeply analysed
+                for some cases here, other pass-through cases work well
 1221	vm27	extra labels associated with
 		openmetrics.vmware_exporter.vmware_vm_guest_disk_* metrics
 		for no known reason

--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -71,7 +71,7 @@ typedef struct seriesQueryBaton {
 static void series_pattern_match(seriesQueryBaton *, node_t *);
 static int series_union(series_set_t *, series_set_t *);
 static int series_intersect(series_set_t *, series_set_t *);
-static int series_calculate(seriesQueryBaton *, node_t *, int);
+static int series_calculate(node_t *, int, void *);
 static void series_redis_hash_expression(seriesQueryBaton *, char *, int);
 static void series_node_get_metric_name(seriesQueryBaton *, seriesGetSID *, series_sample_set_t *);
 static void series_node_get_desc(seriesQueryBaton *, sds, series_sample_set_t *);
@@ -1369,14 +1369,14 @@ static void
 on_series_solve_setup(void *arg)
 {
     if (pmDebugOptions.query)
-	fprintf(stderr, "on_series_solve_setup\n");
+	fprintf(stderr, "%s\n", "on_series_solve_setup");
 }
 
 static void
 on_series_solve_log(pmLogLevel level, sds message, void *arg)
 {
     if (pmDebugOptions.query)
-	fprintf(stderr, "on_series_solve_log: %s\n", message);
+	fprintf(stderr, "%s: %s\n", "on_series_solve_log", message);
 }
 
 static void
@@ -1386,7 +1386,7 @@ on_series_solve_done(int status, void *arg)
 
     seriesBatonCheckMagic(baton, MAGIC_QUERY, "on_series_solve_done");
     if (pmDebugOptions.query && pmDebugOptions.desperate)
-	fprintf(stderr, "on_series_solve_done: arg=%p status=%d\n", arg, status);
+	fprintf(stderr, "%s: arg=%p status=%d\n", "on_series_solve_done", arg, status);
     baton->callbacks->on_done(status, baton->userdata);
 }
 
@@ -1397,7 +1397,7 @@ on_series_solve_value(pmSID sid, pmSeriesValue *value, void *arg)
 
     seriesBatonCheckMagic(baton, MAGIC_QUERY, "on_series_solve_value");
     if (pmDebugOptions.query && pmDebugOptions.desperate)
-	fprintf(stderr, "on_series_solve_value: arg=%p %s %s %s\n",
+	fprintf(stderr, "%s: arg=%p %s %s %s\n", "on_series_solve_value",
 		arg, value->timestamp, value->data, value->series);
     return baton->callbacks->on_value(sid, value, baton->userdata);
 }
@@ -1408,9 +1408,9 @@ on_series_solve_inst_done(int status, void *arg)
 {
     seriesQueryBaton	*baton = arg;
 
-    seriesBatonCheckMagic(baton, MAGIC_QUERY, "on_series_solve_done");
+    seriesBatonCheckMagic(baton, MAGIC_QUERY, "on_series_solve_inst_done");
     if (pmDebugOptions.query && pmDebugOptions.desperate)
-	fprintf(stderr, "on_series_solve_done: arg=%p status=%d\n", arg, status);
+	fprintf(stderr, "%s: arg=%p status=%d\n", "on_series_solve_done", arg, status);
     /* on_done is called by series_query_finished */
     seriesBatonDereference(baton, "on_series_solve_inst_done");
 }
@@ -1428,7 +1428,7 @@ on_series_solve_inst_value(pmSID sid, pmSeriesValue *value, void *arg)
 
     seriesBatonCheckMagic(baton, MAGIC_QUERY, "on_series_solve_inst_value");
     if (pmDebugOptions.query) {
-	fprintf(stderr, "on_series_solve_inst_value: arg=%p %s %s %s\n",
+	fprintf(stderr, "%s: arg=%p %s %s %s\n", "on_series_solve_inst_value",
 		arg, value->timestamp, value->data, value->series);
     }
 
@@ -1487,11 +1487,11 @@ series_solve_sid_expr(pmSeriesSettings *settings, pmSeriesExpr *expr, void *arg)
     seriesBatonCheckMagic(sid, MAGIC_SID, "series_query_expr_reply");
     seriesBatonCheckMagic(baton, MAGIC_QUERY, "series_query_expr_reply");
 
-    if (pmDebugOptions.query) {
-	fprintf(stderr, "series_solve_sid_expr: SID %s, "
-		"seriesQueryBaton=%p, pmSeriesBaton=userdata=%p expr=\"%s\"\n",
-		sid->name, baton, baton->userdata, expr->query);
-    }
+    if (pmDebugOptions.query)
+	fprintf(stderr, "%s: SID %s, seriesQueryBaton=%p, "
+			"pmSeriesBaton=userdata=%p expr=\"%s\"\n",
+			"series_solve_sid_expr",
+			sid->name, baton, baton->userdata, expr->query);
 
     /* ref baton until on_series_solve_done */
     seriesBatonReference(baton, "series_solve_sid_expr");
@@ -1743,10 +1743,15 @@ series_query_report_matches(void *arg)
 
     seriesBatonReference(baton, "series_query_report_matches");
 
-    has_function = series_calculate(baton, baton->query.root, 0);
-    
+    has_function = series_calculate(baton->query.root, 0, arg);
+
+    /*
+     * Store the canonical query to Redis if this query statement has
+     * function operation.
+     */
     if (has_function != 0)
 	series_redis_hash_expression(baton, hashbuf, sizeof(hashbuf));
+
     series_report_set(baton, baton->query.root);
     series_query_end_phase(baton);
 }
@@ -2612,9 +2617,9 @@ series_rate_check(pmSeriesDesc desc)
  * The number of samples in result is one less than the original samples. 
  */
 static void
-series_calculate_rate(node_t *np)
+series_calculate_rate(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     pmSeriesValue	s_pmval, t_pmval;
     unsigned int	n_instances, n_samples, i, j, k;
     double		s_data, t_data, mult;
@@ -2698,9 +2703,9 @@ series_calculate_rate(node_t *np)
  * Compare and pick the max instance value(s) among samples.
  */
 static void
-series_calculate_time_domain_max(node_t *np)
+series_calculate_time_domain_max(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     unsigned int	n_series, n_samples, n_instances, i, j, k;
     double		max_data, data;
     int			max_pointer;
@@ -2763,9 +2768,9 @@ series_calculate_time_domain_max(node_t *np)
  * Compare and pick the maximal instance value(s) among samples for each metric.
  */
 static void
-series_calculate_max(node_t *np)
+series_calculate_max(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     unsigned int	n_series, n_samples, n_instances, i, j, k;
     double		max_data, data;
     int			max_pointer;
@@ -2827,9 +2832,9 @@ series_calculate_max(node_t *np)
  * Compare and pick the minimal value(s) among samples for each metric across time.
  */
 static void
-series_calculate_time_domain_min(node_t *np)
+series_calculate_time_domain_min(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     unsigned int	n_series, n_samples, n_instances, i, j, k;
     double		min_data, data;
     int			min_pointer;
@@ -2892,9 +2897,9 @@ series_calculate_time_domain_min(node_t *np)
  * Compare and pick the minimal instance value(s) among samples for each metric.
  */
 static void
-series_calculate_min(node_t *np)
+series_calculate_min(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     unsigned int	n_series, n_samples, n_instances, i, j, k;
     double		min_data, data;
     int			min_pointer;
@@ -3049,9 +3054,9 @@ series_pmAtomValue_conv_str(int type, char *str, pmAtomValue *val, int max_len)
  * metrics to be modified. 
  */
 static void
-series_calculate_rescale(node_t *np)
+series_calculate_rescale(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     double		mult;
     pmUnits		iunit;
     char		*errmsg, str_val[256];
@@ -3144,9 +3149,9 @@ series_abs_pmAtomValue(int type, pmAtomValue *val)
 }
 
 static void
-series_calculate_abs(node_t *np)
+series_calculate_abs(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     pmAtomValue		val;
     int			type, sts, str_len, i, j, k;
     char		str_val[256];
@@ -3187,9 +3192,9 @@ series_calculate_abs(node_t *np)
  * calculate top k instances among samples
  */
 static void
-series_calculate_time_domain_topk(node_t *np)
+series_calculate_time_domain_topk(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     unsigned int	n_series, n_samples, n_instances, i, j, k, l;
     sds			msg;
     pmSeriesValue	inst;
@@ -3273,9 +3278,9 @@ series_calculate_time_domain_topk(node_t *np)
  * calculate top k series per-instance over time samples
  */
 static void
-series_calculate_topk(node_t *np)
+series_calculate_topk(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     unsigned int	n_series, n_samples, n_instances, i, j, k, l;
     double		data;
     int 		n, ind;
@@ -3358,9 +3363,9 @@ series_calculate_topk(node_t *np)
  * calculate standard deviation series per-instance over time samples
  */
 static void
-series_calculate_time_domain_standard_deviation(node_t *np)
+series_calculate_time_domain_standard_deviation(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     unsigned int	n_series, n_samples, n_instances, i, j, k;
     double		sum_data, mean, sd, data;
     sds			msg;
@@ -3426,9 +3431,9 @@ series_calculate_time_domain_standard_deviation(node_t *np)
  * calculate standard deviation series per-instance over time samples
  */
 static void
-series_calculate_standard_deviation(node_t *np)
+series_calculate_standard_deviation(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     unsigned int	n_series, n_samples, n_instances, i, j, k;
     double		sum_data, data, sd, mean;
     char		stdev[64];
@@ -3491,9 +3496,9 @@ series_calculate_standard_deviation(node_t *np)
  * calculate the nth percentile in the time series for each sample across time
  */
 static void
-series_calculate_time_domain_nth_percentile(node_t *np)
+series_calculate_time_domain_nth_percentile(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     unsigned int	n_series, n_samples, n_instances, i, j, k, l, m;
     int			n, instance_idx, rank, *n_pointer;
     double              *n_data, data, rank_d;
@@ -3572,9 +3577,9 @@ series_calculate_time_domain_nth_percentile(node_t *np)
  * calculate the nth percentile series per-instance over time samples
  */
 static void
-series_calculate_nth_percentile(node_t *np)
+series_calculate_nth_percentile(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     unsigned int	n_series, n_samples, n_instances, i, j, k, l, m;
     int			n, instance_idx, rank, *n_pointer;
     double              *n_data, data, rank_d;
@@ -3653,9 +3658,10 @@ series_calculate_nth_percentile(node_t *np)
  * calculate sum or avg in the time series for each sample across time
  */
 static void
-series_calculate_time_domain_statistical(node_t *np, nodetype_t func)
+series_calculate_time_domain_statistical(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
+    nodetype_t		func = np->type;
     unsigned int	n_series, n_samples, n_instances, i, j, k;
     double		sum_data, data;
     char		sum_data_str[64];
@@ -3734,9 +3740,10 @@ series_calculate_time_domain_statistical(node_t *np, nodetype_t func)
  * calculate sum or avg series per-instance over time samples
  */
 static void
-series_calculate_statistical(node_t *np, nodetype_t func)
+series_calculate_statistical(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
+    nodetype_t		func = np->type;
     unsigned int	n_series, n_samples, n_instances, i, j, k;
     double		sum_data, data;
     char		sum_data_str[64];
@@ -3841,9 +3848,9 @@ series_floor_pmAtomValue(int type, pmAtomValue *val)
 }
 
 static void
-series_calculate_floor(node_t *np)
+series_calculate_floor(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     pmAtomValue		val;
     int			type, sts, str_len, i, j, k;
     char		str_val[256];
@@ -3926,9 +3933,9 @@ series_log_pmAtomValue(int itype, int *otype, pmAtomValue *val, int is_natural_l
  * Return the logarithm of x to base b (log_b^x).
  */
 static void
-series_calculate_log(node_t *np)
+series_calculate_log(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     double		base;
     pmAtomValue		val;
     int			i, j, k, itype, otype=PM_TYPE_UNKNOWN;
@@ -4020,9 +4027,9 @@ series_sqrt_pmAtomValue(int itype, int *otype, pmAtomValue *val)
 }
 
 static void
-series_calculate_sqrt(node_t *np)
+series_calculate_sqrt(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     pmAtomValue		val;
     int			i, j, k, itype, otype=PM_TYPE_UNKNOWN;
     int			sts, str_len;
@@ -4089,9 +4096,9 @@ series_round_pmAtomValue(int type, pmAtomValue *val)
 }
 
 static void
-series_calculate_round(node_t *np)
+series_calculate_round(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     pmAtomValue		val;
     int			i, j, k, type, sts, str_len;
     char		str_val[256];
@@ -4162,6 +4169,7 @@ series_calculate_binary_check(int ope_type, seriesQueryBaton *baton,
 	baton->error = -EPROTO;
 	return -1;
     }
+
     /*
      * For addition and subtraction all dimensions for each of
      * the operands and result are identical.
@@ -4480,9 +4488,9 @@ series_binary_meta_update(node_t *left, pmUnits *large_units, int *l_sem, int *r
 }
 
 static void
-series_calculate_plus(node_t *np)
+series_calculate_plus(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     node_t		*left = np->left, *right = np->right;
     int			l_type, r_type, otype=PM_TYPE_UNKNOWN;
     int			l_sem, r_sem, j, k;
@@ -4532,9 +4540,9 @@ series_calculate_plus(node_t *np)
 }
 
 static void
-series_calculate_minus(node_t *np)
+series_calculate_minus(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     node_t		*left = np->left, *right = np->right;
     unsigned int	num_samples, num_instances, j, k;
     pmAtomValue		l_val, r_val;
@@ -4584,9 +4592,9 @@ series_calculate_minus(node_t *np)
 }
 
 static void
-series_calculate_star(node_t *np)
+series_calculate_star(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     node_t		*left = np->left, *right = np->right;
     unsigned int	num_samples, num_instances, j, k;
     pmAtomValue		l_val, r_val;
@@ -4636,9 +4644,9 @@ series_calculate_star(node_t *np)
 }
 
 static void
-series_calculate_slash(node_t *np)
+series_calculate_slash(node_t *np, void *arg)
 {
-    seriesQueryBaton	*baton = (seriesQueryBaton *)np->baton;
+    seriesQueryBaton	*baton = (seriesQueryBaton *)arg;
     node_t		*left = np->left, *right = np->right;
     unsigned int	num_samples, num_instances, j, k;
     pmAtomValue		l_val, r_val;
@@ -4647,12 +4655,16 @@ series_calculate_slash(node_t *np)
     int			l_sem, r_sem;
     sds			msg;
 
-    if (left->value_set.num_series == 0 || right->value_set.num_series == 0) return;
-    if (series_calculate_binary_check(N_SLASH, baton, left, right, &l_type, &r_type, &l_sem, &r_sem,
-		 &l_units, &r_units, &large_units, left->value_set.series_values[0].series_desc.indom,
-		 right->value_set.series_values[0].series_desc.indom) != 0) {
+    if (left->value_set.num_series == 0 || right->value_set.num_series == 0)
 	return;
-    }
+
+    if (series_calculate_binary_check(N_SLASH, baton, left, right,
+		&l_type, &r_type, &l_sem, &r_sem,
+		&l_units, &r_units, &large_units,
+		left->value_set.series_values[0].series_desc.indom,
+		right->value_set.series_values[0].series_desc.indom) != 0)
+	return;
+
     num_samples = left->value_set.series_values[0].num_samples;
 
     for (j = 0; j < num_samples; j++) {
@@ -4681,7 +4693,6 @@ series_calculate_slash(node_t *np)
 
     series_binary_meta_update(left, &large_units, &l_sem, &r_sem, &otype);
     np->value_set = left->value_set;
-
 }
 
 /* 
@@ -4693,107 +4704,96 @@ series_calculate_slash(node_t *np)
  * store them into this node.
  */
 static int
-series_calculate(seriesQueryBaton *baton, node_t *np, int level)
+series_calculate(node_t *np, int level, void *arg)
 {
     int		sts;
 
     if (np == NULL)
 	return 0;
-    if ((sts = series_calculate(baton, np->left, level+1)) < 0)
+    if ((sts = series_calculate(np->left, level+1, arg)) < 0)
 	return sts;
-    if ((sts = series_calculate(baton, np->right, level+1)) < 0)
+    if ((sts = series_calculate(np->right, level+1, arg)) < 0)
 	return sts;
 
-    np->baton = baton;
     switch ((sts = np->type)) {
-	case N_RATE:
-	    series_calculate_rate(np);
-	    break;
-	case N_MAX:
-	case N_MAX_INST:
-	    series_calculate_max(np);
-	    break;
-	case N_MAX_SAMPLE:
-	    series_calculate_time_domain_max(np);
-	    break;
-	case N_MIN:
-	case N_MIN_INST:
-	    series_calculate_min(np);
-	    break;
-	case N_MIN_SAMPLE:
-	    series_calculate_time_domain_min(np);
-	    break;
-	case N_RESCALE:
-	    series_calculate_rescale(np);
-	    break;
-	case N_ABS:
-	    series_calculate_abs(np);
-	    break;
-	case N_FLOOR:
-	    series_calculate_floor(np);
-	    break;
-	case N_LOG:
-	    series_calculate_log(np);
-	    break;
-	case N_SQRT:
-	    series_calculate_sqrt(np);
-	    break;
-	case N_ROUND:
-	    series_calculate_round(np);
-	    break;
-	case N_PLUS:
-	    series_calculate_plus(np);
-	    break;
-	case N_MINUS:
-	    series_calculate_minus(np);
-	    break;
-	case N_STAR:
-	    series_calculate_star(np);
-	    break;
-	case N_SLASH:
-	    series_calculate_slash(np);
-	    break;
-	case N_AVG:
-	    series_calculate_statistical(np, N_AVG);
-	    break;
-	case N_AVG_INST:
-	    series_calculate_statistical(np, N_AVG_INST);
-		sts = N_AVG_INST;
-	    break;
-	case N_AVG_SAMPLE:
-	    series_calculate_time_domain_statistical(np, N_AVG_SAMPLE);
-	    sts = N_AVG_SAMPLE;
-	    break;
-	case N_SUM:
-	    series_calculate_statistical(np, N_SUM);
-	    break;
-	case N_SUM_INST:
-	    series_calculate_statistical(np, N_SUM_INST);
-	    break;
-	case N_SUM_SAMPLE:
-	    series_calculate_time_domain_statistical(np, N_SUM_SAMPLE);
-	    break;
-	case N_STDEV_INST:
-	    series_calculate_standard_deviation(np);
-	    break;
-	case N_STDEV_SAMPLE:
-	    series_calculate_time_domain_standard_deviation(np);
-	    break;
-	case N_TOPK_INST:
-	    series_calculate_topk(np);
-	    break;
-	case N_TOPK_SAMPLE:
-	    series_calculate_time_domain_topk(np);
-            break;
-	case N_NTH_PERCENTILE_INST:
-	    series_calculate_nth_percentile(np);
-	    break;
-	case N_NTH_PERCENTILE_SAMPLE:
-	    series_calculate_time_domain_nth_percentile(np);
-	    break;
-	default:
-	    sts = 0;	/* no function */
-	    break;
+    case N_RATE:
+	series_calculate_rate(np, arg);
+	break;
+    case N_MAX:
+    case N_MAX_INST:
+	series_calculate_max(np, arg);
+	break;
+    case N_MAX_SAMPLE:
+	series_calculate_time_domain_max(np, arg);
+	break;
+    case N_MIN:
+    case N_MIN_INST:
+	series_calculate_min(np, arg);
+	break;
+    case N_MIN_SAMPLE:
+	series_calculate_time_domain_min(np, arg);
+	break;
+    case N_RESCALE:
+	series_calculate_rescale(np, arg);
+	break;
+    case N_ABS:
+	series_calculate_abs(np, arg);
+	break;
+    case N_FLOOR:
+	series_calculate_floor(np, arg);
+	break;
+    case N_LOG:
+	series_calculate_log(np, arg);
+	break;
+    case N_SQRT:
+	series_calculate_sqrt(np, arg);
+	break;
+    case N_ROUND:
+	series_calculate_round(np, arg);
+	break;
+    case N_PLUS:
+	series_calculate_plus(np, arg);
+	break;
+    case N_MINUS:
+	series_calculate_minus(np, arg);
+	break;
+    case N_STAR:
+	series_calculate_star(np, arg);
+	break;
+    case N_SLASH:
+	series_calculate_slash(np, arg);
+	break;
+    case N_AVG:
+    case N_SUM:
+    case N_AVG_INST:
+    case N_SUM_INST:
+	series_calculate_statistical(np, arg);
+	break;
+    case N_AVG_SAMPLE:
+    case N_SUM_SAMPLE:
+	series_calculate_time_domain_statistical(np, arg);
+	break;
+    case N_STDEV_INST:
+	series_calculate_standard_deviation(np, arg);
+	break;
+    case N_STDEV_SAMPLE:
+	series_calculate_time_domain_standard_deviation(np, arg);
+	break;
+    case N_TOPK_INST:
+	series_calculate_topk(np, arg);
+	break;
+    case N_TOPK_SAMPLE:
+	series_calculate_time_domain_topk(np, arg);
+        break;
+    case N_NTH_PERCENTILE_INST:
+	series_calculate_nth_percentile(np, arg);
+	break;
+    case N_NTH_PERCENTILE_SAMPLE:
+	series_calculate_time_domain_nth_percentile(np, arg);
+	break;
+    default:
+	sts = 0;	/* no function */
+	break;
     }
     return sts;
 }
@@ -4883,17 +4883,18 @@ series_redis_hash_expression(seriesQueryBaton *baton, char *hashbuf, int len_has
 
     for (i = 0; i < num_series; i++) {
 	if (!np->value_set.series_values[i].compatibility) {
-	    infofmt(msg, "Descriptors for metric '%s' do not satisfy compatibility between different hosts/sources.\n",
+	    infofmt(msg, "Descriptors for metric '%s' between different sources are incompatible.\n",
 		np->value_set.series_values[i].metric_name);
 	    batoninfo(baton, PMLOG_ERROR, msg);
 	    baton->error = -EPROTO;
-	    continue;
+	    break;
 	}
 
 	if (strncmp(np->value_set.series_values[i].series_desc.units, "none", 4) == 0)
 	    memset(&units0, 0, sizeof(units0));
-	else if (pmParseUnitsStr(np->value_set.series_values[i].series_desc.units,
-	    &units0, &mult, &errmsg) != 0) {
+	else if (pmParseUnitsStr(
+			np->value_set.series_values[i].series_desc.units,
+			&units0, &mult, &errmsg) != 0) {
 	    np->value_set.series_values[i].compatibility = 0;
 	    infofmt(msg, "Invalid units string: %s\n",
 		    np->value_set.series_values[i].series_desc.units);
@@ -4922,7 +4923,12 @@ series_redis_hash_expression(seriesQueryBaton *baton, char *hashbuf, int len_has
 
 	    if (check_compatibility(&units0, &units1) != 0) {
 		np->value_set.series_values[j].compatibility = 0;
-		infofmt(msg, "Incompatible units between operand metrics or expressions\n");
+		infofmt(msg, "Incompatible units between operand metrics or expressions\n"
+				"'%s' (%s)\nvs\'%s' (%s)\n",
+				np->value_set.series_values[i].metric_name,
+				np->value_set.series_values[i].series_desc.units,
+				np->value_set.series_values[j].metric_name,
+				np->value_set.series_values[j].series_desc.units);
 		batoninfo(baton, PMLOG_ERROR, msg);
 		baton->error = -EPROTO;
 		break;
@@ -4987,7 +4993,7 @@ series_query_funcs_report_values(void *arg)
     seriesBatonReference(baton, "series_query_funcs_report_values");
 
     /* For function-type nodes, calculate actual values */
-    has_function = series_calculate(baton, baton->query.root, 0);
+    has_function = series_calculate(baton->query.root, 0, baton->userdata);
 
     /*
      * Store the canonical query to Redis if this query statement has


### PR DESCRIPTION
In the situation where we are calling a function based on an
expanded fabricted SID, we need to pass the userdata rather
than the baton pointer, as this is holding the baton in this
special case situation.  If not we may attempt dereferencing
an invalid pointer in the high level API calling code, such
as pmproxy, when handling error conditions (pmseries_log).

This resolves a crash when handling query division, but logic
errors remain to be sorted out on that code path (fix is WIP).

Related to https://github.com/performancecopilot/pcp/issues/1636