### PR TITLE
Update libpcp_archive.pc.in

### DIFF
--- a/src/libpcp_archive/src/libpcp_archive.pc.in
+++ b/src/libpcp_archive/src/libpcp_archive.pc.in
@@ -3,8 +3,8 @@ exec_prefix=@PREFIX@
 libdir=@LIBDIR@
 includedir=@INCDIR@
 
-Name: libpcp_arch
+Name: libpcp_archive
 Description: The Performance Co-Pilot archive writer library
 Version: @VERSION@
-Libs: -L${libdir} -lpcp_arch -lpcp
+Libs: -L${libdir} -lpcp_archive -lpcp
 Cflags: -I${includedir}


### PR DESCRIPTION
The Name and Libs fields reference lib_arch but the filename of the the library is libpcp_archive. Correct the fields to match the filename