### PR TITLE
build: default to using a path-prefixed PCP_PYTHON_PROG

### DIFF
--- a/configure
+++ b/configure
@@ -8259,14 +8259,16 @@ do
 set dummy $ac_prog; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_PYTHON+y}
+if test ${ac_cv_path_PYTHON+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  if test -n "$PYTHON"; then
-  ac_cv_prog_PYTHON="$PYTHON" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+  case $PYTHON in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_PYTHON="$PYTHON" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
@@ -8277,7 +8279,7 @@ do
   esac
     for ac_exec_ext in '' $ac_executable_extensions; do
   if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_prog_PYTHON="$ac_prog"
+    ac_cv_path_PYTHON="$as_dir$ac_word$ac_exec_ext"
     printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
     break 2
   fi
@@ -8285,9 +8287,10 @@ done
   done
 IFS=$as_save_IFS
 
+  ;;
+esac
 fi
-fi
-PYTHON=$ac_cv_prog_PYTHON
+PYTHON=$ac_cv_path_PYTHON
 if test -n "$PYTHON"; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PYTHON" >&5
 printf "%s\n" "$PYTHON" >&6; }
@@ -8308,14 +8311,16 @@ do
 set dummy $ac_prog; ac_word=$2
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_PYTHON3+y}
+if test ${ac_cv_path_PYTHON3+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  if test -n "$PYTHON3"; then
-  ac_cv_prog_PYTHON3="$PYTHON3" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+  case $PYTHON3 in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_PYTHON3="$PYTHON3" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
@@ -8326,7 +8331,7 @@ do
   esac
     for ac_exec_ext in '' $ac_executable_extensions; do
   if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_prog_PYTHON3="$ac_prog"
+    ac_cv_path_PYTHON3="$as_dir$ac_word$ac_exec_ext"
     printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
     break 2
   fi
@@ -8334,9 +8339,10 @@ done
   done
 IFS=$as_save_IFS
 
+  ;;
+esac
 fi
-fi
-PYTHON3=$ac_cv_prog_PYTHON3
+PYTHON3=$ac_cv_path_PYTHON3
 if test -n "$PYTHON3"; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PYTHON3" >&5
 printf "%s\n" "$PYTHON3" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -869,11 +869,11 @@ AC_CHECK_PROGS(PYLINT, pylint, /bin/true)
 AC_SUBST(PYLINT)
 
 dnl check if python available for the build and runtime
-AC_CHECK_PROGS(PYTHON, [/usr/bin/python2 python2 python2.7 python])
+AC_PATH_PROGS(PYTHON, [/usr/bin/python2 python2 python2.7 python])
 AC_SUBST(PYTHON)
 
 dnl check if python3 available for the build and runtime
-AC_CHECK_PROGS(PYTHON3, [/usr/bin/python3 python3])
+AC_PATH_PROGS(PYTHON3, [/usr/bin/python3 python3])
 AC_SUBST(PYTHON3)
 
 dnl check availability of Python header files


### PR DESCRIPTION
This corrects an earlier change which attempted this but used the wrong autoconf macro.  Fix both python2 and 3 - reported issue is only for py3 however py2 is wrong too.

Resolves Red Hat BZ #2227011