### PR TITLE
pcp-zoneinfo:Fixing the issue where pcp-zoneinfo utility will fail with older version of pcp

### DIFF
--- a/qa/1973.out
+++ b/qa/1973.out
@@ -2,119 +2,119 @@ QA output created by 1973
 
 pcp-zoneinfo output : Display default output
 Linux  5.4.17-2136.317.5.3.el8uek.x86_64  (localhost.localdomain)  08/23/23  x86_64    (4 CPU)
-TimeStamp =  00:25:18
+TimeStamp = 00:25:18
 NODE  0, per-node status
-	 nr_inactive_anon 35933
-	 nr_active_anon 533154
-	 nr_inactive_file 760769
-	 nr_active_file 513583
-	 nr_unevictable 3105
-	 nr_slab_reclaimable 140646
-	 nr_slab_unreclaimable 54046
-	 nr_isolated_anon 0
-	 nr_isolated_file 0
-	 nr_anon_pages 523670
-	 nr_mapped 173358
-	 nr_file_pages 1313502
-	 nr_dirty 35
-	 nr_writeback 0
-	 nr_writeback_temp 0
-	 nr_shmem 36501
-	 nr_shmem_hugepages 0
-	 nr_shmem_pmdmapped 0
-	 nr_file_hugepages 0
-	 nr_file_pmdmapped 0
-	 nr_anon_transparent_hugepages 582
-	 nr_unstable 0
-	 nr_vmscan_write 0
-	 nr_vmscan_immediate_reclaim 0
-	 nr_dirtied 594934
-	 nr_written 572571
-	 nr_kernel_misc_reclaimable 0
-Node 0, zone    DMA32
-	 pages free 814439
-	       min 2637
-	       low 3437
-	       high 4237
-	       spanned 1044480
-	       present 913392
-	       managed 815354
-               protection [0, 0, 16881, 16881, 16881]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 13
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 13
-	 numa_other 0
+	nr_inactive_anon 35933
+	nr_active_anon 533154
+	nr_inactive_file 760769
+	nr_active_file 513583
+	nr_unevictable 3105
+	nr_slab_reclaimable 140646
+	nr_slab_unreclaimable 54046
+	nr_isolated_anon 0
+	nr_isolated_file 0
+	nr_anon_pages 523670
+	nr_mapped 173358
+	nr_file_pages 1313502
+	nr_dirty 35
+	nr_writeback 0
+	nr_writeback_temp 0
+	nr_shmem 36501
+	nr_anon_transparent_hugepages 582
+	nr_unstable 0
+	nr_vmscan_write 0
+	nr_vmscan_immediate_reclaim 0
+	nr_dirtied 594934
+	nr_written 572571
+	nr_shmem_hugepages 0
+	nr_shmem_pmdmapped 0
+	nr_file_hugepages 0
+	nr_file_pmdmapped 0
+	nr_kernel_misc_reclaimable 0
 Node 0, zone    DMA
-	 pages free 3840
-	       min 12
-	       low 15
-	       high 18
-	       spanned 4095
-	       present 3998
-	       managed 3840
-               protection [0, 3125, 20006, 20006, 20006]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 0
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 0
-	 numa_other 0
+	pages free 3840
+	      min 12
+	      low 15
+	      high 18
+	      spanned 4095
+	      present 3998
+	      managed 3840
+              protection [0, 3125, 20006, 20006, 20006]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 0
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 0
+	nr_zone_inactive_anon 0
+Node 0, zone    DMA32
+	pages free 814439
+	      min 2637
+	      low 3437
+	      high 4237
+	      spanned 1044480
+	      present 913392
+	      managed 815354
+              protection [0, 0, 16881, 16881, 16881]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 13
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 13
+	nr_zone_inactive_anon 0
 Node 0, zone    Normal
-	 pages free 2149304
-	       min 14245
-	       low 18566
-	       high 22887
-	       spanned 4417792
-	       present 4417792
-	       managed 4321635
-               protection [0, 0, 0, 0, 0]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 35933
-	 nr_zone_active_anon 533154
-	 nr_zone_inactive_file 760769
-	 nr_zone_active_file 513583
-	 nr_zone_unevictable 3105
-	 nr_zone_write_pending 35
-	 nr_mlock 3105
-	 nr_page_table_pages 15186
-	 nr_kernel_stack 12616
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 87458144
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 28603
-	 numa_local 87458144
-	 numa_other 0
+	pages free 2149304
+	      min 14245
+	      low 18566
+	      high 22887
+	      spanned 4417792
+	      present 4417792
+	      managed 4321635
+              protection [0, 0, 0, 0, 0]
+	nr_free_pages 0
+	nr_mlock 3105
+	nr_page_table_pages 15186
+	nr_kernel_stack 12616
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 87458144
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 28603
+	numa_other 0
+	nr_zone_active_anon 533154
+	nr_zone_inactive_file 760769
+	nr_zone_active_file 513583
+	nr_zone_unevictable 3105
+	nr_zone_write_pending 35
+	nr_zspages 0
+	numa_local 87458144
+	nr_zone_inactive_anon 35933
 Node 0, zone    Device
 	 pages free 0
 	       min 0
@@ -123,7 +123,7 @@ Node 0, zone    Device
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 Node 0, zone    Movable
 	 pages free 0
 	       min 0
@@ -132,121 +132,121 @@ Node 0, zone    Movable
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 Linux  5.4.17-2136.317.5.3.el8uek.x86_64  (localhost.localdomain)  08/23/23  x86_64    (4 CPU)
-TimeStamp =  00:25:21
+TimeStamp = 00:25:21
 NODE  0, per-node status
-	 nr_inactive_anon 35933
-	 nr_active_anon 533154
-	 nr_inactive_file 760769
-	 nr_active_file 513583
-	 nr_unevictable 3105
-	 nr_slab_reclaimable 140646
-	 nr_slab_unreclaimable 54046
-	 nr_isolated_anon 0
-	 nr_isolated_file 0
-	 nr_anon_pages 523670
-	 nr_mapped 173358
-	 nr_file_pages 1313502
-	 nr_dirty 35
-	 nr_writeback 0
-	 nr_writeback_temp 0
-	 nr_shmem 36501
-	 nr_shmem_hugepages 0
-	 nr_shmem_pmdmapped 0
-	 nr_file_hugepages 0
-	 nr_file_pmdmapped 0
-	 nr_anon_transparent_hugepages 582
-	 nr_unstable 0
-	 nr_vmscan_write 0
-	 nr_vmscan_immediate_reclaim 0
-	 nr_dirtied 594934
-	 nr_written 572571
-	 nr_kernel_misc_reclaimable 0
-Node 0, zone    DMA32
-	 pages free 814439
-	       min 2637
-	       low 3437
-	       high 4237
-	       spanned 1044480
-	       present 913392
-	       managed 815354
-               protection [0, 0, 16881, 16881, 16881]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 13
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 13
-	 numa_other 0
+	nr_inactive_anon 35933
+	nr_active_anon 533154
+	nr_inactive_file 760769
+	nr_active_file 513583
+	nr_unevictable 3105
+	nr_slab_reclaimable 140646
+	nr_slab_unreclaimable 54046
+	nr_isolated_anon 0
+	nr_isolated_file 0
+	nr_anon_pages 523670
+	nr_mapped 173358
+	nr_file_pages 1313502
+	nr_dirty 35
+	nr_writeback 0
+	nr_writeback_temp 0
+	nr_shmem 36501
+	nr_anon_transparent_hugepages 582
+	nr_unstable 0
+	nr_vmscan_write 0
+	nr_vmscan_immediate_reclaim 0
+	nr_dirtied 594934
+	nr_written 572571
+	nr_shmem_hugepages 0
+	nr_shmem_pmdmapped 0
+	nr_file_hugepages 0
+	nr_file_pmdmapped 0
+	nr_kernel_misc_reclaimable 0
 Node 0, zone    DMA
-	 pages free 3840
-	       min 12
-	       low 15
-	       high 18
-	       spanned 4095
-	       present 3998
-	       managed 3840
-               protection [0, 3125, 20006, 20006, 20006]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 0
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 0
-	 numa_other 0
+	pages free 3840
+	      min 12
+	      low 15
+	      high 18
+	      spanned 4095
+	      present 3998
+	      managed 3840
+              protection [0, 3125, 20006, 20006, 20006]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 0
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 0
+	nr_zone_inactive_anon 0
+Node 0, zone    DMA32
+	pages free 814439
+	      min 2637
+	      low 3437
+	      high 4237
+	      spanned 1044480
+	      present 913392
+	      managed 815354
+              protection [0, 0, 16881, 16881, 16881]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 13
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 13
+	nr_zone_inactive_anon 0
 Node 0, zone    Normal
-	 pages free 2149304
-	       min 14245
-	       low 18566
-	       high 22887
-	       spanned 4417792
-	       present 4417792
-	       managed 4321635
-               protection [0, 0, 0, 0, 0]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 35933
-	 nr_zone_active_anon 533154
-	 nr_zone_inactive_file 760769
-	 nr_zone_active_file 513583
-	 nr_zone_unevictable 3105
-	 nr_zone_write_pending 35
-	 nr_mlock 3105
-	 nr_page_table_pages 15186
-	 nr_kernel_stack 12616
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 87458144
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 28603
-	 numa_local 87458144
-	 numa_other 0
+	pages free 2149304
+	      min 14245
+	      low 18566
+	      high 22887
+	      spanned 4417792
+	      present 4417792
+	      managed 4321635
+              protection [0, 0, 0, 0, 0]
+	nr_free_pages 0
+	nr_mlock 3105
+	nr_page_table_pages 15186
+	nr_kernel_stack 12616
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 87458144
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 28603
+	numa_other 0
+	nr_zone_active_anon 533154
+	nr_zone_inactive_file 760769
+	nr_zone_active_file 513583
+	nr_zone_unevictable 3105
+	nr_zone_write_pending 35
+	nr_zspages 0
+	numa_local 87458144
+	nr_zone_inactive_anon 35933
 Node 0, zone    Device
 	 pages free 0
 	       min 0
