### PR TITLE
dstat: fix columns for --net-packets with multiple network interfaces

### DIFF
--- a/src/pcp/dstat/pcp-dstat.py
+++ b/src/pcp/dstat/pcp-dstat.py
@@ -502,6 +502,7 @@ class DstatTool(object):
         self.partlist = None
         self.intlist = None
         self.netlist = None
+        self.netpacketlist = None
         self.swaplist = None
 
         ### Implicit if no terminal is used
@@ -693,6 +694,8 @@ class DstatTool(object):
                     plugin.prepare_grouptype(self.intlist, self.full)
                 elif section == 'net':
                     plugin.prepare_grouptype(self.netlist, self.full)
+                elif section == 'net-packets':
+                    plugin.prepare_grouptype(self.netpacketlist, self.full)
                 elif section == 'swap':
                     plugin.prepare_grouptype(self.swaplist, self.full)
 
@@ -890,8 +893,10 @@ class DstatTool(object):
         elif opt in ['N']:
             insts = arg.split(',')
             self.netlist = sorted([x for x in insts if x != 'total'])
+            self.netpacketlist = sorted([x for x in insts if x != 'total'])
             if 'total' in insts:
                 self.netlist.append('total')
+                self.netpacketlist.append('total')
         elif opt in ['p']:
             self.append_plugin('proc')
         elif opt in ['r']:

--- a/src/pcp/dstat/plugins/net
+++ b/src/pcp/dstat/plugins/net
@@ -13,6 +13,7 @@ bits_out.label = send
 bits_out = network.interface.out.bytes
 
 [net-packets]
+label = pkt/%I
 width = 5
 printtype = d
 pkts_in.label = #recv


### PR DESCRIPTION
When using `dstat --net-packets` with more network interfaces (defined by `-N`), both terminal and CSV outputs are corrupted, e.g.
![pcp-dstat-current](https://user-images.githubusercontent.com/9115892/203561002-96ce2ad8-db66-4060-8404-6565a137dac1.png)
This patch fixes this.
![pcp-dstat-patched](https://user-images.githubusercontent.com/9115892/203561389-2f53daab-84c8-4ace-97f8-21cc6d996fe3.png)
The output is the same (up to general differences) as with the original no-pcp `dstat` command.