### PR TITLE
pmie: making pmie rule print consistent along with or without archive input

### DIFF
--- a/src/pmie/src/act.sk
+++ b/src/pmie/src/act.sk
@@ -392,7 +392,7 @@ actFake(Expr *x)
 	x->smpls[0].stamp = now;
 	pmCtime(&clock, bfr);
 	bfr[24] = '\0';
-	printf("%s %s: %s\n", opStrings(x->op), bfr, (char *)arg1->ring);
+	printf("%s: %s\n", bfr, (char *)arg1->ring);
     }
 }
 


### PR DESCRIPTION
There is "print" written while running the pmie rule on archives but it is not there while running the same rule on the live system, this commit makes it consistent for both cases.