### PR TITLE
Allow pcp-pmproxy read and write to the io_uring api

### DIFF
--- a/src/selinux/pcp.te
+++ b/src/selinux/pcp.te
@@ -225,6 +225,9 @@ optional_policy(`
     allow pcp_pmproxy_t self:io_uring { sqpoll };
 ')
 
+ifdef(`kernel_io_uring_use',`
+	kernel_io_uring_use(pcp_pmproxy_t)
+')
 kernel_search_network_sysctl(pcp_pmproxy_t)
 
 logging_send_syslog_msg(pcp_pmproxy_t)


### PR DESCRIPTION
With the 65b9e0bdceb ("Implement proper anon_inode support") selinux-policy commit, individual SELinux types are used for each anon_inode type, so domains using any of them need corresponding allow rules.