### PR TITLE
pmdadenki: ensure copied env var string termination (covscan)

### DIFF
--- a/src/pmdas/denki/denki.c
+++ b/src/pmdas/denki/denki.c
@@ -317,10 +317,6 @@ static int read_batteries(void) {
 				pmNotifyErr(LOG_DEBUG, "Could not read %s.",filename);
 		fclose(fff);
 	
-		// correct power_now, if we got a negative value
-		if ( power_now[bat]<0 )
-			power_now[bat]*=-1.0;
-
 		// capacity
 		pmsprintf(filename,sizeof(filename),"%s/capacity",battery_basepath[bat]);
 		fff=fopen(filename,"r");

--- a/src/pmdas/denki/denki.c
+++ b/src/pmdas/denki/denki.c
@@ -687,8 +687,8 @@ denki_init(pmdaInterface *dp)
 	     * DENKI_SYSPATH in the environment
 	     */
 	    char	*envpath = getenv("DENKI_SYSPATH");
-	    if (envpath != NULL)
-		strcpy(rootpath, envpath);
+	    if (envpath)
+		pmsprintf(rootpath, sizeof(rootpath), "%s", envpath);
 	}
 	pmsprintf(mypath, sizeof(mypath), "%s%c" "denki" "%c" "help",
 		pmGetConfig("PCP_PMDAS_DIR"), sep, sep);
@@ -751,8 +751,7 @@ main(int argc, char **argv)
     while ((c = pmdaGetOptions(argc, argv, &opts, &dispatch)) != EOF) {
         switch (c) {
 	        case 'r':
-        		strncpy(rootpath, opts.optarg, sizeof(rootpath));
-			rootpath[sizeof(rootpath)-1] = '\0';
+			pmsprintf(rootpath, sizeof(rootpath), "%s", opts.optarg);
             		break;
         }
     }


### PR DESCRIPTION
Coverity scan reports a pmdadenki string termination issue - switch to using pmsprintf(3), and use it consistently in a second similar location, to ensure valid string construction.