### PR TITLE
rc scripts: ensure pmcd.conf not rewritten unnecessarily

### DIFF
--- a/src/pmdas/bcc/Upgrade
+++ b/src/pmdas/bcc/Upgrade
@@ -26,8 +26,11 @@ then
     else
 	sed -i -e "s,^\(bcc.*binary\),\1 notready,g" $PCP_PMCDCONF_PATH
     fi
-    sed -i \
-	-e "s,python $PCP_PMDAS_DIR/bcc/,$PCP_PYTHON_PROG $PCP_PMDAS_DIR/bcc/,g" \
-	$PCP_PMCDCONF_PATH 2>/dev/null
+    if grep -q '^bcc.*python ' "$PCP_PMCDCONF_PATH" 2>/dev/null
+    then
+	sed -i \
+	    -e "s,python $PCP_PMDAS_DIR/bcc/,$PCP_PYTHON_PROG $PCP_PMDAS_DIR/bcc/,g" \
+	    $PCP_PMCDCONF_PATH 2>/dev/null
+    fi
 fi
 exit 0

--- a/src/pmdas/kvm/Upgrade
+++ b/src/pmdas/kvm/Upgrade
@@ -17,7 +17,7 @@
 
 . $PCP_DIR/etc/pcp.env
 
-if grep -q ^kvm "$PCP_PMCDCONF_PATH" 2>/dev/null
+if grep -q '^kvm.*perl.*' "$PCP_PMCDCONF_PATH" 2>/dev/null
 then
     sed -i -e "s,perl $PCP_PMDAS_DIR/kvm/pmdakvm.pl,$PCP_PMDAS_DIR/kvm/pmdakvm -d 95,g" $PCP_PMCDCONF_PATH 2>/dev/null
 fi

--- a/src/pmdas/mssql/Upgrade
+++ b/src/pmdas/mssql/Upgrade
@@ -17,11 +17,17 @@
 
 . $PCP_DIR/etc/pcp.env
 
-if grep -q ^mssql "$PCP_PMCDCONF_PATH" 2>/dev/null
+if grep -q '^mssql.*perl ' "$PCP_PMCDCONF_PATH" 2>/dev/null
+then
+    sed -i \
+	-e "s,perl $PCP_PMDAS_DIR/mssql/pmdamssql.pl,$PCP_PYTHON_PROG $PCP_PMDAS_DIR/mssql/pmdamssql.python,g" \
+	$PCP_PMCDCONF_PATH 2>/dev/null
+fi
+
+if grep -q '^mssql.*python ' "$PCP_PMCDCONF_PATH" 2>/dev/null
 then
     sed -i \
 	-e "s,python $PCP_PMDAS_DIR/mssql/,$PCP_PYTHON_PROG $PCP_PMDAS_DIR/mssql/,g" \
-	-e "s,perl $PCP_PMDAS_DIR/mssql/pmdamssql.pl,$PCP_PYTHON_PROG $PCP_PMDAS_DIR/mssql/pmdamssql.python,g" \
 	$PCP_PMCDCONF_PATH 2>/dev/null
 fi
 

--- a/src/pmdas/openmetrics/Upgrade
+++ b/src/pmdas/openmetrics/Upgrade
@@ -36,7 +36,7 @@ then
     rm -f "$PCP_VAR_DIR/pmns/prometheus" 2>/dev/null
 fi
 
-if grep -q ^openmetrics "$PCP_PMCDCONF_PATH" 2>/dev/null
+if grep -q '^openmetrics.*python ' "$PCP_PMCDCONF_PATH" 2>/dev/null
 then
     sed -i -e "s,python $PCP_PMDAS_DIR/openmetrics/,$PCP_PYTHON_PROG $PCP_PMDAS_DIR/openmetrics/,g" $PCP_PMCDCONF_PATH 2>/dev/null
 fi

--- a/src/pmdas/postgresql/Upgrade
+++ b/src/pmdas/postgresql/Upgrade
@@ -17,11 +17,17 @@
 
 . $PCP_DIR/etc/pcp.env
 
-if grep -q ^postgresql "$PCP_PMCDCONF_PATH" 2>/dev/null
+if grep -q '^postgresql.*perl ' "$PCP_PMCDCONF_PATH" 2>/dev/null
+then
+    sed -i \
+	-e "s,perl $PCP_PMDAS_DIR/postgresql/pmdapostgresql.pl,$PCP_PYTHON_PROG $PCP_PMDAS_DIR/postgresql/pmdapostgresql.python,g" \
+	$PCP_PMCDCONF_PATH 2>/dev/null
+fi
+
+if grep -q '^postgresql.*python ' "$PCP_PMCDCONF_PATH" 2>/dev/null
 then
     sed -i \
 	-e "s,python $PCP_PMDAS_DIR/postgresql/,$PCP_PYTHON_PROG $PCP_PMDAS_DIR/postgresql/,g" \
-	-e "s,perl $PCP_PMDAS_DIR/postgresql/pmdapostgresql.pl,$PCP_PYTHON_PROG $PCP_PMDAS_DIR/postgresql/pmdapostgresql.python,g" \
 	$PCP_PMCDCONF_PATH 2>/dev/null
 fi
 


### PR DESCRIPTION
It was observed that pmcd.conf inode modification times were updated on every restart of pmcd.  Turns out its because of the PMDA Upgrade scripts, where some were using 'sed -i' to affect a no-op change to the contents.  We're now take more care ensuring sed is only done when the contents of the file are definitely going to be modified.

Resolves Red Hat BZ #2166819.