### PR TITLE
janitor: convert fgrep and egrep over to grep -F and -E

### DIFF
--- a/Makepkgs
+++ b/Makepkgs
@@ -2,7 +2,7 @@
 #
 # Make whichever packages the system supports
 #
-# Copyright (c) 2012-2017 Red Hat.
+# Copyright (c) 2012-2017,2022 Red Hat.
 # Copyright (c) 2004 Silicon Graphics, Inc.  All Rights Reserved.
 # 
 # This program is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ gnu_tool()
 	    if [ -n "$exec" ]
 	    then
 		LC_ALL=C $command --help >$tmp/help 2>&1
-		if egrep "(bug-$oldcmd@gnu.org)|(FreeBSD $command)|(NetBSD $command)|(OpenBSD $command)|(Apple $command)" $tmp/help >/dev/null
+		if grep -E "(bug-$oldcmd@gnu.org)|(FreeBSD $command)|(NetBSD $command)|(OpenBSD $command)|(Apple $command)" $tmp/help >/dev/null
 		then
 		    echo $exec
 		    return 0
@@ -82,7 +82,7 @@ gnu_tool()
 BEGIN				{ want = 0 }
 /This\** tar defaults to:/	{ want=1; next }
 want == 1			{ print; exit }'
-		if egrep '[-][-]format=(gnu)|(posix)' <$tmp/check >/dev/null
+		if grep -E '[-][-]format=(gnu)|(posix)' <$tmp/check >/dev/null
 		then
 		    echo $exec
 		    return 0

--- a/configure
+++ b/configure
@@ -6932,10 +6932,10 @@ if test -n "$SYSTEMD_SYSUSERSDIR"; then
     pkg_cv_SYSTEMD_SYSUSERSDIR="$SYSTEMD_SYSUSERSDIR"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"systemd\""; } >&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"systemd\""; } >&5
   ($PKG_CONFIG --exists --print-errors "systemd") 2>&5
   ac_status=$?
-  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
   pkg_cv_SYSTEMD_SYSUSERSDIR=`$PKG_CONFIG --variable="sysusersdir" "systemd" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
@@ -6947,9 +6947,10 @@ fi
 fi
 SYSTEMD_SYSUSERSDIR=$pkg_cv_SYSTEMD_SYSUSERSDIR
 
-if test "x$SYSTEMD_SYSUSERSDIR" = x""; then :
+if test "x$SYSTEMD_SYSUSERSDIR" = x""
+then :
   pcp_systemdsysusers_dir=$pcp_lib32_dir/sysusers.d
-else
+else $as_nop
   pcp_systemdsysusers_dir=$SYSTEMD_SYSUSERSDIR
 fi
 
@@ -13607,7 +13608,7 @@ then :
     && pcp_selinux_hostname_exec_map=true
 
     seinfo -x --class=bpf $seinfo_common_flag 2>/dev/null \
-    | egrep '^[ 	][ 	]*(class |)bpf$' >/dev/null \
+    | grep -E '^[ 	][ 	]*(class |)bpf$' >/dev/null \
     && pcp_selinux_bpf=true
 
     seinfo -a 2>/dev/null \
@@ -13623,44 +13624,44 @@ then :
     && pcp_selinux_capability2_bpf=true
 
     seinfo -x --class=icmp_socket $seinfo_common_flag 2>/dev/null \
-    | egrep '^[ 	][ 	]*(class |)icmp_socket$' >/dev/null \
+    | grep -E '^[ 	][ 	]*(class |)icmp_socket$' >/dev/null \
     && pcp_selinux_icmp_socket_class=true
 
     seinfo -x --class=lockdown $seinfo_common_flag 2>/dev/null \
-    | egrep '^[ 	][ 	]*(class |)lockdown$' >/dev/null \
+    | grep -E '^[ 	][ 	]*(class |)lockdown$' >/dev/null \
     && pcp_selinux_lockdown_class=true
 
 
     seinfo -x --class=netlink_selinux_socket $seinfo_common_flag 2>/dev/null \
-    | egrep '^[ 	][ 	]*(class |)netlink_selinux_socket$' >/dev/null \
+    | grep -E '^[ 	][ 	]*(class |)netlink_selinux_socket$' >/dev/null \
     && pcp_selinux_netlink_selinux_socket_class=true
 
     seinfo -x --class=netlink_audit_socket $seinfo_common_flag 2>/dev/null \
-    | egrep '^[ 	][ 	]*(class |)netlink_audit_socket$' >/dev/null \
+    | grep -E '^[ 	][ 	]*(class |)netlink_audit_socket$' >/dev/null \
     && pcp_selinux_netlink_audit_socket_class=true
 
     seinfo -x --class=sock_file $seinfo_common_flag 2>/dev/null \
-    | egrep '^[ 	][ 	]*(class |)sock_file$' >/dev/null \
+    | grep -E '^[ 	][ 	]*(class |)sock_file$' >/dev/null \
     && pcp_selinux_sock_file_class=true
 
     seinfo -x --class=security $seinfo_common_flag 2>/dev/null \
-    | egrep '^[ 	][ 	]*(class |)security$' >/dev/null \
+    | grep -E '^[ 	][ 	]*(class |)security$' >/dev/null \
     && pcp_selinux_security_class=true
 
             seinfo -x --class=dir $seinfo_common_flag 2>/dev/null \
-    | egrep '^[ 	][ 	]*(class |)dir$' >/dev/null \
+    | grep -E '^[ 	][ 	]*(class |)dir$' >/dev/null \
     && pcp_selinux_dir_class=true
 
     seinfo -x --class=rawip_socket $seinfo_common_flag 2>/dev/null \
-    | egrep '^[ 	][ 	]*(class |)rawip_socket$' >/dev/null \
+    | grep -E '^[ 	][ 	]*(class |)rawip_socket$' >/dev/null \
     && pcp_selinux_rawip_socket_class=true
 
     seinfo -x --class=netlink_generic_socket $seinfo_common_flag 2>/dev/null \
-    | egrep '^[ 	][ 	]*(class |)netlink_generic_socket$' >/dev/null \
+    | grep -E '^[ 	][ 	]*(class |)netlink_generic_socket$' >/dev/null \
     && pcp_selinux_netlink_generic_socket_class=true
 
     seinfo -x --class=netlink_tcpdiag_socket $seinfo_common_flag 2>/dev/null \
-    | egrep '^[ 	][ 	]*(class |)netlink_tcpdiag_socket$' >/dev/null \
+    | grep -E '^[ 	][ 	]*(class |)netlink_tcpdiag_socket$' >/dev/null \
     && pcp_selinux_netlink_tcpdiag_socket_class=true
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -2350,7 +2350,7 @@ AS_IF([test "x$enable_selinux" != "xfalse"], [
     && pcp_selinux_hostname_exec_map=true
 
     seinfo -x --class=bpf $seinfo_common_flag 2>/dev/null \
-    | egrep '^[[ 	]][[ 	]]*(class |)bpf$' >/dev/null \
+    | grep -E '^[[ 	]][[ 	]]*(class |)bpf$' >/dev/null \
     && pcp_selinux_bpf=true
 
     seinfo -a 2>/dev/null \
@@ -2366,47 +2366,47 @@ AS_IF([test "x$enable_selinux" != "xfalse"], [
     && pcp_selinux_capability2_bpf=true
 
     seinfo -x --class=icmp_socket $seinfo_common_flag 2>/dev/null \
-    | egrep '^[[ 	]][[ 	]]*(class |)icmp_socket$' >/dev/null \
+    | grep -E '^[[ 	]][[ 	]]*(class |)icmp_socket$' >/dev/null \
     && pcp_selinux_icmp_socket_class=true
 
     seinfo -x --class=lockdown $seinfo_common_flag 2>/dev/null \
-    | egrep '^[[ 	]][[ 	]]*(class |)lockdown$' >/dev/null \
+    | grep -E '^[[ 	]][[ 	]]*(class |)lockdown$' >/dev/null \
     && pcp_selinux_lockdown_class=true
 
     dnl these ones are for pcpqa.te
 
     seinfo -x --class=netlink_selinux_socket $seinfo_common_flag 2>/dev/null \
-    | egrep '^[[ 	]][[ 	]]*(class |)netlink_selinux_socket$' >/dev/null \
+    | grep -E '^[[ 	]][[ 	]]*(class |)netlink_selinux_socket$' >/dev/null \
     && pcp_selinux_netlink_selinux_socket_class=true
 
     seinfo -x --class=netlink_audit_socket $seinfo_common_flag 2>/dev/null \
-    | egrep '^[[ 	]][[ 	]]*(class |)netlink_audit_socket$' >/dev/null \
+    | grep -E '^[[ 	]][[ 	]]*(class |)netlink_audit_socket$' >/dev/null \
     && pcp_selinux_netlink_audit_socket_class=true
 
     seinfo -x --class=sock_file $seinfo_common_flag 2>/dev/null \
-    | egrep '^[[ 	]][[ 	]]*(class |)sock_file$' >/dev/null \
+    | grep -E '^[[ 	]][[ 	]]*(class |)sock_file$' >/dev/null \
     && pcp_selinux_sock_file_class=true
 
     seinfo -x --class=security $seinfo_common_flag 2>/dev/null \
-    | egrep '^[[ 	]][[ 	]]*(class |)security$' >/dev/null \
+    | grep -E '^[[ 	]][[ 	]]*(class |)security$' >/dev/null \
     && pcp_selinux_security_class=true
 
     dnl pcp_selinux_dir already used for something else, so name to
     dnl set is pcp_selinux_dir_class
     seinfo -x --class=dir $seinfo_common_flag 2>/dev/null \
-    | egrep '^[[ 	]][[ 	]]*(class |)dir$' >/dev/null \
+    | grep -E '^[[ 	]][[ 	]]*(class |)dir$' >/dev/null \
     && pcp_selinux_dir_class=true
 
     seinfo -x --class=rawip_socket $seinfo_common_flag 2>/dev/null \
-    | egrep '^[[ 	]][[ 	]]*(class |)rawip_socket$' >/dev/null \
+    | grep -E '^[[ 	]][[ 	]]*(class |)rawip_socket$' >/dev/null \
     && pcp_selinux_rawip_socket_class=true
 
     seinfo -x --class=netlink_generic_socket $seinfo_common_flag 2>/dev/null \
-    | egrep '^[[ 	]][[ 	]]*(class |)netlink_generic_socket$' >/dev/null \
+    | grep -E '^[[ 	]][[ 	]]*(class |)netlink_generic_socket$' >/dev/null \
     && pcp_selinux_netlink_generic_socket_class=true
 
     seinfo -x --class=netlink_tcpdiag_socket $seinfo_common_flag 2>/dev/null \
-    | egrep '^[[ 	]][[ 	]]*(class |)netlink_tcpdiag_socket$' >/dev/null \
+    | grep -E '^[[ 	]][[ 	]]*(class |)netlink_tcpdiag_socket$' >/dev/null \
     && pcp_selinux_netlink_tcpdiag_socket_class=true
 
 ])

--- a/debian/fixcontrol
+++ b/debian/fixcontrol
@@ -61,7 +61,7 @@ then
     exit 1
 fi
 
-eval `egrep '^(ENABLE_|PMDA_|HAVE_|QT_)' ../src/include/builddefs | sed -e 's/ //g'`
+eval `grep -E '^(ENABLE_|PMDA_|HAVE_|QT_)' ../src/include/builddefs | sed -e 's/ //g'`
 
 if $PMDA_PERFEVENT
 then

--- a/qa/002
+++ b/qa/002
@@ -14,4 +14,4 @@ echo "QA output created by $seq"
 
 trap "rm -f $tmp.*; exit" 0 1 2 3 15
 
-pminfo -v sample 2>&1 | egrep -v 'sample\.dynamic|sample\.sysinfo|sample\.darkness|sample\.secret|sample\.event\.'
+pminfo -v sample 2>&1 | grep -E -v 'sample\.dynamic|sample\.sysinfo|sample\.darkness|sample\.secret|sample\.event\.'

--- a/qa/003
+++ b/qa/003
@@ -149,7 +149,7 @@ do
     then
 	# we killed pmcd, that's not good!
 	#
-	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mcd' >>$seq.full
+	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mcd' >>$seq.full
 	for log in pmcd sample linux darwin solaris openbsd freebsd netbsd
 	do
 	    for suff in "" ".prev"

--- a/qa/033
+++ b/qa/033
@@ -84,11 +84,11 @@ else
 fi
 echo "symroot=$symroot" >>$seq.full
 echo "--- mount | filter ---" >>$seq.full
-mount | egrep "$root|/dev/root|$symroot" >>$seq.full
+mount | grep -E "$root|/dev/root|$symroot" >>$seq.full
 pminfo -f filesys.mountdir >>$seq.full
 pminfo -f filesys \
 | tee -a $seq.full \
-| egrep "(^filesys)|\"$root\"|/dev/root|$symroot\"|\"overlay\"" \
+| grep -E "(^filesys)|\"$root\"|/dev/root|$symroot\"|\"overlay\"" \
 | _filter_dumpresult 2>&1 > $tmp.out
 
 cat $tmp.out

--- a/qa/039
+++ b/qa/039
@@ -50,7 +50,7 @@ sleep 1		# get into sync
 pmlogger -c $tmp.config -l $tmp.log -s 4 $tmp &
 logger_pid=$!
 echo "logger_pid=$logger_pid" >>$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger' >>$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger' >>$seq.full
 sleep 2
 
 echo "Partial, expect meta data"

--- a/qa/041
+++ b/qa/041
@@ -118,7 +118,7 @@ then
     exit
 fi
 echo "pmcd pid=$pid" >>$seq.full
-ps $PCP_PS_ALL_FLAGS | egrep "PID|$pid" >>$seq.full
+ps $PCP_PS_ALL_FLAGS | grep -E "PID|$pid" >>$seq.full
 
 $sudo kill -STOP $pid
 
@@ -132,7 +132,7 @@ export PMCD_CONNECT_TIMEOUT
 pminfo -f sample.long.million >$tmp.tmp 2>&1 &
 
 _expect "Forcing termination"
-ps $PCP_PS_ALL_FLAGS | egrep "PID|$pid" >>$seq.full
+ps $PCP_PS_ALL_FLAGS | grep -E "PID|$pid" >>$seq.full
 ( $sudo $PCP_RC_DIR/pmcd restart; $sudo $PCP_RC_DIR/pmlogger restart ) >$tmp.two 2>&1
 _wait_for_pmcd
 _wait_for_pmlogger

--- a/qa/047
+++ b/qa/047
@@ -33,7 +33,7 @@ _pminfo_value()
 {
     inst="$1"
 
-    fgrep " or \"$inst\"" | \
+    grep -F " or \"$inst\"" | \
     sed \
 	-e "s/^ *inst .* or \"$inst\". value //g" \
     #end

--- a/qa/061
+++ b/qa/061
@@ -54,9 +54,9 @@ s/posn=[0-9]*/posn=NNN/g
     # is not deterministic, so deal with that ...
     # Ditto for the control_req: line
     #
-    egrep -v '^(check_local_creds|control_req):' <$tmp.tmp
+    grep -E -v '^(check_local_creds|control_req):' <$tmp.tmp
     echo "..."
-    egrep '^(check_local_creds|control_req):' <$tmp.tmp \
+    grep -E '^(check_local_creds|control_req):' <$tmp.tmp \
     | LC_COLLATE=POSIX sort
 }
 

--- a/qa/066
+++ b/qa/066
@@ -221,7 +221,7 @@ do
 	ls -l `dirname $log`
 	cat ${log}.prev >>$seq.full
 	exit
-    elif [ `egrep '^Host access' $log | wc -l` = 2 ]
+    elif [ `grep -E '^Host access' $log | wc -l` = 2 ]
     then
 	break
     fi

--- a/qa/067
+++ b/qa/067
@@ -196,7 +196,7 @@ $sudo $signal -a -s HUP pmcd
 # wait for PMCD to finish writing log (or 5 seconds)
 for t in 1 2 3 4 5
 do
-    if egrep '^Cleanup "test" agent' $log >/dev/null 2>&1
+    if grep -E '^Cleanup "test" agent' $log >/dev/null 2>&1
     then
 	break
     fi

--- a/qa/069
+++ b/qa/069
@@ -204,7 +204,7 @@ echo "host1: ip=$other1_ip hex_ip=$other1_xip" >>$seq.full
 echo "host2: ip=$other2_ip hex_ip=$other2_xip" >>$seq.full
 
 echo "# Installed by PCP QA test $seq on `date`" >$nconfig
-egrep '^(linux|darwin|solaris)' $config >>$nconfig
+grep -E '^(linux|darwin|solaris)' $config >>$nconfig
 grep '^pmcd' $config >>$nconfig
 
 $sudo cp $config $oconfig

--- a/qa/072
+++ b/qa/072
@@ -80,7 +80,7 @@ do
     echo "pmdumplog:" >>$seq.full
     pmdumplog $tmp 2>&1 \
     | tee -a $seq.full \
-    | egrep 'disk\.|network\.' \
+    | grep -E 'disk\.|network\.' \
     | _filter \
     | LC_COLLATE=POSIX sort
 done

--- a/qa/083
+++ b/qa/083
@@ -83,7 +83,7 @@ _await_logger()
 	    # ...but meant to die
 	    echo
 	    echo "primary pmlogger won't die, can't do QA test, ...giving up!"
-	    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p]m|[P]PID'
+	    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p]m|[P]PID'
 	    exit 1
 	fi
     else
@@ -97,7 +97,7 @@ _await_logger()
 	    cat $log
 	    echo "pmlogger sh log:"
 	    cat $tmp/sh.log
-	    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p]m|[P]PID'
+	    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p]m|[P]PID'
 	    exit 1
 	else
 	    echo "primary pmlogger terminated"
@@ -239,7 +239,7 @@ if [ -s $errors ]
 then
     echo Errors: | tee -a $here/$seq.full
     _filter < $errors
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p]m|[P]PID'
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p]m|[P]PID'
     exit 1
 fi
 

--- a/qa/102
+++ b/qa/102
@@ -64,7 +64,7 @@ pmlc -P </dev/null 2>&1 >>$seq.full
 _service pcp restart 2>&1 | _filter_pcp_start
 _wait_for_pmcd
 _wait_for_pmlogger
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([P]ID)|([p]mlogger)' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([P]ID)|([p]mlogger)' >>$here/$seq.full
 
 cat <<End-of-File >$tmp.pmlc
 # not connected

--- a/qa/1046
+++ b/qa/1046
@@ -41,7 +41,6 @@ head -9 $tmp.pmie
 
 echo
 echo "=== now print out some deltas"
-# note use fgrep in case of bogus double delta
 echo o  global
 pmieconf -r ./pconf -f $tmp.pmie l global | _filter
 echo o  memory

--- a/qa/1055
+++ b/qa/1055
@@ -103,7 +103,7 @@ echo "archive contents before pmda simple restart..."
 echo "expect no <mark> record"
 echo "---------------------------------------------------------------"
 pmdumplog $archive >$tmp.out 2>&1
-egrep '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
+grep -E '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
 | _filter_pmdumplog \
 | uniq
 echo "---------------------------------------------------------------"
@@ -133,7 +133,7 @@ echo "archive contents after pmda simple restart..."
 echo "expect no <mark> record"
 echo "---------------------------------------------------------------"
 pmdumplog $archive >$tmp.out 2>&1
-egrep '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
+grep -E '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
 | _filter_pmdumplog \
 | uniq
 echo "---------------------------------------------------------------"

--- a/qa/1059
+++ b/qa/1059
@@ -36,7 +36,7 @@ else
     if [ "`wc -l <$tmp.pid | sed -e 's/ //g'`" -gt 1 ]
     then
 	echo "Error: multiple pmcd processes running"
-	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]PID|pmcd'
+	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]PID|pmcd'
 	error=true
     fi
     if [ -d $PCP_RUN_DIR ]

--- a/qa/1067
+++ b/qa/1067
@@ -162,7 +162,7 @@ echo '2 two' >>$tmp.indom
 $sudo cp $tmp.indom $control
 $zabbix_agentd -p \
 | tee -a $seq.full \
-| fgrep pcp.sample. \
+| grep -F pcp.sample. \
 | _filter_values
 
 # derived metrics

--- a/qa/107
+++ b/qa/107
@@ -64,7 +64,7 @@ End-of-File
 cat $tmp.tmp >>$seq.full
 
 $PCP_ECHO_PROG $PCP_ECHO_N "Expect at least one metric with logging state \"on\" ...""$PCP_ECHO_C"
-if egrep '^    (mand on )|(adv  on )' $tmp.tmp >/dev/null
+if grep -E '^    (mand on )|(adv  on )' $tmp.tmp >/dev/null
 then
     echo " PASS"
 else
@@ -72,7 +72,7 @@ else
 fi
 
 $PCP_ECHO_PROG $PCP_ECHO_N "Expect at least 250 metrics to be reported ...""$PCP_ECHO_C"
-num=`egrep '^(disk|network|kernel|pmcd|sample|sampledso)\.' $tmp.tmp | wc -l | sed -e 's/ //g'`
+num=`grep -E '^(disk|network|kernel|pmcd|sample|sampledso)\.' $tmp.tmp | wc -l | sed -e 's/ //g'`
 if [ $num -ge 250 ]
 then
     echo " PASS"

--- a/qa/108
+++ b/qa/108
@@ -20,9 +20,9 @@ _filter()
     cat >$tmp.in
     sed <$tmp.in \
 	-e 's/value [0-9][0-9]*/value NUMBER/' >$tmp.tmp
-    if [ `egrep 'red|green|blue' $tmp.tmp | wc -l | sed -e 's/  *//g'` -ge 1 ]
+    if [ `grep -E 'red|green|blue' $tmp.tmp | wc -l | sed -e 's/  *//g'` -ge 1 ]
     then
-	egrep -v 'red|green|blue' $tmp.tmp
+	grep -E -v 'red|green|blue' $tmp.tmp
 	echo "... at least one value"
     else
 	cat $tmp.in

--- a/qa/1083
+++ b/qa/1083
@@ -23,7 +23,7 @@ _cleanup()
     _restore_auto_restart pmcd
     _service pmcd restart 2>&1 | _filter_pcp_start
     _wait_for_pmcd
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p]mcd|[P]ID' >>$here/$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p]mcd|[P]ID' >>$here/$seq.full
     _restore_auto_restart pmlogger
     _service pmlogger restart 2>&1 | _filter_pcp_start
     _wait_for_pmlogger
@@ -46,19 +46,19 @@ _service pmcd restart >>$here/$seq.full 2>&1
 date >>$here/$seq.full 2>&1
 _wait_for_pmcd
 date >>$here/$seq.full 2>&1
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p]mcd|[P]ID' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p]mcd|[P]ID' >>$here/$seq.full
 
 # real QA test starts here
 _service pmcd stop >>$here/$seq.full 2>&1
 _wait_for_pmcd_stop
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p]mcd|[P]ID' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p]mcd|[P]ID' >>$here/$seq.full
 
 echo "expect failure ..."
 pmprobe hinv.ncpu
 
 _service pmcd start >>$here/$seq.full 2>&1
 _wait_for_pmcd
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p]mcd|[P]ID' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p]mcd|[P]ID' >>$here/$seq.full
 
 echo "expect success ..."
 pmprobe hinv.ncpu

--- a/qa/1091
+++ b/qa/1091
@@ -25,7 +25,7 @@ trap "cd $here; rm -rf $tmp.*; exit \$status" 0 1 2 3 15
 #
 _filter()
 {
-    egrep '^(load|pmGetPMNSLocation:)' $tmp.err \
+    grep -E '^(load|pmGetPMNSLocation:)' $tmp.err \
     | sed \
 	-e "s@$PCP_VAR_DIR@PCP_VAR_DIR@g" \
 	-e "s@$tmp@TMP@g" \
@@ -43,8 +43,8 @@ End-of-File
 # pick some disk metrics that are always likely to be present
 #
 metrics=`pminfo -Dpmns disk.dev 2>$tmp.err \
