### PR TITLE
configure.ac: Fixes for improved C99 compatibility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3103,7 +3103,7 @@ AC_TRY_LINK(
 ],
 [
     double x = 123.456;
-    if (fpclassify(x) == FP_NAN) exit(1);
+    if (fpclassify(x) == FP_NAN) return 1;
 ], ac_cv_func_fpclassify=yes)
 AC_MSG_RESULT($ac_cv_func_fpclassify)
 if test $ac_cv_func_fpclassify = no
@@ -3118,7 +3118,7 @@ then
 ],
 [
     double x = 123.456;
-    if (fpclassify(x) == FP_NAN) exit(1);
+    if (fpclassify(x) == FP_NAN) return 1;
 ], ac_cv_func_fpclassify=yes)
     AC_MSG_RESULT($ac_cv_func_fpclassify)
     if test $ac_cv_func_fpclassify = yes
@@ -3743,6 +3743,7 @@ AC_MSG_CHECKING([if strftime knows about %z])
 AC_TRY_RUN(
 [
 #include <time.h>
+#include <string.h>
 int main () {
     char b[32]="";
     time_t t = time(NULL);


### PR DESCRIPTION
Avoid calling the undeclared exit function.  Include <string.h> for strcmp.  C99 removed implicit function declarations from the language, and future compilers are likely to reject them by default.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
