### PR TITLE
pmlogconf: remove latency-inducing fsync on config write

### DIFF
--- a/qa/1940
+++ b/qa/1940
@@ -1,0 +1,40 @@
+#!/bin/sh
+# PCP QA Test No. 1940
+# Additional pmlogconf memory leak checks.
+#
+# Copyright (c) 2023 Red Hat.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+_check_valgrind
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=0	# success is the default!
+$sudo rm -rf $tmp $tmp.* $seq.full
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_filter()
+{
+    sed \
+	-e "s@$tmp@TMP@g" \
+	-e "s@$PCP_BINADM_DIR@PCP_BINADM_DIR@g" \
+    # end
+}
+
+# real QA test starts here
+_run_valgrind $PCP_BINADM_DIR/pmlogconf -r -c -q -h local: $tmp.probed | _filter
+
+# success, all done
+exit

--- a/qa/1940.out
+++ b/qa/1940.out
@@ -1,0 +1,12 @@
+QA output created by 1940
+=== std out ===
+Creating config file "TMP.probed" using default settings ...
+
+=== std err ===
+=== filtered valgrind report ===
+Memcheck, a memory error detector
+Command: PCP_BINADM_DIR/pmlogconf -r -c -q -h local: TMP.probed
+LEAK SUMMARY:
+definitely lost: 0 bytes in 0 blocks
+indirectly lost: 0 bytes in 0 blocks
+ERROR SUMMARY: 0 errors from 0 contexts ...

--- a/qa/group
+++ b/qa/group
@@ -2081,6 +2081,7 @@ x11
 1931 pmda.bpf local
 1936 other local pmclient
 1937 pmlogrewrite pmda.xfs local pmlogdump
+1940 pmlogconf valgrind local
 1955 libpcp pmda pmda.pmcd local
 1956 pmda.linux pmcd local
 1957 libpcp local valgrind

--- a/src/pmlogconf/pmlogconf.c
+++ b/src/pmlogconf/pmlogconf.c
@@ -104,6 +104,8 @@ group_free(group_t *group)
 	free(group->value);
     for (i = 0; i < group->nmetrics; i++)
 	free(group->metrics[i]);
+    if (group->metrics)
+	free(group->metrics);
     if (group->saved_delta)
 	free(group->saved_delta);
     memset(group, 0, sizeof(group_t));

--- a/src/pmlogconf/pmlogconf.c
+++ b/src/pmlogconf/pmlogconf.c
@@ -1771,7 +1771,6 @@ pmlogconf(int argc, char **argv)
 	pmlogger_create(file);
     else
 	pmlogger_update(file, &sbuf);
-    fsync(fileno(file));
     fclose(file);
     return 0;
 }

--- a/src/pmlogconf/pmrepconf.c
+++ b/src/pmlogconf/pmrepconf.c
@@ -608,7 +608,6 @@ pmrepconf(int argc, char **argv)
 	pmrep_create(file);
     else
 	pmrep_update(file, &sbuf);
-    fsync(fileno(file));
     fclose(file);
     return 0;
 }


### PR DESCRIPTION
The fsync during pmlogconf probe was originally added to
attempt to improve robustness.  However, it can have the
opposite effect - on a busy system (like after a package
upgrade across the OS), and during boot, it may induce a
slowdown that brings systemd service timeouts into play,
since its run during pmlogger service start.

It's hypothesized this is the root cause of BZ 2229441 -
a detailed valgrind-based forensic analysis has found no
possible cause within pmlogconf itself there.

Related to Fedora BZ 2229441.
