### PR TITLE
build: require libbpf 1.0 for mountsnoop and oomkill bpf modules

### DIFF
--- a/configure
+++ b/configure
@@ -9144,8 +9144,8 @@ pmdabpf_arch=`uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/p
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $pmdabpf_arch" >&5
 printf "%s\n" "$pmdabpf_arch" >&6; }
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for vmlinux.h" >&5
-printf %s "checking for vmlinux.h... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libbpf-tools vmlinux.h" >&5
+printf %s "checking for libbpf-tools vmlinux.h... " >&6; }
 pmdabpf_vmlinuxh="`pwd`/vendor/github.com/iovisor/bcc/libbpf-tools/$pmdabpf_arch/vmlinux.h"
 if test -f "$pmdabpf_vmlinuxh"; then
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $pmdabpf_vmlinuxh" >&5
@@ -9168,9 +9168,7 @@ if test "x$do_pmdabpf" = "xcheck"
 then :
 
         $have_libbpf && $have_libelf && \
-	test $clang_major_version -ge 10 && \
-	test -f "$pmdabpf_vmlinuxh" && \
-	pmda_bpf=true
+	test $clang_major_version -ge 10 -a -f "$pmdabpf_vmlinuxh" && pmda_bpf=true
 
 fi
 PMDA_BPF=$pmda_bpf
@@ -9184,14 +9182,25 @@ if $pmda_bpf; then
     libbpf_version_minor=`echo $libbpf_version | cut -d. -f2`
     pmdabpf_modules="biolatency.so runqlat.so"
 
+    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if bpf PMDA modules using bpf_buffer__new should be included" >&5
+printf %s "checking if bpf PMDA modules using bpf_buffer__new should be included... " >&6; }
+    if test "$libbpf_version_major" -eq 0; then
+       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no (libbpf version required: 1.0.0, installed: $libbpf_version)" >&5
+printf "%s\n" "no (libbpf version required: 1.0.0, installed: $libbpf_version)" >&6; }
+    else
+       pmdabpf_modules="${pmdabpf_modules} mountsnoop.so oomkill.so"
+       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf "%s\n" "yes" >&6; }
+    fi
+
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if bpf PMDA modules using perf_buffer__poll should be included" >&5
 printf %s "checking if bpf PMDA modules using perf_buffer__poll should be included... " >&6; }
     if test "$libbpf_version_major" -eq 0 -a "$libbpf_version_minor" -lt 7; then
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no (libbpf version required: 0.7.0, installed: $libbpf_version)" >&5
+       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no (libbpf version required: 0.7.0, installed: $libbpf_version)" >&5
 printf "%s\n" "no (libbpf version required: 0.7.0, installed: $libbpf_version)" >&6; }
     else
-	pmdabpf_modules="${pmdabpf_modules} bashreadline.so biolatency.so execsnoop.so exitsnoop.so fsslower.so mountsnoop.so oomkill.so opensnoop.so runqlat.so statsnoop.so tcpconnect.so tcpconnlat.so vfsstat.so biosnoop.so"
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+       pmdabpf_modules="${pmdabpf_modules} bashreadline.so biolatency.so execsnoop.so exitsnoop.so fsslower.so opensnoop.so runqlat.so statsnoop.so tcpconnect.so tcpconnlat.so vfsstat.so biosnoop.so"
+       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1200,7 +1200,7 @@ pmdabpf_arch=`uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/p
 AC_SUBST(pmdabpf_arch)
 AC_MSG_RESULT($pmdabpf_arch)
 
-AC_MSG_CHECKING([for vmlinux.h])
+AC_MSG_CHECKING([for libbpf-tools vmlinux.h])
 pmdabpf_vmlinuxh="`pwd`/vendor/github.com/iovisor/bcc/libbpf-tools/$pmdabpf_arch/vmlinux.h"
 if test -f "$pmdabpf_vmlinuxh"; then
     AC_MSG_RESULT($pmdabpf_vmlinuxh)
@@ -1214,11 +1214,9 @@ AC_MSG_CHECKING([if the bpf PMDA should be included])
 pmda_bpf=false
 AS_IF([test "x$do_pmdabpf" = "xyes"], [pmda_bpf=true])
 AS_IF([test "x$do_pmdabpf" = "xcheck"], [
-    dnl pmdabpf requires libbpf, libelf and bpftool
+    dnl pmdabpf requires libbpf, libelf, clang 10+ and a bpftool-generated arch-specific vmlinux.h
     $have_libbpf && $have_libelf && \
-	test $clang_major_version -ge 10 && \
-	test -f "$pmdabpf_vmlinuxh" && \
-	pmda_bpf=true
+	test $clang_major_version -ge 10 -a -f "$pmdabpf_vmlinuxh" && pmda_bpf=true
 ])
 AC_SUBST(PMDA_BPF, $pmda_bpf)
 if $pmda_bpf; then AC_MSG_RESULT(yes); else AC_MSG_RESULT(no); fi
