### PR TITLE
ci: fix pylint warnings relating to use-before-init in py tools

### DIFF
--- a/src/pcp/buddyinfo/pcp-buddyinfo.py
+++ b/src/pcp/buddyinfo/pcp-buddyinfo.py
@@ -65,10 +65,11 @@ class BuddyStatUtil:
         return data.keys()
 
 class BuddyinfoReport(pmcc.MetricGroupPrinter):
-    def __init__(self,samples,group,context):
-        self.samples = samples
+    def __init__(self,opts,group):
+        self.opts=opts
         self.group=group
-        self.context=context
+        self.context=opts.context
+        self.samples=opts.samples
 
     def __get_ncpu(self, group):
         return group['hinv.ncpu'].netValues[0][2]
@@ -151,7 +152,7 @@ class BuddyinfoReport(pmcc.MetricGroupPrinter):
 
     def report(self, manager):
         group = manager["sysinfo"]
-        self.samples=opts.pmGetOptionSamples()
+        self.samples=self.opts.pmGetOptionSamples()
         t_s = group.contextCache.pmLocaltime(int(group.timestamp))
         timestamp = time.strftime(BuddyinfoOptions.timefmt, t_s.struct_time())
         header_indentation = "        " if len(timestamp) < 9 else (len(timestamp) - 7) * " "
@@ -183,7 +184,7 @@ if __name__ == '__main__':
         mngr["buddyinfo"] = BUDDYSTAT_METRICS
         mngr["sysinfo"] = SYS_MECTRICS
         mngr["allinfo"]=ALL_METRICS
-        mngr.printer = BuddyinfoReport(opts.samples,mngr,opts.context)
+        mngr.printer = BuddyinfoReport(opts,mngr)
         sts = mngr.run()
         sys.exit(sts)
     except pmapi.pmErr as error:

