### PR TITLE
build: raise the minimum libbpf version to 0.8.0

### DIFF
--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -96,7 +96,7 @@ Source2: %{pcp_git_url}/main/debian/pcp.sysusers
 %endif
 
 # support for pmdabpf, check bcc.spec for supported architectures of libbpf-tools
-%if 0%{?fedora} >= 33 || 0%{?rhel} > 8
+%if 0%{?fedora} >= 37 || 0%{?rhel} > 8
 %ifarch x86_64 ppc64 ppc64le aarch64
 %global disable_bpf 0
 %else

--- a/configure
+++ b/configure
@@ -5289,11 +5289,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
 printf %s "checking for $CXX option to enable C++11 features... " >&6; }
-if test ${ac_cv_prog_cxx_11+y}
+if test ${ac_cv_prog_cxx_cxx11+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_11=no
+  ac_cv_prog_cxx_cxx11=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -5335,11 +5335,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
 printf %s "checking for $CXX option to enable C++98 features... " >&6; }
-if test ${ac_cv_prog_cxx_98+y}
+if test ${ac_cv_prog_cxx_cxx98+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_98=no
+  ac_cv_prog_cxx_cxx98=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -8878,12 +8878,12 @@ if test -n "$libbpf_CFLAGS"; then
     pkg_cv_libbpf_CFLAGS="$libbpf_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libbpf >= 0.4.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libbpf >= 0.4.0") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libbpf >= 0.8.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libbpf >= 0.8.0") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_libbpf_CFLAGS=`$PKG_CONFIG --cflags "libbpf >= 0.4.0" 2>/dev/null`
+  pkg_cv_libbpf_CFLAGS=`$PKG_CONFIG --cflags "libbpf >= 0.8.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -8895,12 +8895,12 @@ if test -n "$libbpf_LIBS"; then
     pkg_cv_libbpf_LIBS="$libbpf_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libbpf >= 0.4.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libbpf >= 0.4.0") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libbpf >= 0.8.0\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libbpf >= 0.8.0") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_libbpf_LIBS=`$PKG_CONFIG --libs "libbpf >= 0.4.0" 2>/dev/null`
+  pkg_cv_libbpf_LIBS=`$PKG_CONFIG --libs "libbpf >= 0.8.0" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -8921,9 +8921,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-	        libbpf_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libbpf >= 0.4.0" 2>&1`
+	        libbpf_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libbpf >= 0.8.0" 2>&1`
         else
-	        libbpf_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libbpf >= 0.4.0" 2>&1`
+	        libbpf_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libbpf >= 0.8.0" 2>&1`
         fi
 	# Put the nasty error message in config.log where it belongs
 	echo "$libbpf_PKG_ERRORS" >&5
@@ -9192,18 +9192,7 @@ printf "%s\n" "no (libbpf version required: 1.0.0, installed: $libbpf_version)" 
        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf "%s\n" "yes" >&6; }
     fi
-
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if bpf PMDA modules using perf_buffer__poll should be included" >&5
-printf %s "checking if bpf PMDA modules using perf_buffer__poll should be included... " >&6; }
-    if test "$libbpf_version_major" -eq 0 -a "$libbpf_version_minor" -lt 7; then
-       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no (libbpf version required: 0.7.0, installed: $libbpf_version)" >&5
-printf "%s\n" "no (libbpf version required: 0.7.0, installed: $libbpf_version)" >&6; }
-    else
-       pmdabpf_modules="${pmdabpf_modules} bashreadline.so biolatency.so execsnoop.so exitsnoop.so fsslower.so opensnoop.so runqlat.so statsnoop.so tcpconnect.so tcpconnlat.so vfsstat.so biosnoop.so"
-       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-    fi
-
+    pmdabpf_modules="${pmdabpf_modules} bashreadline.so biolatency.so execsnoop.so exitsnoop.so fsslower.so opensnoop.so runqlat.so statsnoop.so tcpconnect.so tcpconnlat.so vfsstat.so biosnoop.so"
 
     { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking which bpf PMDA modules should be included" >&5
 printf %s "checking which bpf PMDA modules should be included... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -1163,7 +1163,7 @@ AS_IF([test "x$do_pmdabcc" = "xcheck"], [
 AC_SUBST(PMDA_BCC, $pmda_bcc)
 if $pmda_bcc; then AC_MSG_RESULT(yes); else AC_MSG_RESULT(no); fi
 
-PKG_CHECK_MODULES([libbpf], [libbpf >= 0.4.0], [have_libbpf=true], [have_libbpf=false])
+PKG_CHECK_MODULES([libbpf], [libbpf >= 0.8.0], [have_libbpf=true], [have_libbpf=false])
 AC_SUBST(HAVE_LIBBPF, [$have_libbpf])
 AS_IF([$have_libbpf], [
     AC_MSG_CHECKING([libbpf version])
@@ -1233,15 +1233,7 @@ if $pmda_bpf; then
        pmdabpf_modules="${pmdabpf_modules} mountsnoop.so oomkill.so"
        AC_MSG_RESULT(yes)
     fi
-
-    AC_MSG_CHECKING([if bpf PMDA modules using perf_buffer__poll should be included])
-    if test "$libbpf_version_major" -eq 0 -a "$libbpf_version_minor" -lt 7; then
-       AC_MSG_RESULT([no (libbpf version required: 0.7.0, installed: $libbpf_version)])
-    else
-       pmdabpf_modules="${pmdabpf_modules} bashreadline.so biolatency.so execsnoop.so exitsnoop.so fsslower.so opensnoop.so runqlat.so statsnoop.so tcpconnect.so tcpconnlat.so vfsstat.so biosnoop.so"
-       AC_MSG_RESULT(yes)
-    fi
-
+    pmdabpf_modules="${pmdabpf_modules} bashreadline.so biolatency.so execsnoop.so exitsnoop.so fsslower.so opensnoop.so runqlat.so statsnoop.so tcpconnect.so tcpconnlat.so vfsstat.so biosnoop.so"
     AC_SUBST(pmdabpf_modules)
     AC_MSG_CHECKING([which bpf PMDA modules should be included])
     AC_MSG_RESULT($pmdabpf_modules)

--- a/debian/fixcontrol
+++ b/debian/fixcontrol
@@ -97,7 +97,7 @@ if $PMDA_BPF
 then
     echo "s/?{clang}, /clang, /" >>$tmp.sed
     echo "s/?{llvm}, /llvm, /" >>$tmp.sed
-    echo "s/?{libbpf-dev}, /libbpf-dev (>= 0.4.0), /" >>$tmp.sed
+    echo "s/?{libbpf-dev}, /libbpf-dev (>= 0.8.0), /" >>$tmp.sed
 else
     echo "s/?{clang}, //" >>$tmp.sed
     echo "s/?{llvm}, //" >>$tmp.sed


### PR DESCRIPTION
Recent updates to the vendored bcc code resulted in a newer version of libbpf-tools/compat.c merged which uses bpf_map__set_autocreate. This is only available in libbpf 0.8.0 and later and quite a few of the shipped modules are affected as a result.

This resolves a series of CI problems observed in the f36 BPF tests.