### PR TITLE
pmfind, libpcp_web: MMV and shutdown memory management fixes

### DIFF
--- a/qa/1985
+++ b/qa/1985
@@ -1,0 +1,38 @@
+#!/bin/sh
+# PCP QA Test No. 1985
+# Exercise a pmfind fix - valgrind-enabled variant.
+#
+# Copyright (c) 2022 Red Hat.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+_check_valgrind
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=0	# success is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+# real QA test starts here
+export seq
+./1986 --valgrind \
+| $PCP_AWK_PROG '
+skip == 1 && $1 == "==="       { skip = 0 }
+/^=== std err ===/             { skip = 1 }
+skip == 0              { print }
+skip == 1              { print >>"'$here/$seq.full'" }'
+
+# success, all done
+exit

--- a/qa/1985.out
+++ b/qa/1985.out
@@ -1,0 +1,11 @@
+QA output created by 1985
+QA output created by 1986 --valgrind
+=== std out ===
+SOURCE HOSTNAME
+=== filtered valgrind report ===
+Memcheck, a memory error detector
+Command: pmfind -S -m probe=127.0.0.1/32
+LEAK SUMMARY:
+definitely lost: 0 bytes in 0 blocks
+indirectly lost: 0 bytes in 0 blocks
+ERROR SUMMARY: 0 errors from 0 contexts ...

--- a/qa/1986
+++ b/qa/1986
@@ -1,0 +1,62 @@
+#!/bin/sh
+# PCP QA Test No. 1986
+# Exercise libpcp_web timers pmfind regression fix.
+#
+# Copyright (c) 2022 Red Hat.  All Rights Reserved.
+#
+
+if [ $# -eq 0 ]
+then
+    seq=`basename $0`
+    echo "QA output created by $seq"
+else
+    # use $seq from caller, unless not set
+    [ -n "$seq" ] || seq=`basename $0`
+    echo "QA output created by `basename $0` $*"
+fi
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+do_valgrind=false
+if [ "$1" = "--valgrind" ]
+then
+    _check_valgrind
+    do_valgrind=true
+fi
+
+test -x $PCP_BIN_DIR/pmfind || _notrun No support for pmfind
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=0	# success is the default!
+hostname=`hostname || echo localhost`
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_filter()
+{
+    sed \
+	-e "s@$tmp@TMP@g" \
+	-e "s/ $hostname/ HOSTNAME/" \
+	-e 's/^[a-f0-9][a-f0-9]* /SOURCE /' \
+    # end
+}
+
+# real QA test starts here
+if $do_valgrind
+then
+    _run_valgrind pmfind -S -m probe=127.0.0.1/32
+else
+    pmfind -S -m probe=127.0.0.1/32
+fi \
+| _filter
+
+# success, all done
+exit

--- a/qa/1986.out
+++ b/qa/1986.out
@@ -1,0 +1,2 @@
+QA output created by 1986
+SOURCE HOSTNAME

--- a/qa/group
+++ b/qa/group
@@ -2049,4 +2049,6 @@ x11
 1970 pmda.bpf local
 1978 atop local
 1984 pmlogconf pmda.redis local
+1985 pmfind local valgrind
+1986 pmfind local
 4751 libpcp threads valgrind local pcp helgrind


### PR DESCRIPTION
Resolve libpcp_web handling in any cases with no MMV metrics being updated but still using webgroups (pmfind use case). New regression tests 1985 and 1986 are added to exercise the fix - which uncovered memory leaks primarily during shutdown through their use of valgrind.  These cases are also fixed.

Resolves Red Hat bugzilla #2135314