### PR TITLE
 pmdas/snmp: install the agent specific configuration file to PMDATMPDIR 

### DIFF
--- a/src/pmdas/snmp/GNUmakefile
+++ b/src/pmdas/snmp/GNUmakefile
@@ -44,7 +44,7 @@ install_pcp install: default
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/pmda$(IAM).pl pmda$(IAM).pl $(PMDAADMDIR)/pmda$(IAM).pl
 	$(INSTALL) -m 755 -d $(PMDACONFIG)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR)/snmp.conf snmp.conf $(PMDACONFIG)/snmp.conf
+	$(INSTALL) -m 644 -t $(PMDATMPDIR)/$(IAM).conf $(IAM).conf $(PMDACONFIG)/$(IAM).conf
 	@$(INSTALL_MAN)
 else
 build-me:

--- a/src/pmdas/snmp/GNUmakefile
+++ b/src/pmdas/snmp/GNUmakefile
@@ -44,7 +44,7 @@ install_pcp install: default
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/pmda$(IAM).pl pmda$(IAM).pl $(PMDAADMDIR)/pmda$(IAM).pl
 	$(INSTALL) -m 755 -d $(PMDACONFIG)
-	$(INSTALL) -m 644 snmp.conf $(PMDACONFIG)/snmp.conf
+	$(INSTALL) -m 644 -t $(PMDATMPDIR)/snmp.conf snmp.conf $(PMDACONFIG)/snmp.conf
 	@$(INSTALL_MAN)
 else
 build-me:


### PR DESCRIPTION
When running ./Install of the agent, the following line is printed in
/var/log/pcp/pmcd/snmp.log.

```
  Log for pmdasnmp on pcp-netsnmp started Tue Oct 18 22:45:23 2022

  opening /var/lib/pcp/pmdas/snmp/snmp.conf No such file or directory at /var/lib/pcp/pmdas/snmp/pmdasnmp.pl line 90.
```

As a result, pmdasnmp.pl cannot read its configuration file though it is "./Install"ed.
