### PR TITLE
pmdagfs2: Correct permissions in makefile (v2)

### DIFF
--- a/src/pmdas/gfs2/GNUmakefile
+++ b/src/pmdas/gfs2/GNUmakefile
@@ -47,9 +47,9 @@ build-me: $(CMDTARGET) $(LIBTARGET)
 
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
-	$(INSTALL) -m 775 -d $(PMDATMPDIR)
+	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR) root pmns domain.h help $(PMDAADMDIR)
-	$(INSTALL) -m 775 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(SCRIPTS) $(PMDAADMDIR)
+	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(SCRIPTS) $(PMDAADMDIR)
 	@$(INSTALL_MAN)
 else
 build-me:


### PR DESCRIPTION
Correct permissions to 755 instead of 775 in makefile for GFS2 PMDA.