### PR TITLE
src/libpcp/src/check-statics: fix regexp error with objects in subdirectories

### DIFF
--- a/src/libpcp/src/check-statics
+++ b/src/libpcp/src/check-statics
@@ -619,7 +619,7 @@ do
 		# extras from the last object code file
 		sed <$tmp/out \
 		    -e 's/^[^ ]* //' \
-		    -e "s/^\(.\) \(.*\)/$obj: \1 \2 : Error: additional symbol/"
+		    -e "s!^\(.\) \(.*\)!$obj: \1 \2 : Error: additional symbol!"
 		touch $tmp/fail
 	    fi
 	fi


### PR DESCRIPTION
Using `/` as separator in `sed` fails when `$obj` contains that character, as is the case for `deps/jsonsl/jsonsl.o`. I propose using `!` as an alternative.