### PR TITLE
pcp-zoneinfo: ensure determinism in pcp-zoneinfo output

### DIFF
--- a/qa/1973.out
+++ b/qa/1973.out
@@ -297,6 +297,34 @@ NODE  0, per-node status
 	 nr_dirtied 594934
 	 nr_written 572571
 	 nr_kernel_misc_reclaimable 0
+Node 0, zone    DMA32
+	 pages free 814439
+	       min 2637
+	       low 3437
+	       high 4237
+	       spanned 1044480
+	       present 913392
+	       managed 815354
+               protection [0, 0, 16881, 16881, 16881]
+	 nr_free_pages 0
+	 nr_zone_inactive_anon 0
+	 nr_zone_active_anon 0
+	 nr_zone_inactive_file 0
+	 nr_zone_active_file 0
+	 nr_zone_unevictable 0
+	 nr_zone_write_pending 0
+	 nr_mlock 0
+	 nr_page_table_pages 0
+	 nr_kernel_stack 0
+	 nr_bounce 0
+	 nr_zspages 0
+	 nr_free_cma 0
+	 numa_hit 13
+	 numa_miss 0
+	 numa_foreign 0
+	 numa_interleave 0
+	 numa_local 13
+	 numa_other 0
 Node 0, zone    DMA
 	 pages free 3840
 	       min 12
@@ -353,35 +381,7 @@ Node 0, zone    Normal
 	 numa_interleave 28603
 	 numa_local 87458144
 	 numa_other 0
-Node 0, zone    DMA32
-	 pages free 814439
-	       min 2637
-	       low 3437
-	       high 4237
-	       spanned 1044480
-	       present 913392
-	       managed 815354
-               protection [0, 0, 16881, 16881, 16881]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 13
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 13
-	 numa_other 0
-Node 0, zone    Movable
+Node 0, zone    Device
 	 pages free 0
 	       min 0
 	       low 0
@@ -390,7 +390,7 @@ Node 0, zone    Movable
 	       present 0
 	       managed 0
                protection [0, 0, 0, 0, 0]
-Node 0, zone    Device
+Node 0, zone    Movable
 	 pages free 0
 	       min 0
 	       low 0
@@ -429,6 +429,34 @@ NODE  0, per-node status
 	 nr_dirtied 594934
 	 nr_written 572571
 	 nr_kernel_misc_reclaimable 0
+Node 0, zone    DMA32
+	 pages free 814439
+	       min 2637
+	       low 3437
+	       high 4237
+	       spanned 1044480
+	       present 913392
+	       managed 815354
+               protection [0, 0, 16881, 16881, 16881]
+	 nr_free_pages 0
+	 nr_zone_inactive_anon 0
+	 nr_zone_active_anon 0
+	 nr_zone_inactive_file 0
+	 nr_zone_active_file 0
+	 nr_zone_unevictable 0
+	 nr_zone_write_pending 0
+	 nr_mlock 0
+	 nr_page_table_pages 0
+	 nr_kernel_stack 0
+	 nr_bounce 0
+	 nr_zspages 0
+	 nr_free_cma 0
+	 numa_hit 13
+	 numa_miss 0
+	 numa_foreign 0
+	 numa_interleave 0
+	 numa_local 13
+	 numa_other 0
 Node 0, zone    DMA
 	 pages free 3840
 	       min 12
@@ -485,35 +513,7 @@ Node 0, zone    Normal
 	 numa_interleave 28603
 	 numa_local 87458144
 	 numa_other 0
-Node 0, zone    DMA32
-	 pages free 814439
-	       min 2637
-	       low 3437
-	       high 4237
-	       spanned 1044480
-	       present 913392
-	       managed 815354
-               protection [0, 0, 16881, 16881, 16881]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 13
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 13
-	 numa_other 0
-Node 0, zone    Movable
+Node 0, zone    Device
 	 pages free 0
 	       min 0
 	       low 0
@@ -522,7 +522,7 @@ Node 0, zone    Movable
 	       present 0
 	       managed 0
                protection [0, 0, 0, 0, 0]
