### PR TITLE
Add packages to Debian 12.1 package-lists

### DIFF
--- a/qa/admin/package-lists/Debian+12.1+x86_64
+++ b/qa/admin/package-lists/Debian+12.1+x86_64
@@ -24,6 +24,7 @@ cron
 curl
 debhelper
 dh-python
+docker.io
 dpkg-dev
 ed
 flex
@@ -35,6 +36,7 @@ gfs2-utils
 git
 grep
 iproute2
+kubernetes-client
 libavahi-common-dev
 libbpf1
 libbpf-dev


### PR DESCRIPTION
I ran the list-packages script in the qa/admin directory on a Debian 12.1 virtual machine. The output was a list of packages that could be added to the qa/admin/package-lists/Debian+12.1+x86_64. This PR adds those packages.