### PR TITLE
build: update actions set-output handling based on githubs advice

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -161,6 +161,7 @@ jobs:
         continue-on-error: true
         with:
           script: |
+            const core = require('@actions/core');
             const fs = require('fs');
             const head_sha = context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha;
             const response = await github.rest.checks.create({
@@ -174,7 +175,7 @@ jobs:
                 summary: '```\n' + fs.readFileSync('summary.txt', 'utf8') + '\n```',
               }
             });
-            console.log(`::set-output name=summary_url::${response.data.html_url}`);
+            core.setOutput('summary_url', response.data.html_url);
             console.log(`::notice::Test summary is available at ${response.data.html_url}`);
 
       - name: Create interactive test report

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -134,7 +134,7 @@ jobs:
         id: parse_test_results
         run: |
           REPORT_ID=$(date +'%Y%m%d_%H%M%S')-${GITHUB_SHA::8}
-          echo "::set-output name=report_id::${REPORT_ID}"
+          echo "report_id=${REPORT_ID}" >> $GITHUB_OUTPUT
 
           # generate Allure inputs
           build/ci/test-report.py \


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/