### PR TITLE
Proposed drop of i386/i686 architectures from build

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -8,6 +8,7 @@ URL:     https://pcp.io
 BuildRoot: @build_root@
 Distribution: @package_distribution@
 Source0: pcp-%{version}.src.tar.gz
+ExcludeArch: %{ix86}
 
 # The additional linker flags break out-of-tree PMDAs.
 # https://bugzilla.redhat.com/show_bug.cgi?id=2043092

--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -8,7 +8,9 @@ URL:     https://pcp.io
 BuildRoot: @build_root@
 Distribution: @package_distribution@
 Source0: pcp-%{version}.src.tar.gz
+%if 0%{?fedora} >= 40 || 0%{?rhel} >= 10
 ExcludeArch: %{ix86}
+%endif
 
 # The additional linker flags break out-of-tree PMDAs.
 # https://bugzilla.redhat.com/show_bug.cgi?id=2043092

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -6,6 +6,7 @@ License: GPL-2.0-or-later AND LGPL-2.1-or-later AND CC-BY-3.0
 URL:     https://pcp.io
 
 Source0: https://github.com/performancecopilot/pcp/releases/pcp-%{version}.src.tar.gz
+ExcludeArch: %{ix86}
 
 # The additional linker flags break out-of-tree PMDAs.
 # https://bugzilla.redhat.com/show_bug.cgi?id=2043092

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -6,7 +6,9 @@ License: GPL-2.0-or-later AND LGPL-2.1-or-later AND CC-BY-3.0
 URL:     https://pcp.io
 
 Source0: https://github.com/performancecopilot/pcp/releases/pcp-%{version}.src.tar.gz
+%if 0%{?fedora} >= 40 || 0%{?rhel} >= 10
 ExcludeArch: %{ix86}
+%endif
 
 # The additional linker flags break out-of-tree PMDAs.
 # https://bugzilla.redhat.com/show_bug.cgi?id=2043092


### PR DESCRIPTION
Drop of i386/i686 builds from Fedora to avoid conflicts in installed RPMs. Alignment with
https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval 

Resolves: bz#2248841