### PR TITLE
libpcp_web: Redis proxying: support Redis pipelining

### DIFF
--- a/qa/1602
+++ b/qa/1602
@@ -85,7 +85,7 @@ pmproxy_pid=$!
 echo "proxyport=$proxyport" >>$seq.full
 echo "pmproxy_pid=$pmproxy_pid" >>$seq.full
 _wait_for_pmproxy $proxyport $tmp.pmproxy.log
-which netstat >/dev/null && netstat -a | egrep "$redis_node1_port|$redis_node2_port|$redis_node3_port|$proxyport" >>$seq.full
+which netstat >/dev/null && netstat -l | egrep "$redis_node1_port|$redis_node2_port|$redis_node3_port|$proxyport" >>$seq.full
 _check_redis_ping $proxyport
 echo
 

--- a/qa/triaged
+++ b/qa/triaged
@@ -42,9 +42,6 @@
 		errors in the sample time calculation (that's a guess)
 1210	vm[0-9][0-9]	may collide with pmlogger_check and (correctly)
 			detects presence of /etc/pcp/pmlogger/lock
-1214	.*	known proxy mishandling of Redis protocol pass-through;
-		hiredis buffering code needs to be more deeply analysed
-		for some cases here, other pass-through cases work well
 1221	vm27	extra labels associated with
 		openmetrics.vmware_exporter.vmware_vm_guest_disk_* metrics
 		for no known reason


### PR DESCRIPTION
The buffer can contain multiple Redis requests (Redis pipelining).

Previously, if the buffer contained multiple Redis requests, redisSlotsRequest was called with multiple Redis requests.
This triggered an assertion in hiredis code, because only one reply per request is expected, but in this case it received multiple replies.

This fixes qa/1214.