@@ -255,7 +255,7 @@ Node 0, zone    Device
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 Node 0, zone    Movable
 	 pages free 0
 	       min 0
@@ -264,123 +264,123 @@ Node 0, zone    Movable
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 
 pcp-zoneinfo output : Display output
 Linux  5.4.17-2136.317.5.3.el8uek.x86_64  (localhost.localdomain)  08/23/23  x86_64    (4 CPU)
-TimeStamp =  00:25:16
+TimeStamp = 00:25:16
 NODE  0, per-node status
-	 nr_inactive_anon 35933
-	 nr_active_anon 533154
-	 nr_inactive_file 760769
-	 nr_active_file 513583
-	 nr_unevictable 3105
-	 nr_slab_reclaimable 140646
-	 nr_slab_unreclaimable 54046
-	 nr_isolated_anon 0
-	 nr_isolated_file 0
-	 nr_anon_pages 523670
-	 nr_mapped 173358
-	 nr_file_pages 1313502
-	 nr_dirty 35
-	 nr_writeback 0
-	 nr_writeback_temp 0
-	 nr_shmem 36501
-	 nr_shmem_hugepages 0
-	 nr_shmem_pmdmapped 0
-	 nr_file_hugepages 0
-	 nr_file_pmdmapped 0
-	 nr_anon_transparent_hugepages 582
-	 nr_unstable 0
-	 nr_vmscan_write 0
-	 nr_vmscan_immediate_reclaim 0
-	 nr_dirtied 594934
-	 nr_written 572571
-	 nr_kernel_misc_reclaimable 0
-Node 0, zone    DMA32
-	 pages free 814439
-	       min 2637
-	       low 3437
-	       high 4237
-	       spanned 1044480
-	       present 913392
-	       managed 815354
-               protection [0, 0, 16881, 16881, 16881]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 13
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 13
-	 numa_other 0
+	nr_inactive_anon 35933
+	nr_active_anon 533154
+	nr_inactive_file 760769
+	nr_active_file 513583
+	nr_unevictable 3105
+	nr_slab_reclaimable 140646
+	nr_slab_unreclaimable 54046
+	nr_isolated_anon 0
+	nr_isolated_file 0
+	nr_anon_pages 523670
+	nr_mapped 173358
+	nr_file_pages 1313502
+	nr_dirty 35
+	nr_writeback 0
+	nr_writeback_temp 0
+	nr_shmem 36501
+	nr_anon_transparent_hugepages 582
+	nr_unstable 0
+	nr_vmscan_write 0
+	nr_vmscan_immediate_reclaim 0
+	nr_dirtied 594934
+	nr_written 572571
+	nr_shmem_hugepages 0
+	nr_shmem_pmdmapped 0
+	nr_file_hugepages 0
+	nr_file_pmdmapped 0
+	nr_kernel_misc_reclaimable 0
 Node 0, zone    DMA
-	 pages free 3840
-	       min 12
-	       low 15
-	       high 18
-	       spanned 4095
-	       present 3998
-	       managed 3840
-               protection [0, 3125, 20006, 20006, 20006]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 0
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 0
-	 numa_other 0
+	pages free 3840
+	      min 12
+	      low 15
+	      high 18
+	      spanned 4095
+	      present 3998
+	      managed 3840
+              protection [0, 3125, 20006, 20006, 20006]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 0
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 0
+	nr_zone_inactive_anon 0
+Node 0, zone    DMA32
+	pages free 814439
+	      min 2637
+	      low 3437
+	      high 4237
+	      spanned 1044480
+	      present 913392
+	      managed 815354
+              protection [0, 0, 16881, 16881, 16881]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 13
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 13
+	nr_zone_inactive_anon 0
 Node 0, zone    Normal
-	 pages free 2149304
-	       min 14245
-	       low 18566
-	       high 22887
-	       spanned 4417792
-	       present 4417792
-	       managed 4321635
-               protection [0, 0, 0, 0, 0]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 35933
-	 nr_zone_active_anon 533154
-	 nr_zone_inactive_file 760769
-	 nr_zone_active_file 513583
-	 nr_zone_unevictable 3105
-	 nr_zone_write_pending 35
-	 nr_mlock 3105
-	 nr_page_table_pages 15186
-	 nr_kernel_stack 12616
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 87458144
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 28603
-	 numa_local 87458144
-	 numa_other 0
+	pages free 2149304
+	      min 14245
+	      low 18566
+	      high 22887
+	      spanned 4417792
+	      present 4417792
+	      managed 4321635
+              protection [0, 0, 0, 0, 0]
+	nr_free_pages 0
+	nr_mlock 3105
+	nr_page_table_pages 15186
+	nr_kernel_stack 12616
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 87458144
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 28603
+	numa_other 0
+	nr_zone_active_anon 533154
+	nr_zone_inactive_file 760769
+	nr_zone_active_file 513583
+	nr_zone_unevictable 3105
+	nr_zone_write_pending 35
+	nr_zspages 0
+	numa_local 87458144
+	nr_zone_inactive_anon 35933
 Node 0, zone    Device
 	 pages free 0
 	       min 0
@@ -389,7 +389,7 @@ Node 0, zone    Device
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 Node 0, zone    Movable
 	 pages free 0
 	       min 0
@@ -398,121 +398,121 @@ Node 0, zone    Movable
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 Linux  5.4.17-2136.317.5.3.el8uek.x86_64  (localhost.localdomain)  08/23/23  x86_64    (4 CPU)
-TimeStamp =  00:25:19
+TimeStamp = 00:25:19
 NODE  0, per-node status
-	 nr_inactive_anon 35933
-	 nr_active_anon 533154
-	 nr_inactive_file 760769
-	 nr_active_file 513583
-	 nr_unevictable 3105
-	 nr_slab_reclaimable 140646
-	 nr_slab_unreclaimable 54046
-	 nr_isolated_anon 0
-	 nr_isolated_file 0
-	 nr_anon_pages 523670
-	 nr_mapped 173358
-	 nr_file_pages 1313502
-	 nr_dirty 35
-	 nr_writeback 0
-	 nr_writeback_temp 0
-	 nr_shmem 36501
-	 nr_shmem_hugepages 0
-	 nr_shmem_pmdmapped 0
-	 nr_file_hugepages 0
-	 nr_file_pmdmapped 0
-	 nr_anon_transparent_hugepages 582
-	 nr_unstable 0
-	 nr_vmscan_write 0
-	 nr_vmscan_immediate_reclaim 0
-	 nr_dirtied 594934
-	 nr_written 572571
-	 nr_kernel_misc_reclaimable 0
-Node 0, zone    DMA32
-	 pages free 814439
-	       min 2637
-	       low 3437
-	       high 4237
-	       spanned 1044480
-	       present 913392
-	       managed 815354
-               protection [0, 0, 16881, 16881, 16881]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 13
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 13
-	 numa_other 0
+	nr_inactive_anon 35933
+	nr_active_anon 533154
+	nr_inactive_file 760769
+	nr_active_file 513583
+	nr_unevictable 3105
+	nr_slab_reclaimable 140646
+	nr_slab_unreclaimable 54046
+	nr_isolated_anon 0
+	nr_isolated_file 0
+	nr_anon_pages 523670
+	nr_mapped 173358
+	nr_file_pages 1313502
+	nr_dirty 35
+	nr_writeback 0
+	nr_writeback_temp 0
+	nr_shmem 36501
+	nr_anon_transparent_hugepages 582
+	nr_unstable 0
+	nr_vmscan_write 0
+	nr_vmscan_immediate_reclaim 0
+	nr_dirtied 594934
+	nr_written 572571
+	nr_shmem_hugepages 0
+	nr_shmem_pmdmapped 0
+	nr_file_hugepages 0
+	nr_file_pmdmapped 0
+	nr_kernel_misc_reclaimable 0
 Node 0, zone    DMA
-	 pages free 3840
-	       min 12
-	       low 15
-	       high 18
-	       spanned 4095
-	       present 3998
-	       managed 3840
-               protection [0, 3125, 20006, 20006, 20006]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 0
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 0
-	 numa_other 0
+	pages free 3840
+	      min 12
+	      low 15
+	      high 18
+	      spanned 4095
+	      present 3998
+	      managed 3840
+              protection [0, 3125, 20006, 20006, 20006]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 0
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 0
+	nr_zone_inactive_anon 0
+Node 0, zone    DMA32
+	pages free 814439
+	      min 2637
+	      low 3437
+	      high 4237
+	      spanned 1044480
+	      present 913392
+	      managed 815354
+              protection [0, 0, 16881, 16881, 16881]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 13
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 13
+	nr_zone_inactive_anon 0
 Node 0, zone    Normal
-	 pages free 2149304
-	       min 14245
-	       low 18566
-	       high 22887
-	       spanned 4417792
-	       present 4417792
-	       managed 4321635
-               protection [0, 0, 0, 0, 0]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 35933
-	 nr_zone_active_anon 533154
-	 nr_zone_inactive_file 760769
-	 nr_zone_active_file 513583
-	 nr_zone_unevictable 3105
-	 nr_zone_write_pending 35
-	 nr_mlock 3105
-	 nr_page_table_pages 15186
-	 nr_kernel_stack 12616
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 87458144
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 28603
-	 numa_local 87458144
-	 numa_other 0
+	pages free 2149304
+	      min 14245
+	      low 18566
+	      high 22887
+	      spanned 4417792
+	      present 4417792
+	      managed 4321635
+              protection [0, 0, 0, 0, 0]
+	nr_free_pages 0
+	nr_mlock 3105
+	nr_page_table_pages 15186
+	nr_kernel_stack 12616
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 87458144
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 28603
+	numa_other 0
+	nr_zone_active_anon 533154
+	nr_zone_inactive_file 760769
+	nr_zone_active_file 513583
+	nr_zone_unevictable 3105
+	nr_zone_write_pending 35
+	nr_zspages 0
+	numa_local 87458144
+	nr_zone_inactive_anon 35933
 Node 0, zone    Device
 	 pages free 0
 	       min 0