-Node 0, zone    Device
+Node 0, zone    Movable
 	 pages free 0
 	       min 0
 	       low 0
@@ -561,6 +561,34 @@ NODE  0, per-node status
 	 nr_dirtied 594934
 	 nr_written 572571
 	 nr_kernel_misc_reclaimable 0
+Node 0, zone    DMA32
+	 pages free 814439
+	       min 2637
+	       low 3437
+	       high 4237
+	       spanned 1044480
+	       present 913392
+	       managed 815354
+               protection [0, 0, 16881, 16881, 16881]
+	 nr_free_pages 0
+	 nr_zone_inactive_anon 0
+	 nr_zone_active_anon 0
+	 nr_zone_inactive_file 0
+	 nr_zone_active_file 0
+	 nr_zone_unevictable 0
+	 nr_zone_write_pending 0
+	 nr_mlock 0
+	 nr_page_table_pages 0
+	 nr_kernel_stack 0
+	 nr_bounce 0
+	 nr_zspages 0
+	 nr_free_cma 0
+	 numa_hit 13
+	 numa_miss 0
+	 numa_foreign 0
+	 numa_interleave 0
+	 numa_local 13
+	 numa_other 0
 Node 0, zone    DMA
 	 pages free 3840
 	       min 12
@@ -617,35 +645,7 @@ Node 0, zone    Normal
 	 numa_interleave 28603
 	 numa_local 87458144
 	 numa_other 0
-Node 0, zone    DMA32
-	 pages free 814439
-	       min 2637
-	       low 3437
-	       high 4237
-	       spanned 1044480
-	       present 913392
-	       managed 815354
-               protection [0, 0, 16881, 16881, 16881]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 13
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 13
-	 numa_other 0
-Node 0, zone    Movable
+Node 0, zone    Device
 	 pages free 0
 	       min 0
 	       low 0
@@ -654,7 +654,7 @@ Node 0, zone    Movable
 	       present 0
 	       managed 0
                protection [0, 0, 0, 0, 0]
-Node 0, zone    Device
+Node 0, zone    Movable
 	 pages free 0
 	       min 0
 	       low 0
@@ -695,34 +695,6 @@ NODE  0, per-node status
 	 nr_dirtied 594934
 	 nr_written 572571
 	 nr_kernel_misc_reclaimable 0
-Node 0, zone    DMA
-	 pages free 3840
-	       min 12
-	       low 15
-	       high 18
-	       spanned 4095
-	       present 3998
-	       managed 3840
-               protection [0, 3125, 20006, 20006, 20006]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 0
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 0
-	 numa_other 0
 Node 0, zone    DMA32
 	 pages free 814439
 	       min 2637
@@ -750,6 +722,34 @@ Node 0, zone    DMA32
 	 numa_foreign 0
 	 numa_interleave 0
 	 numa_local 13
+	 numa_other 0
+Node 0, zone    DMA
+	 pages free 3840
+	       min 12
+	       low 15
+	       high 18
+	       spanned 4095
+	       present 3998
+	       managed 3840
+               protection [0, 3125, 20006, 20006, 20006]
+	 nr_free_pages 0
+	 nr_zone_inactive_anon 0
+	 nr_zone_active_anon 0
+	 nr_zone_inactive_file 0
+	 nr_zone_active_file 0
+	 nr_zone_unevictable 0
+	 nr_zone_write_pending 0
+	 nr_mlock 0
+	 nr_page_table_pages 0
+	 nr_kernel_stack 0
+	 nr_bounce 0
+	 nr_zspages 0
+	 nr_free_cma 0
+	 numa_hit 0
+	 numa_miss 0
+	 numa_foreign 0
+	 numa_interleave 0
+	 numa_local 0
 	 numa_other 0
 Node 0, zone    Normal
 	 pages free 2149304
@@ -779,7 +779,7 @@ Node 0, zone    Normal
 	 numa_interleave 28603
 	 numa_local 87458144
 	 numa_other 0
