### PR TITLE
pmproxy: support http compression

### DIFF
--- a/qa/1543
+++ b/qa/1543
@@ -390,6 +390,10 @@ curl -s "http://localhost:$port/pmapi/metrics?target=sample.long" \
 	| _filter_text "scrape one metric tree"
 curl -s "http://localhost:$port/pmapi/metrics?target=sample.colour" \
 	| _filter_text "scrape metric instances"
+curl -s  --compressed "http://localhost:$port/metrics?name=sample.long.one" \
+	| _filter_text "small curl compression command"
+curl -s  --compressed "http://localhost:$port/metrics?name=sample,sampledso" \
+	| _filter_text "large curl compression command" | head -8
 echo "== scrape all metrics =="
 curl -s "http://localhost:$port/metrics" \
 	> /dev/null	# checking pmproxy remains up here (too much to filter)

--- a/qa/1543.out
+++ b/qa/1543.out
@@ -1014,6 +1014,19 @@ sample_dupnames_four_colour{model="RGB",hostname="HOSTNAME",instid="2",instname=
 sample_colour{model="RGB",hostname="HOSTNAME",instid="0",instname="red",domainname="DOMAINNAME",machineid="MACHINEID"} 143
 sample_colour{model="RGB",hostname="HOSTNAME",instid="1",instname="green",domainname="DOMAINNAME",machineid="MACHINEID"} 244
 sample_colour{model="RGB",hostname="HOSTNAME",instid="2",instname="blue",domainname="DOMAINNAME",machineid="MACHINEID"} 345
+== small curl compression command ==
+# PCP5 sample.long.one 29.0.10 32 PM_INDOM_NULL instant none
+# HELP sample_long_one 1 as a 32-bit integer
+# TYPE sample_long_one gauge
+sample_long_one{hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME"} 1
+== large curl compression command ==
+# PCP5 sample.control 29.0.0 32 PM_INDOM_NULL instant none
+# HELP sample_control A control variable for the "sample" PMDA
+# TYPE sample_control gauge
+sample_control{hostname="HOSTNAME",machineid="MACHINEID",domainname="DOMAINNAME"} 0
+# PCP5 sample.dupnames.pid_daemon 29.0.1 u32 PM_INDOM_NULL instant none
+# HELP sample_dupnames_pid_daemon Process id of PMDA daemon
+# TYPE sample_dupnames_pid_daemon gauge
 == scrape all metrics ==
 done full scrape
 == check pmproxy is running ==

--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -326,6 +326,8 @@ HAVE_SASL = @HAVE_SASL@
 LIB_FOR_LIBSASL2 = @libsasl2_LIBS@
 HAVE_OPENSSL = @HAVE_OPENSSL@
 LIB_FOR_OPENSSL = @openssl_LIBS@
+HAVE_ZLIB = @HAVE_ZLIB@
+LIB_FOR_ZLIB = @zlib_LIBS@
 
 # configuration state for optional performance domains
 SYSTEMD_CFLAGS = @SYSTEMD_CFLAGS@

--- a/src/pmproxy/src/GNUmakefile
+++ b/src/pmproxy/src/GNUmakefile
@@ -40,6 +40,10 @@ ifeq "$(HAVE_OPENSSL)" "true"
 LCFLAGS += $(OPENSSLCFLAGS) -DHAVE_OPENSSL=1
 CFILES += secure.c
 endif
+ifeq "$(HAVE_ZLIB)" "true"
+LCFLAGS += $(ZLIBCFLAGS) -DHAVE_ZLIB=1
+LLDLIBS += $(LIB_FOR_ZLIB) 
+endif
 endif
 CFILES += deprecated.c
 

--- a/src/pmproxy/src/http.c
+++ b/src/pmproxy/src/http.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019-2020 Red Hat.
- * 
+ *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published
  * by the Free Software Foundation; either version 2.1 of the License, or
@@ -17,6 +17,12 @@
 #include "encoding.h"
 #include "dict.h"
 #include "util.h"
+#include "sds.h"
+#include <pcp/mmv_stats.h>
+
+#ifdef HAVE_ZLIB
+#include "zlib.h"
+#endif
 
 static int chunked_transfer_size; /* pmproxy.chunksize, pagesize by default */
 static int smallest_buffer_size = 128;
@@ -221,9 +227,12 @@ http_response_header(struct client *client, unsigned int length, http_code_t sts
 
     header = sdscatfmt(header, "Content-Type: %s%s\r\n",
 		http_content_type(flags), http_content_encoding(flags));
+	if (flags & HTTP_FLAG_COMPRESS_GZIP) {
+		header = sdscatfmt(header, "Content-Encoding: gzip\r\n");
+	}
     header = sdscatfmt(header, "Date: %s\r\n\r\n",
 		http_date_string(time(NULL), date, sizeof(date)));
-
+	
     if (pmDebugOptions.http && pmDebugOptions.desperate) {
 	fprintf(stderr, "reply headers for response to client %p\n", client);
 	fputs(header, stderr);
@@ -380,21 +389,22 @@ http_reply(struct client *client, sds message,
 		http_code_t sts, http_flags_t type, http_options_t options)
 {
     enum http_flags	flags = client->u.http.flags;
+    struct proxy 	*proxy = client->proxy;
     char		length[32]; /* hex length */
     sds			buffer, suffix;
+    void 		*map = proxy->map;
 
     if (flags & HTTP_FLAG_STREAMING) {
 	buffer = sdsempty();
 	if (client->buffer == NULL) {	/* no data currently accumulated */
-	    pmsprintf(length, sizeof(length), "%lX", (unsigned long)sdslen(message));
-	    buffer = sdscatfmt(buffer, "%s\r\n%S\r\n", length, message);
+		pmsprintf(length, sizeof(length), "%lX", (unsigned long)sdslen(message));
+	    	buffer = sdscatfmt(buffer, "%s\r\n%S\r\n", length, message);
 	} else if (message != NULL) {
-	    pmsprintf(length, sizeof(length), "%lX",
+		pmsprintf(length, sizeof(length), "%lX",
 				(unsigned long)sdslen(client->buffer) + sdslen(message));
-	    buffer = sdscatfmt(buffer, "%s\r\n%S%S\r\n",
+	   	buffer = sdscatfmt(buffer, "%s\r\n%S%S\r\n",
 				length, client->buffer, message);
 	}
-
 	sdsfree(message);
 	sdsfree(client->buffer);
 	client->buffer = NULL;
@@ -410,10 +420,29 @@ http_reply(struct client *client, sds message,
 	else	/* HTTP_HEAD */
 	    buffer = http_response_header(client, 0, sts, type);
 	suffix = NULL;
-    } else {	/* regular non-chunked response - headers + response body */
+	} else {	/* regular non-chunked response - headers + response body */
 	if (client->buffer == NULL) {
 	    suffix = message;
 	} else if (message != NULL) {
+	    pmAtomValue av;
+	    if (flags & HTTP_FLAG_COMPRESS_GZIP) {
+		if (pmDebugOptions.http)
+			fprintf(stderr, "Length of response buffer before compression: %s\n", client->buffer);
+		compress_GZIP(client);
+		if (pmDebugOptions.http)
+			fprintf(stderr, "Length of repsonse buffer after compression: %s\n", client->buffer);
+		av.ull = sdslen(client->buffer);
+		if (map) {
+			mmv_inc(proxy->map, proxy->values[VALUE_HTTP_COMPRESSED_COUNT]);
+			mmv_inc_atomvalue(proxy->map, proxy->values[VALUE_HTTP_COMPRESSED_BYTES], &av);
+		}
+	    } else {
+		av.ull = sdslen(client->buffer);
+		if (map) {
+			mmv_inc(proxy->map, proxy->values[VALUE_HTTP_UNCOMPRESSED_COUNT]);
+			mmv_inc_atomvalue(proxy->map, proxy->values[VALUE_HTTP_UNCOMPRESSED_BYTES], &av);
+		}
+	    }
 	    suffix = sdscatsds(client->buffer, message);
 	    sdsfree(message);
 	    client->buffer = NULL;
@@ -468,15 +497,18 @@ void
 http_transfer(struct client *client)
 {
     struct http_parser	*parser = &client->u.http.parser;
+    struct proxy 	*proxy = client->proxy;
     enum http_flags	flags = client->u.http.flags;
     const char		*method;
     sds			buffer, suffix;
+    void		*map = proxy->map;
 
     /* If the client buffer length is now beyond a set maximum size,
      * send it using chunked transfer encoding.  Once buffer pointer
      * is copied into the uv_buf_t, clear it in the client, and then
      * return control to caller.
      */
+
     if (sdslen(client->buffer) >= chunked_transfer_size) {
 	if (parser->http_major == 1 && parser->http_minor > 0) {
 	    if (!(flags & HTTP_FLAG_STREAMING)) {
@@ -488,6 +520,28 @@ http_transfer(struct client *client)
 		/* headers already sent, send the next chunk of content */
 		buffer = sdsempty();
 	    }
+
+	    pmAtomValue av;
+	    if ((flags & HTTP_FLAG_COMPRESS_GZIP)){
+		if (pmDebugOptions.http)
+			fprintf(stderr, "Length of response buffer before compression: %s\n", client->buffer);
+		compress_GZIP(client);
+		if (pmDebugOptions.http)
+			fprintf(stderr, "Length of repsonse buffer after compression: %s\n", client->buffer);
+		av.ull = sdslen(client->buffer);
+		if (map) {
+			mmv_inc(proxy->map, proxy->values[VALUE_HTTP_COMPRESSED_COUNT]);
+			mmv_inc_atomvalue(proxy->map, proxy->values[VALUE_HTTP_COMPRESSED_BYTES], &av);
+		}
+	    } else {
+		av.ull = sdslen(client->buffer);
+		if (map) {
+			mmv_inc(proxy->map, proxy->values[VALUE_HTTP_UNCOMPRESSED_COUNT]);
+			mmv_inc_atomvalue(proxy->map, proxy->values[VALUE_HTTP_UNCOMPRESSED_BYTES], &av);
+		}
+
+	    }
+
 	    /* prepend a chunked transfer encoding message length (hex) */
 	    buffer = sdscatprintf(buffer, "%lX\r\n",
 				 (unsigned long)sdslen(client->buffer));
@@ -522,6 +576,8 @@ http_client_release(struct client *client)
 	servlet->on_release(client);
     client->u.http.privdata = NULL;
     client->u.http.servlet = NULL;
+    if (client->u.http.flags & HTTP_FLAG_COMPRESS_GZIP)
+    	deflateEnd(&client->u.http.strm);
     client->u.http.flags = 0;
 
     if (client->u.http.headers) {
@@ -544,6 +600,7 @@ http_client_release(struct client *client)
 	sdsfree(client->u.http.realm);
 	client->u.http.realm = NULL;
     }
+
 }
 
 static int
@@ -774,7 +831,8 @@ on_header_value(http_parser *request, const char *offset, size_t length)
     struct client	*client = (struct client *)request->data;
     dictEntry		*entry;
     char		*colon;
-    sds			field, value, decoded;
+    sds			field, value, decoded, *values;
+    int 		i, nvalues = 0;
 
     if (client->u.http.parser.status_code || !client->u.http.headers)
 	return 0;	/* already in process of failing connection */
@@ -805,6 +863,18 @@ on_header_value(http_parser *request, const char *offset, size_t length)
 	    client->u.http.parser.status_code = HTTP_STATUS_UNAUTHORIZED;
 	}
     }
+	if (strncmp(field, "Accept-Encoding", 15) == 0) {
+		values = sdssplitlen(value, sdslen(value), ", ", 2, &nvalues);
+		for (i = 0; values && i < nvalues; i++) {
+			if (strcmp(values[i], "gzip") == 0) {
+				client->u.http.flags |= HTTP_FLAG_COMPRESS_GZIP;
+				if (deflateInit2(&client->u.http.strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 | 16, 8, Z_DEFAULT_STRATEGY) != Z_OK)
+					client->u.http.parser.status_code = HTTP_STATUS_INTERNAL_SERVER_ERROR;
+			}
+		}
+		sdsfreesplitres(values, nvalues);
+
+	}
 
     return 0;
 }
@@ -974,8 +1044,33 @@ void
 setup_http_module(struct proxy *proxy)
 {
     sds			option;
+    void		*map;
+    pmAtomValue 	**values = proxy->values;
+    mmv_registry_t 	*registry = proxymetrics(proxy, METRICS_HTTP);
+    const pmUnits	units_count = MMV_UNITS(0, 0, 1, 0, 0, PM_COUNT_ONE);
+    const pmUnits	units_bytes = MMV_UNITS(1, 0, 0, PM_SPACE_BYTE, 0, 0);
 
-    proxymetrics(proxy, METRICS_HTTP);
+    if (proxy == NULL || registry == NULL)
+    	return; /* no metric registry has been set up*/
+
+    mmv_stats_add_metric(registry, "compressed.count", 1,
+    MMV_TYPE_U64, MMV_SEM_COUNTER, units_count, MMV_INDOM_NULL,
+    "Count of compressed transfers", "Number of compressed HTTP transfers");
+    mmv_stats_add_metric(registry, "uncompressed.count", 2,
+    MMV_TYPE_U64, MMV_SEM_COUNTER, units_count, MMV_INDOM_NULL,
+    "Count of uncompresed transfers", "Number of uncompressed HTTP transfers");
+    mmv_stats_add_metric(registry, "uncompressed.bytes", 3,
+    MMV_TYPE_U64, MMV_SEM_COUNTER, units_bytes, MMV_INDOM_NULL,
+    "Count of uncompressed bytes sent", "Total number of uncompressed bytes sent ");
+    mmv_stats_add_metric(registry, "compressed.bytes", 4,
+    MMV_TYPE_U64, MMV_SEM_COUNTER, units_bytes, MMV_INDOM_NULL,
+    "Count of compressed bytes sent", "Total number of compressed bytes sent");
+    proxy->map = map = mmv_stats_start(registry);
+
+    values[VALUE_HTTP_COMPRESSED_COUNT] = mmv_lookup_value_desc(map,"compressed.count", NULL);
+    values[VALUE_HTTP_UNCOMPRESSED_COUNT] = mmv_lookup_value_desc(map,"uncompressed.count", NULL);
+    values[VALUE_HTTP_COMPRESSED_BYTES] = mmv_lookup_value_desc(map,"compressed.bytes", NULL);
+    values[VALUE_HTTP_UNCOMPRESSED_BYTES] = mmv_lookup_value_desc(map,"uncompressed.bytes", NULL);
 
     if ((option = pmIniFileLookup(config, "pmproxy", "chunksize")) != NULL)
 	chunked_transfer_size = atoi(option);
@@ -1022,4 +1117,34 @@ close_http_module(struct proxy *proxy)
     sdsfree(HEADER_CONTENT_LENGTH);
     sdsfree(HEADER_ORIGIN);
     sdsfree(HEADER_WWW_AUTHENTICATE);
+}
+
+
+int compress_GZIP(struct client *client) {
+	z_stream *stream = &client->u.http.strm;
+	size_t input_len = sdslen(client->buffer);
+	uLong upper_bound = deflateBound(stream, input_len);
+	sds final_buffer = sdsnewlen(NULL, upper_bound);
+
+	if (deflateReset(stream) != Z_OK) {
+		http_error(client, HTTP_STATUS_INTERNAL_SERVER_ERROR, "Deflate reset failed");
+		return -1;
+	}
+
+	stream->next_in = (Bytef *)client->buffer;
+	stream->avail_in = (uInt)input_len;
+	stream->next_out = (Bytef *)final_buffer;
+	stream->avail_out = (uInt)(upper_bound);
+
+	if (deflate(stream, Z_FINISH) != Z_STREAM_END) {
+		http_error(client, HTTP_STATUS_INTERNAL_SERVER_ERROR, "Deflate failed");
+		return -1;
+	}
+
+	assert(stream->total_out <= upper_bound);
+	sdssetlen(final_buffer, stream->total_out);
+	sdsfree(client->buffer);
+	client->buffer = final_buffer;
+
+	return 0;
 }

--- a/src/pmproxy/src/http.h
+++ b/src/pmproxy/src/http.h
@@ -36,8 +36,8 @@ typedef enum http_flags {
     HTTP_FLAG_HTML	= (1<<2),
     HTTP_FLAG_UTF8	= (1<<10),
     HTTP_FLAG_UTF16	= (1<<11),
-    HTTP_FLAG_NO_BODY	= (1<<13),
-    HTTP_FLAG_COMPRESS	= (1<<14),
+    HTTP_FLAG_NO_BODY	= (1<<12),
+    HTTP_FLAG_COMPRESS_GZIP	= (1<<14),
     HTTP_FLAG_STREAMING	= (1<<15),
     /* maximum 16 for server.h */
 } http_flags_t;
@@ -71,6 +71,7 @@ extern const char *http_content_type(http_flags_t);
 
 extern sds http_get_buffer(struct client *);
 extern void http_set_buffer(struct client *, sds, http_flags_t);
+extern int compress_GZIP(struct client *);
 
 typedef void (*httpSetupCallBack)(struct proxy *);
 typedef void (*httpCloseCallBack)(struct proxy *);

--- a/src/pmproxy/src/server.c
+++ b/src/pmproxy/src/server.c
@@ -82,18 +82,18 @@ proxymetrics(struct proxy *proxy, enum proxy_registry prid)
 	return proxy->metrics[prid];
 
     pmsprintf(path, sizeof(path), "%s%cpmproxy%c%s",
-	    pmGetConfig("PCP_TMP_DIR"), sep, sep, server_metrics[prid].group);
+	    pmGetConfig("PCP_TMP_DIR"), sep, sep, server_metrics[prid].group); //creates a new file
     if ((file = strdup(path)) == NULL)
 	return NULL;
 
     if (prid == METRICS_SERVER)
 	flags |= MMV_FLAG_NOPREFIX;
-    if ((registry = mmv_stats_registry(file, prid, flags)) != NULL)
+    if ((registry = mmv_stats_registry(file, prid, flags)) != NULL) 
 	server_metrics[prid].path = file;
     else
 	free(file);
     proxy->metrics[prid] = registry;
-    return registry;
+    return registry; //once you have a registry you can start adding metrics to it 
 }
 
 void


### PR DESCRIPTION
Add http compression to the REST API for grafana-pcp where large transfers have been observed with pmseries queries. This implementation supports zlib compression only so far. Additionally, several new http metrics are added to pmproxy showing compression effectiveness.

Resolves #1685