@@ -521,7 +521,7 @@ Node 0, zone    Device
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 Node 0, zone    Movable
 	 pages free 0
 	       min 0
@@ -530,121 +530,121 @@ Node 0, zone    Movable
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 Linux  5.4.17-2136.317.5.3.el8uek.x86_64  (localhost.localdomain)  08/23/23  x86_64    (4 CPU)
-TimeStamp =  00:25:22
+TimeStamp = 00:25:22
 NODE  0, per-node status
-	 nr_inactive_anon 35933
-	 nr_active_anon 533154
-	 nr_inactive_file 760769
-	 nr_active_file 513583
-	 nr_unevictable 3105
-	 nr_slab_reclaimable 140646
-	 nr_slab_unreclaimable 54046
-	 nr_isolated_anon 0
-	 nr_isolated_file 0
-	 nr_anon_pages 523670
-	 nr_mapped 173358
-	 nr_file_pages 1313502
-	 nr_dirty 35
-	 nr_writeback 0
-	 nr_writeback_temp 0
-	 nr_shmem 36501
-	 nr_shmem_hugepages 0
-	 nr_shmem_pmdmapped 0
-	 nr_file_hugepages 0
-	 nr_file_pmdmapped 0
-	 nr_anon_transparent_hugepages 582
-	 nr_unstable 0
-	 nr_vmscan_write 0
-	 nr_vmscan_immediate_reclaim 0
-	 nr_dirtied 594934
-	 nr_written 572571
-	 nr_kernel_misc_reclaimable 0
-Node 0, zone    DMA32
-	 pages free 814439
-	       min 2637
-	       low 3437
-	       high 4237
-	       spanned 1044480
-	       present 913392
-	       managed 815354
-               protection [0, 0, 16881, 16881, 16881]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 13
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 13
-	 numa_other 0
+	nr_inactive_anon 35933
+	nr_active_anon 533154
+	nr_inactive_file 760769
+	nr_active_file 513583
+	nr_unevictable 3105
+	nr_slab_reclaimable 140646
+	nr_slab_unreclaimable 54046
+	nr_isolated_anon 0
+	nr_isolated_file 0
+	nr_anon_pages 523670
+	nr_mapped 173358
+	nr_file_pages 1313502
+	nr_dirty 35
+	nr_writeback 0
+	nr_writeback_temp 0
+	nr_shmem 36501
+	nr_anon_transparent_hugepages 582
+	nr_unstable 0
+	nr_vmscan_write 0
+	nr_vmscan_immediate_reclaim 0
+	nr_dirtied 594934
+	nr_written 572571
+	nr_shmem_hugepages 0
+	nr_shmem_pmdmapped 0
+	nr_file_hugepages 0
+	nr_file_pmdmapped 0
+	nr_kernel_misc_reclaimable 0
 Node 0, zone    DMA
-	 pages free 3840
-	       min 12
-	       low 15
-	       high 18
-	       spanned 4095
-	       present 3998
-	       managed 3840
-               protection [0, 3125, 20006, 20006, 20006]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 0
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 0
-	 numa_other 0
+	pages free 3840
+	      min 12
+	      low 15
+	      high 18
+	      spanned 4095
+	      present 3998
+	      managed 3840
+              protection [0, 3125, 20006, 20006, 20006]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 0
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 0
+	nr_zone_inactive_anon 0
+Node 0, zone    DMA32
+	pages free 814439
+	      min 2637
+	      low 3437
+	      high 4237
+	      spanned 1044480
+	      present 913392
+	      managed 815354
+              protection [0, 0, 16881, 16881, 16881]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 13
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 13
+	nr_zone_inactive_anon 0
 Node 0, zone    Normal
-	 pages free 2149304
-	       min 14245
-	       low 18566
-	       high 22887
-	       spanned 4417792
-	       present 4417792
-	       managed 4321635
-               protection [0, 0, 0, 0, 0]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 35933
-	 nr_zone_active_anon 533154
-	 nr_zone_inactive_file 760769
-	 nr_zone_active_file 513583
-	 nr_zone_unevictable 3105
-	 nr_zone_write_pending 35
-	 nr_mlock 3105
-	 nr_page_table_pages 15186
-	 nr_kernel_stack 12616
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 87458144
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 28603
-	 numa_local 87458144
-	 numa_other 0
+	pages free 2149304
+	      min 14245
+	      low 18566
+	      high 22887
+	      spanned 4417792
+	      present 4417792
+	      managed 4321635
+              protection [0, 0, 0, 0, 0]
+	nr_free_pages 0
+	nr_mlock 3105
+	nr_page_table_pages 15186
+	nr_kernel_stack 12616
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 87458144
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 28603
+	numa_other 0
+	nr_zone_active_anon 533154
+	nr_zone_inactive_file 760769
+	nr_zone_active_file 513583
+	nr_zone_unevictable 3105
+	nr_zone_write_pending 35
+	nr_zspages 0
+	numa_local 87458144
+	nr_zone_inactive_anon 35933
 Node 0, zone    Device
 	 pages free 0
 	       min 0
@@ -653,7 +653,7 @@ Node 0, zone    Device
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 Node 0, zone    Movable
 	 pages free 0
 	       min 0
@@ -662,123 +662,123 @@ Node 0, zone    Movable
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 
 pcp-zoneinfo output : Display output when given specified number of samples
 Linux  5.4.17-2136.317.5.3.el8uek.x86_64  (localhost.localdomain)  08/23/23  x86_64    (4 CPU)
-TimeStamp =  00:25:16
+TimeStamp = 00:25:16
 NODE  0, per-node status
-	 nr_inactive_anon 35933
-	 nr_active_anon 533154
-	 nr_inactive_file 760769
-	 nr_active_file 513583
-	 nr_unevictable 3105
-	 nr_slab_reclaimable 140646
-	 nr_slab_unreclaimable 54046
-	 nr_isolated_anon 0
-	 nr_isolated_file 0
-	 nr_anon_pages 523670
-	 nr_mapped 173358
-	 nr_file_pages 1313502
-	 nr_dirty 35
-	 nr_writeback 0
-	 nr_writeback_temp 0
-	 nr_shmem 36501
-	 nr_shmem_hugepages 0
-	 nr_shmem_pmdmapped 0
-	 nr_file_hugepages 0
-	 nr_file_pmdmapped 0
-	 nr_anon_transparent_hugepages 582
-	 nr_unstable 0
-	 nr_vmscan_write 0
-	 nr_vmscan_immediate_reclaim 0
-	 nr_dirtied 594934
-	 nr_written 572571
-	 nr_kernel_misc_reclaimable 0
-Node 0, zone    DMA32
-	 pages free 814439
-	       min 2637
-	       low 3437
-	       high 4237
-	       spanned 1044480
-	       present 913392
-	       managed 815354
-               protection [0, 0, 16881, 16881, 16881]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 13
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 13
-	 numa_other 0
+	nr_inactive_anon 35933
+	nr_active_anon 533154
+	nr_inactive_file 760769
+	nr_active_file 513583
+	nr_unevictable 3105
+	nr_slab_reclaimable 140646
+	nr_slab_unreclaimable 54046
+	nr_isolated_anon 0
+	nr_isolated_file 0
+	nr_anon_pages 523670
+	nr_mapped 173358
+	nr_file_pages 1313502
+	nr_dirty 35
+	nr_writeback 0
+	nr_writeback_temp 0
+	nr_shmem 36501
+	nr_anon_transparent_hugepages 582
+	nr_unstable 0
+	nr_vmscan_write 0
+	nr_vmscan_immediate_reclaim 0
+	nr_dirtied 594934
+	nr_written 572571
+	nr_shmem_hugepages 0
+	nr_shmem_pmdmapped 0
+	nr_file_hugepages 0
+	nr_file_pmdmapped 0
+	nr_kernel_misc_reclaimable 0
 Node 0, zone    DMA
-	 pages free 3840
-	       min 12
-	       low 15
-	       high 18
-	       spanned 4095
-	       present 3998
-	       managed 3840
-               protection [0, 3125, 20006, 20006, 20006]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 0
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 0
-	 numa_other 0
+	pages free 3840
+	      min 12
+	      low 15
+	      high 18
+	      spanned 4095
+	      present 3998
+	      managed 3840
+              protection [0, 3125, 20006, 20006, 20006]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 0
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 0
+	nr_zone_inactive_anon 0
+Node 0, zone    DMA32
+	pages free 814439
+	      min 2637
+	      low 3437
+	      high 4237
+	      spanned 1044480
+	      present 913392
+	      managed 815354
+              protection [0, 0, 16881, 16881, 16881]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 13
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 13
+	nr_zone_inactive_anon 0
 Node 0, zone    Normal
