### PR TITLE
libpcp_web: implement config override by canonical env vars

### DIFF
--- a/man/man1/pmseries.1
+++ b/man/man1/pmseries.1
@@ -721,6 +721,13 @@ then a short-hand form can be used:
 .SAMPLE
 $ pmseries --load $PCP_LOG_DIR/pmlogger/acme.0
 .ESAMPLE
+.PP
+NOTE: Timeseries loading is
+.B append-only
+(timestamp-wise) and if more than
+.B stream.maxlen
+entries (defined in /etc/pcp/pmproxy/pmproxy.conf) are loaded for
+a given metric, the oldest entries are dropped.
 .SH OPTIONS
 The available command line options, in addition to timeseries
 metadata and sources options described above, are:


### PR DESCRIPTION
======== Commit message ========
~~~
Extending utility of PCP_* environment variables to be generally
usable to override settings detected via libpcp_web config.c

Introduces canonical form of config options as:
    "PCP_<SECTION|GROUP>_<OPTION|KEY>"
where dots '.' are represented as underscores '_'.

Example usage:
    $ export PCP_PMSERIERS_STREAM_MAXLEN=424242
    $ pmseries --load <archive> -Dlibweb
    ...
    pmIniFileParse set pmseries.stream.maxlen = 424242

Primary motivation was to create an easy and convenient way to
to adjust configuration inside the archive-analysis container.
~~~
========= Extra info ===========

The archive analysis container uses `pmseries --load` to add the archive data into the Redis DB. However it always passes the optional MAXLEN parameter to Redis XADD command (see `src/libpcp_web/src/schema.c`), which limits the number of entries per loaded metric.

This can be inconvenient when loading more than 1 day worth of PCP data (for example all-default pmlogger archives).

The used MAXLEN parameter passed to Redis XADD is taken from pmproxy.conf file as `stream.maxlen`. (default = 86400 ~= 1 day)

======== PR content notes ========

This PR contains two commits:
1) Note down this limitation to pmseries(1) man page (I spent many hours investigating source code to figure this out - ref https://github.com/performancecopilot/pcp/issues/1706 - while such a simple note in man page would have saved all that time)
2) Enchance libpcp_web config detection to check for canonical ENV variables that override set configuration. (see commit message)
