### PR TITLE
Pcp ps and pcp pidstat give broken pipe errors while output is piped to head

### DIFF
--- a/src/pcp/pidstat/pcp-pidstat.py
+++ b/src/pcp/pidstat/pcp-pidstat.py
@@ -22,6 +22,7 @@ import os
 import sys
 import re
 import time
+import signal
 from pcp import pmcc
 from pcp import pmapi
 
@@ -1050,5 +1051,7 @@ if __name__ == "__main__":
     except pmapi.pmUsageErr as usage:
         usage.message()
         sys.exit(1)
+    except IOError:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
     except KeyboardInterrupt:
         pass

--- a/src/pcp/ps/pcp-ps.py
+++ b/src/pcp/ps/pcp-ps.py
@@ -20,6 +20,7 @@
 
 import sys
 import time
+import signal
 from pcp import pmcc
 from pcp import pmapi
 import datetime
@@ -40,6 +41,7 @@ SCHED_POLICY = ['NORMAL', 'FIFO', 'RR', 'BATCH', '', 'IDLE', 'DEADLINE']
 class StdoutPrinter:
     def Print(self, args):
         print(args)
+
 
 class NoneHandlingPrinterDecorator:
     def __init__(self, printer):
@@ -720,7 +722,7 @@ class ProcessStatOptions(pmapi.pmOptions):
         # """Override standard Pcp-ps option to show all process """
         return bool(opts in ['p', 'c', 'o', 'P', 'U'])
 
-    def extraOptions(self, opts, optarg,index):
+    def extraOptions(self, opts, optarg, index):
         if opts == 'e':
             ProcessStatOptions.show_all_process = True
         elif opts == 'c':
@@ -808,6 +810,8 @@ if __name__ == "__main__":
     except pmapi.pmUsageErr as usage:
         usage.message()
         sys.exit(1)
+    except IOError:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
     except KeyboardInterrupt:
         print("Interrupted")
         sys.exit(0)


### PR DESCRIPTION
Pcp ps and pcp pidstat give broken pipe errors while their output is the pipe to head.

It is because when the head is done reading data it stops prematurely the pipe, which needs to be handled in python as an IOexpection and terminate the program gracefully.