--- a/src/pcp/meminfo/pcp-meminfo.py
+++ b/src/pcp/meminfo/pcp-meminfo.py
@@ -127,8 +127,9 @@ SYS_METRICS = ["kernel.uname.sysname",
 ALL_METRICS = METRICS + SYS_METRICS
 
 class MeminfoReport(pmcc.MetricGroupPrinter):
-    samples = 0
-    Machine_info_count = 0
+    def __init__(self, opts):
+        self.opts = opts
+        self.Machine_info_count = 0
 
     def __get_ncpu(self, group):
         return group['hinv.ncpu'].netValues[0][2]
@@ -148,9 +149,6 @@ class MeminfoReport(pmcc.MetricGroupPrinter):
         header_string += group['kernel.uname.machine'].netValues[0][2] + '  '
 
         print("%s  (%s CPU)" % (header_string, self.__get_ncpu(group)))
-
-    def __init__(self, samples):
-        self.samples = samples
 
     def getMetricName(self, idx):
         metric_name = ""
@@ -174,7 +172,7 @@ class MeminfoReport(pmcc.MetricGroupPrinter):
 
         group = manager["meminfo"]
 
-        opts.pmGetOptionSamples()
+        self.opts.pmGetOptionSamples()
 
         t_s = group.contextCache.pmLocaltime(int(group.timestamp))
         time_string = time.strftime(MeminfoOptions.timefmt, t_s.struct_time())
@@ -197,13 +195,12 @@ class MeminfoReport(pmcc.MetricGroupPrinter):
             idx += 1
         print("")
 
-        if MeminfoOptions.context is not PM_CONTEXT_ARCHIVE and opts.pmGetOptionSamples() is None:
+        if MeminfoOptions.context is not PM_CONTEXT_ARCHIVE and self.opts.pmGetOptionSamples() is None:
             sys.exit(0)
 
 class MeminfoOptions(pmapi.pmOptions):
     context = None
     timefmt = "%H:%M:%S"
-    samples = 0
 
     def __init__(self):
         pmapi.pmOptions.__init__(self, "a:s:S:T:z:A:t:")
@@ -224,7 +221,7 @@ if __name__ == '__main__':
 
         mngr["meminfo"] = METRICS
         mngr["sysinfo"] = SYS_METRICS
-        mngr.printer = MeminfoReport(opts.samples)
+        mngr.printer = MeminfoReport(opts)
         sts = mngr.run()
         sys.exit(sts)
 

--- a/src/pcp/netstat/pcp-netstat.py
+++ b/src/pcp/netstat/pcp-netstat.py
@@ -317,8 +317,10 @@ METRICS_DICT["IpExt_METRICS"] = [IP_EXT_METRICS, IP_EXT_METRICS_DESC]
 
 MISSING_METRICS = []
 
-class NestatReport(pmcc.MetricGroupPrinter):
-    Machine_info_count = 0
+class NetstatReport(pmcc.MetricGroupPrinter):
+    def __init__(self, opts):
+        self.opts = opts
+        self.Machine_info_count = 0
 
     def __get_ncpu(self, group):
         return group['hinv.ncpu'].netValues[0][2]
@@ -375,7 +377,7 @@ class NestatReport(pmcc.MetricGroupPrinter):
             return
 
         group = manager["netstat"]
-        opts.pmGetOptionSamples()
+        self.opts.pmGetOptionSamples()
 
         t_s = group.contextCache.pmLocaltime(int(group.timestamp))
         time_string = time.strftime(NetstatOptions.timefmt, t_s.struct_time())
@@ -431,13 +433,12 @@ class NestatReport(pmcc.MetricGroupPrinter):
 
             print(ifstats_str)
 
-        if NetstatOptions.context is not PM_CONTEXT_ARCHIVE and opts.pmGetOptionSamples() is None:
+        if NetstatOptions.context is not PM_CONTEXT_ARCHIVE and self.opts.pmGetOptionSamples() is None:
             sys.exit(0)
 
 class NetstatOptions(pmapi.pmOptions):
     context = None
     timefmt = "%H:%M:%S"
-    samples = 0
     all_stats_flag = False
     filter_protocol_flag = False
     filter_protocol = None
@@ -492,7 +493,7 @@ if __name__ == '__main__':
 
         mngr["netstat"] = METRICS + IFACE_METRICS
         mngr["sysinfo"] = SYS_METRICS
-        mngr.printer = NestatReport()
+        mngr.printer = NetstatReport(opts)
         sts = mngr.run()
         sys.exit(sts)
 

--- a/src/pcp/slabinfo/pcp-slabinfo.py
+++ b/src/pcp/slabinfo/pcp-slabinfo.py
@@ -88,10 +88,11 @@ class SlabStatUtil:
         return data.keys()
 
 class SlabinfoReport(pmcc.MetricGroupPrinter):
-    def __init__(self,samples,group,context):
-        self.samples = samples
-        self.group=group
-        self.context=context
+    def __init__(self,opts,group):
+        self.opts = opts
+        self.group = group
+        self.samples = opts.samples
+        self.context = opts.context
 
     def __get_ncpu(self, group):
         return group['hinv.ncpu'].netValues[0][2]
@@ -162,7 +163,7 @@ class SlabinfoReport(pmcc.MetricGroupPrinter):
 
     def report(self, manager):
         group = manager["sysinfo"]
-        self.samples=opts.pmGetOptionSamples()
+        self.samples = self.opts.pmGetOptionSamples()
         t_s = group.contextCache.pmLocaltime(int(group.timestamp))
         timestamp = time.strftime(SlabinfoOptions.timefmt, t_s.struct_time())
         header_indentation = "        " if len(timestamp) < 9 else (len(timestamp) - 7) * " "
@@ -194,7 +195,7 @@ if __name__ == '__main__':
         mngr["slabinfo"] = SLABSTAT_METRICS
         mngr["sysinfo"] = SYS_MECTRICS
         mngr["allinfo"]=ALL_METRICS
-        mngr.printer = SlabinfoReport(opts.samples,mngr,opts.context)
+        mngr.printer = SlabinfoReport(opts,mngr)
         sts = mngr.run()
         sys.exit(sts)
     except pmapi.pmErr as error:


### PR DESCRIPTION
Resolves CI failures on the Fedora39 platform.