### PR TITLE
Update fedora container to 38

### DIFF
--- a/build/containers/archive-analysis/Dockerfile
+++ b/build/containers/archive-analysis/Dockerfile
@@ -1,5 +1,5 @@
 ## Build
-FROM registry.fedoraproject.org/fedora:36 AS build
+FROM registry.fedoraproject.org/fedora:38 AS build
 COPY . /usr/src/pcp
 
 WORKDIR /usr/src/pcp
@@ -18,7 +18,7 @@ RUN mkdir /build && \
       /build
 
 ## Deploy
-FROM registry.fedoraproject.org/fedora:36
+FROM registry.fedoraproject.org/fedora:38
 COPY --from=build /build /build
 
 RUN dnf install -y --setopt=tsflags=nodocs procps-ng gettext /build/*.rpm redis grafana grafana-pcp && \


### PR DESCRIPTION
Updates the base image for the fedora container from 36 to 38 as 36 is out of support.