### PR TITLE
pmdasmart: set LC_ALL=C before running smartctl

### DIFF
--- a/src/pmdas/smart/smart_stats.c
+++ b/src/pmdas/smart/smart_stats.c
@@ -524,7 +524,7 @@ nvme_smart_refresh_data(const char *name, struct nvme_smart_data *nvme_smart_dat
 void
 smart_stats_setup(void)
 {
-	static char smart_command[] = "smartctl";
+	static char smart_command[] = "LC_ALL=C smartctl";
 	char *env_command;
 
 	/* allow override at startup for QA testing */


### PR DESCRIPTION
The smartctl output uses a dot as a thousands separator when the system
is configured with a German locale. The input parsing code didn't handle
this case correctly.

This commit runs LC_ALL=C smartctl, i.e. resetting the locale to a
fixed locale, irrespective of the user's configured locale.

To avoid pitfalls like this in the future, it would be better if the PMDA reads the JSON output of `smartctl` (`-j` flag).