### PR TITLE
denki: derived metrics assigning power draw to individual processes

### DIFF
--- a/src/derived/denki.conf
+++ b/src/derived/denki.conf
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2023, Red Hat.
+#
+# This file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+#
+# Denki (power) derived metrics
+# These derived metrics use RAPL hardware metrics to assign power usage
+# to processes based on the processor and memory power draw metrics.
+#
+proc.denki.cpu = scalar((rate(denki.rapl.raw))[core]) * (rate(proc.psinfo.utime) + rate(proc.psinfo.stime)) / (kernel.all.uptime - proc.psinfo.start_time)
+proc.denki.cpu(oneline) = Power used for processors by individual processes
+proc.denki.cpu(helptext) = '\
+Power used (in watts) by processors, broken down by individual
+processes based on RAPL hardware metrics from x86_64 machines.'
+
+proc.denki.mem = scalar((rate(denki.rapl.raw))[dram]) * (proc.memory.vmrss / (mem.util.other - mem.util.shmem - mem.util.slab - mem.util.vmallocUsed - mem.util.hugepagesTotalBytes))
+proc.denki.mem(oneline) = Power used for memory by individual processes
+proc.denki.mem(helptext) = '\
+Power used (in watts) by memory for individual processes.  This
+calculation is based on using RAPL hardware metrics from x86_64
+machines and resident set size (RSS) for each running process.'


### PR DESCRIPTION
Denki (power) derived metrics, based on discussion with Christian Horn over the last few weeks.

These derived metrics use RAPL hardware metrics to assign power usage to processes based on the processor and memory power draw metrics.