### PR TITLE
libpcp_web: guard client struct during callbacks

### DIFF
--- a/src/pmproxy/src/series.c
+++ b/src/pmproxy/src/series.c
@@ -593,6 +593,9 @@ on_pmseries_done(int status, void *arg)
 	flags |= HTTP_FLAG_JSON;
     }
     http_reply(client, msg, code, flags, options);
+
+    /* release lock of pmseries_request_done */
+    client_put(client);
 }
 
 static void
@@ -896,10 +899,16 @@ pmseries_request_load(struct client *client, pmSeriesBaton *baton)
 	message = sdsnewlen(failed, sizeof(failed) - 1);
 	http_reply(client, message, HTTP_STATUS_BAD_REQUEST,
 			HTTP_FLAG_JSON, baton->options);
+
+	/* release lock of pmseries_request_done */
+	client_put(client);
     } else if (baton->working) {
 	message = sdsnewlen(loading, sizeof(loading) - 1);
 	http_reply(client, message, HTTP_STATUS_CONFLICT,
 			HTTP_FLAG_JSON, baton->options);
+
+	/* release lock of pmseries_request_done */
+	client_put(client);
     } else {
         baton->loading.data = baton;         
 	uv_queue_work(client->proxy->events, &baton->loading,
@@ -912,6 +921,9 @@ pmseries_request_done(struct client *client)
 {
     pmSeriesBaton	*baton = (pmSeriesBaton *)client->u.http.data;
     int			sts;
+
+    /* take a reference on the client to prevent freeing while waiting for a Redis reply callback */
+    client_get(client);
 
     if (client->u.http.parser.status_code) {
 	on_pmseries_done(-EINVAL, baton);

--- a/src/pmproxy/src/server.c
+++ b/src/pmproxy/src/server.c
@@ -317,6 +317,18 @@ on_write_callback(uv_callback_t *handle, void *data)
     struct client		*client = (struct client *)request->writer.data;
     int				sts;
 
+    /*
+     * client_write() checks if the client is opened, and calls uv_callback_fire(&proxy->write_callbacks, ...).
+     * In a later loop iteration, on_write_callback() is called and tries to write to the client.
+     * However, the client can be closed between the call to uv_callback_fire() and the actual on_write_callback() callback.
+     * Therefore we need to check this condition again.
+     */
+    if (client_is_closed(client)) {
+	/* release lock of client_write */
+	client_put(client);
+	return 0;
+    }
+
     (void)handle;
     if (pmDebugOptions.af)
 	fprintf(stderr, "%s: client=%p\n", "on_write_callback", client);
@@ -332,6 +344,9 @@ on_write_callback(uv_callback_t *handle, void *data)
 	}
     } else
 	secure_client_write(client, request);
+
+    /* release lock of client_write */
+    client_put(client);
     return 0;
 }
 
@@ -360,6 +375,8 @@ client_write(struct client *client, sds buffer, sds suffix)
 	request->writer.data = client;
 	request->callback = on_client_write;
 
+	/* client must not get freed while waiting for the write callback to fire */
+	client_get(client);
 	uv_callback_fire(&proxy->write_callbacks, request, NULL);
     } else {
 	client_close(client);


### PR DESCRIPTION
This resolves multiple race conditions when the client closes the connection before the REST API is sending the entire response.

Case 1: Client sends request, Redis is queried, client closes connection due to timeout and client struct gets freed, Redis reply arrives and is getting sent to the already free'd client. Added locks in `pmseries_request_done`/`on_pmseries_done`.

Case 2: client_write checks if the client is still opened, and then calls uv_callback_fire which calls on_write_callback in a later loop iteration. Meanwhile, the client could be closed. Solved by adding another client_is_closed check in on_write_callback.

Case 3: Guard client struct while client_write/uv_callback_fire and on_write_callback. Client connection could be closed, and the client free'd meanwhile.

I only encountered these race conditions with a PCP archive with a big amount of instances (almost 400 cores, dozens of disks) and Grafana/grafana-pcp closing the connection early because of a timeout. Additional investigation is required to improve the performance for metrics with a large number of instances.