### PR TITLE
pmdahaproxy: fix connect script handling of string quoting

### DIFF
--- a/src/pmdas/haproxy/connect
+++ b/src/pmdas/haproxy/connect
@@ -57,7 +57,7 @@ if config.has_section('pmda'):
             sys.exit(1)
 
 if len(sys.argv) > 1 and (sys.argv[1] == '-c' or sys.argv[1] == '--config'):
-    sys.stdout.write("user=%s\nsocket=%s\nurl=%s\n" % (user, skt, url.replace(";", "\;").replace("&", "\&")))
+    sys.stdout.write("user=%s\nsocket=%s\nurl=%s\n" % (user, skt, url.replace(";", "\\;").replace("&", "\\&")))
     sys.exit(0)
 
 try:


### PR DESCRIPTION
From qa/1110 on rawhide
> $PCP_VAR_DIR/pmdas/haproxy/connect:60: SyntaxWarning: invalid escape sequence '\&'

Python 3.12 is producing errors on invalid escape sequences embedded in strings on rawhide - use double-backslash which seems to be the original intention here.