### PR TITLE
build: install some pmlogtools onto the default PATH

### DIFF
--- a/man/man1/pmlogredact.1
+++ b/man/man1/pmlogredact.1
@@ -17,7 +17,7 @@
 .SH NAME
 \f3pmlogredact\f1 \- remove sensitive information from PCP archives
 .SH SYNOPSIS
-\f3$PCP_BINADM_DIR/pmlogredact\f1
+\f3pmlogredact\f1
 [\f3\-vx?\f1]
 [\f3\-c\f1 \f2config\f1]
 \f2inarch\f1 [\f2outarch\f1]

--- a/man/man1/pmlogreduce.1
+++ b/man/man1/pmlogreduce.1
@@ -18,7 +18,7 @@
 .SH NAME
 \f3pmlogreduce\f1 \- temporal reduction of Performance Co-Pilot archives
 .SH SYNOPSIS
-\f3$PCP_BINADM_DIR/pmlogreduce\f1
+\f3pmlogreduce\f1
 [\f3\-z?\f1]
 [\f3\-A\f1 \f2align\f1]
 [\f3\-s\f1 \f2samples\f1]

--- a/man/man1/pmlogrewrite.1
+++ b/man/man1/pmlogrewrite.1
@@ -18,7 +18,7 @@
 .SH NAME
 \f3pmlogrewrite\f1 \- rewrite Performance Co-Pilot archives
 .SH SYNOPSIS
-\f3$PCP_BINADM_DIR/pmlogrewrite\f1
+\f3pmlogrewrite\f1
 [\f3\-Cdiqsvw?\f1]
 [\f3\-c\f1 \f2config\f1]
 [\f3\-V\f1 \f2version\f1]

--- a/src/pmlogredact/GNUmakefile
+++ b/src/pmlogredact/GNUmakefile
@@ -1,30 +1,36 @@
 #
 # Copyright (c) 2023 Ken McDonell.  All Rights Reserved.
-# 
+#
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 # for more details.
-# 
+#
 
 TOPDIR = ../..
 include $(TOPDIR)/src/include/builddefs
+
+CMDSCRIPT = pmlogredact.sh
+CMDTARGET = pmlogredact$(SHELLSUFFIX)
+SYSCONFIG = $(PCP_SYSCONF_DIR)/pmlogredact
+VARCONFIG = $(PCP_VAR_DIR)/config/pmlogredact
 
 default:
 
 include $(BUILDRULES)
 
 install:	default
-	$(INSTALL) -m 755 pmlogredact.sh $(PCP_BINADM_DIR)/pmlogredact$(SHELLSUFFIX)
-	$(INSTALL) -m 755 -d $(PCP_SYSCONF_DIR)/pmlogredact
-	$(INSTALL) -m 755 -d $(PCP_VAR_DIR)/config/pmlogredact
-	$(INSTALL) -m 644 -t $(PCP_VAR_DIR)/config/pmlogredact/network network $(PCP_SYSCONF_DIR)/pmlogredact/network
-	$(INSTALL) -m 644 -t $(PCP_VAR_DIR)/config/pmlogredact/usernames usernames $(PCP_SYSCONF_DIR)/pmlogredact/usernames
+	$(INSTALL) -m 755 $(CMDSCRIPT) $(PCP_BIN_DIR)/$(CMDTARGET)
+	$(INSTALL) -S $(PCP_BIN_DIR)/$(CMDTARGET) $(PCP_BINADM_DIR)/$(CMDTARGET)
+	$(INSTALL) -m 755 -d $(SYSCONFIG)/pmlogredact
+	$(INSTALL) -m 755 -d $(VARCONFIG)
+	$(INSTALL) -m 644 -t $(VARCONFIG)/network network $(SYSCONFIG)/network
+	$(INSTALL) -m 644 -t $(VARCONFIG)/usernames usernames $(SYSCONFIG)/usernames
 
 default_pcp:	default
 

--- a/src/pmlogreduce/GNUmakefile
+++ b/src/pmlogreduce/GNUmakefile
@@ -28,7 +28,8 @@ include $(BUILDRULES)
 pmlogreduce : $(OBJECTS)
 
 install: $(CMDTARGET)
-	$(INSTALL) -m 755 $(CMDTARGET) $(PCP_BINADM_DIR)/$(CMDTARGET)
+	$(INSTALL) -m 755 $(CMDTARGET) $(PCP_BIN_DIR)/$(CMDTARGET)
+	$(INSTALL) -S $(PCP_BIN_DIR)/$(CMDTARGET) $(PCP_BINADM_DIR)/$(CMDTARGET)
 
 pmlogreduce.o:	pmlogreduce.h
 logio.o:	pmlogreduce.h

--- a/src/pmlogrewrite/GNUmakefile
+++ b/src/pmlogrewrite/GNUmakefile
@@ -2,17 +2,17 @@
 # Copyright (c) 2000,2004 Silicon Graphics, Inc.  All Rights Reserved.
 # Copyright (c) 2011 Ken McDonell.  All Rights Reserved.
 # Copyright (c) 2012,2018,2020 Red Hat, Inc. All Rights Reserved.
-# 
+#
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 # for more details.
-# 
+#
 
 TOPDIR = ../..
 include $(TOPDIR)/src/include/builddefs
@@ -37,7 +37,8 @@ pmlogrewrite$(EXECSUFFIX):	$(OBJECTS)
 install:	$(CMDTARGET)
 	$(INSTALL) -m 755 -d $(PCP_SYSCONF_DIR)/pmlogrewrite
 	$(INSTALL) -m 755 -d $(PCP_VAR_DIR)/config/pmlogrewrite
-	$(INSTALL) -m 755 $(CMDTARGET) $(PCP_BINADM_DIR)/$(CMDTARGET)
+	$(INSTALL) -m 755 $(CMDTARGET) $(PCP_BIN_DIR)/$(CMDTARGET)
+	$(INSTALL) -S $(PCP_BIN_DIR)/$(CMDTARGET) $(PCP_BINADM_DIR)/$(CMDTARGET)
 
 .NOTPARALLEL:
 gram.tab.h gram.tab.c:	gram.y


### PR DESCRIPTION
Several pmlog*tools have been traditionally installed into the (internal) PCP_BINADM_DIR.  Move these to /usr/bin and maintain the earlier path via symlinks as has been done in the past to ensure we don't break existing installations - this makes it easier for people to find these as sometimes we do want to run them directly/interactively too, and not exclusively via the automated pmlogger scripts.

Affects pmlogredact(1), pmlogreduce(1) and pmlogrewrite(1).