-         | egrep 'read|write|total' \
-	 | egrep -v 'rawactive|_merge|_time|blk' \
+         | grep -E 'read|write|total' \
+	 | grep -E -v 'rawactive|_merge|_time|blk' \
 	 | LC_COLLATE=POSIX sort`
 # real QA test starts here
 echo "PM_CONTEXT_LOCAL, default PMNS ..."

--- a/qa/1105
+++ b/qa/1105
@@ -43,19 +43,19 @@ for verify in "" -d
 do
     echo
     echo "full PMNS traversal $verify ..."
-    PCP_DERIVED_CONFIG=$tmp.derive pminfo $verify 2>$tmp.err | egrep 'qa\.(hide|ok)'
+    PCP_DERIVED_CONFIG=$tmp.derive pminfo $verify 2>$tmp.err | grep -E 'qa\.(hide|ok)'
     _filter_err <$tmp.err
 
     echo
     echo "traverse PMNS below qa $verify ..."
-    PCP_DERIVED_CONFIG=$tmp.derive pminfo $verify qa 2>$tmp.err | egrep 'qa\.(hide|ok)'
+    PCP_DERIVED_CONFIG=$tmp.derive pminfo $verify qa 2>$tmp.err | grep -E 'qa\.(hide|ok)'
     _filter_err <$tmp.err
 
     echo
     echo "exact matches in PMNS $verify ..."
     PCP_DERIVED_CONFIG=$tmp.derive pminfo $verify 2>$tmp.err \
 	qa.hide.ok qa.hide.syntax qa.hide.semantic qa.ok \
-    | egrep 'qa\.(hide|ok)'
+    | grep -E 'qa\.(hide|ok)'
     _filter_err <$tmp.err
 
     echo

--- a/qa/1111
+++ b/qa/1111
@@ -53,11 +53,11 @@ p2ipid=$!
 sleep 3
 $signal $pid $p2ipid 2>/dev/null
 wait
-egrep -q "^POST \/write\?db=roar" $tmp.socat.out
+grep -E -q "^POST \/write\?db=roar" $tmp.socat.out
 [ $? -eq 0 ] && echo "Found POST URL in noauth output"
-egrep -q "hinv_ncpu value=[0-9]+(\.[0-9]+)? [0-9]+$" $tmp.socat.out
+grep -E -q "hinv_ncpu value=[0-9]+(\.[0-9]+)? [0-9]+$" $tmp.socat.out
 [ $? -eq 0 ] && echo "Found proper metric body in noauth output"
-egrep -q "sample_control value=0 [0-9]+$" $tmp.socat.out
+grep -E -q "sample_control value=0 [0-9]+$" $tmp.socat.out
 [ $? -eq 0 ] && echo "Found correct zero value in noauth output"
 _full_stash
 
@@ -71,9 +71,9 @@ p2ipid=$!
 sleep 3
 $signal $pid $p2ipid 2>/dev/null
 wait
-egrep -q "^POST \/write\?db=roar" $tmp.socat.out
+grep -E -q "^POST \/write\?db=roar" $tmp.socat.out
 [ $? -eq 0 ] && echo "Found POST URL in noauth output"
-egrep -q "hinv_ncpu,host=me\.example\.com value=[0-9]+(\.[0-9]+)? [0-9]+$" $tmp.socat.out
+grep -E -q "hinv_ncpu,host=me\.example\.com value=[0-9]+(\.[0-9]+)? [0-9]+$" $tmp.socat.out
 [ $? -eq 0 ] && echo "Found proper metric body in noauth output"
 _full_stash
 
@@ -88,11 +88,11 @@ p2ipid=$!
 sleep 3
 $signal $pid $p2ipid 2>/dev/null
 wait
-egrep -q "^POST \/write\?db=roar" $tmp.socat.out
+grep -E -q "^POST \/write\?db=roar" $tmp.socat.out
 [ $? -eq 0 ] && echo "Found POST URL in output"
-egrep -q "Authorization: Basic cGNwOmhleQ==" $tmp.socat.out
+grep -E -q "Authorization: Basic cGNwOmhleQ==" $tmp.socat.out
 [ $? -eq 0 ] && echo "Found auth data in HTTP request"
-egrep -q "hinv_ncpu,host=me\.example\.com value=[0-9]+(\.[0-9]+)? [0-9]+$" $tmp.socat.out
+grep -E -q "hinv_ncpu,host=me\.example\.com value=[0-9]+(\.[0-9]+)? [0-9]+$" $tmp.socat.out
 [ $? -eq 0 ] && echo "Found proper metric body in output"
 _full_stash
 

--- a/qa/1130
+++ b/qa/1130
@@ -83,9 +83,9 @@ $pcp2elasticsearch -t 1 -s 1 hinv.ncpu >$tmp.p2e.out 2>$tmp.p2e.err
 sleep 2
 $signal $pid 2>/dev/null
 wait
-egrep -q '^PUT /+pcp HTTP/' $tmp.socat.err
+grep -E -q '^PUT /+pcp HTTP/' $tmp.socat.err
 [ $? -eq 0 ] && echo "Found correct index in output"
-egrep -q '"hinv": {"ncpu": '$ncpu'}' $tmp.socat.err
+grep -E -q '"hinv": {"ncpu": '$ncpu'}' $tmp.socat.err
 [ $? -eq 0 ] && echo "Found correct value in output"
 _full_stash
 
@@ -97,9 +97,9 @@ $pcp2elasticsearch -t 1 -s 1 -X QAHOST -x INDEX hinv.ncpu >$tmp.p2e.out 2>$tmp.p
 sleep 2
 $signal $pid 2>/dev/null
 wait
-egrep -q '^PUT /+INDEX HTTP/' $tmp.socat.err
+grep -E -q '^PUT /+INDEX HTTP/' $tmp.socat.err
 [ $? -eq 0 ] && echo "Found correct index in output"
-egrep -q '"@host-id": "QAHOST"' $tmp.socat.err
+grep -E -q '"@host-id": "QAHOST"' $tmp.socat.err
 [ $? -eq 0 ] && echo "Found proper hostid in output"
 _full_stash
 
@@ -112,7 +112,7 @@ sleep 2
 $signal $pid 2>/dev/null
 wait
 echo "--- Start of received data ---"
-egrep '(mappings|slack)' $tmp.socat.err | sed -e 's,< [1-9].*,,g' >$tmp.archive.data
+grep -E '(mappings|slack)' $tmp.socat.err | sed -e 's,< [1-9].*,,g' >$tmp.archive.data
 while read -r line
 do
   echo $line | _filter_prec | pmjson | LC_COLLATE=POSIX sort | tr -d ,
@@ -129,7 +129,7 @@ sleep 2
 $signal $pid 2>/dev/null
 wait
 echo "--- Start of received data ---"
-egrep -q '^POST /+INDEX/test_search_type HTTP/' $tmp.socat.err
+grep -E -q '^POST /+INDEX/test_search_type HTTP/' $tmp.socat.err
 [ $? -eq 0 ] && echo "Found correct index in output"
 _full_stash
 

--- a/qa/1141
+++ b/qa/1141
@@ -19,7 +19,7 @@ which sedismod >/dev/null 2>&1 || _notrun "sedismod tool not installed (module d
 which semodule >/dev/null 2>&1 || _notrun "semodule tool not installed"
 $sudo semodule -l >$tmp.out 2>&1
 [ $? -eq 0 ] || _notrun "semodule -l fails"
-egrep '^pcpupstream([ 	]|$)' $tmp.out >/dev/null
+grep -E '^pcpupstream([ 	]|$)' $tmp.out >/dev/null
 [ $? -eq 0 ] || _notrun "pcpupstream module not loaded"
 which seinfo >/dev/null 2>&1 || _notrun "seinfo tool not installed"
 [ -f "$policy_file" ] || _notrun "upstream policy package not installed"

--- a/qa/1147
+++ b/qa/1147
@@ -45,7 +45,7 @@ if [ -z "$pid" ]
 then
     echo "Arrgh ... no primary pmlogger?"
     echo "Likely looking processes ..."
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([p]m)|([P]ID)'
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([p]m)|([P]ID)'
     exit
 fi
 _stop_auto_restart pmlogger

--- a/qa/115
+++ b/qa/115
@@ -128,7 +128,7 @@ skip == 0		{ print }
 
 _count_pmies()
 {
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([P]ID)|([p]mie)' >>$here/$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([P]ID)|([p]mie)' >>$here/$seq.full
     count=0
     if [ -d $PCP_TMP_DIR/pmie ] 
     then
@@ -284,9 +284,9 @@ LOCALHOSTNAME   n n $tmp.locker/ok.$case -c $tmp.conf
 EOF
 rm -f $tmp.locker/ok.$case.lock
 touch $tmp.locker/ok.$case.lock
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([P]ID)|([p]mie)' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([P]ID)|([p]mie)' >>$here/$seq.full
 pmie_check -V -V -N -c $tmp.warning.$case >$tmp.warning.$case.log
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([P]ID)|([p]mie)' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([P]ID)|([p]mie)' >>$here/$seq.full
 cat $tmp.warning.$case.log | _filter
 rm -f $tmp.warning.$case.log
 echo

--- a/qa/1159
+++ b/qa/1159
@@ -55,13 +55,13 @@ pid=$!
 
 echo "pmlogger PID=$pid" >>$here/$seq.full
 
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger' >>$here/$seq.full
 
 sleep 4
 kill -INT $pid
 wait
 
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger' >>$here/$seq.full
 
 # Counting is real tricky here ... pmlogger may split the one group in
 # the config file into multiple pmFetch's, so just count the number of

--- a/qa/1190
+++ b/qa/1190
@@ -152,13 +152,13 @@ else
     echo "Count of pmcd's ... BAD ($n not 1)"
     echo "From _get_pids_by_name"
     sed -e 's/^/ /' <$tmp.pids
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mcd |[p]mcd$' \
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mcd |[p]mcd$' \
     | sed -e 's/^/  /'
     _systemctl_status pmcd
     status=1
 fi
 
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger .*-P ' >$tmp.out
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger .*-P ' >$tmp.out
 n=`grep -v PID <$tmp.out | wc -l | sed -e 's/ //g'`
 if [ "$n" -eq 1 ]
 then

--- a/qa/1191
+++ b/qa/1191
@@ -51,7 +51,7 @@ then
     exit
 fi
 
-if pminfo -dtTf `pminfo openmetrics | fgrep -v openmetrics.control | LC_COLLATE=POSIX sort` > $tmp.info 2> $tmp.err
+if pminfo -dtTf `pminfo openmetrics | grep -F -v openmetrics.control | LC_COLLATE=POSIX sort` > $tmp.info 2> $tmp.err
 then
     :
 else

--- a/qa/1196
+++ b/qa/1196
@@ -129,11 +129,11 @@ echo "=== no-error case ===" | tee -a $here/$seq.full
 $sudo ./Install </dev/null 2>&1 | _filter_cull
 ( echo "--- after Install"; cat $PCP_PMCDCONF_PATH ) >>$here/$seq.full
 pminfo -mf whacko | _filter
-pminfo -f pmcd.agent.status | egrep 'whacko|sample'
+pminfo -f pmcd.agent.status | grep -E 'whacko|sample'
 $sudo ./Remove 2>&1 | _filter_cull
 ( echo "--- after Remove"; cat $PCP_PMCDCONF_PATH ) >>$here/$seq.full
 pminfo -mf whacko | _filter
-pminfo -f pmcd.agent.status | egrep 'whacko|sample'
+pminfo -f pmcd.agent.status | grep -E 'whacko|sample'
 
 echo | tee -a $here/$seq.full
 echo "=== domain number clash case ... will clobber and remove sample PMDA ===" | tee -a $here/$seq.full
@@ -142,11 +142,11 @@ echo '#define WHACKO 29' >domain.h
 $sudo ./Install </dev/null 2>&1 | _filter_cull
 ( echo "--- after Install"; cat $PCP_PMCDCONF_PATH ) >>$here/$seq.full
 pminfo -mf whacko | _filter
-pminfo -f pmcd.agent.status | egrep 'whacko|sample'
+pminfo -f pmcd.agent.status | grep -E 'whacko|sample'
 $sudo ./Remove 2>&1 | _filter_cull
 ( echo "--- after Remove"; cat $PCP_PMCDCONF_PATH ) >>$here/$seq.full
 pminfo -mf whacko | _filter
-pminfo -f pmcd.agent.status | egrep 'whacko|sample'
+pminfo -f pmcd.agent.status | grep -E 'whacko|sample'
 
 # Reinstate pmcd.conf and reinstall the sample PMDA ... the PMNS will
 # have been trashed, so putting pmcd.conf is not enough.
@@ -170,11 +170,11 @@ echo '#define WHACKO 241' >domain.h
 $sudo sh -c "iam=sample ./Install" </dev/null 2>&1 | _filter_cull
 ( echo "--- after Install"; cat $PCP_PMCDCONF_PATH ) >>$here/$seq.full
 pminfo -mf whacko | _filter
-pminfo -f pmcd.agent.status | egrep 'whacko|sample'
+pminfo -f pmcd.agent.status | grep -E 'whacko|sample'
 $sudo sh -c "iam=sample ./Remove" 2>&1 | _filter_cull
 ( echo "--- after Remove"; cat $PCP_PMCDCONF_PATH ) >>$here/$seq.full
 pminfo -mf whacko | _filter
-pminfo -f pmcd.agent.status | egrep 'whacko|sample'
+pminfo -f pmcd.agent.status | grep -E 'whacko|sample'
 
 # success, all done
 status=0

--- a/qa/1200
+++ b/qa/1200
@@ -45,7 +45,7 @@ _my_wait_for_pmlogger()
     do
 	if $sudo -u pcp pmlc -P </dev/null 2>&1 \
 		| tee $tmp.err \
-		| egrep "Connection refused|Transport endpoint is not connected" >/dev/null
+		| grep -E "Connection refused|Transport endpoint is not connected" >/dev/null
 	then
 	    sleep 1
 	    _i=`expr $_i + 1`
@@ -93,13 +93,13 @@ myhost=`hostname`
 
 # real QA test starts here
 echo "initially" >>$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p](mcd|mlogger)' >>$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p](mcd|mlogger)' >>$seq.full
 
 # stop pmcd, primary pmlogger
 #
 _service pcp stop 2>&1 | _filter_pcp_stop
 echo "pcp stop" >>$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p](mcd|mlogger)' >>$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p](mcd|mlogger)' >>$seq.full
 
 # from here on, don't use any "_service" wrapper ... we need to dodge
 # any linking of the services and starting stuff under the covers
@@ -111,7 +111,7 @@ echo "pmcd not running, expect this to timeout"
 $sudo $PCP_RC_DIR/pmlogger start 2>&1 | _filter_pcp_start
 _my_wait_for_pmlogger | _filter
 echo "pmlogger start fail case" >>$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p](mcd|mlogger)' >>$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p](mcd|mlogger)' >>$seq.full
 
 $sudo $PCP_RC_DIR/pmcd start 2>&1 | _filter_pcp_start
 _wait_for_pmcd
@@ -121,7 +121,7 @@ echo "pmcd running, expect this to work"
 $sudo $PCP_RC_DIR/pmlogger start 2>&1 | _filter_pcp_start
 _wait_for_pmlogger
 echo "pmlogger start success case" >>$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p](mcd|mlogger)' >>$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p](mcd|mlogger)' >>$seq.full
 
 # success, all done
 status=0

--- a/qa/1201
+++ b/qa/1201
@@ -47,7 +47,7 @@ _my_wait_for_pmlogger()
     do
 	if $sudo -u pcp pmlc -P </dev/null 2>&1 \
 		| tee $tmp.err \
-		| egrep "Connection refused|Transport endpoint is not connected" >/dev/null
+		| grep -E "Connection refused|Transport endpoint is not connected" >/dev/null
 	then
 	    sleep 1
 	    _i=`expr $_i + 1`
@@ -112,13 +112,13 @@ $sudo cp $tmp.control ${PCP_PMLOGGERCONTROL_PATH}.d/$remote
 
 # real QA test starts here
 echo "initially" >>$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p](mcd|mlogger)' >>$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p](mcd|mlogger)' >>$seq.full
 
 # stop pmcd, and all pmloggers
 #
 _service pcp stop 2>&1 | _filter_pcp_stop
 echo "pcp stop" >>$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p](mcd|mlogger)' >>$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p](mcd|mlogger)' >>$seq.full
 
 # from here on, don't use any "_service" wrapper ... we need to dodge
 # any linking of the services and starting stuff under the covers
@@ -130,7 +130,7 @@ echo "pmcd not running, expect this to timeout"
 $sudo $PCP_RC_DIR/pmlogger start 2>&1 | _filter_pcp_start
 _my_wait_for_pmlogger | _filter
 echo "pmlogger start fail case" >>$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p](mcd|mlogger)' >>$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p](mcd|mlogger)' >>$seq.full
 
 $sudo $PCP_RC_DIR/pmcd start 2>&1 | _filter_pcp_start
 _wait_for_pmcd
@@ -140,7 +140,7 @@ echo "pmcd running, expect this to work"
 $sudo $PCP_RC_DIR/pmlogger start 2>&1 | _filter_pcp_start
 _wait_for_pmlogger
 echo "pmlogger start success case" >>$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p](mcd|mlogger)' >>$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p](mcd|mlogger)' >>$seq.full
 pminfo -f pmcd.pmlogger.pmcd_host | tee -a $seq.full >$tmp.tmp
 if grep '"primary"' $tmp.tmp >/dev/null
 then

--- a/qa/1213
+++ b/qa/1213
@@ -57,7 +57,7 @@ _filter()
 	-e 's/TERM [0-9][0-9]*/TERM <somepid>/' \
 	-e '/^------.*\/lock/s/.* /------ ... ls output ... /' \
     # end
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger' >>$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger' >>$seq.full
 }
 
 # Build filter for any existing non-qa and non-primary pmlogger instances.

--- a/qa/1220
+++ b/qa/1220
@@ -35,7 +35,7 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 # real QA test starts here
 mypid=$$
 mytty=`pminfo -f proc.psinfo.ttyname | \