-Node 0, zone    Movable
+Node 0, zone    Device
 	 pages free 0
 	       min 0
 	       low 0
@@ -788,7 +788,7 @@ Node 0, zone    Movable
 	       present 0
 	       managed 0
                protection [0, 0, 0, 0, 0]
-Node 0, zone    Device
+Node 0, zone    Movable
 	 pages free 0
 	       min 0
 	       low 0
@@ -827,34 +827,6 @@ NODE  0, per-node status
 	 nr_dirtied 594934
 	 nr_written 572571
 	 nr_kernel_misc_reclaimable 0
-Node 0, zone    DMA
-	 pages free 3840
-	       min 12
-	       low 15
-	       high 18
-	       spanned 4095
-	       present 3998
-	       managed 3840
-               protection [0, 3125, 20006, 20006, 20006]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 0
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 0
-	 numa_other 0
 Node 0, zone    DMA32
 	 pages free 814439
 	       min 2637
@@ -882,6 +854,34 @@ Node 0, zone    DMA32
 	 numa_foreign 0
 	 numa_interleave 0
 	 numa_local 13
+	 numa_other 0
+Node 0, zone    DMA
+	 pages free 3840
+	       min 12
+	       low 15
+	       high 18
+	       spanned 4095
+	       present 3998
+	       managed 3840
+               protection [0, 3125, 20006, 20006, 20006]
+	 nr_free_pages 0
+	 nr_zone_inactive_anon 0
+	 nr_zone_active_anon 0
+	 nr_zone_inactive_file 0
+	 nr_zone_active_file 0
+	 nr_zone_unevictable 0
+	 nr_zone_write_pending 0
+	 nr_mlock 0
+	 nr_page_table_pages 0
+	 nr_kernel_stack 0
+	 nr_bounce 0
+	 nr_zspages 0
+	 nr_free_cma 0
+	 numa_hit 0
+	 numa_miss 0
+	 numa_foreign 0
+	 numa_interleave 0
+	 numa_local 0
 	 numa_other 0
 Node 0, zone    Normal
 	 pages free 2149304
@@ -911,7 +911,7 @@ Node 0, zone    Normal
 	 numa_interleave 28603
 	 numa_local 87458144
 	 numa_other 0
-Node 0, zone    Movable
+Node 0, zone    Device
 	 pages free 0
 	       min 0
 	       low 0
@@ -920,7 +920,7 @@ Node 0, zone    Movable
 	       present 0
 	       managed 0
                protection [0, 0, 0, 0, 0]
-Node 0, zone    Device
+Node 0, zone    Movable
 	 pages free 0
 	       min 0
 	       low 0

--- a/src/pcp/zoneinfo/pcp-zoneinfo.py
+++ b/src/pcp/zoneinfo/pcp-zoneinfo.py
@@ -220,7 +220,7 @@ class ZoneinfoReport(pmcc.MetricGroupPrinter):
                 print("NODE {:>2},".format(node_name[4:]),"per-node status")
                 for key,value in ZONEINFO_PER_NODE.items():
                     print ("\t",key,manager.metric_value(value,node_name))
-                for node in nodes:
+                for node in sorted(nodes):
                     print(self.__format_node_name(node))
                     for key,value in ZONEINFO_PAGE_INFO.items():
                         print("\t",key,manager.metric_value(value,node))
@@ -231,7 +231,7 @@ class ZoneinfoReport(pmcc.MetricGroupPrinter):
                 #these nodes will have only pages information for them so just printing them out
                 remaining_nodes = set(node_types) - nodes
                 if remaining_nodes:
-                    for node in remaining_nodes:
+                    for node in sorted(remaining_nodes):
                         print(self.__format_node_name(node))
                         for key,value in ZONEINFO_PAGE_INFO.items():
                             print("\t",key,manager.metric_value(value,node))


### PR DESCRIPTION
An earlier attempt missed a couple of locations where unsorted nodes and zones could occur, affecting output.

Fixes qa/1973.