### PR TITLE
pmieconf: move test_action from primary into a separate group

### DIFF
--- a/src/pmieconf/.gitignore
+++ b/src/pmieconf/.gitignore
@@ -9,6 +9,7 @@ perdisk/GNUmakefile
 pernetif/GNUmakefile
 power/GNUmakefile
 primary/GNUmakefile
+testing/GNUmakefile
 zeroconf/GNUmakefile
 pmieconf
 pmieconf.static

--- a/src/pmieconf/GNUmakefile
+++ b/src/pmieconf/GNUmakefile
@@ -18,7 +18,7 @@ include	$(TOPDIR)/src/include/builddefs
 include $(TOPDIR)/src/libpcp/src/GNUlibrarydefs
 
 MKFILE_SUBDIRS = cpu entropy filesys memory network percpu perdisk pernetif \
-		 power global primary zeroconf
+		 power global primary testing zeroconf
 SUBDIRS	= $(MKFILE_SUBDIRS)
 
 CMDTARGET = pmieconf$(EXECSUFFIX)

--- a/src/pmieconf/testing/localdefs
+++ b/src/pmieconf/testing/localdefs
@@ -1,2 +1,2 @@
-ALL_RULES = pmda_status
+ALL_RULES = test_actions
 LOCAL_RULES = $(ALL_RULES)

--- a/src/pmieconf/testing/test_actions
+++ b/src/pmieconf/testing/test_actions
@@ -2,7 +2,7 @@
 # --- DO NOT MODIFY THIS FILE --- see pmieconf(5)
 #
 
-rule	primary.test_actions
+rule	testing.test_actions
 	default	= "$rule$"
 	predicate = "hinv.ncpu > 0"
 	enabled	= no


### PR DESCRIPTION
Problem with using primary is that it is automatically enabled as part of the primary pmie startup and thats not whats needed for this diagnostic rule.

Resolves Red Hat BZ #2223348