-	fgrep "[${mypid} or " | \
+	grep -F "[${mypid} or " | \
 	awk '{ print $NF }'`
 
 echo "$mytty" | grep \?

--- a/qa/1221
+++ b/qa/1221
@@ -69,7 +69,7 @@ then
     exit
 fi
 
-if pminfo -l `pminfo openmetrics | fgrep -v openmetrics.control | LC_COLLATE=POSIX sort` 2> $tmp.err | _filter | tee $tmp.info
+if pminfo -l `pminfo openmetrics | grep -F -v openmetrics.control | LC_COLLATE=POSIX sort` 2> $tmp.err | _filter | tee $tmp.info
 then
     :
 else

--- a/qa/1248
+++ b/qa/1248
@@ -258,7 +258,7 @@ pmlogctl -V status | _filter_status
 for metric in sample.lights network.interface.total.bytes disk.dev.total
 do
     echo "check $metric ..."
-    egrep "$metric( |\$)" $PCP_ARCHIVE_DIR/$seq-a/$seq-a.config
+    grep -E "$metric( |\$)" $PCP_ARCHIVE_DIR/$seq-a/$seq-a.config
     PCP_DERIVED_CONFIG= pmafm $PCP_ARCHIVE_DIR/$seq-a/Latest pminfo -v $metric \
     | _filter
 done
@@ -275,7 +275,7 @@ pmlogctl -V status | _filter_status
 for metric in sample.lights network.interface.total.bytes disk.dev.total
 do
     echo "check $metric ..."
-    egrep "$metric( |\$)" $PCP_ARCHIVE_DIR/$seq-b/$seq-b.config
+    grep -E "$metric( |\$)" $PCP_ARCHIVE_DIR/$seq-b/$seq-b.config
     PCP_DERIVED_CONFIG= pmafm $PCP_ARCHIVE_DIR/$seq-b/Latest pminfo -v $metric \
     | _filter
 done
@@ -292,7 +292,7 @@ pmlogctl -V status | _filter_status
 for metric in sample.lights network.interface.total.bytes disk.dev.total
 do
     echo "check $metric ..."
-    egrep "$metric( |\$)" $PCP_ARCHIVE_DIR/$seq-c/$seq-c.config
+    grep -E "$metric( |\$)" $PCP_ARCHIVE_DIR/$seq-c/$seq-c.config
     PCP_DERIVED_CONFIG= pmafm $PCP_ARCHIVE_DIR/$seq-c/Latest pminfo -v $metric \
     | _filter
 done

--- a/qa/1249
+++ b/qa/1249
@@ -285,7 +285,7 @@ pmiectl -V status | _filter_status
 for metric in sample.lights network.interface.total.bytes
 do
     echo "check $metric ..."
-    egrep "$metric( |\$)" $PCP_LOG_DIR/pmie/$seq-a/$seq-a.config
+    grep -E "$metric( |\$)" $PCP_LOG_DIR/pmie/$seq-a/$seq-a.config
 done
 pmsleep 0.5		# give pmie a chance to warm up
 _filter_pmie <$PCP_LOG_DIR/pmie/$seq-a/pmie.log | sort | uniq
@@ -302,7 +302,7 @@ pmiectl -V status | _filter_status
 for metric in sample.lights network.interface.total.bytes
 do
     echo "check $metric ..."
-    egrep "$metric( |\$)" $PCP_LOG_DIR/pmie/$seq-b/$seq-b.config
+    grep -E "$metric( |\$)" $PCP_LOG_DIR/pmie/$seq-b/$seq-b.config
 done
 pmsleep 0.5		# give pmie a chance to warm up
 _filter_pmie <$PCP_LOG_DIR/pmie/$seq-b/pmie.log | sort | uniq
@@ -319,7 +319,7 @@ pmiectl -V status | _filter_status
 for metric in sample.lights network.interface.total.bytes
 do
     echo "check $metric ..."
-    egrep "$metric( |\$)" $PCP_LOG_DIR/pmie/$seq-c/$seq-c.config
+    grep -E "$metric( |\$)" $PCP_LOG_DIR/pmie/$seq-c/$seq-c.config
 done
 pmsleep 0.5		# give pmie a chance to warm up
 _filter_pmie <$PCP_LOG_DIR/pmie/$seq-c/pmie.log | sort | uniq

--- a/qa/1251
+++ b/qa/1251
@@ -85,7 +85,7 @@ fi
 
 # real QA test starts here
 cat <<'End-of-File' | sed -e '/^#/d' -e '/^[ 	]*$/d' | while read sect key altname pat
-# section	keyword	altname	egrep for text in man page
+# section	keyword	altname	grep -E for text in man page
 # for keyword, avoid case aliasing (different man's have different rules)
 # and use (one of) the .SH NAME names
 #
@@ -147,11 +147,11 @@ do
     if [ -s $tmp.out ]
     then
 	tr '[A-Z]' '[a-z'] <$tmp.out >$tmp.tmp
-	if egrep "^$lc_key *\($sect" $tmp.tmp >/dev/null
+	if grep -E "^$lc_key *\($sect" $tmp.tmp >/dev/null
 	then
 	    # matching simple entry found from man -k
 	    :
-	elif [ X"$altname" != X- ] && egrep "^$lc_altname *\($sect" $tmp.tmp >/dev/null
+	elif [ X"$altname" != X- ] && grep -E "^$lc_altname *\($sect" $tmp.tmp >/dev/null
 	then
 	    # matching altname entry found from man -k ... needed for
 	    # *BSD where man -k is really apropos and *BSD apropos does
@@ -206,7 +206,7 @@ do
     echo "--- ($sect) ---" | tee -a $seq.full
     TERM=dumb LANG=POSIX LC_MESSAGES=POSIX man $sect $key 2>&1 \
     | sed -e 's/_//g' -e 's/.//g' -e 's/[ 	][ 	]*/ /g' >$tmp.out
-    if egrep "$pat" $tmp.out >/dev/null
+    if grep -E "$pat" $tmp.out >/dev/null
     then
 	echo OK
     else

--- a/qa/126
+++ b/qa/126
@@ -16,7 +16,7 @@ echo "QA output created by $seq"
 rm -f $seq.out
 if [ -f /etc/redhat-release ]
 then
-    if egrep -q '^CentOS [^0-9]*5\.[0-9]|^Red Hat [^0-9]*5\.[0-9]' </etc/redhat-release
+    if grep -E -q '^CentOS [^0-9]*5\.[0-9]|^Red Hat [^0-9]*5\.[0-9]' </etc/redhat-release
     then
 	# not all the snmp metrics are there ...
 	ln $seq.out.2 $seq.out

--- a/qa/1272
+++ b/qa/1272
@@ -1,6 +1,6 @@
 #!/bin/sh
 # PCP QA Test No. 1272
-# pmlogmv with egrep and sh meta chars in file names
+# pmlogmv with grep -E and sh meta chars in file names
 #
 # Copyright (c) 2020 Ken McDonell.  All Rights Reserved.
 #

--- a/qa/1287
+++ b/qa/1287
@@ -64,11 +64,11 @@ fi
 ## pmstore openmetrics.control.debug 1
 
 echo; echo === pminfo listing.
-names=`pminfo openmetrics | fgrep -v openmetrics.control | LC_COLLATE=POSIX sort` 2>$tmp.err
+names=`pminfo openmetrics | grep -F -v openmetrics.control | LC_COLLATE=POSIX sort` 2>$tmp.err
 if [ -z "$names" ]; then
     echo "FAILED - no openmetrics metrics to show"
 else
-    if pminfo -dtTf `pminfo openmetrics | fgrep -v openmetrics.control | LC_COLLATE=POSIX sort` > $tmp.info 2>$tmp.err
+    if pminfo -dtTf `pminfo openmetrics | grep -F -v openmetrics.control | LC_COLLATE=POSIX sort` > $tmp.info 2>$tmp.err
     then
 	:
     else
@@ -81,7 +81,7 @@ fi
 echo == Note: check $seq.full for expected log entries
 echo == pmdaopenmetrics LOG == >>$here/$seq.full
 cat $PCP_LOG_DIR/pmcd/openmetrics.log >>$here/$seq.full
-egrep 'Ready to process requests|notready' $PCP_LOG_DIR/pmcd/openmetrics.log | \
+grep -E 'Ready to process requests|notready' $PCP_LOG_DIR/pmcd/openmetrics.log | \
 sed -e 's/\[.*\]/[DATE]/' -e 's/([0-9]*)/(PID)/'
 
 _pmdaopenmetrics_remove

--- a/qa/1290
+++ b/qa/1290
@@ -154,10 +154,10 @@ log advisory on default {
 End-of-File
 }
 
-$PCP_PS_PROG $PCP_PS_APP_FLAGS | egrep '[P]ID|[p]mproxy' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_APP_FLAGS | grep -E '[P]ID|[p]mproxy' >>$here/$seq.full
 _service pmproxy stop >/dev/null 2>&1
 $sudo $signal -a pmproxy >/dev/null 2>&1
-$PCP_PS_PROG $PCP_PS_APP_FLAGS | egrep '[P]ID|[p]mproxy' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_APP_FLAGS | grep -E '[P]ID|[p]mproxy' >>$here/$seq.full
 
 mkdir -p $tmp.rundir
 export PCP_RUN_DIR=$tmp.rundir
@@ -381,7 +381,7 @@ valgrind \
 
 _wait_for_pmproxy
 $PCP_BINADM_DIR/pmcd_wait -t 5sec -h localhost@localhost
-$PCP_PS_PROG $PCP_PS_APP_FLAGS | egrep '[P]ID|[p]mproxy' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_APP_FLAGS | grep -E '[P]ID|[p]mproxy' >>$here/$seq.full
 
 # real QA test starts here
 export PMPROXY_HOST=localhost

--- a/qa/1306
+++ b/qa/1306
@@ -89,11 +89,11 @@ echo; echo === URL configuration file contains
 sed -e "s|$here|QA_DIR|g" < $PCP_PMDAS_DIR/openmetrics/config.d/$urlbase.url
 
 echo; echo === pminfo listing. Note some labels in the pminfo listing have been removed, see _filter
-names=`pminfo openmetrics | fgrep -v openmetrics.control | LC_COLLATE=POSIX sort` 2>$tmp.err
+names=`pminfo openmetrics | grep -F -v openmetrics.control | LC_COLLATE=POSIX sort` 2>$tmp.err
 if [ -z "$names" ]; then
     echo "FAILED - no openmetrics metrics to show"
 else
-    if pminfo -fl `pminfo openmetrics | fgrep -v openmetrics.control | LC_COLLATE=POSIX sort` > $tmp.info 2>$tmp.err
+    if pminfo -fl `pminfo openmetrics | grep -F -v openmetrics.control | LC_COLLATE=POSIX sort` > $tmp.info 2>$tmp.err
     then
 	:
     else

--- a/qa/131
+++ b/qa/131
@@ -27,7 +27,7 @@ PMCD_CONNECT_TIMEOUT=0.00001
 export PMCD_CONNECT_TIMEOUT
 
 # check basic connectivity to avoid false failures (non-timeout errors)
-$PCP_BINADM_DIR/pmcd_wait -h $farhost -v 2>&1 | egrep -q 'No route to host'
+$PCP_BINADM_DIR/pmcd_wait -h $farhost -v 2>&1 | grep -E -q 'No route to host'
 [ $? -ne 0 ] || _notrun "Cannot connect to far away host \"$farhost\""
 
 echo "Expect: Connection timed out"

--- a/qa/1337
+++ b/qa/1337
@@ -20,7 +20,7 @@ test -x /opt/mssql/bin/sqlservr || _notrun "Microsoft SQL Server not installed"
 test -d "$PCP_PMDAS_DIR/mssql" || _notrun "Microsoft SQL Server PMDA not installed"
 
 # extract username and password, check connection to SQL Server
-eval `$sudo egrep 'server=|username=|password=' "$PCP_PMDAS_DIR/mssql/mssql.conf"`
+eval `$sudo grep -E 'server=|username=|password=' "$PCP_PMDAS_DIR/mssql/mssql.conf"`
 if $sudo test -f /var/opt/mssql/secrets/assessment; then
     username=`$sudo head -1 /var/opt/mssql/secrets/assessment`
     password=`$sudo tail -1 /var/opt/mssql/secrets/assessment`

--- a/qa/134
+++ b/qa/134
@@ -129,7 +129,7 @@ $1 ~ /TIMESTAMP/ && NF == 4	{ print $1 "     " $2 "       OFFSET       OFFSET"; 
 _do_metrics()
 {
     echo "Metrics in archive:"
-    egrep 'sample|pmcd' \
+    grep -E 'sample|pmcd' \
     | sed -e 's/.*(//' -e 's/).*//' -e 's/^/    /'
 }
 

--- a/qa/1340
+++ b/qa/1340
@@ -35,7 +35,7 @@ echo "== Attempt operations"
 pminfo -f sample.control
 pmprobe -I sample.ulong.bin
 echo "== Verify PMDA status"
-pminfo -f pmcd.agent.fenced | egrep "pmcd|mmv|sample" | grep -v sampledso
+pminfo -f pmcd.agent.fenced | grep -E "pmcd|mmv|sample" | grep -v sampledso
 
 echo
 echo "== Lower the fence for MMV and sample PMDAs"
@@ -47,7 +47,7 @@ pminfo -f sample.control
 pmprobe -I sample.ulong.bin
 
 echo "== Verify PMDA status"
-pminfo -f pmcd.agent.fenced | egrep "pmcd|mmv|sample" | grep -v sampledso
+pminfo -f pmcd.agent.fenced | grep -E "pmcd|mmv|sample" | grep -v sampledso
 
 # success, all done
 status=0

--- a/qa/1342
+++ b/qa/1342
@@ -81,11 +81,11 @@ echo; echo === URL configuration file contains
 sed -e "s|$HERE|QA_DIR|g" < $PCP_PMDAS_DIR/openmetrics/config.d/$urlbase.url
 
 echo; echo === pminfo listing. Note openmetrics.simple_metric.metric2 should be filtered out
-names=`pminfo openmetrics | fgrep -v openmetrics.control | LC_COLLATE=POSIX sort` 2>$tmp.err
+names=`pminfo openmetrics | grep -F -v openmetrics.control | LC_COLLATE=POSIX sort` 2>$tmp.err
 if [ -z "$names" ]; then
     echo "FAILED - no openmetrics metrics to show"
 else
-    if pminfo -dtTf `pminfo openmetrics | fgrep -v openmetrics.control | LC_COLLATE=POSIX sort` > $tmp.info 2>$tmp.err
+    if pminfo -dtTf `pminfo openmetrics | grep -F -v openmetrics.control | LC_COLLATE=POSIX sort` > $tmp.info 2>$tmp.err
     then
 	:
     else

--- a/qa/1358
+++ b/qa/1358
@@ -43,8 +43,8 @@ pmdapodman_install()
 
 _filter()
 {
-    #egrep "^podman|$pod1|$pod2|$container1|$container2" | \
-    egrep "^podman|$container1|$container2" | \
+    #grep -E "^podman|$pod1|$pod2|$container1|$container2" | \
+    grep -E "^podman|$container1|$container2" | \
     sed \
 	-e "s/$container1/CONTAINER/g" \
 	-e "s/$container2/CONTAINER/g" \

--- a/qa/1385
+++ b/qa/1385
@@ -82,7 +82,7 @@ else
     cat $tmp.out
 fi
 cat $tmp.info $tmp.err
-if pminfo -b 10000000 -fd `pminfo openmetrics | fgrep -v .control | LC_COLLATE=POSIX sort` > $tmp.info 2>$tmp.err
+if pminfo -b 10000000 -fd `pminfo openmetrics | grep -F -v .control | LC_COLLATE=POSIX sort` > $tmp.info 2>$tmp.err
    then
     echo "Fetch and desc openmetrics metrics: success"
     cat $tmp.info

--- a/qa/1429
+++ b/qa/1429
@@ -178,7 +178,7 @@ else
     echo "No log file?"
 fi
 echo "daily dir ..."
-ls $tmp | _filter | egrep '.(index|meta|0)$' | grep -v TODAY
+ls $tmp | _filter | grep -E '.(index|meta|0)$' | grep -v TODAY
 
 echo "--- cannot write in dest dir ---" | tee -a $here/$seq.full
 
@@ -203,9 +203,9 @@ else
     echo "No log file?"
 fi
 echo "daily dir ..."
-ls $tmp | _filter | egrep '.(index|meta|0)$' | grep -v TODAY
+ls $tmp | _filter | grep -E '.(index|meta|0)$' | grep -v TODAY
 echo "autosave dir ..."
-ls $tmp.nowrite | _filter | egrep '.(index|meta|0)$'
+ls $tmp.nowrite | _filter | grep -E '.(index|meta|0)$'
 
 echo "--- dest dir ok ---" | tee -a $here/$seq.full
 
@@ -231,9 +231,9 @@ else
     echo "No log file?"
 fi
 echo "daily dir ..."
-ls $tmp | _filter | egrep '.(index|meta|0)$' | grep -v TODAY
+ls $tmp | _filter | grep -E '.(index|meta|0)$' | grep -v TODAY
 echo "autosave dir ..."
-ls $tmp.ok | _filter | egrep '.(index|meta|0)$'
+ls $tmp.ok | _filter | grep -E '.(index|meta|0)$'
 
 echo "--- dest dir with DATEXX components does not exist ---" | tee -a $here/$seq.full
 
@@ -270,9 +270,9 @@ else
     echo "No log file?"
 fi
 echo "daily dir ..."
-ls $tmp | _filter | egrep '.(index|meta|0)$' | grep -v TODAY
+ls $tmp | _filter | grep -E '.(index|meta|0)$' | grep -v TODAY
 echo "autosave dir ..."
-ls -R $tmp.ok | _filter | egrep '.(index|meta|0)$' \
+ls -R $tmp.ok | _filter | grep -E '.(index|meta|0)$' \
 | sed \
     -e "s/`date +%Y`/YYYY/g" \
     -e "s/-`date +%m`-/-MM-/" \
@@ -313,7 +313,7 @@ else
     echo "No log file?"
 fi
 echo "daily dir ..."
-ls $tmp | _filter | egrep '.(index|meta|0)$' | grep -v TODAY
+ls $tmp | _filter | grep -E '.(index|meta|0)$' | grep -v TODAY
 echo "autosave dir ..."
 ls -R $tmp.ok | _filter
 

--- a/qa/1480
+++ b/qa/1480
@@ -54,7 +54,7 @@ pminfo --verify $iam | _filter
 # How many sensors did PMDA lmsensors register?
 PMDA=`pminfo lmsensors|wc -l`
 # How many sensors did binary lmsensors find?
-SENS=`/usr/bin/sensors -u 2>/dev/null|egrep '_input: '|wc -l`
+SENS=`/usr/bin/sensors -u 2>/dev/null|grep -E '_input: '|wc -l`
 
 if [ $PMDA -eq $SENS ]; then
     echo -n "number of sensors from '/usr/bin/sensors -u' and from 'pminfo "
@@ -64,8 +64,8 @@ else
     echo "lmsensors' does not match."
     echo "pminfo lmsensors|wc -l:" >>$here/$seq.full
     pminfo lmsensors |wc -l >>$here/$seq.full
-    echo "/usr/bin/sensors -u|egrep '_input: '|wc -l" >>$here/$seq.full
-    /usr/bin/sensors -u 2>/dev/null|egrep '_input: '|wc -l >>$here/$seq.full
+    echo "/usr/bin/sensors -u|grep -E '_input: '|wc -l" >>$here/$seq.full
+    /usr/bin/sensors -u 2>/dev/null|grep -E '_input: '|wc -l >>$here/$seq.full
 fi
 
 # Now, I can not check if the actual values for sensors are the same,

--- a/qa/152
+++ b/qa/152
@@ -48,7 +48,7 @@ done
 pminfo -f pmcd.numclients | tee -a $here/$seq.full | sed -e '/^$/d' >$tmp.out
 ( date; pminfo -f pmcd.client ) >$tmp.after
 
-if egrep "value $PAT" $tmp.out >/dev/null
+if grep -E "value $PAT" $tmp.out >/dev/null
 then
     sed <$tmp.out \
 	-e "s/$MIN/N+4/" \

--- a/qa/1543
+++ b/qa/1543
@@ -18,7 +18,7 @@ _check_series
 _cleanup()
 {
     echo "Entering _cleanup ..." >>$here/$seq.full
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mproxy' >>$here/$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mproxy' >>$here/$seq.full
     cat $PCP_LOG_DIR/pmproxy/pmproxy.log >>$here/$seq.full
     cd $here
     _restore_auto_restart pmproxy
@@ -39,7 +39,7 @@ _cleanup()
 	_service pmproxy stop >>$here/$seq.full 2>&1
     fi
     echo "Exiting _cleanup ..." >>$here/$seq.full
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mproxy' >>$here/$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mproxy' >>$here/$seq.full
     $sudo rm -rf $tmp $tmp.*
 }
 
@@ -187,7 +187,7 @@ _service pmproxy start >>$here/$seq.full 2>&1
 _wait_for_pmproxy
 
 echo "After initial _service start ..." >>$here/$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mproxy' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mproxy' >>$here/$seq.full
 
 port=44322
 

--- a/qa/160
+++ b/qa/160
@@ -20,7 +20,7 @@ rm -f $seq.full
 
 _filter()
 {
-    egrep 'QA-clientid|Error|__pmSetClientId' \
+    grep -E 'QA-clientid|Error|__pmSetClientId' \
     | sed -e 's/value ".* QA/value "<host> QA/' \
     | sed -e 's/\[/[ /' -e 's/]/ ]/' \
     | awk '

--- a/qa/1600
+++ b/qa/1600
@@ -196,7 +196,7 @@ pmproxy_pid=$!
 pmcd_wait -h localhost@localhost:$proxyport -v -t 5sec
 pmsleep 0.5	# time for pmproxy to start discovering
 
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep 'pmlogger|pmproxy|redis' >> $seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E 'pmlogger|pmproxy|redis' >> $seq.full
 redis-cli $options keys pcp:* >> $seq.full
 ls -lR $PCP_ARCHIVE_DIR >> $seq.full
 cat $tmp.pmproxy.log >> $seq.full

--- a/qa/1602
+++ b/qa/1602
@@ -85,7 +85,7 @@ pmproxy_pid=$!
 echo "proxyport=$proxyport" >>$seq.full
 echo "pmproxy_pid=$pmproxy_pid" >>$seq.full
 _wait_for_pmproxy $proxyport $tmp.pmproxy.log
-which netstat >/dev/null && netstat -l | egrep "$redis_node1_port|$redis_node2_port|$redis_node3_port|$proxyport" >>$seq.full
+which netstat >/dev/null && netstat -l | grep -E "$redis_node1_port|$redis_node2_port|$redis_node3_port|$proxyport" >>$seq.full
 _check_redis_ping $proxyport
 echo
 

--- a/qa/1626
+++ b/qa/1626
@@ -104,7 +104,7 @@ while true; do
     then
 	echo FAILED sz=\"$sz\" after $count iterations
 	pminfo -f pmproxy >>$seq.full
-	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mproxy' >>$seq.full
+	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mproxy' >>$seq.full
 	pminfo -f pmcd.agent.status >>$seq.full
 	exit
     fi
@@ -138,7 +138,7 @@ while true; do
     then
 	echo FAILED partial=\"$partial\" after $count iterations
 	pminfo -f pmproxy >>$seq.full
-	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mproxy' >>$seq.full
+	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mproxy' >>$seq.full
 	pminfo -f pmcd.agent.status >>$seq.full
 	exit
     fi
@@ -153,7 +153,7 @@ if [ "$partial" != 0 ]
 then
     echo FAIL \"$partial\" partial reads, should be zero
     pminfo -f pmproxy >>$seq.full
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mproxy' >>$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mproxy' >>$seq.full
     pminfo -f pmcd.agent.status >>$seq.full
     exit
 fi

--- a/qa/1661
+++ b/qa/1661
@@ -113,7 +113,7 @@ _wait_for_pmproxy
 pmproxy_pid=`_get_pids_by_name -a pmproxy`
 [ -z "$pmproxy_pid" ] && echo === pmproxy not running && exit
 date >>$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mproxy' >>$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mproxy' >>$seq.full
 echo "pmproxy_pid=$pmproxy_pid" >>$seq.full
 
 #debug# echo "sudo gdb -p $pmproxy_pid"
@@ -133,7 +133,7 @@ then
     $sudo ls -l /proc/$pmproxy_pid/fd | grep 'testarchive.*(deleted)'
 else
     echo "Arrgh: pmproxy pid=$pmproxy_pid has vanished" | tee -a $seq.full
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mproxy' >>$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mproxy' >>$seq.full
     for log in $PCP_LOG_DIR/pmproxy/pmproxy.log*
     do
 	if [ -f "$log" ]
@@ -213,7 +213,7 @@ while true; do
 	    echo "Arrgh ... curlogvol not found from ..."
 	    $sudo ls -l /proc/$pmproxy_pid/fd/
 	    echo "pmproxy_pid=$pmproxy_pid"
-	    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mproxy'
+	    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mproxy'
 	    exit
 	else
 	    retry=`expr $retry + 1`
@@ -244,7 +244,7 @@ then
     echo "Arrgh ... newlogvol not found from ..."
     $sudo ls -l /proc/$pmproxy_pid/fd/
     echo "pmproxy_pid=$pmproxy_pid"
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mproxy'
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mproxy'
     exit
 fi
 if [ `expr $curlogvol + 1` -ne $newlogvol ]

--- a/qa/1672
+++ b/qa/1672
@@ -124,7 +124,7 @@ do
     echo
     echo "=== method: ${method}, authentication with invalid password ===" | tee -a $seq.full
     pminfo -f -h "pcp://localhost?method=${method}&username=${username}&password=n" pmcd.feature.authentication 2>&1 | tee -a $seq.full \
-    | grep 'Authentication - ' | egrep -q "authentication failure|Cannot connect"
+    | grep 'Authentication - ' | grep -E -q "authentication failure|Cannot connect"
     test $? -eq 0 && echo "authentication failure"
 
     echo

--- a/qa/1681
+++ b/qa/1681
@@ -97,7 +97,7 @@ else
 fi | _filter
 cat $tmp.option >> $here/$seq.full
 echo Check options saved | tee -a $here/$seq.full
-egrep '^globals|^timestamp' $tmp.option
+grep -E '^globals|^timestamp' $tmp.option
 echo done
 
 # success, all done

--- a/qa/169
+++ b/qa/169
@@ -96,7 +96,7 @@ _check_pmcd_procs()
 {
     n_pmcd=`$PCP_PS_PROG $PCP_PS_ALL_FLAGS \
 	    | tee $tmp.pmcd \
-	    | fgrep "$PCP_PMCD_PATH" \
+	    | grep -F "$PCP_PMCD_PATH" \
 	    | grep -v pmcd_wait \
 	    | grep -v grep \
 	    | wc -l \
@@ -197,7 +197,7 @@ else
 fi
 
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | sed -e 's/$/ /' >$tmp.ps
-egrep '[P]ID|[p]m|[d]umb' $tmp.ps >>$seq.full
+grep -E '[P]ID|[p]m|[d]umb' $tmp.ps >>$seq.full
 old_dumb_pid=`$PCP_AWK_PROG <$tmp.ps '/\/src\/dumb_pmda /{print $2}'`
 echo "old_dumb_pid=$old_dumb_pid" >>$seq.full
 old_pmcd_pid=`$PCP_AWK_PROG <$tmp.ps '/\/bin\/pmcd /{print $2}'`
@@ -239,7 +239,7 @@ sleep 2
 pminfo -n $pmns -d dummyproc >/dev/null 2>&1
 
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | sed -e 's/$/ /' >$tmp.ps
-egrep '[P]ID|[p]m|[d]umb' $tmp.ps >>$seq.full
+grep -E '[P]ID|[p]m|[d]umb' $tmp.ps >>$seq.full
 new_dumb_pid=`$PCP_AWK_PROG <$tmp.ps '/\/src\/dumb_pmda /{print $2}'`
 echo "new_dumb_pid=$new_dumb_pid" >>$seq.full
 new_pmcd_pid=`$PCP_AWK_PROG <$tmp.ps '/\/bin\/pmcd /{print $2}'`
@@ -286,7 +286,7 @@ else
 fi
 
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | sed -e 's/$/ /' >$tmp.ps
-egrep '[P]ID|[p]m|[d]umb' $tmp.ps >>$seq.full
+grep -E '[P]ID|[p]m|[d]umb' $tmp.ps >>$seq.full
 new_dumb_pid=`$PCP_AWK_PROG <$tmp.ps '/\/src\/dumb_pmda /{print $2}'`
 echo "new_dumb_pid=$new_dumb_pid" >>$seq.full
 new_pmcd_pid=`$PCP_AWK_PROG <$tmp.ps '/\/bin\/pmcd /{print $2}'`
@@ -338,7 +338,7 @@ echo "After pminfo: `date`" >>$seq.full
 _echo ""
 
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | sed -e 's/$/ /' >$tmp.ps
-egrep '[P]ID|[p]m|[d]umb' $tmp.ps >>$seq.full
+grep -E '[P]ID|[p]m|[d]umb' $tmp.ps >>$seq.full
 new_dumb_pid=`$PCP_AWK_PROG <$tmp.ps '/\/src\/dumb_pmda /{print $2}'`
 echo "new_dumb_pid=$new_dumb_pid" >>$seq.full
 new_pmcd_pid=`$PCP_AWK_PROG <$tmp.ps '/\/bin\/pmcd /{print $2}'`
@@ -377,7 +377,7 @@ _echo ""
 sleep 8
 
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | sed -e 's/$/ /' >$tmp.ps
-egrep '[P]ID|[p]mcd|[p]mda' $tmp.ps >>$seq.full
+grep -E '[P]ID|[p]mcd|[p]mda' $tmp.ps >>$seq.full
 new_dumb_pid=`$PCP_AWK_PROG <$tmp.ps '/\/src\/dumb_pmda /{print $2}'`
 echo "new_dumb_pid=$new_dumb_pid" >>$seq.full
 new_pmcd_pid=`$PCP_AWK_PROG <$tmp.ps '/\/bin\/pmcd /{print $2}'`

--- a/qa/170
+++ b/qa/170
@@ -46,7 +46,7 @@ else
     echo 'Error: $PCP_LOG_DIR/pmcd/pmcd.log not created' | tee -a $here/$seq.full
     date >>$here/$seq.full
     ls -l $PCP_LOG_DIR/pmcd >>$here/$seq.full
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mcd' >>$here/$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mcd' >>$here/$seq.full
     
     status=1
 fi