-	 pages free 2149304
-	       min 14245
-	       low 18566
-	       high 22887
-	       spanned 4417792
-	       present 4417792
-	       managed 4321635
-               protection [0, 0, 0, 0, 0]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 35933
-	 nr_zone_active_anon 533154
-	 nr_zone_inactive_file 760769
-	 nr_zone_active_file 513583
-	 nr_zone_unevictable 3105
-	 nr_zone_write_pending 35
-	 nr_mlock 3105
-	 nr_page_table_pages 15186
-	 nr_kernel_stack 12616
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 87458144
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 28603
-	 numa_local 87458144
-	 numa_other 0
+	pages free 2149304
+	      min 14245
+	      low 18566
+	      high 22887
+	      spanned 4417792
+	      present 4417792
+	      managed 4321635
+              protection [0, 0, 0, 0, 0]
+	nr_free_pages 0
+	nr_mlock 3105
+	nr_page_table_pages 15186
+	nr_kernel_stack 12616
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 87458144
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 28603
+	numa_other 0
+	nr_zone_active_anon 533154
+	nr_zone_inactive_file 760769
+	nr_zone_active_file 513583
+	nr_zone_unevictable 3105
+	nr_zone_write_pending 35
+	nr_zspages 0
+	numa_local 87458144
+	nr_zone_inactive_anon 35933
 Node 0, zone    Device
 	 pages free 0
 	       min 0
@@ -787,7 +787,7 @@ Node 0, zone    Device
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 Node 0, zone    Movable
 	 pages free 0
 	       min 0
@@ -796,121 +796,121 @@ Node 0, zone    Movable
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 Linux  5.4.17-2136.317.5.3.el8uek.x86_64  (localhost.localdomain)  08/23/23  x86_64    (4 CPU)
-TimeStamp =  00:25:19
+TimeStamp = 00:25:19
 NODE  0, per-node status
-	 nr_inactive_anon 35933
-	 nr_active_anon 533154
-	 nr_inactive_file 760769
-	 nr_active_file 513583
-	 nr_unevictable 3105
-	 nr_slab_reclaimable 140646
-	 nr_slab_unreclaimable 54046
-	 nr_isolated_anon 0
-	 nr_isolated_file 0
-	 nr_anon_pages 523670
-	 nr_mapped 173358
-	 nr_file_pages 1313502
-	 nr_dirty 35
-	 nr_writeback 0
-	 nr_writeback_temp 0
-	 nr_shmem 36501
-	 nr_shmem_hugepages 0
-	 nr_shmem_pmdmapped 0
-	 nr_file_hugepages 0
-	 nr_file_pmdmapped 0
-	 nr_anon_transparent_hugepages 582
-	 nr_unstable 0
-	 nr_vmscan_write 0
-	 nr_vmscan_immediate_reclaim 0
-	 nr_dirtied 594934
-	 nr_written 572571
-	 nr_kernel_misc_reclaimable 0
-Node 0, zone    DMA32
-	 pages free 814439
-	       min 2637
-	       low 3437
-	       high 4237
-	       spanned 1044480
-	       present 913392
-	       managed 815354
-               protection [0, 0, 16881, 16881, 16881]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 13
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 13
-	 numa_other 0
+	nr_inactive_anon 35933
+	nr_active_anon 533154
+	nr_inactive_file 760769
+	nr_active_file 513583
+	nr_unevictable 3105
+	nr_slab_reclaimable 140646
+	nr_slab_unreclaimable 54046
+	nr_isolated_anon 0
+	nr_isolated_file 0
+	nr_anon_pages 523670
+	nr_mapped 173358
+	nr_file_pages 1313502
+	nr_dirty 35
+	nr_writeback 0
+	nr_writeback_temp 0
+	nr_shmem 36501
+	nr_anon_transparent_hugepages 582
+	nr_unstable 0
+	nr_vmscan_write 0
+	nr_vmscan_immediate_reclaim 0
+	nr_dirtied 594934
+	nr_written 572571
+	nr_shmem_hugepages 0
+	nr_shmem_pmdmapped 0
+	nr_file_hugepages 0
+	nr_file_pmdmapped 0
+	nr_kernel_misc_reclaimable 0
 Node 0, zone    DMA
-	 pages free 3840
-	       min 12
-	       low 15
-	       high 18
-	       spanned 4095
-	       present 3998
-	       managed 3840
-               protection [0, 3125, 20006, 20006, 20006]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 0
-	 nr_zone_active_anon 0
-	 nr_zone_inactive_file 0
-	 nr_zone_active_file 0
-	 nr_zone_unevictable 0
-	 nr_zone_write_pending 0
-	 nr_mlock 0
-	 nr_page_table_pages 0
-	 nr_kernel_stack 0
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 0
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 0
-	 numa_local 0
-	 numa_other 0
+	pages free 3840
+	      min 12
+	      low 15
+	      high 18
+	      spanned 4095
+	      present 3998
+	      managed 3840
+              protection [0, 3125, 20006, 20006, 20006]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 0
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 0
+	nr_zone_inactive_anon 0
+Node 0, zone    DMA32
+	pages free 814439
+	      min 2637
+	      low 3437
+	      high 4237
+	      spanned 1044480
+	      present 913392
+	      managed 815354
+              protection [0, 0, 16881, 16881, 16881]
+	nr_free_pages 0
+	nr_mlock 0
+	nr_page_table_pages 0
+	nr_kernel_stack 0
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 13
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 0
+	numa_other 0
+	nr_zone_active_anon 0
+	nr_zone_inactive_file 0
+	nr_zone_active_file 0
+	nr_zone_unevictable 0
+	nr_zone_write_pending 0
+	nr_zspages 0
+	numa_local 13
+	nr_zone_inactive_anon 0
 Node 0, zone    Normal
-	 pages free 2149304
-	       min 14245
-	       low 18566
-	       high 22887
-	       spanned 4417792
-	       present 4417792
-	       managed 4321635
-               protection [0, 0, 0, 0, 0]
-	 nr_free_pages 0
-	 nr_zone_inactive_anon 35933
-	 nr_zone_active_anon 533154
-	 nr_zone_inactive_file 760769
-	 nr_zone_active_file 513583
-	 nr_zone_unevictable 3105
-	 nr_zone_write_pending 35
-	 nr_mlock 3105
-	 nr_page_table_pages 15186
-	 nr_kernel_stack 12616
-	 nr_bounce 0
-	 nr_zspages 0
-	 nr_free_cma 0
-	 numa_hit 87458144
-	 numa_miss 0
-	 numa_foreign 0
-	 numa_interleave 28603
-	 numa_local 87458144
-	 numa_other 0
+	pages free 2149304
+	      min 14245
+	      low 18566
+	      high 22887
+	      spanned 4417792
+	      present 4417792
+	      managed 4321635
+              protection [0, 0, 0, 0, 0]
+	nr_free_pages 0
+	nr_mlock 3105
+	nr_page_table_pages 15186
+	nr_kernel_stack 12616
+	nr_bounce 0
+	nr_free_cma 0
+	numa_hit 87458144
+	numa_miss 0
+	numa_foreign 0
+	numa_interleave 28603
+	numa_other 0
+	nr_zone_active_anon 533154
+	nr_zone_inactive_file 760769
+	nr_zone_active_file 513583
+	nr_zone_unevictable 3105
+	nr_zone_write_pending 35
+	nr_zspages 0
+	numa_local 87458144
+	nr_zone_inactive_anon 35933
 Node 0, zone    Device
 	 pages free 0
 	       min 0
@@ -919,7 +919,7 @@ Node 0, zone    Device
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]
 Node 0, zone    Movable
 	 pages free 0
 	       min 0
@@ -928,4 +928,4 @@ Node 0, zone    Movable
 	       spanned 0
 	       present 0
 	       managed 0
-               protection [0, 0, 0, 0, 0]
+              protection [0, 0, 0, 0, 0]

--- a/src/pcp/zoneinfo/pcp-zoneinfo.py
+++ b/src/pcp/zoneinfo/pcp-zoneinfo.py
@@ -259,7 +259,7 @@ class ZoneinfoReport(pmcc.MetricGroupPrinter):
                 # these nodes will have only pages information for them so just printing them out
                 remaining_nodes = set(node_types) - set(nodes)
                 if remaining_nodes:
-                    for node in remaining_nodes:
+                    for node in sorted(remaining_nodes):
                         print(self.__format_node_name(node))
                         for key, value in ZONEINFO_PAGE_INFO:
                             print("\t", key, manager.metric_value(value, node))

--- a/src/pcp/zoneinfo/pcp-zoneinfo.py
+++ b/src/pcp/zoneinfo/pcp-zoneinfo.py
@@ -21,14 +21,15 @@ import sys
 import time
 from pcp import pmapi, pmcc
 from cpmapi import PM_CONTEXT_ARCHIVE
+from cpmapi import PM_CONTEXT_HOST
 
-# By default we are assuming we are runnig on the latest pcp version
+# By default we are assuming we are running on the latest pcp version
 # Later will figure out the version and will change the newVersionFlag
 
 newVersionFlag = True
 