@@ -1228,12 +1226,20 @@ if $pmda_bpf; then
     libbpf_version_minor=`echo $libbpf_version | cut -d. -f2`
     pmdabpf_modules="biolatency.so runqlat.so"
 
+    AC_MSG_CHECKING([if bpf PMDA modules using bpf_buffer__new should be included])
+    if test "$libbpf_version_major" -eq 0; then
+       AC_MSG_RESULT([no (libbpf version required: 1.0.0, installed: $libbpf_version)])
+    else
+       pmdabpf_modules="${pmdabpf_modules} mountsnoop.so oomkill.so"
+       AC_MSG_RESULT(yes)
+    fi
+
     AC_MSG_CHECKING([if bpf PMDA modules using perf_buffer__poll should be included])
     if test "$libbpf_version_major" -eq 0 -a "$libbpf_version_minor" -lt 7; then
-	AC_MSG_RESULT([no (libbpf version required: 0.7.0, installed: $libbpf_version)])
+       AC_MSG_RESULT([no (libbpf version required: 0.7.0, installed: $libbpf_version)])
     else
-	pmdabpf_modules="${pmdabpf_modules} bashreadline.so biolatency.so execsnoop.so exitsnoop.so fsslower.so mountsnoop.so oomkill.so opensnoop.so runqlat.so statsnoop.so tcpconnect.so tcpconnlat.so vfsstat.so biosnoop.so"
-	AC_MSG_RESULT(yes)
+       pmdabpf_modules="${pmdabpf_modules} bashreadline.so biolatency.so execsnoop.so exitsnoop.so fsslower.so opensnoop.so runqlat.so statsnoop.so tcpconnect.so tcpconnlat.so vfsstat.so biosnoop.so"
+       AC_MSG_RESULT(yes)
     fi
 
     AC_SUBST(pmdabpf_modules)

--- a/qa/1475
+++ b/qa/1475
@@ -12,7 +12,7 @@ echo "QA output created by $seq"
 
 _pmdabpf_check
 _pmdabpf_require_kernel_version 5 0
-_pmdabpf_require_libbpf_version 0 7
+_pmdabpf_require_libbpf_version 1 0
 
 status=1       # failure is the default!
 signal=$PCP_BINADM_DIR/pmsignal

--- a/qa/1810
+++ b/qa/1810
@@ -12,7 +12,7 @@ echo "QA output created by $seq"
 
 _pmdabpf_check
 _pmdabpf_require_kernel_version 5 0
-_pmdabpf_require_libbpf_version 0 7
+_pmdabpf_require_libbpf_version 1 0
 
 status=1       # failure is the default!
 signal=$PCP_BINADM_DIR/pmsignal

--- a/src/pmdas/bpf/GNUmakefile
+++ b/src/pmdas/bpf/GNUmakefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/src/include/builddefs
 CFILES	= bpf.c
 CMDTARGET = pmdabpf$(EXECSUFFIX)
 LIBTARGET = pmda_bpf.$(DSOSUFFIX)
-LLDLIBS = $(PCP_WEBLIB) -lbpf -lelf -lz -lm -ldl
+LLDLIBS = $(PCP_WEBLIB) $(LIB_FOR_LIBBPF) $(LIB_FOR_LIBELF) -lz -lm -ldl
 LCFLAGS = -I.
 CONFIG	= bpf.conf
 DFILES	= README

--- a/src/pmdas/bpf/modules/GNUmakefile
+++ b/src/pmdas/bpf/modules/GNUmakefile
@@ -2,7 +2,7 @@ TOPDIR = ../../../..
 include $(TOPDIR)/src/include/builddefs
 
 IAM	= bpf
-LDLIBS = $(PCP_WEBLIB) -lbpf -lelf -lz -lm -ldl
+LDLIBS = $(PCP_WEBLIB) $(LIB_FOR_LIBBPF) $(LIB_FOR_LIBELF) -lz -lm -ldl
 LDIRT = $(HELPERS_H) $(HELPERS_C) $(APPS_H) $(APPS_BPF) vmlinux.h
 MODULETMP = $(PCP_PMDAS_DIR)/$(IAM)/modules
 MODULEDIR = $(PCP_PMDASADM_DIR)/$(IAM)/modules


### PR DESCRIPTION
This aims to resolve recent fallout on Fedora36 which, although a recent Fedora, does not have the symbols we need for latest pmdabpf modules.

This is an alternative approach to #1728 which keeps our pmdabpf modules using the system libbpf at runtime.