--- a/qa/1774
+++ b/qa/1774
@@ -76,7 +76,7 @@ remotestate=`pmlogctl status | tee -a $seq.full | $PCP_AWK_PROG '$1 == "'"$remot
 echo "remotestate=$remotestate" >>$seq.full
 if [ "$remotestate" != dead ]; then
     echo "FAILED to kill pmlogger (pid=$remotepid) for host $remote"
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([P]ID)|([p]mlogger)' >>$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([P]ID)|([p]mlogger)' >>$seq.full
     exit
 fi
 
@@ -90,7 +90,7 @@ remotestate=`pmlogctl status | tee -a $seq.full | $PCP_AWK_PROG '$1 == "'"$remot
 echo "remotestate=$remotestate" >>$seq.full
 if [ "$remotestate" != running ]; then
     echo FAILED to restart dead pmlogger for host $remote
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([P]ID)|([p]mlogger)' >>$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([P]ID)|([p]mlogger)' >>$seq.full
     exit
 fi
 

--- a/qa/180
+++ b/qa/180
@@ -50,7 +50,7 @@ fi
 cat $tmp.out
 echo
 echo "samples: `grep '^[0-9][0-9]:' $tmp.out | wc -l | sed -e 's/  *//g'`"
-egrep '^(user|sys)' $tmp.err | _do_cpu
+grep -E '^(user|sys)' $tmp.err | _do_cpu
 pmval -z -Dlog -n $tmp.pmns -a $arch -t $DELTA foo 2>$tmp.err >/dev/null
 echo "__pmLogReads: `grep __pmLogRead $tmp.err | wc -l | sed -e 's/  *//g'`"
 cat $tmp.err >>$seq.full
@@ -66,6 +66,6 @@ fi
 cat $tmp.out
 echo
 echo "samples: `grep '^[0-9][0-9]:' $tmp.out | wc -l | sed -e 's/  *//g'`"
-egrep '^(user|sys)' $tmp.err | _do_cpu
+grep -E '^(user|sys)' $tmp.err | _do_cpu
 pmval -z -Dlog -i 4653127 -n $tmp.pmns -a $arch -t $DELTA foo 2>$tmp.err >/dev/null
 echo "__pmLogReads: `grep __pmLogRead $tmp.err | wc -l | sed -e 's/  *//g'`"

--- a/qa/1893
+++ b/qa/1893
@@ -49,7 +49,7 @@ pminfo -v proc.psinfo.exe
 echo done
 
 echo == check exe value for self | tee -a $seq.full
-pminfo -f proc.psinfo.exe | tee -a $seq.full | fgrep "inst [$mypid " | _filter
+pminfo -f proc.psinfo.exe | tee -a $seq.full | grep -F "inst [$mypid " | _filter
 echo done
 
 echo == check for any cwd failure
@@ -57,12 +57,12 @@ pminfo -v proc.psinfo.cwd
 echo done
 
 echo == check cwd value for self | tee -a $seq.full
-pminfo -f proc.psinfo.cwd | tee -a $seq.full | fgrep "inst [$mypid " | _filter
+pminfo -f proc.psinfo.cwd | tee -a $seq.full | grep -F "inst [$mypid " | _filter
 echo done
 
 echo == check for psargs with leading space | tee -a $seq.full
 pminfo -f proc.psinfo.psargs > $tmp.psargs
-fgrep ' value " ' $tmp.psargs
+grep -F ' value " ' $tmp.psargs
 [ $? -ne 0 ] && cat $tmp.psargs >> $seq.full
 echo done
 

--- a/qa/1927
+++ b/qa/1927
@@ -83,7 +83,7 @@ cat $tmp.out $tmp.err | _filter_sockets
 
 echo "Check the values for v6only metric are 0 or 1 ..."
 pminfo -f network.persocket.v6only > $tmp.out 2> $tmp.err
-cat $tmp.out $tmp.err | _filter_sockets | egrep -v 'value [01]$' | sed -e '/^$/d'
+cat $tmp.out $tmp.err | _filter_sockets | grep -E -v 'value [01]$' | sed -e '/^$/d'
 
 pmdasockets_remove
 status=0

--- a/qa/200
+++ b/qa/200
@@ -66,12 +66,12 @@ _wait_for_pmcd_exit()
 		cat $PCP_LOG_DIR/pmcd/pmcd.log
 
 		echo "likely looking processes ..."
-		ps "$PCP_PS_ALL_FLAGS" | egrep "[p]m|[P]ID"
+		ps "$PCP_PS_ALL_FLAGS" | grep -E "[p]m|[P]ID"
 		;;
 	    *)
 		# assume a remote PMCD
 		#
-		ssh pcpqa@$_host "sh -c '. \$PCP_DIR/etc/pcp.env; echo; echo "=== pmcd.log ==="; [ -f \$PCP_LOG_DIR/pmcd/pmcd.log ] && cat \$PCP_LOG_DIR/pmcd/pmcd.log; [ -f \$PCP_LOG_DIR/pmcd.log ] && cat \$PCP_LOG_DIR/pmcd.log; echo; echo likely looking processes ...; ( ps \$PCP_PS_ALL_FLAGS | egrep \"[p]m|[P]ID\" )'" </dev/null
+		ssh pcpqa@$_host "sh -c '. \$PCP_DIR/etc/pcp.env; echo; echo "=== pmcd.log ==="; [ -f \$PCP_LOG_DIR/pmcd/pmcd.log ] && cat \$PCP_LOG_DIR/pmcd/pmcd.log; [ -f \$PCP_LOG_DIR/pmcd.log ] && cat \$PCP_LOG_DIR/pmcd.log; echo; echo likely looking processes ...; ( ps \$PCP_PS_ALL_FLAGS | grep -E \"[p]m|[P]ID\" )'" </dev/null
 		;;
 	esac
 	status=2

