### PR TITLE
fix(statsd): internal stats and blocklisted metric names alignment

### DIFF
--- a/qa/1709.out
+++ b/qa/1709.out
@@ -19,6 +19,33 @@ statsd.pmda.metrics_tracked
     inst [1 or "gauge"] value 0
     inst [2 or "duration"] value 0
     inst [3 or "total"] value 0
+statsd.pmda.settings.duration_aggregation_type
+    value "HDR histogram"
+statsd.pmda.settings.parser_type
+    value "Basic"
+statsd.pmda.settings.port
+    value 8125
+statsd.pmda.settings.debug_output_filename
+    value "debug"
+statsd.pmda.settings.verbose
+    value 0
+statsd.pmda.settings.max_unprocessed_packets
+    value 1024
+statsd.pmda.settings.max_udp_packet_size
+    value 1472
+statsd.pmda.received
+    value 14
+statsd.pmda.parsed
+    value 14
+statsd.pmda.aggregated
+    value 0
+statsd.pmda.dropped
+    value 14
+statsd.pmda.metrics_tracked
+    inst [0 or "counter"] value 0
+    inst [1 or "gauge"] value 0
+    inst [2 or "duration"] value 0
+    inst [3 or "total"] value 0
 Restoring config file...
 
 [global]

--- a/qa/statsd/src/cases/03.py
+++ b/qa/statsd/src/cases/03.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env pmpython
 # -*- coding: utf-8 -*-
 
-# Exercises default values of hardcoded metrics, all should equal 0
+# Exercises hardcoded metrics, including conflict handling when such metrics are received
 
-import sys 
+import sys
+import socket
 import glob
 import os
 
@@ -15,6 +16,11 @@ import pmdastatsd_test_utils as utils
 utils.print_test_file_separator()
 print(os.path.basename(__file__))
 
+ip = "0.0.0.0"
+port = 8125
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+
 def run_test():
     utils.print_test_section_separator()
     utils.pmdastatsd_install()
@@ -25,6 +31,35 @@ def run_test():
     utils.print_metric('statsd.pmda.time_spent_parsing')
     utils.print_metric('statsd.pmda.time_spent_aggregating')
     utils.print_metric('statsd.pmda.metrics_tracked')
+    utils.print_metric('statsd.pmda.settings.duration_aggregation_type')
+    utils.print_metric('statsd.pmda.settings.parser_type')
+    utils.print_metric('statsd.pmda.settings.port')
+    utils.print_metric('statsd.pmda.settings.debug_output_filename')
+    utils.print_metric('statsd.pmda.settings.verbose')
+    utils.print_metric('statsd.pmda.settings.max_unprocessed_packets')
+    utils.print_metric('statsd.pmda.settings.max_udp_packet_size')
+
+    sock.sendto("pmda.received:1|c".encode("utf-8"), (ip, port))
+    sock.sendto("pmda.parsed:1|c".encode("utf-8"), (ip, port))
+    sock.sendto("pmda.aggregated:1|c".encode("utf-8"), (ip, port))
+    sock.sendto("pmda.dropped:1|c".encode("utf-8"), (ip, port))
+    sock.sendto("pmda.time_spent_parsing:1|c".encode("utf-8"), (ip, port))
+    sock.sendto("pmda.time_spent_aggregating:1|c".encode("utf-8"), (ip, port))
+    sock.sendto("pmda.metrics_tracked:1|c".encode("utf-8"), (ip, port))
+    sock.sendto('pmda.settings.duration_aggregation_type:1|c'.encode("utf-8"), (ip, port))
+    sock.sendto('pmda.settings.parser_type:1|c'.encode("utf-8"), (ip, port))
+    sock.sendto('pmda.settings.port:1|c'.encode("utf-8"), (ip, port))
+    sock.sendto('pmda.settings.debug_output_filename:1|c'.encode("utf-8"), (ip, port))
+    sock.sendto('pmda.settings.verbose:1|c'.encode("utf-8"), (ip, port))
+    sock.sendto('pmda.settings.max_unprocessed_packets:1|c'.encode("utf-8"), (ip, port))
+    sock.sendto('pmda.settings.max_udp_packet_size:1|c'.encode("utf-8"), (ip, port))
+
+    utils.print_metric('statsd.pmda.received')
+    utils.print_metric('statsd.pmda.parsed')
+    utils.print_metric('statsd.pmda.aggregated')
+    utils.print_metric('statsd.pmda.dropped')
+    utils.print_metric('statsd.pmda.metrics_tracked')
+    
     utils.pmdastatsd_remove()
     utils.restore_config()
 

--- a/src/pmdas/statsd/src/aggregator-metrics.c
+++ b/src/pmdas/statsd/src/aggregator-metrics.c
@@ -449,10 +449,7 @@ check_metric_name_available(struct pmda_metrics_container* container, char* key)
     };
     size_t i;
     for (i = 0; i < sizeof(g_blocklist) / sizeof(g_blocklist[0]); i++) {
-        const char* ampptr = strchr(key, '&');
-        if (ampptr) {
-            if (strncmp(key, g_blocklist[i], ampptr - key) == 0) return 0;
-        }
+        if (strcmp(key, g_blocklist[i]) == 0) return 0;
     }
     if (!find_metric_by_name(container, key, NULL)) {
         return 1;

--- a/src/pmdas/statsd/src/pmdastatsd.c
+++ b/src/pmdas/statsd/src/pmdastatsd.c
@@ -114,16 +114,6 @@ create_statsd_hardcoded_metrics(struct pmda_data_extension* data) {
     static struct pmda_metric_helper helper;
     size_t agent_stat_count = 7;
     helper.data = data;
-    // statsd.pmda.received
-    data->pcp_metrics[0] = (pmdaMetric) {
-        .m_user = &helper,
-        .m_desc = {
-            .pmid = pmID_build(STATSD, 0, 1),
-            .sem = PM_SEM_COUNTER,
-            .type = PM_TYPE_U64,
-            .indom = PM_INDOM_NULL,
-        }
-    };
     for (i = 0; i < hardcoded_count; i++) {
         data->pcp_metrics[i].m_user = &helper;
         data->pcp_metrics[i].m_desc.pmid = pmID_build(STATSD, 0, i);

--- a/src/pmdas/statsd/src/pmdastatsd.c
+++ b/src/pmdas/statsd/src/pmdastatsd.c
@@ -114,6 +114,16 @@ create_statsd_hardcoded_metrics(struct pmda_data_extension* data) {
     static struct pmda_metric_helper helper;
     size_t agent_stat_count = 7;
     helper.data = data;
+    // statsd.pmda.received
+    data->pcp_metrics[0] = (pmdaMetric) {
+        .m_user = &helper,
+        .m_desc = {
+            .pmid = pmID_build(STATSD, 0, 1),
+            .sem = PM_SEM_COUNTER,
+            .type = PM_TYPE_U64,
+            .indom = PM_INDOM_NULL,
+        }
+    };
     for (i = 0; i < hardcoded_count; i++) {
         data->pcp_metrics[i].m_user = &helper;
         data->pcp_metrics[i].m_desc.pmid = pmID_build(STATSD, 0, i);


### PR DESCRIPTION
The blocklisted metric names weren't being matched properly so they werent actually blocklisted - for some reason they didn't end up being mapped to PCP metrics, so outwardly only incorrect thing about the ordeal were the internal stats metrics which didn't add up which is how I found out about this. Not sure what I was thinking when I was writing that code 4 years ago.