### PR TITLE
build: default to using a path-prefixed PCP_PYTHON_PROG

### DIFF
--- a/configure
+++ b/configure
@@ -8316,7 +8316,7 @@ test -n "$PYLINT" || PYLINT="/bin/true"
 
 
 
-for ac_prog in python2 python2.7 python
+for ac_prog in /usr/bin/python2 python2 python2.7 python
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
@@ -8365,7 +8365,7 @@ done
 
 
 
-for ac_prog in python3 python3.7 python3.6 python3.4
+for ac_prog in /usr/bin/python3 python3
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2

--- a/configure.ac
+++ b/configure.ac
@@ -893,11 +893,11 @@ AC_CHECK_PROGS(PYLINT, pylint, /bin/true)
 AC_SUBST(PYLINT)
 
 dnl check if python available for the build and runtime
-AC_CHECK_PROGS(PYTHON, [python2 python2.7 python])
+AC_CHECK_PROGS(PYTHON, [/usr/bin/python2 python2 python2.7 python])
 AC_SUBST(PYTHON)
 
 dnl check if python3 available for the build and runtime
-AC_CHECK_PROGS(PYTHON3, [python3 python3.7 python3.6 python3.4])
+AC_CHECK_PROGS(PYTHON3, [/usr/bin/python3 python3])
 AC_SUBST(PYTHON3)
 
 dnl check availability of Python header files


### PR DESCRIPTION
This removes ambiguity that can cause applications using PCP python APIs to fail when users have unusual settings for their PATH or are using a python venv, for example.

Resolves Red Hat BZ #2227011