--- a/qa/215
+++ b/qa/215
@@ -40,7 +40,7 @@ _interrupt()
 
 _filter()
 {
-    egrep '(Rconnect direct)|(debug)|(value)|(^[ 0-9]*$)' \
+    grep -E '(Rconnect direct)|(debug)|(value)|(^[ 0-9]*$)' \
 	| sed -e 's/ret=0,.*/no error/' \
 	| sed -e 's/discrete instantaneous/DISCRETE or INSTANTANEOUS/' \
 	| sed -e 's/instantaneous/DISCRETE or INSTANTANEOUS/'

--- a/qa/243
+++ b/qa/243
@@ -108,7 +108,7 @@ then
     _filter_info < pmcd.log > pmcd.log1.$$
 else
     echo "No pmcd.log, pmcd failed to start?"
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mcd'
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mcd'
     exit
 fi
 

--- a/qa/252
+++ b/qa/252
@@ -39,7 +39,7 @@ _tolerance()
 
 _num_recs()
 {
-  num_recs=`$pmdumplog $tmp | egrep -c '^[0-9][0-9]:[0-9][0-9]:'`
+  num_recs=`$pmdumplog $tmp | grep -E -c '^[0-9][0-9]:[0-9][0-9]:'`
   # subtract 1 for the prologue and 1 for the epilogue
   num_recs=`expr $num_recs - 2`
   [ $debug ] && echo "found $num_recs samples after the prologue+epilogue"

--- a/qa/254
+++ b/qa/254
@@ -60,7 +60,7 @@ _hunt_pmcd_socket()
     netstat -a | grep ':44321' >>$here/$seq.full
     if which fstat >/dev/null 2>&1
     then
-	fstat | egrep '([P]ID)|(:[4]4321)' >$tmp.out 2>>$here/$seq.full
+	fstat | grep -E '([P]ID)|(:[4]4321)' >$tmp.out 2>>$here/$seq.full
 	# fstat output ...
 	# pcp      pmcd       81043    0* internet stream tcp 0x0 *:44321
 	$PCP_AWK_PROG <$tmp.out '{ print $3 }' \

--- a/qa/258
+++ b/qa/258
@@ -99,7 +99,7 @@ _wait_for_pmlogger
 
 # time_sucker transaction sleeps for 10 secs - wait for this
 sleep 11
-vals=`pminfo -f trace.transact.count | fgrep 'No value(s) available!' | wc -l`
+vals=`pminfo -f trace.transact.count | grep -F 'No value(s) available!' | wc -l`
 if [ $vals -eq 1 ]
 then
     echo "Error: No value(s) available!"

--- a/qa/295
+++ b/qa/295
@@ -55,8 +55,8 @@ _filter_pmproxy()
 
 _check()
 {
-    connects=`egrep 'AcceptNewClient|accept new client' $tmp.log | wc -l`
-    disconnects=`egrep 'DeleteClient|connection closed' $tmp.log | wc -l`
+    connects=`grep -E 'AcceptNewClient|accept new client' $tmp.log | wc -l`
+    disconnects=`grep -E 'DeleteClient|connection closed' $tmp.log | wc -l`
     difference=`expr $connects - $disconnects`
     echo "N connects"
     echo "N-$difference disconnects"

--- a/qa/300
+++ b/qa/300
@@ -116,7 +116,7 @@ _check_need $PCP_VAR_DIR/pmdas/bozo .NeedRemove
 echo
 echo "Check pmpost messages ..."
 cat $PCP_LOG_DIR/NOTICES > $seq.full
-egrep '(Install|Remove).*bozo$' $PCP_LOG_DIR/NOTICES \
+grep -E '(Install|Remove).*bozo$' $PCP_LOG_DIR/NOTICES \
 | sed \
     -e 's/^[0-9][0-9]*:[0-9][0-9]*:[0-9]*\.[0-9]* /TIME /' \
     -e 's/\(check for host \).*/\1HOSTNAME/'

--- a/qa/308
+++ b/qa/308
@@ -103,7 +103,7 @@ then
 fi
 
 echo "inst=$inst" >>$seq.full
-ps $PCP_PS_ALL_FLAGS | egrep "PID|$inst" >>$seq.full
+ps $PCP_PS_ALL_FLAGS | grep -E "PID|$inst" >>$seq.full
 
 cat <<end-of-file >$tmp.conf
 log advisory on once { proc.psinfo.ppid[$inst] }
@@ -167,7 +167,7 @@ log advisory on once { proc.psinfo.ppid[$inst] }
 end-of-file
 
 echo "inst=$inst" >>$seq.full
-ssh -q pcpqa@$host1 ps -e | egrep "PID|$inst" >>$seq.full
+ssh -q pcpqa@$host1 ps -e | grep -E "PID|$inst" >>$seq.full
 echo "=== pmlogger config ===" >>$seq.full
 cat $tmp.conf >>$seq.full
 
@@ -238,7 +238,7 @@ log advisory on once { proc.psinfo.ppid[$inst] }
 end-of-file
 
 echo "inst=$inst" >>$seq.full
-ssh -q pcpqa@$host2 ps -e | egrep "PID|$inst" >>$seq.full
+ssh -q pcpqa@$host2 ps -e | grep -E "PID|$inst" >>$seq.full
 echo "=== pmlogger config ===" >>$seq.full
 cat $tmp.conf >>$seq.full
 

--- a/qa/309
+++ b/qa/309
@@ -50,7 +50,7 @@ _stop_auto_restart pmcd
 #
 echo 'expect "disk.dev.read: pmStore: No permission to perform requested operation"'
 pmstore disk.dev.read 1 2>&1 \
-| fgrep 'pmStore:' \
+| grep -F 'pmStore:' \
 | sed -e 's/Permission denied/No permission to perform requested operation/'
 
 # success, all done

--- a/qa/318
+++ b/qa/318
@@ -20,7 +20,7 @@ trap "rm -f $tmp.*; exit \$status" 0 1 2 3 15
 # real QA test starts here
 cat <<'End-of-File' \
 | pmie -A 1min -t 1min -z -v -a archives/20041125.0 2>&1 \
-| fgrep -v "evaluator exiting"
+| grep -F -v "evaluator exiting"
 $minute;
 $hour;
 $minute > 34 -> print "OK1";

--- a/qa/321
+++ b/qa/321
@@ -20,7 +20,7 @@ trap "rm -f $tmp.*; exit \$status" 0 1 2 3 15
 
 # real QA test starts here
 pmie -z -a archives/conn20070309 -S @17:00 -T @17:10 <<'End-of-File' 2>&1 \
-| fgrep -v "evaluator exiting"
+| grep -F -v "evaluator exiting"
 service_name_cn = "CON_USE";
 sample_count = "@0..4";
 acx_filter = "echo";
@@ -44,7 +44,7 @@ some_inst (count_sample ($conn_used >= $conn_critical) >= 4)
 End-of-File
 
 pmie -v -T 2sec <<'End-of-File' 2>&1 \
-| fgrep -v "evaluator exiting" \
+| grep -F -v "evaluator exiting" \
 | sed -e '/warning cannot create stats file dir/d' \
 | _filter_pmie_log
 delta=3sec;

--- a/qa/325
+++ b/qa/325
@@ -18,13 +18,13 @@ which pmconfirm >/dev/null 2>&1 || _notrun pmconfirm not installed
 _cleanup()
 {
     echo "at end ..." >>$seq.full
-    pid=`ps $PCP_PS_ALL_FLAGS | egrep '[p]mconfirm' | tee -a $seq.full | $PCP_AWK_PROG '{print $2}'`
+    pid=`ps $PCP_PS_ALL_FLAGS | grep -E '[p]mconfirm' | tee -a $seq.full | $PCP_AWK_PROG '{print $2}'`
     echo "[p]mconfirm pid: $pid" >>$seq.full
     [ -n "$pid" ] && $signal -s KILL $pid >/dev/null 2>&1
-    pid=`ps $PCP_PS_ALL_FLAGS | egrep '[p]mprintf' | tee -a $seq.full | $PCP_AWK_PROG '{print $2}'`
+    pid=`ps $PCP_PS_ALL_FLAGS | grep -E '[p]mprintf' | tee -a $seq.full | $PCP_AWK_PROG '{print $2}'`
     echo "[p]mprintf pid: $pid" >>$seq.full
     [ -n "$pid" ] && $signal -s KILL $pid >/dev/null 2>&1
-    pid=`ps $PCP_PS_ALL_FLAGS | egrep '[p]mquery' | tee -a $seq.full | $PCP_AWK_PROG '{print $2}'`
+    pid=`ps $PCP_PS_ALL_FLAGS | grep -E '[p]mquery' | tee -a $seq.full | $PCP_AWK_PROG '{print $2}'`
     echo "[p]mquery pid: $pid" >>$seq.full >/dev/null 2>&1
     [ -n "$pid" ] && $signal -s KILL $pid
     _clean_display

--- a/qa/326
+++ b/qa/326
@@ -20,7 +20,7 @@ then
     # repeatedly to make this test work on this platform and it is not worth
     # investing any more effort on.
     #
-    if egrep -q '^CentOS .* 6\.[0-9]|^Red Hat .* 6\.[0-9]' </etc/redhat-release
+    if grep -E -q '^CentOS .* 6\.[0-9]|^Red Hat .* 6\.[0-9]' </etc/redhat-release
     then
 	_notrun "don't bother on CentOS/RHEL 6"
     fi
@@ -131,7 +131,7 @@ if [ -z "$pmda_pid" ]
 then
     echo "Arrgh ... lost pmdasample process?"
     echo "See $seq.full for details"
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([P]ID)|(/[p]mcd)' >>$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([P]ID)|(/[p]mcd)' >>$seq.full
     [ -n "$pmlogger_pid" ] && $signal -s TERM $pmlogger_pid
     [ -n "$pmval_pid" ] && $signal -s TERM $pmval_pid
     cat $tmp.pmcd.log >>$seq.full
@@ -150,7 +150,7 @@ if [ -z "$pmda_pid" ]
 then
     echo "Arrgh ... lost pmdasample process?"
     echo "See $seq.full for details"
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([P]ID)|(/[p]m[cd])' >>$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([P]ID)|(/[p]m[cd])' >>$seq.full
     [ -n "$pmlogger_pid" ] && $signal -s TERM $pmlogger_pid
     [ -n "$pmval_pid" ] && $signal -s TERM $pmval_pid
     cat $tmp.pmcd.log >>$seq.full
@@ -193,7 +193,7 @@ cat $tmp.pmcd.log >>$seq.full
 
 echo
 echo "Trace of observed state changes and PMDA count ..."
-egrep '(state changes)|( value )' $tmp.pmval \
+grep -E '(state changes)|( value )' $tmp.pmval \
 | _filter_pmval_live \
 | uniq
 
@@ -204,7 +204,7 @@ cat $tmp.log >>$seq.full
 echo
 echo "archive contents ..."
 pmdumplog $tmp >$tmp.out 2>&1
-egrep '(<mark>)|(pmcd.numagents)' $tmp.out \
+grep -E '(<mark>)|(pmcd.numagents)' $tmp.out \
 | _filter_pmdumplog \
 | uniq
 

--- a/qa/347
+++ b/qa/347
@@ -116,7 +116,7 @@ echo "=== validate values ==="
 pminfo -f `pminfo $iam | LC_COLLATE=POSIX sort` >$tmp.out
 _filter_info <$tmp.out
 
-if fgrep -s "No PMCD agent" $tmp.out >/dev/null 2>&1
+if grep -F -s "No PMCD agent" $tmp.out >/dev/null 2>&1
 then
     echo
     echo "Looks bad ..."

--- a/qa/348
+++ b/qa/348
@@ -23,8 +23,8 @@ count=`$sudo ls $kvm_stats_path | wc -l`
 lockdown=/sys/kernel/security/lockdown
 if [ -f $lockdown ]
 then
-    $sudo fgrep -q '[integrity]' $lockdown && _notrun "Kernel in lockdown"
-    $sudo fgrep -q '[confidentiality]' $lockdown && _notrun "Kernel in lockdown"
+    $sudo grep -F -q '[integrity]' $lockdown && _notrun "Kernel in lockdown"
+    $sudo grep -F -q '[confidentiality]' $lockdown && _notrun "Kernel in lockdown"
 fi
 
 status=1

--- a/qa/354
+++ b/qa/354
@@ -175,7 +175,7 @@ fi
 
 for i in 1 2 3 4 5
 do
-    if pmlc $pid </dev/null 2>&1 | egrep "Connection refused|Transport endpoint is not connected" >/dev/null
+    if pmlc $pid </dev/null 2>&1 | grep -E "Connection refused|Transport endpoint is not connected" >/dev/null
     then
 	# pmlogger has gone away, continue
 	#
@@ -260,7 +260,7 @@ fi
 
 for i in 1 2 3 4 5
 do
-    if pmlc $pid </dev/null 2>&1 | egrep "Connection refused|Transport endpoint is not connected" >/dev/null
+    if pmlc $pid </dev/null 2>&1 | grep -E "Connection refused|Transport endpoint is not connected" >/dev/null
     then
 	# pmlogger has gone away, continue
 	#

--- a/qa/355
+++ b/qa/355
@@ -37,7 +37,7 @@ fi
 
 _countinst()
 {
-    fgrep ' value ' | sed -e 's/.* value //g' | $PCP_AWK_PROG '
+    grep -F ' value ' | sed -e 's/.* value //g' | $PCP_AWK_PROG '
 BEGIN   { sum = 0 }
         { if (NF == 1) sum = sum + $1 }
 END     { printf "%d\n",sum }'

--- a/qa/381
+++ b/qa/381
@@ -89,12 +89,12 @@ _ping()
     echo "Remote host: $rem_host [pid: $rem_pid port: $rem_port]" >>$here/$seq.full
     pminfo -f -h $rem_host pmcd.pmlogger.port >>$here/$seq.full 2>&1
     ssh $rem_host '. /etc/pcp.env; $PCP_PS_PROG $PCP_PS_ALL_FLAGS' 2>&1 \
-    | egrep "PID|pmlogger" >>$here/$seq.full
+    | grep -E "PID|pmlogger" >>$here/$seq.full
     echo >>$here/$seq.full
     echo "Local host: $myhost [pid: $pid port: $port]" >>$here/$seq.full
     pminfo -f -h $myhost pmcd.pmlogger.port >>$here/$seq.full 2>&1
     $PCP_PS_PROG $PCP_PS_ALL_FLAGS \
-    | egrep "PID|pmlogger" \
+    | grep -E "PID|pmlogger" \
     | grep -v grep >>$here/$seq.full
 }
 

--- a/qa/408
+++ b/qa/408
@@ -18,8 +18,8 @@ trap "exit \$status" 0 1 2 3 15
 
 _filter()
 {
-fgrep "One-line or help text is not available" |\
-   egrep -v "^irix\.|^hw\.|^hinv\.|^mmv\."
+grep -F "One-line or help text is not available" |\
+   grep -E -v "^irix\.|^hw\.|^hinv\.|^mmv\."
 }
 
 # real QA test starts here

--- a/qa/427
+++ b/qa/427
@@ -109,14 +109,14 @@ cat $PCP_PMCDLOG_PATH >> $seq.full
 echo
 echo "errors for bogus in pmcd related log file(s):"
 [ -f $PCP_PMDAROOT_LOG ] && \
-egrep "^pmdaroot:" $PCP_PMDAROOT_LOG | _filter
-egrep "^pmcd:" $PCP_PMCDLOG_PATH | _filter
+grep -E "^pmdaroot:" $PCP_PMDAROOT_LOG | _filter
+grep -E "^pmcd:" $PCP_PMCDLOG_PATH | _filter
 
 # check that the pmcd.agent.status metric is correct
 echo
 echo "pmcd agent metrics for bogus:"
-pminfo -f pmcd.agent.type | egrep '^pmcd|bogus'
-pminfo -f pmcd.agent.status | egrep '^pmcd|bogus'
+pminfo -f pmcd.agent.type | grep -E '^pmcd|bogus'
+pminfo -f pmcd.agent.status | grep -E '^pmcd|bogus'
 echo
 
 # success, all done

--- a/qa/430
+++ b/qa/430
@@ -28,7 +28,7 @@ rm -f $seq.full
 realhost=`hostname`
 LOCALHOST=`echo $realhost | sed -e 's/\..*//'`
 hostsfile="/etc/hosts"
-egrep '^[^#].*[ 	]'$realhost'([ 	]|$)' <$hostsfile >/dev/null || \
+grep -E '^[^#].*[ 	]'$realhost'([ 	]|$)' <$hostsfile >/dev/null || \
     _notrun "No entry for hostname of local host in $hostsfile"
 
 signal="$sudo $PCP_BINADM_DIR/pmsignal"
@@ -37,7 +37,7 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 
 _stop_auto_restart pmlogger
 _service pmlogger stop | _filter_pcp_stop
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger' >>$here/$seq.full
 
 _filter()
 {
@@ -140,7 +140,7 @@ _update_hostsfile()
 	    # so dodge this one in the counting test
 	    # - kenj 2 May 2021
 	    #
-	    egrep '^[^#].*[ 	]'$realhost'([ 	]|$)' <$hostsfile \
+	    grep -E '^[^#].*[ 	]'$realhost'([ 	]|$)' <$hostsfile \
 	    | grep -v '^127\.0\.1\.1' >$tmp.tmp
 	    # we used to test for exactly one line matching $realhost
 	    # but the introduction of IPv6 means we may legitimately have
@@ -160,7 +160,7 @@ _update_hostsfile()
 	    cat $tmp.tmp >>$tmp.etc.hosts
 	    echo "127.0.0.$i	$extra_hostname" >>$tmp.etc.hosts
 	    echo "" >>$tmp.etc.hosts
-	    egrep -v '^[^#].*[ 	]'$realhost'([ 	]|$)' <$hostsfile >>$tmp.etc.hosts
+	    grep -E -v '^[^#].*[ 	]'$realhost'([ 	]|$)' <$hostsfile >>$tmp.etc.hosts
 	    break
 	fi
     done
@@ -275,10 +275,10 @@ do
     echo >>$here/$seq.full
     echo "=== test $i ===" >>$here/$seq.full
     echo "--- before _setup() ---" >>$here/$seq.full
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger' >>$here/$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger' >>$here/$seq.full
     _setup
     echo "--- after _setup() ---" >>$here/$seq.full
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger' >>$here/$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger' >>$here/$seq.full
     
     # create the control file from primary
     _extract_control $i > $logdir/control
@@ -322,7 +322,7 @@ do
 	echo "Arrgh ... failed to find just one pmlogger to kill ... see $seq.full"
 	echo "" >>$here/$seq.full
 	echo "Arrgh ... failed to find just one pmlogger to kill ..." >>$here/$seq.full
-	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger' >>$here/$seq.full
+	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger' >>$here/$seq.full
 	echo "$log contents ..." >>$here/$seq.full
 	ls -l $log >>$here/$seq.full
 	for ctl in $PCP_TMP_DIR/pmlogger/[0-9]*
@@ -381,7 +381,7 @@ $2 == '"$pid"' { print; exit(0) }'
     if [ ! -f $tmp.found ]
     then
 	echo "Arrgh ... pmlogger_check failed to restart pmloggers" | tee -a $here/$seq.full
-	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger' >>$here/$seq.full
+	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger' >>$here/$seq.full
 	for state in $PCP_TMP_DIR/pmlogger/[0-9]*
 	do
 	    echo "=== $state ==="

--- a/qa/439
+++ b/qa/439
@@ -45,12 +45,12 @@ unset PMLOGGER_REQUEST_TIMEOUT
 echo
 # $PM_LOG_ALL_PIDS is not useful
 src/logcontrol -Dpmlc -p-1 enquire sample.long.write_me 2>&1 \
-| egrep '(__pmConnectLogger)|(logcontrol)'
+| grep -E '(__pmConnectLogger)|(logcontrol)'
 
 echo
 # punt that pid 1 is not pmlogger!
 src/logcontrol -Dpmlc -p1 enquire sample.long.write_me 2>&1 \
-| egrep '(__pmConnectLogger)|(logcontrol)' \
+| grep -E '(__pmConnectLogger)|(logcontrol)' \
 | _filter
 
 # start playing with libpcp's mind by munging files in
@@ -58,17 +58,17 @@ src/logcontrol -Dpmlc -p1 enquire sample.long.write_me 2>&1 \
 touch $tmp.ctl
 $sudo cp $tmp.ctl $PCP_TMP_DIR/pmlogger/$$
 src/logcontrol -Dpmlc,log -p$$ enquire sample.long.write_me 2>&1 \
-| egrep '(/__pmConnectLogger)|(__pmLog)|(logcontrol)' \
+| grep -E '(/__pmConnectLogger)|(__pmLog)|(logcontrol)' \
 | _filter
 echo "bad port" >$tmp.ctl
 $sudo cp $tmp.ctl $PCP_TMP_DIR/pmlogger/$$
 src/logcontrol -Dpmlc,log -p$$ enquire sample.long.write_me 2>&1 \
-| egrep '(/__pmConnectLogger)|(__pmLog)|(logcontrol)' \
+| grep -E '(/__pmConnectLogger)|(__pmLog)|(logcontrol)' \
 | _filter
 echo "123456" >$tmp.ctl
 $sudo cp $tmp.ctl $PCP_TMP_DIR/pmlogger/$$
 src/logcontrol -Dpmlc,log -p$$ enquire sample.long.write_me 2>&1 \
-| egrep '(/__pmConnectLogger)|(__pmLog)|(logcontrol)' \
+| grep -E '(/__pmConnectLogger)|(__pmLog)|(logcontrol)' \
 | _filter
 cat <<End-of-File >$tmp.ctl
 123456
@@ -76,7 +76,7 @@ no.such.host.pcp.io
 End-of-File
 $sudo cp $tmp.ctl $PCP_TMP_DIR/pmlogger/$$
 src/logcontrol -Dpmlc,log -p$$ enquire sample.long.write_me 2>&1 \
-| egrep '(/__pmConnectLogger)|(__pmLog)|(logcontrol)' \
+| grep -E '(/__pmConnectLogger)|(__pmLog)|(logcontrol)' \
 | _filter
 cat <<End-of-File >$tmp.ctl
 123456
@@ -85,7 +85,7 @@ no.such.host.pcp.io
 End-of-File
 $sudo cp $tmp.ctl $PCP_TMP_DIR/pmlogger/$$
 src/logcontrol -Dpmlc,log -p$$ enquire sample.long.write_me 2>&1 \
-| egrep '(/__pmConnectLogger)|(__pmLog)|(logcontrol)' \
+| grep -E '(/__pmConnectLogger)|(__pmLog)|(logcontrol)' \
 | _filter
 
 

--- a/qa/440
+++ b/qa/440
@@ -44,7 +44,7 @@ _tolerance()
 
 _num_recs()
 {
-  num_recs=`$pmdumplog $tmp | egrep -c '^[0-9][0-9]:[0-9][0-9]:'`
+  num_recs=`$pmdumplog $tmp | grep -E -c '^[0-9][0-9]:[0-9][0-9]:'`
   # subtract 1 for the prologue and 1 for the epilogue
   num_recs=`expr $num_recs - 2`
   echo "found $num_recs samples after the prologue+epilogue" >>$seq.full

--- a/qa/445
+++ b/qa/445
@@ -116,7 +116,7 @@ sleep 15
 
 for log in ${TRACELOG}?
 do
-    fgrep "Address already in use" <$log >/dev/null 2>&1
+    grep -F "Address already in use" <$log >/dev/null 2>&1
     status=$?
     if [ $status -eq 0 ]
     then

--- a/qa/457
+++ b/qa/457
@@ -164,7 +164,7 @@ i=0
 while [ $i -lt 20 ]
 do
     echo "wait #$i" >>$here/$seq.full
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep "[P]PID|$seq.pip[e]" >>$here/$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E "[P]PID|$seq.pip[e]" >>$here/$seq.full
     [ -s $here/$seq.pipe.pid ] && break
     sleep 1
     i=`expr $i + 1`
@@ -172,7 +172,7 @@ done
 if [ ! -s $here/$seq.pipe.pid ]
 then
     echo "Arrgh ..."
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep "[P]PID|$seq.pip[e]"
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E "[P]PID|$seq.pip[e]"
     _fail "PID file from command pipe not found"
 fi
 

--- a/qa/482
+++ b/qa/482
@@ -96,10 +96,10 @@ echo
 echo "=== testing instanteous metric value distribution ==="
 nbins=3
 _xtract sample.scale_step.time_up_nanosecs | _noncounter_values > $tmp.noncount
-eval `fgrep COUNT $tmp.noncount`
+eval `grep -F COUNT $tmp.noncount`
 #echo count=$COUNT maximum=$MAX minimum=$MIN
 $PCP_ECHO_PROG $PCP_ECHO_N "QA calculates: ""$PCP_ECHO_C"
-fgrep -v COUNT $tmp.noncount | _dobinning $nbins $MIN $MAX
+grep -F -v COUNT $tmp.noncount | _dobinning $nbins $MIN $MAX
 
 $PCP_ECHO_PROG $PCP_ECHO_N "pmlogsummary calculates: ""$PCP_ECHO_C"
 pmlogsummary -ymMB $nbins archives/binning sample.scale_step.time_up_nanosecs \
@@ -109,13 +109,13 @@ echo
 echo "=== testing counter metric value distribution ==="
 nbins=4
 _xtract sample.milliseconds | _counter_values > $tmp.count
-eval `fgrep COUNT $tmp.count`
+eval `grep -F COUNT $tmp.count`
 #echo count=$COUNT maximum=$MAX minimum=$MIN
 $PCP_ECHO_PROG $PCP_ECHO_N "QA calculates: ""$PCP_ECHO_C"
-fgrep -v COUNT $tmp.count | _dobinning $nbins $MIN $MAX
+grep -F -v COUNT $tmp.count | _dobinning $nbins $MIN $MAX
 
 $PCP_ECHO_PROG $PCP_ECHO_N "pmlogsummary calculates: ""$PCP_ECHO_C"
-pmlogsummary -ymMB $nbins archives/binning | fgrep sample.milliseconds \
+pmlogsummary -ymMB $nbins archives/binning | grep -F sample.milliseconds \
 	| _filterbins $nbins
 
 # misc checks

--- a/qa/507
+++ b/qa/507
@@ -61,7 +61,7 @@ $NF == "RAM"	{ x = $(NF-1); x = (int(x/128)+1)*128; $(NF-1) = x }
 	-e "/^ licenses:.*/d" \
 	-e "s/$qahost/HOST/g" \
 	-e "s/$local/HOST/g" \
-    | fgrep -v "archive:"
+    | grep -F -v "archive:"
 }
 
 _config()
@@ -147,14 +147,14 @@ echo === Comparing noargs and args
 if [ -s $tmp.noargslocalnoh ] ; then cat $tmp.noargslocalnoh ; fi
 
 echo === Checking for missing archive metrics
-egrep '(Unknown)|( unknown)' $tmp.arch
+grep -E '(Unknown)|( unknown)' $tmp.arch
 
 echo === Checking bug 640234
 echo 'pminfo(1) output:'
 pminfo -fa archives/pcpcmd pmcd.pmlogger
 echo
 echo 'pcp(1) output:'
-pcp -O +.001sec -n src/root_irix -a archives/pcpcmd | fgrep -v "$PCP_PMDAS_DIR/summary"
+pcp -O +.001sec -n src/root_irix -a archives/pcpcmd | grep -F -v "$PCP_PMDAS_DIR/summary"
 # dont use services/pmie output here cos archive doesn't have all metrics
 
 echo === Checking transient problem

--- a/qa/519
+++ b/qa/519
@@ -108,8 +108,8 @@ sed <$tmp.out \
     -e "/^$other2:/d" \
     -e "/^$o2:/d" \
 #
-egrep "^($other1|$o1):" <$tmp.out >/dev/null && echo "... at least one line for other1 host"
-egrep "^($other2|$o2)*:" <$tmp.out >/dev/null && echo "... at least one line for other2 host"
+grep -E "^($other1|$o1):" <$tmp.out >/dev/null && echo "... at least one line for other1 host"
+grep -E "^($other2|$o2)*:" <$tmp.out >/dev/null && echo "... at least one line for other2 host"
 
 echo
 echo "pmie stderr ..."

--- a/qa/555
+++ b/qa/555
@@ -176,10 +176,10 @@ setup()
 
 # real QA test starts here
 echo "ps before setup ..." >>/tmp/syslog.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([P]ID)|([s]yslog)' >>/tmp/syslog.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([P]ID)|([s]yslog)' >>/tmp/syslog.full
 setup
 echo "ps after setup ..." >>/tmp/syslog.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([P]ID)|([s]yslog)' >>/tmp/syslog.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([P]ID)|([s]yslog)' >>/tmp/syslog.full
 
 # syslog	logger -p
 # 5D		daemon.notice		<--- default

--- a/qa/572
+++ b/qa/572
@@ -100,11 +100,11 @@ cp $rootconf $tmp.root.bak
 
 needclean=true
 $sudo cp $tmp.pmcd.conf $pmcdconf 
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([p]mcd)|([P]ID)' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([p]mcd)|([P]ID)' >>$here/$seq.full
 _service pcp restart 2>&1 | _filter_pcp_start
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([p]mcd)|([P]ID)' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([p]mcd)|([P]ID)' >>$here/$seq.full
 _wait_for_pmcd
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([p]mcd)|([P]ID)' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([p]mcd)|([P]ID)' >>$here/$seq.full
 _wait_for_pmlogger
 
 for pmda in '' sample trivial simple

--- a/qa/583
+++ b/qa/583
@@ -166,9 +166,9 @@ sed <$tmp.out \
     -e "/ $local:/d" \
     -e "/ $l:/d" \
 #
-egrep " ($other1|$o1):" <$tmp.out >/dev/null && echo "... at least one line for other1 host"
-egrep " ($other2|$o2):" <$tmp.out >/dev/null && echo "... at least one line for other2 host"
-egrep " (localhost|$local|$l):" <$tmp.out >/dev/null && echo "... at least one line for localhost"
+grep -E " ($other1|$o1):" <$tmp.out >/dev/null && echo "... at least one line for other1 host"
+grep -E " ($other2|$o2):" <$tmp.out >/dev/null && echo "... at least one line for other2 host"
+grep -E " (localhost|$local|$l):" <$tmp.out >/dev/null && echo "... at least one line for localhost"
 
 echo
 echo "pmie stderr ..."

--- a/qa/601
+++ b/qa/601
@@ -66,8 +66,8 @@ cd $here
 
 _wait_for_pmcd
 
-period=`pminfo -f trace.control.period | fgrep value | sed -e 's/.*value //g'`
-interval=`pminfo -f trace.control.interval | fgrep value | sed -e 's/.*value //g'`
+period=`pminfo -f trace.control.period | grep -F value | sed -e 's/.*value //g'`
+interval=`pminfo -f trace.control.interval | grep -F value | sed -e 's/.*value //g'`
 
 if [ -z "$interval" -o -z "$period" ]
 then
@@ -97,8 +97,8 @@ pminfo -f trace.transact.min_time trace.transact.max_time \
 	| sed -e 's/\.[0-9][0-9]*//g'
 
 # These fluctuate slightly above theoretical result (system() & trace overhead):
-rate=`pminfo -f trace.transact.rate | fgrep sleep1 | sed -e 's/.*value //g'`
-ave_time=`pminfo -f trace.transact.ave_time | fgrep sleep1 | sed -e 's/.*value //g'`
+rate=`pminfo -f trace.transact.rate | grep -F sleep1 | sed -e 's/.*value //g'`
+ave_time=`pminfo -f trace.transact.ave_time | grep -F sleep1 | sed -e 's/.*value //g'`
 
 # Use bc to get these as integers, and then compare in the shell ...
 rate=`bc << EOF
@@ -140,7 +140,7 @@ echo "Waiting for buffers to rotate (3/3) ..."
 sleep $interval
 
 pminfo -f trace.observe.count trace.observe.value
-rate=`pminfo -f trace.observe.rate | fgrep obs1 | sed -e 's/.*value //g'`
+rate=`pminfo -f trace.observe.rate | grep -F obs1 | sed -e 's/.*value //g'`
 rate=`bc << EOF
 scale=5
 (5 / $period) * 100000
@@ -168,7 +168,7 @@ echo "Waiting for buffers to rotate (3/3) ..."
 sleep $interval
 
 pminfo -f trace.counter.count trace.counter.value
-rate=`pminfo -f trace.counter.rate | fgrep cnt1 | sed -e 's/.*value //g'`
+rate=`pminfo -f trace.counter.rate | grep -F cnt1 | sed -e 's/.*value //g'`
 rate=`bc << EOF
 scale=5
 (5 / $period) * 100000

--- a/qa/651
+++ b/qa/651
@@ -95,12 +95,12 @@ _wait_for_start()
     if [ -f $tmp.started ]
     then
 	$PCP_PS_PROG $PCP_PS_ALL_FLAGS \
-	| egrep 'PID|pmproxy|pmcd' >>$here/$seq.full
+	| grep -E 'PID|pmproxy|pmcd' >>$here/$seq.full
     else
 	# NB: may be an expected situation at this stage of the test
 	echo "Failed to probe pmproxy" >>$here/$seq.full
 	$PCP_PS_PROG $PCP_PS_ALL_FLAGS \
-	| egrep 'PID|pmproxy|pmcd' >>$here/$seq.full
+	| grep -E 'PID|pmproxy|pmcd' >>$here/$seq.full
 	[ -f $tmp.log ] && cat $tmp.log >>$here/$seq.full
     fi
 }
@@ -126,7 +126,7 @@ _wait_for_stop()
     else
 	echo "Failed to stop pmproxy"
 	$PCP_PS_PROG $PCP_PS_ALL_FLAGS \
-	| egrep '[P]ID|[p]mproxy|[p]mcd'
+	| grep -E '[P]ID|[p]mproxy|[p]mcd'
     fi
 }
 

--- a/qa/652
+++ b/qa/652
@@ -43,18 +43,18 @@ _filter_probe()
 
 _filter_events()
 {
-    fgrep 'MESSAGE=yo'
+    grep -F 'MESSAGE=yo'
 }
 
 _filter_events_raw()
 {
-    fgrep '4d4553534147453d796f'
+    grep -F '4d4553534147453d796f'
 }
 
 _filter_pmda_warning()
 {
     # drop the adm-user-doesn't-exist warnings, optional blank line
-    fgrep -v 'Warning:' | grep . | 
+    grep -F -v 'Warning:' | grep . | 
     grep -v "Starting pm.*"  # don't fuss about what pcp daemons are default-on 
 }
 
@@ -87,7 +87,7 @@ if [ "$numval" -lt 0 ]
 then
     echo "Arrgh ... PMDA is not well!"
     pminfo -f systemd
-    ps "$PCP_PS_ALL_FLAGS" | egrep "[p]m[cd]|[P]ID"
+    ps "$PCP_PS_ALL_FLAGS" | grep -E "[p]m[cd]|[P]ID"
     echo "=== PMDA's log ==="
     cat $PCP_LOG_DIR/pmcd/systemd.log
     echo "=== ==="

--- a/qa/667
+++ b/qa/667
@@ -84,7 +84,7 @@ $signal $scpid $p2gpid >/dev/null 2>&1
 wait
 # python pickle-format 1+ is binary, and python version dependent to boot.
 # but pcp2graphite now uses ascii pickle-format 0 for maximum compatibility
-fgrep -q pcp.hinv.ncpu $tmp.socat.out
+grep -F -q pcp.hinv.ncpu $tmp.socat.out
 [ $? -eq 0 ] && echo "Found pcp.hinv.ncpu in pickled output"
 _full_stash
 
@@ -98,7 +98,7 @@ p2gpid=$!
 sleep 10 # 5sec startup + 5sec ... enough for at least 2 messages
 $signal $scpid $p2gpid >/dev/null 2>&1
 wait
-egrep 'foobar\.hinv\.ncpu|foobar\.sample\.datasize' $tmp.socat.out \
+grep -E 'foobar\.hinv\.ncpu|foobar\.sample\.datasize' $tmp.socat.out \
     | head -2 \
     | sed -e "s,\.ncpu $ncpu ,.ncpu NCPUS ," |    # confirm ncpus value
     sed -r -e 's, [0-9]+[02468]$, TIMESTAMP2,'  # confirm time alignment
@@ -185,7 +185,7 @@ $signal $scpid $p2gpid >/dev/null 2>&1
 wait
 # use same case 1 above approach for detecting something relevant
 # in the pickled output, and assume we have a successful transfer
-fgrep -q pcp.hinv.ncpu $tmp.socat.out
+grep -F -q pcp.hinv.ncpu $tmp.socat.out
 [ $? -eq 0 ] && echo "Found pcp.hinv.ncpu in highest versioned pickled output"
 _full_stash
 

--- a/qa/700
+++ b/qa/700
@@ -26,7 +26,7 @@ status=1	# failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 trap "_cleanup; exit \$status" 0 1 2 3 15
 
-rpm -qa | egrep '(pcp-|-pcp)' >$tmp.rpms
+rpm -qa | grep -E '(pcp-|-pcp)' >$tmp.rpms
 [ -s $tmp.rpms ] || _notrun "No PCP rpms installed"
 
 # filter packages that are known to not be part of PCP

--- a/qa/778
+++ b/qa/778
@@ -120,7 +120,7 @@ _match()
 {
     rm -f $tmp.match $tmp.nomatch
     pat="$1"
-    egrep "\\|$pat\\|" $tmp.db >$tmp.val.db
+    grep -E "\\|$pat\\|" $tmp.db >$tmp.val.db
     if [ ! -s $tmp.val.db ]
     then
 	echo "_match: failed to pick any values from DB using pattern \"|$pat|\""

--- a/qa/787
+++ b/qa/787
@@ -34,7 +34,7 @@ _filter()
 }
 
 pmdumplog -xz archives/bug-1044 >$tmp.tmp
-echo "log records: `egrep '^([A-Z][a-z][a-z] )|([0-2][0-9]:)' <$tmp.tmp | wc -l | sed -e 's/ //g'`"
+echo "log records: `grep -E '^([A-Z][a-z][a-z] )|([0-2][0-9]:)' <$tmp.tmp | wc -l | sed -e 's/ //g'`"
 
 # for full output, lines look like
 # Fri Jan 10 17:58:09.600 2014  60.0.32 (hinv.ncpu): value 4
@@ -47,7 +47,7 @@ do
     echo | tee -a $seq.full
     echo "=== $metric ===" | tee -a $seq.full
     $full && pmdumplog -zL archives/bug-1044 >>$seq.full
-    $full && pmdumplog -xz archives/bug-1044 $metric | egrep '^([A-Z][a-z][a-z] )|([0-2][0-9]:)' | LC_COLLATE=POSIX sort -k 3,3n -k 4,4 >$tmp.tmp
+    $full && pmdumplog -xz archives/bug-1044 $metric | grep -E '^([A-Z][a-z][a-z] )|([0-2][0-9]:)' | LC_COLLATE=POSIX sort -k 3,3n -k 4,4 >$tmp.tmp
     $full && LC_COLLATE=POSIX sort -k 3,3n -k 4,4 $tmp.tmp $tmp.mark >>$seq.full
 
     echo | tee -a $seq.full

--- a/qa/793
+++ b/qa/793
@@ -65,7 +65,7 @@ _stop_loggers()
 {
     echo "entering _stop_loggers ..." >>$here/$seq.full
     $PCP_PS_PROG $PCP_PS_ALL_FLAGS \
-    | egrep '[P]ID|[p]mlogger' \
+    | grep -E '[P]ID|[p]mlogger' \
     | tee -a $here/$seq.full \
     | grep '[p]mlogger ' \
     | $PCP_AWK_PROG '{print $2}' >$tmp.pids
@@ -182,7 +182,7 @@ _check_loggers()
 		fi
 	    done
 	    echo "--- end of logs ---" >>$here/$seq.full
-	    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger' >>$here/$seq.full
+	    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger' >>$here/$seq.full
 	    for state in $PCP_TMP_DIR/pmlogger/[0-9]*
 	    do
 		echo "=== $state ===" | tee -a $here/$seq.full
@@ -271,7 +271,7 @@ done
 sleep 1
 
 echo "pmlogger processes ..." >>$here/$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger' >>$here/$seq.full
 
 # this test has a history of failing in the pmlogger_daily step below
 # when one (or more) of the pmlogger processes vanishes, so we're

--- a/qa/794
+++ b/qa/794
@@ -50,7 +50,7 @@ _exclude_clients()
     # anonymous clients (whoami == "")
     #
     pminfo -f pmcd.client.whoami | \
-    egrep 'pmlogger|pmie|""' | \
+    grep -E 'pmlogger|pmie|""' | \
     sed -e 's/ *inst \[\([0-9][0-9]*\) or .*/-x \1 /g'
 }
 

--- a/qa/832
+++ b/qa/832
@@ -86,7 +86,7 @@ then
     cat $PCP_LOG_DIR/pmcd/pmcd.log >>$seq.full
 else
     echo "No pmcd.log?" >>$seq.full
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mcd' >>$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mcd' >>$seq.full
 fi
 _wait_for_pmcd 10 unix: 2>&1 | tee -a $seq.full | _filter
 grep -i 'starting pmcd' $tmp.out \

--- a/qa/854
+++ b/qa/854
@@ -103,7 +103,7 @@ echo "archive contents before pmda simple restart..."
 echo "expect no <mark> record"
 echo "---------------------------------------------------------------"
 pmdumplog $archive  >$tmp.out 2>&1
-egrep '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
+grep -E '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
 | _filter_pmdumplog \
 | uniq
 echo "---------------------------------------------------------------"
@@ -133,7 +133,7 @@ echo "archive contents after pmda simple restart..."
 echo "expect no <mark> record"
 echo "---------------------------------------------------------------"
 pmdumplog $archive >$tmp.out 2>&1
-egrep '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
+grep -E '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
 | _filter_pmdumplog \
 | uniq
 echo "---------------------------------------------------------------"

--- a/qa/856
+++ b/qa/856
@@ -104,7 +104,7 @@ echo "archive contents before pmda simple restart..."
 echo "expect no <mark> record"
 echo "---------------------------------------------------------------"
 pmafm $LOGGING_DIR/$LOCALHOST/Latest pmdumplog >$tmp.out 2>&1
-egrep '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
+grep -E '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
 | _filter_pmdumplog \
 | uniq
 echo "---------------------------------------------------------------"
@@ -134,7 +134,7 @@ echo "archive contents after pmda simple restart..."
 echo "expect no <mark> record"
 echo "---------------------------------------------------------------"
 pmafm $LOGGING_DIR/$LOCALHOST/Latest pmdumplog >$tmp.out 2>&1
-egrep '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
+grep -E '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
 | _filter_pmdumplog \
 | uniq
 echo "---------------------------------------------------------------"

--- a/qa/870
+++ b/qa/870
@@ -319,7 +319,7 @@ if $present
 then
     echo "Arrggh ... pmlogger appears to be running ..."
     $PCP_PS_PROG $PCP_PS_ALL_FLAGS \
-    | egrep "PID|$pid" \
+    | grep -E "PID|$pid" \
     | grep -v egrep
     echo "kill off the primary pmlogger we just started ..."
     $sudo kill -KILL $pid
@@ -334,11 +334,11 @@ then
     then
 	echo "Arrggh ... failed to kill of pmlogger (pid $pid)"
 	$PCP_PS_PROG $PCP_PS_ALL_FLAGS \
-	| egrep "PID|$pid" \
+	| grep -E "PID|$pid" \
 	| grep -v egrep
     fi
 fi
-egrep 'ERROR:|info:' <$tmp.log \
+grep -E 'ERROR:|info:' <$tmp.log \
 | sed \
     -e 's/pid [0-9][0-9]*/pid SOMEPID/g' \
     -e "s@$PCP_TMP_DIR/@PCP_TMP_DIR/@g"

--- a/qa/882
+++ b/qa/882
@@ -108,7 +108,7 @@ echo "archive contents before pmda simple restart..."
 echo "expect no <mark> record"
 echo "---------------------------------------------------------------"
 pmafm $LOGGING_DIR/$LOCALHOST/Latest pmdumplog >$tmp.out 2>&1
-egrep '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
+grep -E '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
 | _filter_pmdumplog \
 | uniq
 echo "---------------------------------------------------------------"
@@ -139,7 +139,7 @@ echo "archive contents after pmda simple restart..."
 echo "expect no <mark> record"
 echo "---------------------------------------------------------------"
 pmafm $LOGGING_DIR/$LOCALHOST/Latest pmdumplog >$tmp.out 2>&1
-egrep '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
+grep -E '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
 | _filter_pmdumplog \
 | uniq
 echo "---------------------------------------------------------------"

--- a/qa/885
+++ b/qa/885
@@ -24,7 +24,7 @@ root=$tmp.root
 export LINUX_STATSPATH=$root
 pmda=$PCP_PMDAS_DIR/linux/pmda_linux.so,linux_init
 files=`echo $here/linux/cpuinfo-* | LC_COLLATE=POSIX sort`
-metrics=`pminfo hinv.cpu | egrep -v 'online|thermal_throttle|frequency_scaling'`
+metrics=`pminfo hinv.cpu | grep -E -v 'online|thermal_throttle|frequency_scaling'`
 
 for file in $files
 do

--- a/qa/893
+++ b/qa/893
@@ -41,13 +41,13 @@ $tmp.pmcd/pmcd 60 &
 pid=$!
 echo "Fake pmcd pid=$pid" >>$here/$seq.full
 echo "Before restart ..." >>$here/$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mcd' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mcd' >>$here/$seq.full
 echo "_get_pids_by_name pmcd -> `_get_pids_by_name pmcd`" >>$here/$seq.full
 _service pmcd restart 2>&1 | _filter_pcp_start
 _wait_for_pmcd
 _wait_for_pmlogger
 echo "After restart ..." >>$here/$seq.full
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mcd' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mcd' >>$here/$seq.full
 $PCP_ECHO_PROG $PCP_ECHO_N "Local pmcd count: ""$PCP_ECHO_C"
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS \
 | grep "$tmp.pmcd/[p]mcd" \

--- a/qa/903
+++ b/qa/903
@@ -36,7 +36,7 @@ do
     do
 	echo "--- $o ---" >>$here/$seq.full
 	cat $o >>$here/$seq.full
-	egrep -v 'include|exclude| numpmid=1 ' <$o \
+	grep -E -v 'include|exclude| numpmid=1 ' <$o \
 	| sed -e 's/^\[[0-4]]/[x]/' \
 	| LC_COLLATE=posix sort
     done

--- a/qa/914
+++ b/qa/914
@@ -61,7 +61,7 @@ do
    src/profilecrash -v $src -s 100 $metric >$tmp.out 2>$tmp.err
     cat $tmp.err $tmp.out >>$here/$seq.full
     cat $tmp.err $tmp.out \
-    | egrep -v 'include|exclude| numpmid=1 '
+    | grep -E -v 'include|exclude| numpmid=1 '
 done
 
 # success, all done

--- a/qa/917
+++ b/qa/917
@@ -219,7 +219,7 @@ else
 fi
 
 if seinfo -x --class=bpf $common_flag 2>&1 \
-   | egrep '^[ 	][ 	]*(class |)bpf$' >/dev/null
+   | grep -E '^[ 	][ 	]*(class |)bpf$' >/dev/null
 then
     :
 else
@@ -252,13 +252,13 @@ fi
 # to cull the rawip_socket line from $seq.out.in
 #
 if seinfo -x --class=icmp_socket $common_flag 2>&1 \
-   | egrep '^[ 	][ 	]*(class |)icmp_socket$' >/dev/null
+   | grep -E '^[ 	][ 	]*(class |)icmp_socket$' >/dev/null
 then
     echo '/allow \[pcp_pmcd_t\] .*\[rawip_socket\]/d' >>$tmp.sed
 else
     echo '/allow \[pcp_pmcd_t\] .*\[icmp_socket\]/d' >>$tmp.sed
     if seinfo -x --class=rawip_socket $common_flag 2>&1 \
-       | egrep '^[ 	][ 	]*(class |)rawip_socket$' >/dev/null
+       | grep -E '^[ 	][ 	]*(class |)rawip_socket$' >/dev/null
     then
 	:
     else
@@ -267,7 +267,7 @@ else
 fi
 
 if seinfo -x --class=netlink_generic_socket $common_flag 2>&1 \
-   | egrep '^[ 	][ 	]*(class |)netlink_generic_socket$' >/dev/null
+   | grep -E '^[ 	][ 	]*(class |)netlink_generic_socket$' >/dev/null
 then
     :
 else
@@ -307,7 +307,7 @@ else
 fi
 
 if seinfo -x --class=lockdown $common_flag 2>&1 \
-   | egrep '^[ 	][ 	]*(class |)lockdown$' >/dev/null
+   | grep -E '^[ 	][ 	]*(class |)lockdown$' >/dev/null
 then
     :
 else
@@ -315,7 +315,7 @@ else
 fi
 
 if seinfo -x --class=netlink_tcpdiag_socket $common_flag 2>&1 \
-   | egrep '^[ 	][ 	]*(class |)netlink_tcpdiag_socket$' >/dev/null
+   | grep -E '^[ 	][ 	]*(class |)netlink_tcpdiag_socket$' >/dev/null
 then
     :
 else

--- a/qa/918
+++ b/qa/918
@@ -48,7 +48,7 @@ _service pmcd restart >>$here/$seq.full 2>&1
 
 # real QA test starts here
 old_pid=`_get_pids_by_name pmcd`
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mcd' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mcd' >>$here/$seq.full
 echo "old_pid=$old_pid" >>$here/$seq.full
 
 echo "expect success ..."
@@ -58,7 +58,7 @@ $sudo $PCP_BINADM_DIR/pmsignal -a -s TERM pmcd
 _wait_for_pmcd
 
 new_pid=`_get_pids_by_name pmcd`
-$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mcd' >>$here/$seq.full
+$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mcd' >>$here/$seq.full
 echo "new_pid=$new_pid" >>$here/$seq.full
 
 if [ "$new_pid" != "$old_pid" ]

--- a/qa/920
+++ b/qa/920
@@ -50,7 +50,7 @@ _report()
     if [ ! -d $PCP_ARCHIVE_DIR/$seq ]
     then
 	echo "Arrgh: directory $PCP_ARCHIVE_DIR/$seq not created"
-	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger'
+	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger'
 	return
     fi
 

--- a/qa/932
+++ b/qa/932
@@ -110,7 +110,7 @@ echo "archive contents before pmda simple restart..."
 echo "expect no <mark> record"
 echo "---------------------------------------------------------------"
 pmafm $LOGGING_DIR/$LOCALHOST/Latest pmdumplog >$tmp.out 2>&1
-egrep '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
+grep -E '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
 | _filter_pmdumplog \
 | uniq
 echo "---------------------------------------------------------------"
@@ -128,7 +128,7 @@ echo "archive contents after pmda simple restart..."
 echo "expect <mark> record"
 echo "---------------------------------------------------------------"
 pmafm $LOGGING_DIR/$LOCALHOST/Latest pmdumplog >$tmp.out 2>&1
-egrep '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
+grep -E '(<mark>)|(sample.dynamic.meta.metric)' $tmp.out \
 | _filter_pmdumplog \
 | uniq
 echo "---------------------------------------------------------------"

--- a/qa/940
+++ b/qa/940
@@ -19,7 +19,7 @@ which sedismod >/dev/null 2>&1 || _notrun "sedismod tool not installed (module d
 which semodule >/dev/null 2>&1 || _notrun "semodule tool not installed"
 which seinfo >/dev/null 2>&1 || _notrun "seinfo tool not installed"
 [ -f "$policy_file" ] || _notrun "upstream container policy package not installed"
-$sudo semodule -l 2>&1 | egrep -q "^$policy_name([ 	]|$)" || _notrun "upstream container policy package not loaded"
+$sudo semodule -l 2>&1 | grep -E -q "^$policy_name([ 	]|$)" || _notrun "upstream container policy package not loaded"
 
 _cleanup()
 {

--- a/qa/941
+++ b/qa/941
@@ -50,7 +50,7 @@ then
     cat $tmp.pids
     $PCP_PS_PROG $PCP_PS_ALL_FLAGS >$tmp.ps.out
     echo "$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep pmcd ..."
-    egrep 'PID|pmcd' <$tmp.ps.out
+    grep -E 'PID|pmcd' <$tmp.ps.out
     echo "num_pmcds=$num_pmcds (should be 1)"
 fi
 case "$num_pmcds"

--- a/qa/945
+++ b/qa/945
@@ -52,8 +52,8 @@ s/\n */ /g
     #    Data Type: 64-bit unsigned int  InDom: 60.5 0xf000005
     # PMID: 11.30.0 (quota.state.project.accounting)
     #    Data Type: 32-bit unsigned int  InDom: 11.5 0x2c00005
-    egrep 'filesys.free|quota.state.project.accounting' $tmp.1 >$tmp.1a
-    egrep 'filesys.free|quota.state.project.accounting' $tmp.2 >$tmp.2a
+    grep -E 'filesys.free|quota.state.project.accounting' $tmp.1 >$tmp.1a
+    grep -E 'filesys.free|quota.state.project.accounting' $tmp.2 >$tmp.2a
     diff $tmp.1a $tmp.2a
     sed -e 's/PMID: 60\./XX./g' -e 's/PMID: 11\./XX./g' \
         -e '/InDom:/{

--- a/qa/956
+++ b/qa/956
@@ -124,10 +124,10 @@ while [ $i -lt 10 ]
 do
     $PCP_PS_PROG $PCP_PS_ALL_FLAGS >$tmp.tmp
     echo "ps probe #$i" >>$here/$seq.full
-    egrep '[P]ID|[p]mdadynamic' $tmp.tmp >>$here/$seq.full
+    grep -E '[P]ID|[p]mdadynamic' $tmp.tmp >>$here/$seq.full
     # looking for a defunct PMDA process
     #
-    if egrep '(pmdadynamic.*defunct)|( Z .*pmdadynamic)|\(pmdadynamic\)' $tmp.tmp >/dev/null
+    if grep -E '(pmdadynamic.*defunct)|( Z .*pmdadynamic)|\(pmdadynamic\)' $tmp.tmp >/dev/null
     then
 	rm -f $tmp.tmp
 	break
@@ -146,7 +146,7 @@ done
 if [ -f $tmp.tmp ]
 then
     echo "Arrgh ... dynamic PMDA won't die"
-    egrep '[P]ID|[p]mdadynamic' $tmp.tmp
+    grep -E '[P]ID|[p]mdadynamic' $tmp.tmp
     exit
 fi
 date >>$here/$seq.full

--- a/qa/962
+++ b/qa/962
@@ -20,7 +20,7 @@ trap "cd $here; rm -rf $tmp.*; exit \$status" 0 1 2 3 15
 
 # real QA test starts here
 echo "<mark> records ..."
-pmdumplog -z -x archives/count-mark | egrep '(^[^ ])|(pswitch)' >$tmp.out
+pmdumplog -z -x archives/count-mark | grep -E '(^[^ ])|(pswitch)' >$tmp.out
 for line in `$PCP_AWK_PROG <$tmp.out '/<mark>/ { print NR }'`
 do
     a=`expr $line - 4`

--- a/qa/974
+++ b/qa/974
@@ -47,7 +47,7 @@ do
     base=`basename $tgz`
 
     echo "== Extracting subtrees for later use - $base" | tee -a $seq.full
-    trees=`pminfo proc | awk -F. '{ print $2 }' | sort -u | egrep -v 'nproc'`
+    trees=`pminfo proc | awk -F. '{ print $2 }' | sort -u | grep -E -v 'nproc'`
     echo $trees >> $here/$seq.full
 
     echo "== Checking namespace and metric numbering - $base"

--- a/qa/GNUmakefile
+++ b/qa/GNUmakefile
@@ -83,7 +83,7 @@ else
 SELINUX_PCPQA =
 endif
 
-DOTOUTFILES = $(shell [ -f qa_outfiles ] && cat qa_outfiles || ls -1 | grep '^[0-9]' | grep -v '^[0-9][0-9][0-9]$$' | grep -v '^[0-9][0-9][0-9][0-9]$$' | egrep -v '^[0-9][0-9][0-9]*\.(full|out\.bad|notrun|helper|work)' | tee qa_outfiles)
+DOTOUTFILES = $(shell [ -f qa_outfiles ] && cat qa_outfiles || ls -1 | grep '^[0-9]' | grep -v '^[0-9][0-9][0-9]$$' | grep -v '^[0-9][0-9][0-9][0-9]$$' | grep -E -v '^[0-9][0-9][0-9]*\.(full|out\.bad|notrun|helper|work)' | tee qa_outfiles)
 
 qa_outfiles:
 	@echo $(DOTOUTFILES) > qa_outfiles

--- a/qa/admin/check-manifest
+++ b/qa/admin/check-manifest
@@ -892,7 +892,7 @@ do
 	    _perl=`echo "$target" | sed -e 's/:://'`
 	    _target=`find $_perl_dirs -name "$_perl.*" -print 2>/dev/null \
 		     | tee $tmp.debug \
-	             | egrep "/$_perl.(pm|so|dylib|bs)$" \
+	             | grep -E "/$_perl.(pm|so|dylib|bs)$" \
 		     | ( tr '\012' '|'; echo ) \
 		     | sed -e 's/|$//'`
 	    if [ -z "$_target" ]
@@ -920,7 +920,7 @@ do
 	    _perl=`echo "$target" | sed -e 's/.*:://'`
 	    _target=`find $_perl_dirs -name "$_perl.*" -print 2>/dev/null \
 		     | tee $tmp.debug \
-	             | egrep "/$_module/($_submodule|$_submodule/$_perl)/$_perl.(pm|so|dylib|bs)$" \
+	             | grep -E "/$_module/($_submodule|$_submodule/$_perl)/$_perl.(pm|so|dylib|bs)$" \
 		     | ( tr '\012' '|'; echo ) \
 		     | sed -e 's/|$//'`
 	    if [ -z "$_target" ]
@@ -947,7 +947,7 @@ do
 	    _perl=`echo "$target" | sed -e 's/.*:://'`
 	    _target=`find $_perl_dirs -name "$_perl.*" -print 2>/dev/null \
 		     | tee $tmp.debug \
-	             | egrep "/$_module/$_perl.(pm|so|dylib|bs)$" \
+	             | grep -E "/$_module/$_perl.(pm|so|dylib|bs)$" \
 		     | ( tr '\012' '|'; echo ) \
 		     | sed -e 's/|$//'`
 	    if [ -z "$_target" ]

--- a/qa/admin/ci-qa-summary
+++ b/qa/admin/ci-qa-summary
@@ -111,7 +111,7 @@ do
 	# Passed all 67 tests
 	#
 	rm -f $tmp.dbg
-	if egrep '^((Not run:)|Failures:|(Failed [0-9][0-9]* of [0-9][0-9]* tests)|(Passed all [0-9][0-9]* tests)|Info:|===)' <$log >/dev/null
+	if grep -E '^((Not run:)|Failures:|(Failed [0-9][0-9]* of [0-9][0-9]* tests)|(Passed all [0-9][0-9]* tests)|Info:|===)' <$log >/dev/null
 	then
 	    awk <$log >$tmp.out '
     /^Not run:/	{ notrun = NF - 2

--- a/qa/admin/list-packages
+++ b/qa/admin/list-packages
@@ -174,7 +174,7 @@ END							{ exit sts }'
     #
     for pkg in `cat $tmp.require`
     do
-	if egrep "(^$pkg )|(^$pkg$)" <$tmp.list >/dev/null
+	if grep -E "(^$pkg )|(^$pkg$)" <$tmp.list >/dev/null
 	then
 	    : OK
 	else

--- a/qa/admin/pcp-daily
+++ b/qa/admin/pcp-daily
@@ -188,7 +188,7 @@ then
     cp VERSION.pcp VERSION.pcp.daily
 else
     diff VERSION.pcp VERSION.pcp.daily >$tmp.tmp
-    if egrep 'PACKAGE_MAJOR|PACKAGE_MINOR|PACKAGE_REVISION' <$tmp.tmp >/dev/null
+    if grep -E 'PACKAGE_MAJOR|PACKAGE_MINOR|PACKAGE_REVISION' <$tmp.tmp >/dev/null
     then
 	# different PCP release, do an initial build
 	cp VERSION.pcp VERSION.pcp.daily

--- a/qa/admin/qa-summary
+++ b/qa/admin/qa-summary
@@ -226,7 +226,7 @@ do
 	# Passed 67 tests (newer format)
 	#
 	rm -f $tmp.dbg
-	if egrep '^((Not run:)|Failures:|(Failed [0-9][0-9]* of [0-9][0-9]* tests)|Triaged:|(Passed [0-9][0-9]* tests)|(Passed all [0-9][0-9]* tests)|Info:|===)' <$date >/dev/null
+	if grep -E '^((Not run:)|Failures:|(Failed [0-9][0-9]* of [0-9][0-9]* tests)|Triaged:|(Passed [0-9][0-9]* tests)|(Passed all [0-9][0-9]* tests)|Info:|===)' <$date >/dev/null
 	then
 	    awk <$date >$tmp.out '
 # states

--- a/qa/check
+++ b/qa/check
@@ -149,7 +149,7 @@ _addfiles()
 
     for fn in "$@"
     do
-    	fgrep -s "$fn" "$af" >/dev/null
+    	grep -F -s "$fn" "$af" >/dev/null
     	[ $? = 1 ] && echo "$fn" >>"$af"
     done
 
@@ -292,14 +292,14 @@ _checksums()
     	    	buf=$tmp/checksums/$buf
 		if [ ! -f $f ]
 		then
-		    if fgrep "$f" $2 >/dev/null 2>&1
+		    if grep -F "$f" $2 >/dev/null 2>&1
 		    then
 			echo "    Missing: \"$f\""
 		        [ -f $buf ] && $sudo cp -f $buf $f
 		    fi
 		else
 		    _cs=`sum $f`
-		    if fgrep "$_cs" $2 >/dev/null 2>&1
+		    if grep -F "$_cs" $2 >/dev/null 2>&1
 		    then
 			$sudo rm -f $f.$seq.O
 		    else
@@ -339,7 +339,7 @@ p
     do
 	eval `echo "$_line" | sed -e 's/\//\\\\/g' -e 's/^/_re="/' -e 's/	.*/"/'`
 	eval `echo "$_line" | sed -e 's/^[^	]*	/_comments="/' -e 's/$/"/'`
-	if egrep "$_re" $tmp.whatami >/dev/null 2>&1
+	if grep -E "$_re" $tmp.whatami >/dev/null 2>&1
 	then
 	    # triaged, don't treat as a Failure
 	    #

--- a/qa/check-group
+++ b/qa/check-group
@@ -39,13 +39,13 @@ do
     grep '# check-group-' $seq >$tmp.chk
     if [ -s $tmp.chk ]
     then
-	if egrep "check-group-include:.* $1( |\$)" <$tmp.chk >/dev/null
+	if grep -E "check-group-include:.* $1( |\$)" <$tmp.chk >/dev/null
 	then
 	    $debug && echo "$seq: explicit include"
 	    echo $seq >>$tmp.tmp
 	    continue
 	fi
-	if egrep "check-group-exclude:.* $1( |\$)" <$tmp.chk >/dev/null
+	if grep -E "check-group-exclude:.* $1( |\$)" <$tmp.chk >/dev/null
 	then
 	    $debug && echo "$seq: explicit exclude"
 	    continue
@@ -61,21 +61,21 @@ do
 
 	folio)		# executable might be pmafm or mkaf
 	    ( grep -v '^#' $seq \
-	      | egrep -q "(^[ 	]*(pmafm|mkaf)([ '\"]|$))|([ /'\"\`_=](pmafm|mkaf)([ '\"\`_]|$))" \
+	      | grep -E -q "(^[ 	]*(pmafm|mkaf)([ '\"]|$))|([ /'\"\`_=](pmafm|mkaf)([ '\"\`_]|$))" \
 	    ) && echo $seq >>$tmp.tmp
 	    report_group="pmafm or mkaf"
 	    ;;
 
 	logutil)	# pmlogger_ scripts
 	    ( grep -v '^#' $seq \
-	      | egrep -q "(^[ 	]*(pmlogger_check|pmlogger_daily|pmlogger_daily_report|pmlogger_merge|pmlogger_rewrite)([ '\"]|$))|([ /'\"\`_=](pmlogger_check|pmlogger_daily|pmlogger_daily_report|pmlogger_merge|pmlogger_rewrite)([ '\"\`_]|$))" \
+	      | grep -E -q "(^[ 	]*(pmlogger_check|pmlogger_daily|pmlogger_daily_report|pmlogger_merge|pmlogger_rewrite)([ '\"]|$))|([ /'\"\`_=](pmlogger_check|pmlogger_daily|pmlogger_daily_report|pmlogger_merge|pmlogger_rewrite)([ '\"\`_]|$))" \
 	    ) && echo $seq >>$tmp.tmp
 	    report_group="pmlogger_* scripts"
 	    ;;
 
 	pmclient)	# executable might be pmlient_fg
 	    ( grep -v '^#' $seq \
-	      | egrep -q "(^[ 	]*(pmclient|pmclient_fg)([ '\"]|$))|([ /'\"\`_=](pmclient|pmclient_fg)([ '\"\`_]|$))" \
+	      | grep -E -q "(^[ 	]*(pmclient|pmclient_fg)([ '\"]|$))|([ /'\"\`_=](pmclient|pmclient_fg)([ '\"\`_]|$))" \
 	    ) && echo $seq >>$tmp.tmp
 	    report_group="pmclient et al"
 	    ;;
@@ -83,38 +83,38 @@ do
 	pmdumplog)	# executable might be hidden in _exercise_compression
 			# wrapper from common.compress
 	    ( grep -v '^#' $seq \
-	      | egrep -q "(^[ 	]*(pmdumplog|_exercise_compression)([ '\"]|$))|([ /'\"\`_=](pmdumplog|_exercise_compression)([ '\"\`_]|$))" \
+	      | grep -E -q "(^[ 	]*(pmdumplog|_exercise_compression)([ '\"]|$))|([ /'\"\`_=](pmdumplog|_exercise_compression)([ '\"\`_]|$))" \
 	    ) && echo $seq >>$tmp.tmp
 	    ;;
 
 	pmie)		# executable might be hidden in src/grind
 	    ( grep -v '^#' $seq \
-	      | egrep -q "(^[ 	]*(pmie|src/grind-tools)([ '\"]|$))|([ /'\"\`_=](pmie|src/grind-tools)([ '\"\`_]|$))" \
+	      | grep -E -q "(^[ 	]*(pmie|src/grind-tools)([ '\"]|$))|([ /'\"\`_=](pmie|src/grind-tools)([ '\"\`_]|$))" \
 	    ) && echo $seq >>$tmp.tmp
 	    ;;
 
 	pmlogrewrite)	# executable might be hidden in mk.logfarm
 	    ( grep -v '^#' $seq \
-	      | egrep -q "(^[ 	]*(pmlogrewrite|mk.logfarm)([ '\"]|$))|([ /'\"\`_=](pmlogrewrite|mk.logfarm)([ '\"\`_]|$))" \
+	      | grep -E -q "(^[ 	]*(pmlogrewrite|mk.logfarm)([ '\"]|$))|([ /'\"\`_=](pmlogrewrite|mk.logfarm)([ '\"\`_]|$))" \
 	    ) && echo $seq >>$tmp.tmp
 	    ;;
 
 	pmpost)		# executable might be in $PCP_BINADM_DIR
 	    ( grep -v '^#' $seq \
-	      | egrep "(^[ 	]*pmpost([ '\"]|$))|([ '\"\`/]pmpost([ '\"\`]|$))" >$tmp.debug \
+	      | grep -E "(^[ 	]*pmpost([ '\"]|$))|([ '\"\`/]pmpost([ '\"\`]|$))" >$tmp.debug \
 	    ) && echo $seq >>$tmp.tmp
 	    ;;
 
 	valgrind)	# executable maybe hidden in wrappers, so look for
 			# cmd and guard and wrapper
 	    ( grep -v '^#' $seq \
-	      | egrep -q "(^[ 	]*(valgrind|_check_valgrind)([ '\"]|$))|([ /'\"\`_=](valgrind|_run_valgrind)([ '\"\`_]|$))" \
+	      | grep -E -q "(^[ 	]*(valgrind|_check_valgrind)([ '\"]|$))|([ /'\"\`_=](valgrind|_run_valgrind)([ '\"\`_]|$))" \
 	    ) && echo $seq >>$tmp.tmp
 	    ;;
 
 	pcp-*)		# pcp-xxx is cmd, expected group is pcp AND xxx
 	    ( grep -v '^#' $seq \
-	      | egrep "(^[ 	]*$1([ '\"]|$))|([ '\"\`]$1([ '\"\`]|$))" >$tmp.debug \
+	      | grep -E "(^[ 	]*$1([ '\"]|$))|([ '\"\`]$1([ '\"\`]|$))" >$tmp.debug \
 	    ) && echo $seq >>$tmp.tmp
 	    group_list="`echo $1 | sed -e 's/-/ /'`"
 	    ;;
@@ -125,7 +125,7 @@ do
 	    ;;
 	*)
 	    ( grep -v '^#' $seq \
-	      | egrep "(^[ 	]*$1([ '\"]|$))|([ '\"\`]$1([ '\"\`]|$))" >$tmp.debug \
+	      | grep -E "(^[ 	]*$1([ '\"]|$))|([ '\"\`]$1([ '\"\`]|$))" >$tmp.debug \
 	    ) && echo $seq >>$tmp.tmp
 	    $debug && [ -s $tmp.debug ] && echo $seq: && cat $tmp.debug
 	    ;;

--- a/qa/check-pdu-coverage
+++ b/qa/check-pdu-coverage
@@ -46,7 +46,7 @@ do
     esac
     for src in pdu-server.c pducheck.c pducrash.c
     do
-	if egrep "[ 	]$pat[;:) ]" src/$src >/dev/null
+	if grep -E "[ 	]$pat[;:) ]" src/$src >/dev/null
 	then
 	    :
 	else

--- a/qa/check-vars
+++ b/qa/check-vars
@@ -89,12 +89,12 @@ sort $tmp.reserved $tmp.exempt >$tmp.ok
 # but only those variables that begin with a lower case alphabetic
 # (these are potentially the problem ones) ...
 #
-egrep '(\$[a-z])|(\${[a-z])|(\$_[a-z])|(\${_[a-z])' common* \
+grep -E '(\$[a-z])|(\${[a-z])|(\$_[a-z])|(\${_[a-z])' common* \
 | sed \
     -e 's/\${/$/' \
     -e 's/\$/ $/g' \
 | tr '[ ./]' '\012' \
-| egrep '(\$[a-z])|(\$_[a-z])' \
+| grep -E '(\$[a-z])|(\$_[a-z])' \
 | sed >$tmp.used \
     -e 's/^>>*//' \
     -e 's/[^$]*\$/$/' \
@@ -157,14 +157,14 @@ do
     echo $var:
     # report set or used or both in all QA tests
     #
-    egrep -l "(\\\$$var[^a-zA-Z0-9_])|(\\\$$var\$)|(\\\${$var})|(for $var in)|(for $var\$)|([ 	;(]$var=)|(^$var=)|(read $var )|(read .* var )|(read .* $var\$)" [0-9]*[0-9] 2>/dev/null \
+    grep -E -l "(\\\$$var[^a-zA-Z0-9_])|(\\\$$var\$)|(\\\${$var})|(for $var in)|(for $var\$)|([ 	;(]$var=)|(^$var=)|(read $var )|(read .* var )|(read .* $var\$)" [0-9]*[0-9] 2>/dev/null \
     | while read seq
     do
 	./var-use $var $seq
     done
     # show lines where used in common* scripts
     #
-    egrep "(\\\$$var[^a-zA-Z0-9_])|(\\\$$var\$)|(\\\${$var})|(for $var in)|(for $var\$)|([ 	;(]$var=)|(^$var=)|(read $var )|(read .* var )|(read .* $var\$)" $scripts 2>/dev/null
+    grep -E "(\\\$$var[^a-zA-Z0-9_])|(\\\$$var\$)|(\\\${$var})|(for $var in)|(for $var\$)|([ 	;(]$var=)|(^$var=)|(read $var )|(read .* var )|(read .* $var\$)" $scripts 2>/dev/null
 done
 
 togo=`wc -l <$tmp.togo | sed -e 's/  *//g'`

--- a/qa/check.app.ok
+++ b/qa/check.app.ok
@@ -38,7 +38,7 @@ do
 
     cd ..
 
-    seqs=`egrep -l "src/$app( |$)" [0-9][0-9]*[0-9] | tr '\012' ' ' | sed -e 's/  *$//'`
+    seqs=`grep -E -l "src/$app( |$)" [0-9][0-9]*[0-9] | tr '\012' ' ' | sed -e 's/  *$//'`
 
     if [ -z "$seqs" ]
     then

--- a/qa/check.callback.sample
+++ b/qa/check.callback.sample
@@ -82,7 +82,7 @@ then
     echo "--- start pre-check ---"
     ./941 --check $1
     ./870 --check $1
-    $sudo egrep '^type=(AVC|SELINUX).*pcp' $audit >$1.pre-avc 2>/dev/null
+    $sudo grep -E '^type=(AVC|SELINUX).*pcp' $audit >$1.pre-avc 2>/dev/null
     echo "before `wc -l <$1.pre-avc` AVC errors"
     echo "--- end pre-check ---"
     exit
@@ -226,7 +226,7 @@ fi
 # a pmcd restart
 #
 pminfo -v -b 2000 2>&1 \
-| egrep '(Unknown or illegal metric)|(Unknown metric name)' \
+| grep -E '(Unknown or illegal metric)|(Unknown metric name)' \
 | sed >$tmp.out \
     -e '/^sample.*\.bad\.unknown:/d' \
     -e '/^pmproxy\./d' \
@@ -274,7 +274,7 @@ fi
 # Check audit log for any Security Enhanced Linux access denials
 # related to PCP ...
 #
-$sudo egrep '^type=(AVC|SELINUX).*pcp' $audit 2>/dev/null >$1.post-avc
+$sudo grep -E '^type=(AVC|SELINUX).*pcp' $audit 2>/dev/null >$1.post-avc
 if [ -f $1.pre-avc ]
 then
     diff $1.pre-avc $1.post-avc \

--- a/qa/common
+++ b/qa/common
@@ -121,7 +121,7 @@ _haveagents()
 	    [ $__diff = true ] || echo "PMDA probe: pminfo -h $QA_HOST -f $__probe"
 	    if pminfo -h $QA_HOST -f $__probe 2>&1 \
 	       | tail -1 \
-	       | egrep "^[ 	]*((value)|(inst))[ 	]" >/dev/null
+	       | grep -E "^[ 	]*((value)|(inst))[ 	]" >/dev/null
 	    then
 		break
 	    else
@@ -575,7 +575,7 @@ p
 		    else
 			sed -e '/[0-9]:\(retired\|reserved\) /d' <group
 		    fi \
-		    | egrep "^[0-9].*[ 	]$__name([ 	]|$)" \
+		    | grep -E "^[0-9].*[ 	]$__name([ 	]|$)" \
 		    | wc -l \
 		    | sed -e 's/ //g'`
 		printf "%-20.20s %3d\n" $__name $__num
@@ -712,11 +712,11 @@ BEGIN	{ for (t = '$__start'; t <= '$__end'; t++) printf "%03d\n",t }' \
 		fi
 		continue
 	    fi
-	    if egrep -s "^$__id([ 	]|$)" $tmp.group >/dev/null
+	    if grep -E -s "^$__id([ 	]|$)" $tmp.group >/dev/null
 	    then
 		# in group file ... OK
 		echo $__id >>$tmp.list
-	    elif egrep -s "^$__id:retired([ 	]|$)" group >/dev/null
+	    elif grep -E -s "^$__id:retired([ 	]|$)" group >/dev/null
 	    then
 		# in group file, but retired
 		if $__rflag
@@ -725,7 +725,7 @@ BEGIN	{ for (t = '$__start'; t <= '$__end'; t++) printf "%03d\n",t }' \
 		else
 		   $__range || echo "$__id - retired test, ignored"
 		fi
-	    elif egrep -s "^$__id:reserved([ 	]|$)" group >/dev/null
+	    elif grep -E -s "^$__id:reserved([ 	]|$)" group >/dev/null
 	    then
 		# in group file, but reserved
 		if $__rflag

--- a/qa/common.check
+++ b/qa/common.check
@@ -719,12 +719,12 @@ _wait_for_pmcd()
 		cat $PCP_LOG_DIR/pmcd/pmcd.log
 
 		echo "likely looking processes ..."
-		$PCP_PS_PROG "$PCP_PS_ALL_FLAGS" | egrep "[p]m|[P]ID"
+		$PCP_PS_PROG "$PCP_PS_ALL_FLAGS" | grep -E "[p]m|[P]ID"
 		;;
 	    *)
 		# assume a remote PMCD
 		#
-		ssh pcpqa@$__host "sh -c '. \$PCP_DIR/etc/pcp.env; echo; echo "=== pmcd.log ==="; [ -f \$PCP_LOG_DIR/pmcd/pmcd.log ] && cat \$PCP_LOG_DIR/pmcd/pmcd.log; [ -f \$PCP_LOG_DIR/pmcd.log ] && cat \$PCP_LOG_DIR/pmcd.log; echo; echo likely looking processes ...; ( $PCP_PS_PROG \$PCP_PS_ALL_FLAGS | egrep \"[p]m|[P]ID\" )'" </dev/null
+		ssh pcpqa@$__host "sh -c '. \$PCP_DIR/etc/pcp.env; echo; echo "=== pmcd.log ==="; [ -f \$PCP_LOG_DIR/pmcd/pmcd.log ] && cat \$PCP_LOG_DIR/pmcd/pmcd.log; [ -f \$PCP_LOG_DIR/pmcd.log ] && cat \$PCP_LOG_DIR/pmcd.log; echo; echo likely looking processes ...; ( $PCP_PS_PROG \$PCP_PS_ALL_FLAGS | grep -E \"[p]m|[P]ID\" )'" </dev/null
 		;;
 	esac
 	_systemctl_status pmcd
@@ -768,7 +768,7 @@ _wait_for_pmcd_stop()
     else
 	date
 	echo "Arrgghhh ... pmcd failed to stop after $__can_wait seconds"
-	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[p]mcd|[P]ID'
+	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[p]mcd|[P]ID'
 	echo "=== successful pmprobes stdout ==="
 	cat $tmp._wait_for_pmcd_stop.out.all
 	echo "=== successful pmprobes stderr ==="
@@ -827,7 +827,7 @@ _wait_for_pmlogger()
     rm -f $tmp._wait_for_pmlogger.pmlc
     while [ $__i -lt $__maxdelay ]
     do
-	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep "([p]mlogger|[P]ID)" >>$tmp._wait_for_pmlogger.pmlc
+	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E "([p]mlogger|[P]ID)" >>$tmp._wait_for_pmlogger.pmlc
 	echo "pmlc $__pid" >>$tmp._wait_for_pmlogger.pmlc
 	# May need sudo -u pcp here in case we're doing credentials checks
 	# in pmlogger and this is the primary pmlogger (started by user
@@ -926,7 +926,7 @@ _wait_for_pmlogger()
 	done
 	echo
 	echo "Likely looking processes ..."
-	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '([p]m)|([P]ID)'
+	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '([p]m)|([P]ID)'
 	_systemctl_status pmlogger
 	status=0
 	rm -f $tmp._wait_for_pmlogger.*
@@ -983,7 +983,7 @@ _wait_pmlogger_end()
 	    then
 		echo "_wait_pmlogger_end: failed to see $PCP_TMP_DIR/pmlogger/$__pid removed after 100 iterations"
 		cat "$PCP_TMP_DIR/pmlogger/$__pid"
-		$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep "[P]ID|[p]mlogger|$__pid"
+		$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E "[P]ID|[p]mlogger|$__pid"
 		_systemctl_status pmlogger
 		#debug# set +x
 		return
@@ -1159,7 +1159,7 @@ p
 	    if [ "$__i" -ge 100 ]
 	    then
 		echo "_wait_pmie_end: failed to see pid(s) $__pidlist exit after 100 iterations"
-		$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mie'
+		$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mie'
 		_systemctl_status pmie
 		#debug# set +x
 		break
@@ -1210,7 +1210,7 @@ _wait_for_pmproxy()
 	then
 	    echo "pmproxy failed to start on port $__port after $__maxdelay seconds"
 	    echo "likely looking processes ..."
-	    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mproxy'
+	    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mproxy'
 	    if [ -f "$__logfile" ]
 	    then
 		echo "pmproxy logfile ($__logfile) ..."
@@ -3206,7 +3206,7 @@ _try_pmlc()
     while [ $__i -lt $__max_tries ]
     do
 	pmlc -ie <$tmp.pmlc >$tmp.out 2>$tmp.err
-	if egrep "(Address already in use)|(Connection refused)" $tmp.err >/dev/null
+	if grep -E "(Address already in use)|(Connection refused)" $tmp.err >/dev/null
 	then
 	    __i=`expr $__i + 1`
 	    pmsleep 0.1

--- a/qa/common.discovery
+++ b/qa/common.discovery
@@ -70,7 +70,7 @@ _filter_discovery_unresolvable()
 _control_service_discovery()
 {
     echo "*** Initial service status ***" >> $here/$seq.full
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mproxy|[p]mcd' \
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mproxy|[p]mcd' \
 	>> $here/$seq.full
     cat $PCP_LOG_DIR/pmproxy/pmproxy.log >> $here/$seq.full
     cat $PCP_LOG_DIR/pmcd/pmcd.log >> $here/$seq.full
@@ -96,11 +96,11 @@ _cleanup_avahi_service()
     cd $here
     echo "avahi_cleanup: before pmsignal" >>$seq.full
     __grep_service=`echo "$service" | sed -e 's/./[&]/'`
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|$__grep_service |$__grep_service$' >>$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|$__grep_service |$__grep_service$' >>$seq.full
     $sudo $PCP_BINADM_DIR/pmsignal -a "$service" >>$here/$seq.full 2>&1
     pmsleep 0.5
     echo "avahi_cleanup: after pmsignal" >>$seq.full
-    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|$__grep_service |$__grep_service$' >>$seq.full
+    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|$__grep_service |$__grep_service$' >>$seq.full
     _restore_config $PCP_PMCDOPTIONS_PATH
     _restore_config $PCP_PMPROXYOPTIONS_PATH
     if $__service_was_running

--- a/qa/common.filter
+++ b/qa/common.filter
@@ -209,12 +209,12 @@ _filter_pmie_log()
 }
 _show_pmie_exit()
 {
-    fgrep "evaluator exiting" | \
+    grep -F "evaluator exiting" | \
 	sed -e 's/.* Info: evaluator exiting/pmie: note - evaluator exiting/g'
 }
 _show_pmie_errors()
 {
-    egrep -v '^Log finished |^Log for pmie on ' \
+    grep -E -v '^Log finished |^Log for pmie on ' \
 	| $PCP_AWK_PROG '{ if (NF > 0) print }' \
 	| sed \
 	    -e 's/.*Info: evaluator exiting/pmie: note - evaluator exiting/g' \
@@ -745,7 +745,7 @@ _filter_pmproxy_stop()
 _sort_pmdumplog_d()
 {
     cat >$tmp.tmp
-    egrep '(^Descriptions)|(^$)' $tmp.tmp
+    grep -E '(^Descriptions)|(^$)' $tmp.tmp
     $PCP_AWK_PROG <$tmp.tmp '
 /^Descriptions/		{ next }
 NF == 0			{ next }

--- a/qa/common.pcpweb
+++ b/qa/common.pcpweb
@@ -12,7 +12,7 @@
 
 _installed()
 {
-    versions $1 | fgrep $1 > /dev/null 2>&1
+    versions $1 | grep -F $1 > /dev/null 2>&1
 }
 
 _remove_pmda()

--- a/qa/common.rc
+++ b/qa/common.rc
@@ -75,7 +75,7 @@ in
 	# I cannot make this work on Mac OS X ... kenj
 	;;
     *)
-	if $sudo -h 2>&1 | egrep '(\[-[a-zA-DF-Z]*E[a-zA-Z]*\])|(.-E[, 	])' >/dev/null 2>&1
+	if $sudo -h 2>&1 | grep -E '(\[-[a-zA-DF-Z]*E[a-zA-Z]*\])|(.-E[, 	])' >/dev/null 2>&1
 	then
 	    # sudo has -E to preserve the environment
 	    #

--- a/qa/common.secure
+++ b/qa/common.secure
@@ -191,7 +191,7 @@ End-Of-File
     _wait_for_pmlogger
     grep -i 'starting pmcd' $tmp.out | sed -e "s/$$/MYPID/" | _filter_pcp_start
     echo "Checking pmcd.log for unexpected messages" | tee -a $here/$seq.full
-    egrep 'Error:|Info:' $tmp.pmcd.log | sed -e '/PMNS file "DEFAULT" is unchanged/d'
+    grep -E 'Error:|Info:' $tmp.pmcd.log | sed -e '/PMNS file "DEFAULT" is unchanged/d'
     cat $tmp.pmcd.log >> $here/$seq.full
     echo "--- end of pmcd.log ---" >> $here/$seq.full
 }

--- a/qa/findmetric
+++ b/qa/findmetric
@@ -82,7 +82,7 @@ s/ InDom: /|/
 s/ Semantics: /|/
 s/ Units: /|/
 }' \
-    | egrep "$pat" >$tmp.out
+    | grep -E "$pat" >$tmp.out
 
     if [ -s $tmp.out ]
     then

--- a/qa/mk.qa_hosts
+++ b/qa/mk.qa_hosts
@@ -48,7 +48,7 @@ rm -f qa_hosts
 grep "^#order" qa_hosts.primary \
 | while read tag pat recipe
 do
-    if echo $my_fqdn | fgrep "$pat" >/dev/null 2>&1
+    if echo $my_fqdn | grep -F "$pat" >/dev/null 2>&1
     then
 	trap "rm -f /tmp/$$; exit 1" 1 2 3 15
 
@@ -60,7 +60,7 @@ do
 	#
 	for sel in $recipe
 	do
-	    fgrep $sel /tmp/$$ \
+	    grep -F $sel /tmp/$$ \
 	    | $PCP_AWK_PROG '
 BEGIN	{ srand('$$') }
 	{ print 100*rand(),$0 }' \

--- a/qa/new-grind
+++ b/qa/new-grind
@@ -66,7 +66,7 @@ else
     exit 1
 fi
 
-if egrep "_run_(valgrind|helgrind) " $oldseq >/dev/null
+if grep -E "_run_(valgrind|helgrind) " $oldseq >/dev/null
 then
     if grep "_run_valgrind \.\.\.your test goes here\.\.\." $oldseq >/dev/null
     then

--- a/qa/remake
+++ b/qa/remake
@@ -33,7 +33,7 @@ _do_diff()
 
 for seq in $__list
 do
-    if [ -f expunged ] && $expunge && egrep "^$seq([ 	]|\$)" expunged >/dev/null
+    if [ -f expunged ] && $expunge && grep -E "^$seq([ 	]|\$)" expunged >/dev/null
     then
 	echo "Remake: \"$seq\" has been expunged"
     elif [ ! -f $seq ]

--- a/qa/sniff4dodgey
+++ b/qa/sniff4dodgey
@@ -119,7 +119,7 @@ do
 	#
 	cat <<End-of-File | sed -e '/^#/d' | while IFS=: read pat use tags reason
 # control file, 3 fields per feature separated by colons
-# pat - egrep pattern to find this feature being used in QA test scripts
+# pat - grep -E pattern to find this feature being used in QA test scripts
 # use - verbage for -v output
 # tags - tags to search for in group file for -w
 pmrep|pmlogger_daily_report:pmrep:pmrep python
@@ -153,7 +153,7 @@ pcp2zabbix:pcp2zabbix:pcp2zabbix pcp2xxx python
 pmclient_fg:pmclient_fg:pmclient python
 End-of-File
 	do
-	    if egrep "[^a-zA-Z0-9_]$pat[^a-zA-Z0-9]" $tmp.in >/dev/null
+	    if grep -E "[^a-zA-Z0-9_]$pat[^a-zA-Z0-9]" $tmp.in >/dev/null
 	    then
 		if [ -f $tmp.report ]
 		then
@@ -185,7 +185,7 @@ End-of-File
 	# $PCP_PYTHON_PROG or sets PCP_PYTHON_PROG= as the first word in
 	# the command line
 	#
-	if egrep '^[ 	]*(python|python[0-9][0-9].*|$python|$PCP_PYTHON_PROG|PCP_PYTHON_PROG=[^ 	]*) ' $tmp.in >/dev/null
+	if grep -E '^[ 	]*(python|python[0-9][0-9].*|$python|$PCP_PYTHON_PROG|PCP_PYTHON_PROG=[^ 	]*) ' $tmp.in >/dev/null
 	then
 	    if [ -f $tmp.report ]
 	    then
@@ -213,7 +213,7 @@ End-of-File
 	#
 	cat <<End-of-File | sed -e '/^#/d' | while IFS=: read pat use tags reason
 # control file, at least 3 fields per feature separated by colons
-# pat - egrep pattern to find this feature being used in QA test scripts
+# pat - grep -E pattern to find this feature being used in QA test scripts
 # use - verbage for -v output
 # tags - tags to search for in group file for -w
 # reason - (optional and for annotation only) in the form test@host ...
@@ -222,7 +222,7 @@ pcp2elasticsearch:pcp2elasticsearch:pcp2elasticsearch pcp2xxx python:1130@{bozo,
 ([^/]pcp[_ -]pidstat)|(pcp .* pidstat):pcp-pidstat:pidstat pcp python:1396@vm34
 End-of-File
 	do
-	    if egrep "[^a-zA-Z0-9_]$pat[^a-zA-Z0-9]" $tmp.in >/dev/null
+	    if grep -E "[^a-zA-Z0-9_]$pat[^a-zA-Z0-9]" $tmp.in >/dev/null
 	    then
 		if [ -f $tmp.report ]
 		then

--- a/qa/src/mv-me
+++ b/qa/src/mv-me
@@ -161,7 +161,7 @@ do
 	    continue
 	fi
 	# real guard now
-	if egrep -l "src/$arch([.'\"\`\$,:\*{[/ 	]|\$)" $file >/dev/null
+	if grep -E -l "src/$arch([.'\"\`\$,:\*{[/ 	]|\$)" $file >/dev/null
 	then
 	    case $file
 	    in

--- a/qa/tmparch/check-pmcd-stable
+++ b/qa/tmparch/check-pmcd-stable
@@ -101,7 +101,7 @@ then
 	echo "Recent changes to NOTICES ..."
 	[ -f $PCP_LOG_DIR/NOTICES ] && diff $tmp.NOTICES $PCP_LOG_DIR/NOTICES
 	echo "pmcd-related processes ..."
-	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]PID|[p]mcd'
+	$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]PID|[p]mcd'
 	sts=1
     fi
 fi

--- a/qa/triaged
+++ b/qa/triaged
@@ -22,7 +22,7 @@
 #
 # Because the <whatami-RE> field is used with egrep, one needs to
 # (backslash) escape both [ and ( when a literal match is needed ... (none
-# of the other special egrep RE characters appear in the whatami output).
+# of the other special grep -E RE characters appear in the whatami output).
 #
 # Typical whatami output looks like:
 # bozo                6.0.0    x86_64  Ubuntu 20.04 (focal) [kernel=5.4.0 py=3.8.10 se=none]

--- a/scripts/check-rpm-packages
+++ b/scripts/check-rpm-packages
@@ -17,7 +17,7 @@ if [ ! -d pcp-$VER ]; then
 fi
 
 for rpm in pcp-$VER/build/rpm/*.rpm; do
-  echo $rpm | egrep -qs 'debuginfo|debugsource|src\.rpm' && continue
+  echo $rpm | grep -E -qs 'debuginfo|debugsource|src\.rpm' && continue
   pkg=`basename $rpm`
   basepkg=`echo $pkg | sed -e '/src.rpm/d' -e "s/-$VER.*.rpm//"`
   fc_pkg=`echo ~/rpmbuild/RPMS/*/$basepkg-$VER-[0-9]*.fc*.*.rpm`

--- a/scripts/demote
+++ b/scripts/demote
@@ -136,7 +136,7 @@ do
 	    ;;
 
 	*.c|*.h|*.cpp|*.cxx|*.in|*.y|*.l|*.xs|*.[1-8]|*.xml|${topdir}qa/[0-9]*|*.install)
-	    if egrep "$from_pat" $file >/dev/null
+	    if grep -E "$from_pat" $file >/dev/null
 	    then
 		echo >&2 "$file:"
 		# TODO
@@ -181,7 +181,7 @@ then
     fi
     if $showme
     then
-	egrep "[^a-zA-Z0-9_]($from|$to)[^a-zA-Z0-9_]" <$tmp.tmp >$tmp.out
+	grep -E "[^a-zA-Z0-9_]($from|$to)[^a-zA-Z0-9_]" <$tmp.tmp >$tmp.out
 	if [ -s $tmp.out ]
 	then
 	    echo >&2 "details from deprecated.h:"
@@ -228,7 +228,7 @@ do
 	fi
 	if $showme
 	then
-	    egrep "[^a-zA-Z0-9_]($from|$to)[^a-zA-Z0-9_]" <$tmp.tmp >$tmp.out
+	    grep -E "[^a-zA-Z0-9_]($from|$to)[^a-zA-Z0-9_]" <$tmp.tmp >$tmp.out
 	    if [ -s $tmp.out ]
 	    then
 		echo >&2 "details from $inc:"

--- a/scripts/hunter
+++ b/scripts/hunter
@@ -98,7 +98,7 @@ do
     in
 	*.c|*.h|*.cpp|*.cxx|*.in|*.y|*.l|*.xs|*/|*.[1-8])
 	    sed -e 's/$/ /' -e 's/^/ /' $file \
-	    | egrep "[^a-zA-Z_0-9]$1$tail" \
+	    | grep -E "[^a-zA-Z_0-9]$1$tail" \
 	    | sed -e "s@^ @$file:@" -e 's/ $//' >>$tmp.out
 	    ;;
     esac

--- a/scripts/promote
+++ b/scripts/promote
@@ -136,7 +136,7 @@ do
 	    ;;
 
 	*.c|*.h|*.cpp|*.cxx|*.in|*.y|*.l|*.xs|*.[1-8]|*.xml|${topdir}qa/[0-9]*|*.install)
-	    if egrep "$from_pat" $file >/dev/null
+	    if grep -E "$from_pat" $file >/dev/null
 	    then
 		echo >&2 "$file:"
 		# TODO
@@ -181,7 +181,7 @@ then
     fi
     if $showme
     then
-	egrep "[^a-zA-Z0-9_]($from|$to)[^a-zA-Z0-9_]" <$tmp.tmp >$tmp.out
+	grep -E "[^a-zA-Z0-9_]($from|$to)[^a-zA-Z0-9_]" <$tmp.tmp >$tmp.out
 	if [ -s $tmp.out ]
 	then
 	    echo >&2 "details from deprecated.h:"
@@ -228,7 +228,7 @@ do
 	fi
 	if $showme
 	then
-	    egrep "[^a-zA-Z0-9_]($from|$to)[^a-zA-Z0-9_]" <$tmp.tmp >$tmp.out
+	    grep -E "[^a-zA-Z0-9_]($from|$to)[^a-zA-Z0-9_]" <$tmp.tmp >$tmp.out
 	    if [ -s $tmp.out ]
 	    then
 		echo >&2 "details from $inc:"

--- a/scripts/tests-from-commits
+++ b/scripts/tests-from-commits
@@ -16,13 +16,13 @@ _hunt_qa()
 
     cd $topdir/qa
 
-    # use the file name to produce an egrep pattern ($_pat) to be
+    # use the file name to produce an grep -E pattern ($_pat) to be
     # used to search in the QA tests ... to skip the file name, don't
     # set $_pat
     # - use .meta as the representative for each archive, skip the
     #   .index and .N files
     # for some special cases, e.g. archives, they are used but not
-    # named in QA tests, so egrep won't help ... set $_tests to a
+    # named in QA tests, so grep -E won't help ... set $_tests to a
     # list of QA tests in this case
     #
     _pat=''
@@ -372,7 +372,7 @@ _hunt_qa()
 
     if [ -n "$_pat" ]
     then
-	egrep -l "$_pat" [0-9][0-9][0-9] [0-9][0-9][0-9][0-9] >$tmp.tmp
+	grep -E -l "$_pat" [0-9][0-9][0-9] [0-9][0-9][0-9][0-9] >$tmp.tmp
 	if [ -s $tmp.tmp ]
 	then
 	    cat $tmp.tmp

--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -905,7 +905,7 @@ MAC_FRAMEWORKS_DIR=$(MAC_APPSUPPORT_DIR)/Frameworks
 # rule before calling install rule for the binary.
 INSTALL_QT_FRAMEWORKS=\
     otool -L $(1) | awk '{if (NR != 1) {print $$1}}' |\
-    egrep 'Qt.*\.framework' | while read qt; do \
+    grep -E 'Qt.*\.framework' | while read qt; do \
 	tdir=`dirname $$qt`; \
 	install_name_tool -change $$qt $(MAC_FRAMEWORKS_DIR)/$$qt $(1);\
 	$(call INSTALL_DIRECTORY_HIERARCHY,$(MAC_FRAMEWORKS_DIR)/$$tdir,/Library/PCP); \
@@ -913,7 +913,7 @@ INSTALL_QT_FRAMEWORKS=\
 	fwqt="frameworks/$$qt"; \
 	cp /Library/Frameworks/$$qt frameworks/$$qt || exit 1; \
 	otool -L $$fwqt | awk '{if (NR != 1) {print $$1}}' |\
-	egrep 'Qt.*\.framework' | while read dep; do \
+	grep -E 'Qt.*\.framework' | while read dep; do \
 	    install_name_tool -change $$dep $(MAC_FRAMEWORKS_DIR)/$$dep $$fwqt;\
 	done; \
 	$(INSTALL) frameworks/$$qt $(MAC_FRAMEWORKS_DIR)/$$qt; \

--- a/src/pmdas/openmetrics/pmdaopenmetrics.python
+++ b/src/pmdas/openmetrics/pmdaopenmetrics.python
@@ -830,7 +830,7 @@ class Source(object):
                 # each list entry is (uppercase are literal) :
                 #     {INCLUDE|EXCLUDE} METRIC regex
                 #     {INCLUDE|EXCLUDE|OPTIONAL} LABEL regex
-                # These are extended egrep style regexs, disjuncted by '|'
+                # These are extended grep -E style regexs, disjuncted by '|'
                 # Full string matches must be anchored, e.g. ^matchme$|*endswith$
                 header_filter = ''.join(line.split(':', 2)[1]).lstrip()
                 self.filterlist.append(header_filter)

--- a/src/pmdas/samba/Install
+++ b/src/pmdas/samba/Install
@@ -27,7 +27,7 @@ if ! test -x /usr/sbin/smbd; then
     status=1
     exit
 fi
-/usr/sbin/smbd -b | egrep 'WITH_PROFILE|HAVE_PROFILE' >/dev/null
+/usr/sbin/smbd -b | grep -E 'WITH_PROFILE|HAVE_PROFILE' >/dev/null
 if test $? -ne 0; then
     echo "Samba \"smbd\" not built with profiling support"
     status=1

--- a/src/pmdas/shping/Install
+++ b/src/pmdas/shping/Install
@@ -84,7 +84,7 @@ then
 fi
 
 default_configfile=./sample.conf
-if fgrep "CONFIGURE-ME-PLEASE" $default_configfile >/dev/null
+if grep -F "CONFIGURE-ME-PLEASE" $default_configfile >/dev/null
 then
     # nslookup(1) may be hiding, like for OpenIndiana
     #

--- a/src/pmdas/weblog/Install
+++ b/src/pmdas/weblog/Install
@@ -135,7 +135,7 @@ regex_posix WU_FTP_err - failed login
 
 _parse_server()
 {
-    egrep "^server" | $PCP_AWK_PROG '
+    grep -E "^server" | $PCP_AWK_PROG '
 	{ i=index($2, ":");
 	  if (i == 0) {
 	    name = $2;
@@ -157,7 +157,7 @@ _default_config ()
     touch $__tmp.conf
     _defaultRegex $__tmp.conf
     ./server.sh -q -l $__tmp.conf
-    egrep "^server" $__tmp.conf > /dev/null 2>&1
+    grep -E "^server" $__tmp.conf > /dev/null 2>&1
     _st=$?
     if [ $_st -eq 0 ] 
     then
@@ -242,7 +242,7 @@ else
 	if [ -f "$configFile" ]
 	then
 	    if [ $PCP_PLATFORM = linux ] && \
-		egrep '^regex ' $configFile > /dev/null
+		grep -E '^regex ' $configFile > /dev/null
 	    then
 		echo "Warning: previous configuration file \"$configFile\""
 		echo "         appears to be an incompatible version."
@@ -351,7 +351,7 @@ else
 	    touch $__tmp.conf
 	    _defaultRegex $__tmp.conf
 	    ./server.sh -l $__tmp.conf
-	    if egrep "^server" $__tmp.conf > /dev/null 2>&1
+	    if grep -E "^server" $__tmp.conf > /dev/null 2>&1
 	    then
 		echo
 		echo "This is a possible configuration file for your system:"
@@ -503,7 +503,7 @@ else
 	    accessRegex=""
 	    while [ "X$accessRegex" = X ]
 	    do
-		if egrep "^regex_posix CERN " $configFile > /dev/null 2>&1
+		if grep -E "^regex_posix CERN " $configFile > /dev/null 2>&1
 		then
 		    $PCP_ECHO_PROG $PCP_ECHO_N "The regex for the access log [CERN]: ""$PCP_ECHO_C"
 		    accessRegex="CERN"
@@ -518,7 +518,7 @@ else
 		fi
 		if [ "X$accessRegex" != X ]
 		then
-		    if egrep "^regex_posix $accessRegex " $configFile > /dev/null 2>&1
+		    if grep -E "^regex_posix $accessRegex " $configFile > /dev/null 2>&1
 		    then
 			:
 		    else
@@ -532,7 +532,7 @@ else
 	    errorRegex=""
 	    while [ "X$errorRegex" = X ]
 	    do
-		if egrep "^regex_posix CERN_err " $configFile > /dev/null 2>&1
+		if grep -E "^regex_posix CERN_err " $configFile > /dev/null 2>&1
 		then
 		    $PCP_ECHO_PROG $PCP_ECHO_N "The regex for the error log [CERN_err]: ""$PCP_ECHO_C"
 		    errorRegex="CERN_err"
@@ -547,7 +547,7 @@ else
 		fi
 		if [ "X$errorRegex" != X ]
 		then
-		    if egrep "^regex_posix $errorRegex " $configFile > /dev/null 2>&1
+		    if grep -E "^regex_posix $errorRegex " $configFile > /dev/null 2>&1
 		    then
 			:
 		    else

--- a/src/pmie/pmie_daily.sh
+++ b/src/pmie/pmie_daily.sh
@@ -123,7 +123,7 @@ Options:
   -V,--verbose            verbose output (multiple times for very verbose)
   -x=N,--compress-after=N  compress pmie log files after N days
   -X=PROGRAM,--compressor=PROGRAM  use PROGRAM for pmie log file compression
-  -Y=REGEX,--regex=REGEX  egrep filter when compressing files ["$COMPRESSREGEX"]
+  -Y=REGEX,--regex=REGEX  grep -E filter when compressing files ["$COMPRESSREGEX"]
   --help
 EOF
 
@@ -561,7 +561,7 @@ NR == 3	{ printf "p_pmcd_host=\"%s\"\n", $0; next }
 	#
 	if [ ! -z "$COMPRESSAFTER" ]
 	then
-	    _date_filter $COMPRESSAFTER | egrep -v "$COMPRESSREGEX" >$tmp/list
+	    _date_filter $COMPRESSAFTER | grep -E -v "$COMPRESSREGEX" >$tmp/list
 	    if [ -s $tmp/list ]
 	    then
 		if $VERBOSE
@@ -596,17 +596,17 @@ then
     do
 	[ -f $logfile ] && logs="$logs $logfile"
     done
-    egrep -v '( OK | OK$|^$|^Log |^pmie: PID)' $logs > $tmp/logmail
+    grep -E -v '( OK | OK$|^$|^Log |^pmie: PID)' $logs > $tmp/logmail
     if [ ! -s "$tmp/logmail" ]
     then
 	:
     elif [ ! -z "$MAIL" ]
     then
-	egrep -v '( OK | OK$|^$)' $logs | \
+	grep -E -v '( OK | OK$|^$)' $logs | \
 	    $MAIL -s "PMIE summary for $LOCALHOSTNAME" $MAILME
     else
 	echo "$prog: PMIE summary for $LOCALHOSTNAME ..."
-	egrep -v '( OK | OK$|^$)' $logs
+	grep -E -v '( OK | OK$|^$)' $logs
     fi
     rm -f $tmp/mail $tmp/logmail
 fi

--- a/src/pmlogctl/pmlogctl.sh
+++ b/src/pmlogctl/pmlogctl.sh
@@ -198,7 +198,7 @@ _egrep()
 	# possible race here with async execution of ${IAM}_check removing
 	# the file after find saw it ... so check again for existance
 	#
-	[ -f "$__f" ] && egrep "$__pat" "$__f" 2>/dev/null >$tmp/_egrep
+	[ -f "$__f" ] && grep -E "$__pat" "$__f" 2>/dev/null >$tmp/_egrep
 	if [ -s $tmp/_egrep ]
 	then
 	    if $__text
@@ -317,7 +317,7 @@ _get_matching_hosts()
 		# otherwise assume $_host is a regexp and this could match
 		# all manner of lines, including comments (consider .*pat)
 		#
-		if echo "$ctl_host" | egrep "^($pat|#!#$pat)" >/dev/null
+		if echo "$ctl_host" | grep -E "^($pat|#!#$pat)" >/dev/null
 		then
 		    # so far so good (matches first field, not just whole
 		    # line ... still some false matches to weed out
@@ -1197,7 +1197,7 @@ END	{ exit(sts) }'
 			    ;;
 
 			hostname)
-			    if echo "$host" | egrep "$args" >/dev/null
+			    if echo "$host" | grep -E "$args" >/dev/null
 			    then
 				touch $tmp/match
 				$VERBOSE && echo "$policy: host $host hostname($args) true"

--- a/src/pmlogger/pmlogger_check.sh
+++ b/src/pmlogger/pmlogger_check.sh
@@ -943,10 +943,10 @@ s/^\([A-Za-z][A-Za-z0-9_]*\)=/export \1; \1=/p
 		elif _get_pids_by_name pmlogger | grep "^$pid\$" >/dev/null
 		then
 		    $VERY_VERBOSE && echo "primary pmlogger process $pid identified, OK"
-		    $VERY_VERY_VERBOSE && $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger '
+		    $VERY_VERY_VERBOSE && $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger '
 		else
 		    $VERY_VERBOSE && echo "primary pmlogger process $pid not running"
-		    $VERY_VERY_VERBOSE && $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger '
+		    $VERY_VERY_VERBOSE && $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger '
 		    pid=''
 		fi
 	    else
@@ -981,11 +981,11 @@ END				{ print m }'`
 		    if _get_pids_by_name pmlogger | grep "^$pid\$" >/dev/null
 		    then
 			$VERY_VERBOSE && echo "pmlogger process $pid identified, OK"
-			$VERY_VERY_VERBOSE && $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger '
+			$VERY_VERY_VERBOSE && $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger '
 			break
 		    fi
 		    $VERY_VERBOSE && echo "pmlogger process $pid not running, skip"
-		    $VERY_VERY_VERBOSE && $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep '[P]ID|[p]mlogger '
+		    $VERY_VERY_VERBOSE && $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]ID|[p]mlogger '
 		    pid=''
 		else
 		    $VERY_VERBOSE && echo "different directory, skip"

--- a/src/pmlogger/pmlogger_daily.sh
+++ b/src/pmlogger/pmlogger_daily.sh
@@ -335,7 +335,7 @@ Options:
   -V,--verbose            verbose output (multiple times for very verbose)
   -x=TIME,--compress-after=TIME  compress archive data files after TIME (format DD[:HH[:MM]])
   -X=PROGRAM,--compressor=PROGRAM  use PROGRAM for archive data file compression
-  -Y=REGEX,--regex=REGEX  egrep filter when compressing files ["$COMPRESSREGEX_DEFAULT"]
+  -Y=REGEX,--regex=REGEX  grep -E filter when compressing files ["$COMPRESSREGEX_DEFAULT"]
   -Z                      QA mode, force pmlogger re-exec
   -z                      QA mode, do not re-exec pmlogger
   --help
@@ -1351,7 +1351,7 @@ s/^\([A-Za-z][A-Za-z0-9_]*\)=/export \1; \1=/p
 		then
 		    echo >&2 "primary pmlogger process PID not found"
 		    ls >&2 -l "$PCP_TMP_DIR/pmlogger"
-		    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | egrep >&2 '[P]ID|[p]mlogger'
+		    $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E >&2 '[P]ID|[p]mlogger'
 		fi
 	    elif _get_pids_by_name pmlogger | grep "^$pid\$" >/dev/null
 	    then
@@ -1818,7 +1818,7 @@ p
 			find . -type f -mtime +$mtime
 		    fi \
 		    | _filter_filename \
-		    | egrep -v "$COMPRESSREGEX" \
+		    | grep -E -v "$COMPRESSREGEX" \
 		    | sort >$tmp/list
 		    if [ -s $tmp/list -a -n "$current_base" -a -n "$current_vol" ]
 		    then
@@ -1836,7 +1836,7 @@ p
 			# ...DDMM.HH.MM-seq# variants to get the base name
 			# separated from the other part of the file name, but
 			# on the upside compressed file names were stripped out
-			# above by the egrep -v "$COMPRESSREGEX"
+			# above by the grep -E -v "$COMPRESSREGEX"
 			#
 			sed -n <$tmp/list \
 			    -e '/\./s/\.\([^.][^.]*\)$/ \1/p' \

--- a/src/pmlogger/pmlogger_rewrite.sh
+++ b/src/pmlogger/pmlogger_rewrite.sh
@@ -132,7 +132,7 @@ do
 	# crude filter here ... more precise filtering later on
 	#
 	find "$try" -type f \
-	| egrep '(\.meta|\.index|\.[0-9][0-9]*)($|(\.xz|\.lzma|\.bz2|\.bz|\.gz|\.Z|\.z)$)' >>$tmp/args
+	| grep -E '(\.meta|\.index|\.[0-9][0-9]*)($|(\.xz|\.lzma|\.bz2|\.bz|\.gz|\.Z|\.z)$)' >>$tmp/args
     else
 	echo "$try" >>$tmp/args
     fi

--- a/src/pmlogmv/pmlogmv.sh
+++ b/src/pmlogmv/pmlogmv.sh
@@ -110,7 +110,7 @@ then
     # oldname is an existing file, strip any compression suffix,
     # then strip the expected PCP suffix
     #
-    if echo "$1" | egrep -q "\\.$pat\$"
+    if echo "$1" | grep -E -q "\\.$pat\$"
     then
 	base=`echo "$1" | sed -e 's/\.[a-zA-Z][a-zA-Z0-9]*$//'`
     else
@@ -238,7 +238,7 @@ old_noglob=`echo "$old" | sed -e 's/\([?*[]\)/\\\\\1/g'`
 $very_verbose && echo "old_noglob=$old_noglob"
 
 eval ls "$old_noglob".* 2>&1 \
-| egrep "$old_noregex"'\.((index|meta|[0-9][0-9]*)|((index|meta|[0-9][0-9]*)\.'"$pat"'))$' \
+| grep -E "$old_noregex"'\.((index|meta|[0-9][0-9]*)|((index|meta|[0-9][0-9]*)\.'"$pat"'))$' \
 | sed -e 's/\([?*$[]\)/\\\1/g' >$tmp/old
 if [ -s $tmp/old ]
 then
@@ -250,7 +250,7 @@ then
     cat $tmp/old \
     | while read fname
     do
-	if echo "$fname" | egrep -q "\\.$pat\$"
+	if echo "$fname" | grep -E -q "\\.$pat\$"
 	then
 	    echo "$fname" | sed -e 's/\.[a-zA-Z0-9]$//'
 	else
@@ -284,7 +284,7 @@ fi
 if grep -q '\.[0-9][0-9]*$' $tmp/old
 then
     :
-elif egrep -q '\.[0-9][0-9]*\.'"$pat"'$' $tmp/old
+elif grep -E -q '\.[0-9][0-9]*\.'"$pat"'$' $tmp/old
 then
     :
 else
@@ -298,7 +298,7 @@ fi
 if grep -q '\.meta$' $tmp/old
 then
     :
-elif egrep -q '\.meta\.'"$pat"'$' $tmp/old
+elif grep -E -q '\.meta\.'"$pat"'$' $tmp/old
 then
     :
 else

--- a/src/pmlogsummary/pmdiff.sh
+++ b/src/pmlogsummary/pmdiff.sh
@@ -69,7 +69,7 @@ _fix()
 	-e '/^\*.* - insufficient archive data.$/'d \
 	-e '/^Note: timezone set to local timezone of host/d' \
 	-e '/^[ 	]*$/d' \
-    | egrep -v -f $tmp/exclude \
+    | grep -E -v -f $tmp/exclude \
     | sort -t'|' -k 1,1
 }
 