-SYS_MECTRICS = ["kernel.uname.sysname","kernel.uname.release",
-               "kernel.uname.nodename","kernel.uname.machine","hinv.ncpu"]
+SYS_METRICS = ["kernel.uname.sysname", "kernel.uname.release",
+               "kernel.uname.nodename", "kernel.uname.machine", "hinv.ncpu"]
 
 ZONESTAT_METRICS = ["mem.zoneinfo.managed", "mem.zoneinfo.nr_mlock", "mem.zoneinfo.present",
                     "mem.zoneinfo.scanned", "mem.zoneinfo.nr_unstable", "mem.zoneinfo.nr_page_table_pages",
@@ -47,16 +48,16 @@ ZONESTAT_METRICS = ["mem.zoneinfo.managed", "mem.zoneinfo.nr_mlock", "mem.zonein
                     "mem.zoneinfo.nr_active_anon", "mem.zoneinfo.workingset_refault", "mem.zoneinfo.nr_dirtied",
                     "mem.zoneinfo.workingset_activate", "mem.zoneinfo.nr_inactive_anon", "mem.zoneinfo.min"]
 
-ZONESTAT_NEW_METRICS= ["mem.zoneinfo.nr_foll_pin_acquired", "mem.zoneinfo.nr_foll_pin_released",
+ZONESTAT_NEW_METRICS = ["mem.zoneinfo.nr_foll_pin_acquired", "mem.zoneinfo.nr_foll_pin_released",
                         "mem.zoneinfo.nr_zspages", "mem.zoneinfo.workingset_restore_anon",
                         "mem.zoneinfo.workingset_refault_anon", "mem.zoneinfo.nr_zone_active_anon",
                         "mem.zoneinfo.nr_zone_inactive_file", "mem.zoneinfo.nr_swapcached",
                         "mem.zoneinfo.nr_file_pmdmapped", "mem.zoneinfo.workingset_active_file",
                         "mem.zoneinfo.workingset_refault_file", "mem.zoneinfo.cma",
-                        "mem.zoneinfo.workingset_active_anon","mem.zoneinfo.nr_zone_write_pending",
+                        "mem.zoneinfo.workingset_active_anon", "mem.zoneinfo.nr_zone_write_pending",
                         "mem.zoneinfo.nr_shmem_pmdmapped", "mem.zoneinfo.nr_shmem_hugepages",
                         "mem.zoneinfo.nr_kernel_misc_reclaimable", "mem.zoneinfo.nr_zone_active_file",
-                        "mem.zoneinfo.nr_file_hugepages","mem.zoneinfo.nr_zone_unevictable",
+                        "mem.zoneinfo.nr_file_hugepages", "mem.zoneinfo.nr_zone_unevictable",
                         "mem.zoneinfo.nr_zone_inactive_anon", "mem.zoneinfo.workingset_restore_file"]
 
 ZONEINFO_PER_NODE = {
@@ -82,6 +83,11 @@ ZONEINFO_PER_NODE = {
     "nr_vmscan_immediate_reclaim"   :   "mem.zoneinfo.nr_vmscan_immediate_reclaim",
     "nr_dirtied"                    :   "mem.zoneinfo.nr_dirtied",
     "nr_written"                    :   "mem.zoneinfo.nr_written",
+    "nr_shmem_hugepages"            :   "mem.zoneinfo.nr_shmem_hugepages",
+    "nr_shmem_pmdmapped"            :   "mem.zoneinfo.nr_shmem_pmdmapped",
+    "nr_file_hugepages"             :   "mem.zoneinfo.nr_file_hugepages",
+    "nr_file_pmdmapped"             :   "mem.zoneinfo.nr_file_pmdmapped",
+    "nr_kernel_misc_reclaimable"    :   "mem.zoneinfo.nr_kernel_misc_reclaimable"
 }
 
 ZONEINFO_PAGE_INFO = [
@@ -106,61 +112,74 @@ ZONEINFO_NUMBER_ZONE    =   {
     "numa_foreign"          :   "mem.zoneinfo.numa_foreign",
     "numa_interleave"       :   "mem.zoneinfo.numa_interleave",
     "numa_other"            :   "mem.zoneinfo.numa_other",
-    }
+    "nr_zone_active_anon"   :   "mem.zoneinfo.nr_zone_active_anon",
+    "nr_zone_inactive_file" :    "mem.zoneinfo.nr_zone_inactive_file",
+    "nr_zone_active_file"   :   "mem.zoneinfo.nr_zone_active_file",
+    "nr_zone_unevictable"   :   "mem.zoneinfo.nr_zone_unevictable",
+    "nr_zone_write_pending" :   "mem.zoneinfo.nr_zone_write_pending",
+    "nr_zspages"            :   "mem.zoneinfo.nr_zspages",
+    "numa_local"            :   "mem.zoneinfo.numa_local",
+    "nr_zone_inactive_anon" :   "mem.zoneinfo.nr_zone_inactive_anon"
+}
+
 
 class ReportingMetricRepository:
 
-    def __init__(self,group):
+    def __init__(self, group):
         self.group = group
         self.current_cached_values = {}
 
-    def __sorted(self,data):
+    def __sorted(self, data):
         return dict(sorted(data.items(), key=lambda item: item[0].lower()))
 
-    def __fetch_current_value(self,metric):
+    def __fetch_current_value(self, metric):
         val = dict(map(lambda x: (x[1], x[2]), self.group[metric].netValues))
         val = self.__sorted(val)
         return dict(val)
 
-    def current_value(self,metric):
+    def current_value(self, metric):
         if metric not in self.group:
             return None
         if self.current_cached_values.get(metric) is None:
-            first_value=self.__fetch_current_value(metric)
-            self.current_cached_values[metric]=first_value
+            first_value = self.__fetch_current_value(metric)
+            self.current_cached_values[metric] = first_value
         return self.current_cached_values[metric]
 
+
 class ZoneStatUtil:
-    def __init__(self,metrics_repository):
-        self.__metric_repository=metrics_repository
-        self.report=ReportingMetricRepository(self.__metric_repository)
+    def __init__(self, metrics_repository):
+        self.__metric_repository = metrics_repository
+        self.report = ReportingMetricRepository(self.__metric_repository)
 
     def names(self):
         data = self.report.current_value('mem.zoneinfo.present')
         return sorted(data.keys())
 
-    def metric_value(self,metric,node):
-        data = self.report.current_value(metric)
-        data = data.get(node,"0")
-        if data != "0":
-            data = data/4
-        return int(data)
+    def metric_value(self, metric, node):
+        if metric in ALL_METRICS:
+            data = self.report.current_value(metric)
+            data = data.get(node, "0")
+            if data != "0":
+                data = data/4
+            return int(data)
+        return None
 
-    #creating the list of protection values for particular node
-    def protection(self,node):
+    # creating the list of protection values for particular node
+    def protection(self, node):
         data = self.report.current_value("mem.zoneinfo.protection")
-        values = [value // 4  for key, value in data.items() if key.startswith(node)]
-        return values
+        return [value // 4 for key, value in data.items() if key.startswith(node)]
 
-    def protection_names(self,node_name):
+    def protection_names(self, node_name):
         data = self.report.current_value("mem.zoneinfo.protection")
-        filtered_nodes = {key.split("::" + node_name)[0] + "::" + node_name for key in data.keys() if node_name in key}
-        if len(filtered_nodes) == 0:
-            filtered_nodes = None
-        return filtered_nodes
+        return {
+            key.split("::" + node_name)[0] + "::" + node_name
+            for key in data.keys()
+            if node_name in key
+        } or None
+
 
 class ZoneinfoReport(pmcc.MetricGroupPrinter):
-    def __init__(self,samples,group,context):
+    def __init__(self, samples, group, context):
         self.samples = samples
         self.group = group
         self.context = context
@@ -183,73 +202,74 @@ class ZoneinfoReport(pmcc.MetricGroupPrinter):
         header_string += context['kernel.uname.machine'].netValues[0][2] + '  '
         print("%s  (%s CPU)" % (header_string, self.__get_ncpu(context)))
 
-    #Function to format the node name as per the /proc/zoneinfo naming convention
-    def __format_node_name(self,input_str):
+    # Function to format the node name as per the /proc/zoneinfo naming convention
+    def __format_node_name(self, input_str):
         parts = input_str.split("::")
-        if len(parts) == 2 and parts[1].startswith("node"):
-            node_num = parts[1][4:]
-            zone_name = parts[0]
-            return "Node {}, zone    {}".format(node_num, zone_name)
-        else:
+        if len(parts) != 2 or not parts[1].startswith("node"):
             return "Invalid input format"
-    def __print_old_version_values(self,manager):
+        node_num = parts[1][4:]
+        return "Node {}, zone    {}".format(node_num, parts[0])
+
+    def __print_old_version_values(self, manager):
         try:
             total_nodes = manager.names()
             total_nodes = sorted(total_nodes, key=lambda
                                  x: ((x.split('::')[0] != 'DMA')*2,  # Move 'DMA' entries to the front
-                                 x.split('::')[0]))
+                                     x.split('::')[0]))
             for node in total_nodes:
                 print(self.__format_node_name(str(node)))
                 print("\tper-node status")
-                for key,value in ZONEINFO_PER_NODE.items():
-                    print ("\t{} {}".format(key,manager.metric_value(value, node)))
+                # print(ZONEINFO_PER_NODE)
+                for key, value in ZONEINFO_PER_NODE.items():
+                    print("\t{} {}".format(key, manager.metric_value(value, node)))
                 for key, value in ZONEINFO_PAGE_INFO:
                     print("\t{} {}".format(key, manager.metric_value(value, node)))
                 print(" " * 14 + "protection " + str([int(i) for i in sorted(manager.protection(node))]))
-                for key,value in ZONEINFO_NUMBER_ZONE.items():
-                    print ("\t{} {}".format(key, manager.metric_value(value, node)))
+                for key, value in ZONEINFO_NUMBER_ZONE.items():
+                    print("\t{} {}".format(key, manager.metric_value(value, node)))
         except IndexError:
             print("Got some error while printing values for old version zoneinfo")
-    def __print_values(self,manager):
+
+    def __print_values(self, manager):
         total_nodes = manager.names()
-        node_names = set(key.split('::')[1] for key in total_nodes)
-        #sort the node names in decreasing order
+        node_names = {key.split('::')[1] for key in total_nodes}
+        # sort the node names in decreasing order
         node_names = sorted(node_names, key=lambda x: int(x[4:]) if x.startswith('node') else float('inf'))
         try:
-            #lopping through all the available nodes
+            # lopping through all the available nodes
             for node_name in node_names:
-                #get all the types available for the current node on which i'm
-                node_types=manager.protection_names(node_name)
+                # get all the types available for the current node on which i'm
+                node_types = manager.protection_names(node_name)
                 if node_types is None:
                     return
                 nodes = set(node_types).intersection(total_nodes)
                 nodes = sorted(nodes, key=lambda x: ((x.split('::')[0] != 'DMA')*2,  # Move 'DMA' entries to the front
-                                                      x.split('::')[0]))
+                                                     x.split('::')[0]))
                 print("NODE {:>2}, per-node status".format(node_name[4:]))
-                for key,value in ZONEINFO_PER_NODE.items():
-                    print ("\t{} {}".format(key, manager.metric_value(value, node_name)))
+                for key, value in ZONEINFO_PER_NODE.items():
+                    print("\t{} {}".format(key, manager.metric_value(value, node_name)))
                 for node in nodes:
                     print(self.__format_node_name(node))
-                    for key,value in ZONEINFO_PAGE_INFO:
-                        print ("\t{} {}".format(key,manager.metric_value(value,node)))
+                    for key, value in ZONEINFO_PAGE_INFO:
+                        print("\t{} {}".format(key, manager.metric_value(value, node)))
                     print(" " * 14 + "protection " + str([int(i) for i in manager.protection(node)]))
-                    for key,value in ZONEINFO_NUMBER_ZONE.items():
-                        print ("\t{} {}".format(key, manager.metric_value(value, node)))
-                #finding the remaining type of nodes data which i haven't printed so far
-                #these nodes will have only pages information for them so just printing them out
+                    for key, value in ZONEINFO_NUMBER_ZONE.items():
+                        print("\t{} {}".format(key, manager.metric_value(value, node)))
+                # finding the remaining type of nodes data which i haven't printed so far
+                # these nodes will have only pages information for them so just printing them out
                 remaining_nodes = set(node_types) - set(nodes)
                 if remaining_nodes:
                     for node in remaining_nodes:
                         print(self.__format_node_name(node))
-                        for key,value in ZONEINFO_PAGE_INFO:
-                            print("\t",key,manager.metric_value(value,node))
+                        for key, value in ZONEINFO_PAGE_INFO:
+                            print("\t", key, manager.metric_value(value, node))
                         print(" " * 14 + "protection " + str([int(i) for i in manager.protection(node)]))
                 else:
                     continue
         except IndexError:
             print("Got some error while printing values for zoneinfo")
 
-    def print_report(self,group,timestamp,header_indentation,value_indentation,manager_zoneinfo):
+    def print_report(self, group, timestamp, manager_zoneinfo):
         def __print_zone_status():
             zonestatus = ZoneStatUtil(manager_zoneinfo)
             if zonestatus.names():
@@ -282,12 +302,12 @@ class ZoneinfoReport(pmcc.MetricGroupPrinter):
         self.samples = opts.pmGetOptionSamples()
         t_s = group.contextCache.pmLocaltime(int(group.timestamp))
         timestamp = time.strftime(ZoneinfoOptions.timefmt, t_s.struct_time())
-        header_indentation = "        " if len(timestamp) < 9 else (len(timestamp) - 7) * " "
-        value_indentation = ((len(header_indentation) + 9) - len(timestamp)) * " "
-        self.print_report(group,timestamp,header_indentation,value_indentation,manager['zoneinfo'])
+        self.print_report(group, timestamp, manager['zoneinfo'])
+
 
 class ZoneinfoOptions(pmapi.pmOptions):
     timefmt = "%H:%M:%S"
+
     def __init__(self):
         pmapi.pmOptions.__init__(self, "a:s:Z:zV?")
         self.pmSetLongOptionHeader("General options")
@@ -298,8 +318,10 @@ class ZoneinfoOptions(pmapi.pmOptions):
         self.pmSetLongOptionVersion()
         self.samples = None
         self.context = None
+
+
 def updateZoneinfoDataToBeFetched():
-    ZONEINFO_NUMBER_ZONE.update({
+    ZoneinfoNumberZoneElementsToBeRemoved = {
         "nr_zone_active_anon"           :   "mem.zoneinfo.nr_zone_active_anon",
         "nr_zone_inactive_file"         :    "mem.zoneinfo.nr_zone_inactive_file",
         "nr_zone_active_file"           :   "mem.zoneinfo.nr_zone_active_file",
@@ -308,48 +330,48 @@ def updateZoneinfoDataToBeFetched():
         "nr_zspages"                    :   "mem.zoneinfo.nr_zspages",
         "numa_local"                    :   "mem.zoneinfo.numa_local",
         "nr_zone_inactive_anon"         :   "mem.zoneinfo.nr_zone_inactive_anon"
-        })
-    ZONEINFO_PER_NODE.update({
+    }
+
+    ZoneinfoPerNodeElementsToBeRemoved = {
         "nr_shmem_hugepages"            :   "mem.zoneinfo.nr_shmem_hugepages",
         "nr_shmem_pmdmapped"            :   "mem.zoneinfo.nr_shmem_pmdmapped",
         "nr_file_hugepages"             :   "mem.zoneinfo.nr_file_hugepages",
         "nr_file_pmdmapped"             :   "mem.zoneinfo.nr_file_pmdmapped",
         "nr_kernel_misc_reclaimable"    :   "mem.zoneinfo.nr_kernel_misc_reclaimable"
-    })
+    }
+
+    for key in ZoneinfoNumberZoneElementsToBeRemoved:
+        del ZONEINFO_NUMBER_ZONE[key]
+
+    for key in ZoneinfoPerNodeElementsToBeRemoved:
+        del ZONEINFO_PER_NODE[key]
+
 
 
 if __name__ == '__main__':
     try:
         opts = ZoneinfoOptions()
-        mngr = pmcc.MetricGroupManager.builder(opts,sys.argv)
+        mngr = pmcc.MetricGroupManager.builder(opts, sys.argv)
         opts.context = mngr.type
+        ZONESTAT_METRICS = ZONESTAT_METRICS + ZONESTAT_NEW_METRICS
 
-        # After this VERSION new zoneifo metric has been introduced so checking the current version,
-        # if it is the latest version of pcp then get all the data otherwise drop the metrics
-        # which will not be there in older version.
-        # this change make pcp-zoneinfo comptabile with rhel7 and ol7 where VERSION 4.x.x being used.
-        VERSION="5.0.0"
-        current_version=pmapi.pmContext.pmGetConfig("PCP_VERSION")
-
-        if VERSION >= current_version:
-            newVersionFlag=False
-
-        if newVersionFlag:
-            ALL_METRICS= ZONESTAT_METRICS + ZONESTAT_NEW_METRICS + SYS_MECTRICS
-            ZONESTAT_METRICS = ZONESTAT_NEW_METRICS + ZONESTAT_METRICS
+        if opts.context == PM_CONTEXT_HOST:
+            context = pmapi.pmContext(opts.context)
+        elif opts.context == PM_CONTEXT_ARCHIVE:
+            context = pmapi.pmContext.fromOptions(opts,sys.argv)
+        try:
+            metric_ids =context.pmLookupName(ZONESTAT_METRICS)
+            descs= context.pmLookupDescs(metric_ids)
+        except pmapi.pmErr as error:
+            newVersionFlag = False
             updateZoneinfoDataToBeFetched()
-        else:
-            ALL_METRICS= ZONESTAT_METRICS + SYS_MECTRICS
+            ZONESTAT_METRICS = [x for x in ZONESTAT_METRICS if x not in ZONESTAT_NEW_METRICS]
 
-        missing = mngr.checkMissingMetrics(ALL_METRICS)
-        if missing is not None:
-            sys.stderr.write("\nError:some metrics are unavailable ".join(missing) + '\n')
-            sys.exit(1)
-
+        ALL_METRICS = ZONESTAT_METRICS + SYS_METRICS
         mngr["zoneinfo"] = ZONESTAT_METRICS
-        mngr["sysinfo"] = SYS_MECTRICS
+        mngr["sysinfo"] = SYS_METRICS
         mngr["allinfo"] = ALL_METRICS
-        mngr.printer = ZoneinfoReport(opts.samples,mngr,opts.context)
+        mngr.printer = ZoneinfoReport(opts.samples, mngr, opts.context)
         sts = mngr.run()
         sys.exit(sts)
     except pmapi.pmErr as error:

--- a/src/pcp/zoneinfo/pcp-zoneinfo.py
+++ b/src/pcp/zoneinfo/pcp-zoneinfo.py
@@ -22,37 +22,42 @@ import time
 from pcp import pmapi, pmcc
 from cpmapi import PM_CONTEXT_ARCHIVE
 
+# By default we are assuming we are runnig on the latest pcp version
+# Later will figure out the version and will change the newVersionFlag
+
+newVersionFlag = True
+
 SYS_MECTRICS = ["kernel.uname.sysname","kernel.uname.release",
                "kernel.uname.nodename","kernel.uname.machine","hinv.ncpu"]
 
-ZONESTAT_METRICS = [ "mem.zoneinfo.free","mem.zoneinfo.min","mem.zoneinfo.low","mem.zoneinfo.high",
-                    "mem.zoneinfo.scanned","mem.zoneinfo.spanned","mem.zoneinfo.present","mem.zoneinfo.managed",
-                    "mem.zoneinfo.nr_free_pages","mem.zoneinfo.nr_alloc_batch","mem.zoneinfo.nr_inactive_anon",
-                    "mem.zoneinfo.nr_active_anon","mem.zoneinfo.nr_inactive_file","mem.zoneinfo.nr_active_file",
-                    "mem.zoneinfo.nr_unevictable","mem.zoneinfo.nr_mlock","mem.zoneinfo.nr_anon_pages",
-                    "mem.zoneinfo.nr_mapped","mem.zoneinfo.nr_file_pages","mem.zoneinfo.nr_dirty",
-                    "mem.zoneinfo.nr_writeback","mem.zoneinfo.nr_slab_reclaimable","mem.zoneinfo.nr_slab_unreclaimable",
-                    "mem.zoneinfo.nr_page_table_pages","mem.zoneinfo.nr_kernel_stack","mem.zoneinfo.nr_unstable",
-                    "mem.zoneinfo.nr_bounce","mem.zoneinfo.nr_vmscan_write","mem.zoneinfo.nr_vmscan_immediate_reclaim",
-                    "mem.zoneinfo.nr_writeback_temp","mem.zoneinfo.nr_isolated_anon","mem.zoneinfo.nr_isolated_file",
-                    "mem.zoneinfo.nr_shmem","mem.zoneinfo.nr_dirtied","mem.zoneinfo.nr_written","mem.zoneinfo.numa_hit",
-                    "mem.zoneinfo.numa_miss","mem.zoneinfo.numa_foreign","mem.zoneinfo.numa_interleave",
-                    "mem.zoneinfo.numa_local","mem.zoneinfo.numa_other","mem.zoneinfo.workingset_refault",
-                    "mem.zoneinfo.workingset_activate","mem.zoneinfo.workingset_nodereclaim",
-                    "mem.zoneinfo.nr_anon_transparent_hugepages","mem.zoneinfo.nr_free_cma","mem.zoneinfo.cma",
-                    "mem.zoneinfo.nr_swapcached","mem.zoneinfo.nr_shmem_hugepages","mem.zoneinfo.nr_shmem_pmdmapped",
-                    "mem.zoneinfo.nr_file_hugepages","mem.zoneinfo.nr_file_pmdmapped",
-                    "mem.zoneinfo.nr_kernel_misc_reclaimable","mem.zoneinfo.nr_foll_pin_acquired",
-                    "mem.zoneinfo.nr_foll_pin_released","mem.zoneinfo.workingset_refault_anon",
-                    "mem.zoneinfo.workingset_refault_file","mem.zoneinfo.workingset_active_anon",
-                    "mem.zoneinfo.workingset_active_file","mem.zoneinfo.workingset_restore_anon",
-                    "mem.zoneinfo.workingset_restore_file","mem.zoneinfo.nr_zspages",
-                    "mem.zoneinfo.nr_zone_inactive_file","mem.zoneinfo.nr_zone_active_file",
-                    "mem.zoneinfo.nr_zone_inactive_anon","mem.zoneinfo.nr_zone_active_anon",
-                    "mem.zoneinfo.nr_zone_unevictable","mem.zoneinfo.nr_zone_write_pending",
-                    "mem.zoneinfo.protection" ]
+ZONESTAT_METRICS = ["mem.zoneinfo.managed", "mem.zoneinfo.nr_mlock", "mem.zoneinfo.present",
+                    "mem.zoneinfo.scanned", "mem.zoneinfo.nr_unstable", "mem.zoneinfo.nr_page_table_pages",
+                    "mem.zoneinfo.nr_shmem", "mem.zoneinfo.nr_free_pages", "mem.zoneinfo.nr_active_file",
+                    "mem.zoneinfo.nr_dirty", "mem.zoneinfo.nr_writeback", "mem.zoneinfo.free",
+                    "mem.zoneinfo.nr_unevictable", "mem.zoneinfo.nr_alloc_batch", "mem.zoneinfo.low",
+                    "mem.zoneinfo.nr_slab_reclaimable", "mem.zoneinfo.nr_kernel_stack", "mem.zoneinfo.numa_interleave",
+                    "mem.zoneinfo.workingset_nodereclaim", "mem.zoneinfo.nr_isolated_anon", "mem.zoneinfo.nr_bounce",
+                    "mem.zoneinfo.numa_other", "mem.zoneinfo.nr_file_pages", "mem.zoneinfo.numa_hit",
+                    "mem.zoneinfo.nr_isolated_file", "mem.zoneinfo.nr_anon_transparent_hugepages",
+                    "mem.zoneinfo.nr_inactive_file", "mem.zoneinfo.spanned", "mem.zoneinfo.nr_written",
+                    "mem.zoneinfo.numa_foreign", "mem.zoneinfo.nr_vmscan_write", "mem.zoneinfo.nr_free_cma",
+                    "mem.zoneinfo.nr_writeback_temp", "mem.zoneinfo.nr_slab_unreclaimable",
+                    "mem.zoneinfo.nr_vmscan_immediate_reclaim", "mem.zoneinfo.nr_mapped", "mem.zoneinfo.nr_anon_pages",
+                    "mem.zoneinfo.high", "mem.zoneinfo.protection", "mem.zoneinfo.numa_local", "mem.zoneinfo.numa_miss",
+                    "mem.zoneinfo.nr_active_anon", "mem.zoneinfo.workingset_refault", "mem.zoneinfo.nr_dirtied",
+                    "mem.zoneinfo.workingset_activate", "mem.zoneinfo.nr_inactive_anon", "mem.zoneinfo.min"]
 
-ALL_METRICS = ZONESTAT_METRICS + SYS_MECTRICS
+ZONESTAT_NEW_METRICS= ["mem.zoneinfo.nr_foll_pin_acquired", "mem.zoneinfo.nr_foll_pin_released",
+                        "mem.zoneinfo.nr_zspages", "mem.zoneinfo.workingset_restore_anon",
+                        "mem.zoneinfo.workingset_refault_anon", "mem.zoneinfo.nr_zone_active_anon",
+                        "mem.zoneinfo.nr_zone_inactive_file", "mem.zoneinfo.nr_swapcached",
+                        "mem.zoneinfo.nr_file_pmdmapped", "mem.zoneinfo.workingset_active_file",
+                        "mem.zoneinfo.workingset_refault_file", "mem.zoneinfo.cma",
+                        "mem.zoneinfo.workingset_active_anon","mem.zoneinfo.nr_zone_write_pending",
+                        "mem.zoneinfo.nr_shmem_pmdmapped", "mem.zoneinfo.nr_shmem_hugepages",
+                        "mem.zoneinfo.nr_kernel_misc_reclaimable", "mem.zoneinfo.nr_zone_active_file",
+                        "mem.zoneinfo.nr_file_hugepages","mem.zoneinfo.nr_zone_unevictable",
+                        "mem.zoneinfo.nr_zone_inactive_anon", "mem.zoneinfo.workingset_restore_file"]
 
 ZONEINFO_PER_NODE = {
     "nr_inactive_anon"              :   "mem.zoneinfo.nr_inactive_anon",
@@ -71,50 +76,37 @@ ZONEINFO_PER_NODE = {
     "nr_writeback"                  :   "mem.zoneinfo.nr_writeback",
     "nr_writeback_temp"             :   "mem.zoneinfo.nr_writeback_temp",
     "nr_shmem"                      :   "mem.zoneinfo.nr_shmem",
-    "nr_shmem_hugepages"            :   "mem.zoneinfo.nr_shmem_hugepages",
-    "nr_shmem_pmdmapped"            :   "mem.zoneinfo.nr_shmem_pmdmapped",
-    "nr_file_hugepages"             :   "mem.zoneinfo.nr_file_hugepages",
-    "nr_file_pmdmapped"             :   "mem.zoneinfo.nr_file_pmdmapped",
     "nr_anon_transparent_hugepages" :   "mem.zoneinfo.nr_anon_transparent_hugepages",
     "nr_unstable"                   :   "mem.zoneinfo.nr_unstable",
     "nr_vmscan_write"               :   "mem.zoneinfo.nr_vmscan_write",
     "nr_vmscan_immediate_reclaim"   :   "mem.zoneinfo.nr_vmscan_immediate_reclaim",
     "nr_dirtied"                    :   "mem.zoneinfo.nr_dirtied",
     "nr_written"                    :   "mem.zoneinfo.nr_written",
-    "nr_kernel_misc_reclaimable"    :   "mem.zoneinfo.nr_kernel_misc_reclaimable"
 }
 
-ZONEINFO_PAGE_INFO  = {
-    "pages free"    :   "mem.zoneinfo.free",
-    "      min"     :   "mem.zoneinfo.min",
-    "      low"     :   "mem.zoneinfo.low",
-    "      high"    :   "mem.zoneinfo.high",
-    "      spanned" :   "mem.zoneinfo.spanned",
-    "      present" :   "mem.zoneinfo.present",
-    "      managed" :   "mem.zoneinfo.managed"
-}
+ZONEINFO_PAGE_INFO = [
+        ("pages free"   ,   "mem.zoneinfo.free"),
+        ("      min"    ,   "mem.zoneinfo.min"),
+        ("      low"    ,   "mem.zoneinfo.low"),
+        ("      high"   ,   "mem.zoneinfo.high"),
+        ("      spanned",   "mem.zoneinfo.spanned"),
+        ("      present",   "mem.zoneinfo.present"),
+        ("      managed",   "mem.zoneinfo.managed")
+]
 
 ZONEINFO_NUMBER_ZONE    =   {
     "nr_free_pages"         :   "mem.zoneinfo.nr_free_pages",
-    "nr_zone_inactive_anon" :   "mem.zoneinfo.nr_zone_inactive_anon",
-    "nr_zone_active_anon"   :   "mem.zoneinfo.nr_zone_active_anon",
-    "nr_zone_inactive_file" :   "mem.zoneinfo.nr_zone_inactive_file",
-    "nr_zone_active_file"   :   "mem.zoneinfo.nr_zone_active_file",
-    "nr_zone_unevictable"   :   "mem.zoneinfo.nr_zone_unevictable",
-    "nr_zone_write_pending" :   "mem.zoneinfo.nr_zone_write_pending",
     "nr_mlock"              :   "mem.zoneinfo.nr_mlock",
     "nr_page_table_pages"   :   "mem.zoneinfo.nr_page_table_pages",
     "nr_kernel_stack"       :   "mem.zoneinfo.nr_kernel_stack",
     "nr_bounce"             :   "mem.zoneinfo.nr_bounce",
-    "nr_zspages"            :   "mem.zoneinfo.nr_zspages",
     "nr_free_cma"           :   "mem.zoneinfo.nr_free_cma",
     "numa_hit"              :   "mem.zoneinfo.numa_hit",
     "numa_miss"             :   "mem.zoneinfo.numa_miss",
     "numa_foreign"          :   "mem.zoneinfo.numa_foreign",
     "numa_interleave"       :   "mem.zoneinfo.numa_interleave",
-    "numa_local"            :   "mem.zoneinfo.numa_local",
-    "numa_other"            :   "mem.zoneinfo.numa_other"
-}
+    "numa_other"            :   "mem.zoneinfo.numa_other",
+    }
 
 class ReportingMetricRepository:
 
@@ -162,10 +154,7 @@ class ZoneStatUtil:
 
     def protection_names(self,node_name):
         data = self.report.current_value("mem.zoneinfo.protection")
-        filtered_nodes = {
-            key.split("::" + node_name)[0] + "::" +
-            node_name for key in sorted(data.keys()) if node_name in key
-        }
+        filtered_nodes = {key.split("::" + node_name)[0] + "::" + node_name for key in data.keys() if node_name in key}
         if len(filtered_nodes) == 0:
             filtered_nodes = None
         return filtered_nodes
@@ -203,8 +192,25 @@ class ZoneinfoReport(pmcc.MetricGroupPrinter):
             return "Node {}, zone    {}".format(node_num, zone_name)
         else:
             return "Invalid input format"
-
-    def __print_values(self,timestamp,header_indentation,value_indentation,manager):
+    def __print_old_version_values(self,manager):
+        try:
+            total_nodes = manager.names()
+            total_nodes = sorted(total_nodes, key=lambda
+                                 x: ((x.split('::')[0] != 'DMA')*2,  # Move 'DMA' entries to the front
+                                 x.split('::')[0]))
+            for node in total_nodes:
+                print(self.__format_node_name(str(node)))
+                print("\tper-node status")
+                for key,value in ZONEINFO_PER_NODE.items():
+                    print ("\t{} {}".format(key,manager.metric_value(value, node)))
+                for key, value in ZONEINFO_PAGE_INFO:
+                    print("\t{} {}".format(key, manager.metric_value(value, node)))
+                print(" " * 14 + "protection " + str([int(i) for i in sorted(manager.protection(node))]))
+                for key,value in ZONEINFO_NUMBER_ZONE.items():
+                    print ("\t{} {}".format(key, manager.metric_value(value, node)))
+        except IndexError:
+            print("Got some error while printing values for old version zoneinfo")
+    def __print_values(self,manager):
         total_nodes = manager.names()
         node_names = set(key.split('::')[1] for key in total_nodes)
         #sort the node names in decreasing order
@@ -217,32 +223,31 @@ class ZoneinfoReport(pmcc.MetricGroupPrinter):
                 if node_types is None:
                     return
                 nodes = set(node_types).intersection(total_nodes)
-                print("NODE {:>2},".format(node_name[4:]),"per-node status")
+                nodes = sorted(nodes, key=lambda x: ((x.split('::')[0] != 'DMA')*2,  # Move 'DMA' entries to the front
+                                                      x.split('::')[0]))
+                print("NODE {:>2}, per-node status".format(node_name[4:]))
                 for key,value in ZONEINFO_PER_NODE.items():
-                    print ("\t",key,manager.metric_value(value,node_name))
-                for node in sorted(nodes):
+                    print ("\t{} {}".format(key, manager.metric_value(value, node_name)))
+                for node in nodes:
                     print(self.__format_node_name(node))
-                    for key,value in ZONEINFO_PAGE_INFO.items():
-                        print("\t",key,manager.metric_value(value,node))
-                    print(" "*14,"protection",manager.protection(node))
+                    for key,value in ZONEINFO_PAGE_INFO:
+                        print ("\t{} {}".format(key,manager.metric_value(value,node)))
+                    print(" " * 14 + "protection " + str([int(i) for i in manager.protection(node)]))
                     for key,value in ZONEINFO_NUMBER_ZONE.items():
-                        print ("\t",key,manager.metric_value(value,node))
+                        print ("\t{} {}".format(key, manager.metric_value(value, node)))
                 #finding the remaining type of nodes data which i haven't printed so far
                 #these nodes will have only pages information for them so just printing them out
-                remaining_nodes = set(node_types) - nodes
+                remaining_nodes = set(node_types) - set(nodes)
                 if remaining_nodes:
-                    for node in sorted(remaining_nodes):
+                    for node in remaining_nodes:
                         print(self.__format_node_name(node))
-                        for key,value in ZONEINFO_PAGE_INFO.items():
+                        for key,value in ZONEINFO_PAGE_INFO:
                             print("\t",key,manager.metric_value(value,node))
-                        print(" "*14,"protection",manager.protection(node))
+                        print(" " * 14 + "protection " + str([int(i) for i in manager.protection(node)]))
                 else:
                     continue
         except IndexError:
             print("Got some error while printing values for zoneinfo")
-
-
-
 
     def print_report(self,group,timestamp,header_indentation,value_indentation,manager_zoneinfo):
         def __print_zone_status():
@@ -250,8 +255,11 @@ class ZoneinfoReport(pmcc.MetricGroupPrinter):
             if zonestatus.names():
                 try:
                     self.__print_machine_info(group)
-                    print("TimeStamp = ",timestamp)
-                    self.__print_values(timestamp, header_indentation, value_indentation, zonestatus)
+                    print("TimeStamp = {}".format(timestamp))
+                    if newVersionFlag:
+                        self.__print_values(zonestatus)
+                    else:
+                        self.__print_old_version_values(zonestatus)
                 except IndexError:
                     print("Incorrect machine info due to some missing metrics")
                 return
@@ -290,16 +298,54 @@ class ZoneinfoOptions(pmapi.pmOptions):
         self.pmSetLongOptionVersion()
         self.samples = None
         self.context = None
+def updateZoneinfoDataToBeFetched():
+    ZONEINFO_NUMBER_ZONE.update({
+        "nr_zone_active_anon"           :   "mem.zoneinfo.nr_zone_active_anon",
+        "nr_zone_inactive_file"         :    "mem.zoneinfo.nr_zone_inactive_file",
+        "nr_zone_active_file"           :   "mem.zoneinfo.nr_zone_active_file",
+        "nr_zone_unevictable"           :   "mem.zoneinfo.nr_zone_unevictable",
+        "nr_zone_write_pending"         :   "mem.zoneinfo.nr_zone_write_pending",
+        "nr_zspages"                    :   "mem.zoneinfo.nr_zspages",
+        "numa_local"                    :   "mem.zoneinfo.numa_local",
+        "nr_zone_inactive_anon"         :   "mem.zoneinfo.nr_zone_inactive_anon"
+        })
+    ZONEINFO_PER_NODE.update({
+        "nr_shmem_hugepages"            :   "mem.zoneinfo.nr_shmem_hugepages",
+        "nr_shmem_pmdmapped"            :   "mem.zoneinfo.nr_shmem_pmdmapped",
+        "nr_file_hugepages"             :   "mem.zoneinfo.nr_file_hugepages",
+        "nr_file_pmdmapped"             :   "mem.zoneinfo.nr_file_pmdmapped",
+        "nr_kernel_misc_reclaimable"    :   "mem.zoneinfo.nr_kernel_misc_reclaimable"
+    })
+
 
 if __name__ == '__main__':
     try:
         opts = ZoneinfoOptions()
         mngr = pmcc.MetricGroupManager.builder(opts,sys.argv)
         opts.context = mngr.type
+
+        # After this VERSION new zoneifo metric has been introduced so checking the current version,
+        # if it is the latest version of pcp then get all the data otherwise drop the metrics
+        # which will not be there in older version.
+        # this change make pcp-zoneinfo comptabile with rhel7 and ol7 where VERSION 4.x.x being used.
+        VERSION="5.0.0"
+        current_version=pmapi.pmContext.pmGetConfig("PCP_VERSION")
+
+        if VERSION >= current_version:
+            newVersionFlag=False
+
+        if newVersionFlag:
+            ALL_METRICS= ZONESTAT_METRICS + ZONESTAT_NEW_METRICS + SYS_MECTRICS
+            ZONESTAT_METRICS = ZONESTAT_NEW_METRICS + ZONESTAT_METRICS
+            updateZoneinfoDataToBeFetched()
+        else:
+            ALL_METRICS= ZONESTAT_METRICS + SYS_MECTRICS
+
         missing = mngr.checkMissingMetrics(ALL_METRICS)
         if missing is not None:
             sys.stderr.write("\nError:some metrics are unavailable ".join(missing) + '\n')
             sys.exit(1)
+
         mngr["zoneinfo"] = ZONESTAT_METRICS
         mngr["sysinfo"] = SYS_MECTRICS
         mngr["allinfo"] = ALL_METRICS


### PR DESCRIPTION
The requirement of __print_old_version_values is because the older version of PCP metrics is giving data for movable zones also. For eg:- In an older version
$ pminfo -f mem.zoneinfo.nr_vmscan_write
mem.zoneinfo.nr_vmscan_write
    inst [0 or "DMA::node0"] value 0
    inst [1 or "DMA32::node0"] value 0
    inst [2 or "Normal::node0"] value 0
    inst [3 or "Movable::node0"] value 0
    inst [4 or "Device::node0"] value 0
$ pcp --version
pcp version 4.3.2
$

but with the latest version
$ pminfo -f mem.zoneinfo.nr_vmscan_write

mem.zoneinfo.nr_vmscan_write
    inst [0 or "node0"] value 0
$ pcp --version
pcp version 6.1.1
$
So to make it consistent we have implemented new print function  


