### PR TITLE
pmdabpf: set perf_buffer__poll timeout to 0

### DIFF
--- a/src/pmdas/bpf/modules/bashreadline.c
+++ b/src/pmdas/bpf/modules/bashreadline.c
@@ -30,7 +30,7 @@
 #include "uprobe_helpers.h"
 
 #define PERF_BUFFER_PAGES 16
-#define PERF_POLL_TIMEOUT_MS 100
+#define PERF_POLL_TIMEOUT_MS 0
 #define INDOM_COUNT 1
 
 static struct env {

--- a/src/pmdas/bpf/modules/execsnoop.c
+++ b/src/pmdas/bpf/modules/execsnoop.c
@@ -28,7 +28,7 @@
 #include "execsnoop.skel.h"
 
 #define PERF_BUFFER_PAGES 64
-#define PERF_POLL_TIMEOUT_MS 50
+#define PERF_POLL_TIMEOUT_MS 0
 #define MAX_ARGS_KEY 259
 
 #define INDOM_COUNT 1

--- a/src/pmdas/bpf/modules/exitsnoop.c
+++ b/src/pmdas/bpf/modules/exitsnoop.c
@@ -29,7 +29,7 @@
 #include "btf_helpers.h"
 
 #define PERF_BUFFER_PAGES 16
-#define PERF_POLL_TIMEOUT_MS 100
+#define PERF_POLL_TIMEOUT_MS 0
 
 static pid_t target_pid = 0;
 static bool trace_failed_only = false;

--- a/src/pmdas/bpf/modules/fsslower.c
+++ b/src/pmdas/bpf/modules/fsslower.c
@@ -33,7 +33,7 @@
 #include "trace_helpers.h"
 
 #define PERF_BUFFER_PAGES 64
-#define PERF_POLL_TIMEOUT_MS 100
+#define PERF_POLL_TIMEOUT_MS 0
 #define INDOM_COUNT 1
 
 static struct env {

--- a/src/pmdas/bpf/modules/mountsnoop.c
+++ b/src/pmdas/bpf/modules/mountsnoop.c
@@ -30,7 +30,7 @@
 #include "btf_helpers.h"
 
 #define PERF_BUFFER_PAGES 64
-#define PERF_POLL_TIMEOUT_MS 100
+#define PERF_POLL_TIMEOUT_MS 0
 
 /* https://www.gnu.org/software/gnulib/manual/html_node/strerrorname_005fnp.html */
 #if !defined(__GLIBC__) || __GLIBC__ < 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ < 32)

--- a/src/pmdas/bpf/modules/oomkill.c
+++ b/src/pmdas/bpf/modules/oomkill.c
@@ -31,7 +31,7 @@
 #include "oomkill.skel.h"
 #include "btf_helpers.h"
 
-#define PERF_POLL_TIMEOUT_MS 100
+#define PERF_POLL_TIMEOUT_MS 0
 
 static struct env {
     int process_count;

--- a/src/pmdas/bpf/modules/opensnoop.c
+++ b/src/pmdas/bpf/modules/opensnoop.c
@@ -29,14 +29,9 @@
 #include "opensnoop.skel.h"
 #include "btf_helpers.h"
 
-/* Tune the buffer size and wakeup rate. These settings cope with roughly
- * 50k opens/sec.
- */
 #define PERF_BUFFER_PAGES 64
-#define PERF_BUFFER_TIME_MS	10
-/* Set the poll timeout when no events occur. This can affect -d accuracy. */
-#define PERF_POLL_TIMEOUT_MS 100
-#define NSEC_PER_SEC		1000000000ULL
+#define PERF_POLL_TIMEOUT_MS 0
+#define NSEC_PER_SEC 1000000000ULL
 #define INDOM_COUNT 1
 
 static struct env {

--- a/src/pmdas/bpf/modules/statsnoop.c
+++ b/src/pmdas/bpf/modules/statsnoop.c
@@ -29,7 +29,7 @@
 #include "btf_helpers.h"
 
 #define PERF_BUFFER_PAGES 16
-#define PERF_POLL_TIMEOUT_MS 100
+#define PERF_POLL_TIMEOUT_MS 0
 #define INDOM_COUNT 1
 
 static struct env {

--- a/src/pmdas/bpf/modules/tcpconnect.c
+++ b/src/pmdas/bpf/modules/tcpconnect.c
@@ -30,7 +30,7 @@
 #include "btf_helpers.h"
 
 #define PERF_BUFFER_PAGES 128
-#define PERF_POLL_TIMEOUT_MS 100
+#define PERF_POLL_TIMEOUT_MS 0
 #define INDOM_COUNT 1
 
 static struct env {

--- a/src/pmdas/bpf/modules/tcpconnlat.c
+++ b/src/pmdas/bpf/modules/tcpconnlat.c
@@ -29,7 +29,7 @@
 #include "tcpconnlat.skel.h"
 
 #define PERF_BUFFER_PAGES 16
-#define PERF_POLL_TIMEOUT_MS 100
+#define PERF_POLL_TIMEOUT_MS 0
 #define INDOM_COUNT 1
 
 static struct env {


### PR DESCRIPTION
After noticing delays when sampling bpf.* metrics, we found the multiple calls to perf_buffer__poll with a small-number-of-milliseconds timeout were all adding up.  After discussions with Andreas, Jason and Sohaib we believe it is safe to set no timeout on this call, such that it returns immediately when called (whether values are available or not).

This change brings a 1-2sec pmdabpf sample time (with several modules enabled) down to around 10-20msec.