--- a/src/pmview/front-ends/dkvis
+++ b/src/pmview/front-ends/dkvis
@@ -196,7 +196,7 @@ then
 	then
 	    # assume egrep(1) regular expression
 	    #
-	    if egrep "$dk" $tmp.disks >>$tmp.tmp
+	    if grep -E "$dk" $tmp.disks >>$tmp.tmp
 	    then
 	        # found some matches
 		#

--- a/src/pmview/front-ends/mpvis
+++ b/src/pmview/front-ends/mpvis
@@ -186,7 +186,7 @@ then
 	then
 	    # assume egrep(1) regular expression
 	    #
-	    if egrep "$cpu" $tmp.pmview_result >>$tmp.tmp
+	    if grep -E "$cpu" $tmp.pmview_result >>$tmp.tmp
 	    then
 	        # found some matches
 		#

--- a/src/pmview/front-ends/osvis
+++ b/src/pmview/front-ends/osvis
@@ -197,7 +197,7 @@ then
     	touch $tmp.chosen
         for i in $argInterfaces
     	do
-	    egrep $i $tmp.list >> $tmp.chosen
+	    grep -E $i $tmp.list >> $tmp.chosen
     	done
     fi
 

--- a/src/pmview/front-ends/weblogvis
+++ b/src/pmview/front-ends/weblogvis
@@ -207,7 +207,7 @@ else
     touch $tmp.chosen
     for i in $serverList_sp
     do
-	egrep $i $tmp.list >> $tmp.chosen
+	grep -E $i $tmp.list >> $tmp.chosen
     done
 fi
 

--- a/src/pmview/front-ends/webvis
+++ b/src/pmview/front-ends/webvis
@@ -228,7 +228,7 @@ else
     touch $tmp.chosen
     for i in $argInterfaces
     do
-	egrep $i $tmp.list >> $tmp.chosen
+	grep -E $i $tmp.list >> $tmp.chosen
     done
 fi
 


### PR DESCRIPTION
Latest version of grep on Linux (at least) has begun to issue warnings when fgrep/egrep are used.  The backward compatible versions of these commands, are for some odd reason now being considered too old to leave unbroken.