### PR TITLE
pmseries: fix sampling when start < first sample or series has gaps

### DIFF
--- a/qa/1604
+++ b/qa/1604
@@ -1,0 +1,114 @@
+#!/bin/sh
+# PCP QA Test No. 1604
+# Exercise pmproxy REST API /series/values endpoint using curl(1).
+#
+# Copyright (c) 2022 Red Hat.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+_check_series
+which jq >/dev/null 2>&1 || _notrun "jq not installed"
+
+_cleanup()
+{
+    cd $here
+    [ -n "$pmproxy_pid" ] && $signal -s TERM $pmproxy_pid
+    [ -n "$options" ] && redis-cli $options shutdown
+    if $need_restore
+    then
+	need_restore=false
+        _restore_config $PCP_SYSCONF_DIR/pmproxy
+    fi
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+signal=$PCP_BINADM_DIR/pmsignal
+
+userid=`id -u`
+username=`id -u -n`
+hostname=`hostname`
+machineid=`_machine_id`
+domainname=`_domain_name`
+
+need_restore=false
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_filter_source()
+{
+    sed \
+        -e "s,$here,PATH,g" \
+        -e "s,$hostname,QAHOST,g" \
+    #end
+}
+
+_format_timestamps()
+{
+    jq '.[].timestamp |= ((. / 1000 | strftime("%Y-%m-%d %H:%M:%S")) + "." + (. * 1000 % 1000000 | tostring))'
+}
+
+# real QA test starts here
+_save_config $PCP_SYSCONF_DIR/pmproxy
+$sudo rm -f $PCP_SYSCONF_DIR/pmproxy/*
+need_restore=true
+
+echo "Start test Redis server ..."
+redisport=`_find_free_port`
+options="-p $redisport"
+redis-server --port $redisport --save "" > $tmp.redis 2>&1 &
+_check_redis_ping $redisport
+_check_redis_server $redisport
+echo
+
+_check_redis_server_version $redisport
+
+# import some well-known test data into Redis
+pmseries $options --load "$here/archives/bozo-disk" | _filter_source
+
+# start pmproxy
+proxyport=`_find_free_port`
+proxyopts="-p $proxyport -r $redisport -t"  # -Dseries,http,af
+pmproxy -f -U $username -x $seq.full -l $tmp.pmproxy.log $proxyopts &
+pmproxy_pid=$!
+
+# check pmproxy has started and is available for requests
+pmcd_wait -h localhost@localhost:$proxyport -v -t 5sec
+
+series1=`pmseries $options disk.all.read`
+[ -z "$series1" ] && _fail "Cannot find any timeseries matching disk.all.read"
+echo "Using series $series1 for disk.all.read"
+
+
+echo "== no interval" | tee -a $seq.full
+url="http://localhost:$proxyport/series/values?series=$series1&start=1489620673&finish=1489620793"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | _format_timestamps
+
+echo "== 10s interval" | tee -a $seq.full
+url="http://localhost:$proxyport/series/values?series=$series1&start=1489620673&finish=1489620793&interval=10"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | _format_timestamps
+
+echo "== 20s interval" | tee -a $seq.full
+url="http://localhost:$proxyport/series/values?series=$series1&start=1489620673&finish=1489620793&interval=20"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | _format_timestamps
+cat $tmp.pmproxy.log >> $seq.full
+
+echo "== 20s interval, starting 2m before first sample in archive" | tee -a $seq.full
+url="http://localhost:$proxyport/series/values?series=$series1&start=1489620553&finish=1489620793&interval=20"
+echo "$url" >> $seq.full
+curl --get --silent "$url" | tee -a $seq.full | _format_timestamps
+
+
+cat $tmp.pmproxy.log >> $seq.full
+status=0
+exit

--- a/qa/1604.out
+++ b/qa/1604.out
@@ -1,0 +1,204 @@
+QA output created by 1604
+Start test Redis server ...
+PING
+PONG
+
+pmseries: [Info] processed 21 archive records from PATH/archives/bozo-disk
+Using series c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9 for disk.all.read
+== no interval
+[
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:13.890965",
+    "value": "1537640"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:23.891401",
+    "value": "1538109"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:33.891167",
+    "value": "1538453"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:43.891451",
+    "value": "1538888"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:53.891930",
+    "value": "1546137"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:03.891452",
+    "value": "1552940"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:13.891363",
+    "value": "1563099"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:23.891335",
+    "value": "1572878"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:33.891427",
+    "value": "1581847"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:43.891381",
+    "value": "1592546"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:53.891394",
+    "value": "1598167"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:33:03.891344",
+    "value": "1598172"
+  }
+]
+== 10s interval
+[
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:13.890965",
+    "value": "1537640"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:23.891401",
+    "value": "1538109"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:33.891167",
+    "value": "1538453"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:43.891451",
+    "value": "1538888"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:53.891930",
+    "value": "1546137"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:03.891452",
+    "value": "1552940"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:13.891363",
+    "value": "1563099"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:23.891335",
+    "value": "1572878"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:33.891427",
+    "value": "1581847"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:43.891381",
+    "value": "1592546"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:53.891394",
+    "value": "1598167"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:33:03.891344",
+    "value": "1598172"
+  }
+]
+== 20s interval
+[
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:13.890965",
+    "value": "1537640"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:23.891401",
+    "value": "1538109"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:43.891451",
+    "value": "1538888"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:03.891452",
+    "value": "1552940"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:23.891335",
+    "value": "1572878"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:43.891381",
+    "value": "1592546"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:33:03.891344",
+    "value": "1598172"
+  }
+]
+== 20s interval, starting 2m before first sample in archive
+[
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:13.890965",
+    "value": "1537640"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:33.891167",
+    "value": "1538453"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:31:53.891930",
+    "value": "1546137"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:23.891335",
+    "value": "1572878"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:32:43.891381",
+    "value": "1592546"
+  },
+  {
+    "series": "c61812b8ed3def24fa1df3fbf8d19a96cea3e0f9",
+    "timestamp": "2017-03-15 23:33:03.891344",
+    "value": "1598172"
+  }
+]

--- a/qa/admin/package-lists/Fedora+36+x86_64
+++ b/qa/admin/package-lists/Fedora+36+x86_64
@@ -44,6 +44,7 @@ iproute
 httpd
 initscripts
 java-latest-openjdk-headless
+jq
 kubernetes-client
 libbpf
 libbpf-devel

--- a/qa/admin/package-lists/Fedora+37+x86_64
+++ b/qa/admin/package-lists/Fedora+37+x86_64
@@ -44,6 +44,7 @@ iproute
 httpd
 initscripts
 java-latest-openjdk-headless
+jq
 kubernetes-client
 libbpf
 libbpf-devel

--- a/qa/admin/package-lists/Ubuntu+20.04+x86_64
+++ b/qa/admin/package-lists/Ubuntu+20.04+x86_64
@@ -35,6 +35,7 @@ gfs2-utils
 git
 grep
 iproute2
+jq
 libavahi-common-dev
 libclass-dbi-perl
 libcmocka-dev

--- a/qa/admin/package-lists/Ubuntu+22.04+x86_64
+++ b/qa/admin/package-lists/Ubuntu+22.04+x86_64
@@ -36,6 +36,7 @@ gfs2-utils
 git
 grep
 iproute2
+jq
 libavahi-common-dev
 libclass-dbi-perl
 libcmocka-dev

--- a/qa/group
+++ b/qa/group
@@ -1929,6 +1929,7 @@ x11
 1601 pmseries pmproxy local
 1602 pmproxy local
 1603 pmproxy local
+1604 pmseries pmproxy local
 1608 pmproxy local
 1612 pmda.bpf local
 1613 pmda.linux kernel local


### PR DESCRIPTION
If the start timestamp is before the first sample of a series, or the series has gaps, the goal timestamp will lag behind the next timestamp, and therefore the logic will always select the next sample.

This commit resets the goal timestamp if it lags behind.

As mentioned in the description, this is mainly occurring if the `start=` parameter is set to a timestamp before the first sample of a series - a common case when analyzing archives with the `quay.io/performancecopilot/archive-analysis` container. If that's the case, pmproxy sends all samples (because the `goal` timestamp always lags behind), effectively ignoring the `interval=` parameter, resulting in much larger reponse sizes. But it can also occur if there are gaps in a series.

Tests with a (customer) archive show that this PR reduces pmproxy response sizes from 74 MB to 20 MB of JSON for the same time window. Still very high fwiw, maybe it's time to replace JSON with protobuf at some point, or optimize the response data model. Or simply changing the granularity of the charts (by default, Grafana calculates the interval by `time range / panel width`, i.e. one data point per pixel basically).

It's still not perfect though, in the `20s interval, starting 2m before first sample in archive` output there is once a 30s gap, but it's better than before. imho the main issue is that samples in the archive are not exactly 10s apart, but sometimes 10s plus a few nanoseconds and sometimes 10s minus a few nanoseconds, making interval sampling tricky.