### PR TITLE
Skip container build on forked repository and update to fedora 38

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ env:
 # There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
 jobs:
   build-and-push-image:
+    if: github.repository == 'performancecopilot/pcp'
     runs-on: ubuntu-latest
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
     permissions:

--- a/build/containers/pcp/Dockerfile
+++ b/build/containers/pcp/Dockerfile
@@ -1,5 +1,5 @@
 ## Build
-FROM registry.fedoraproject.org/fedora:36 AS build
+FROM registry.fedoraproject.org/fedora:38 AS build
 COPY . /usr/src/pcp
 
 WORKDIR /usr/src/pcp
@@ -25,7 +25,7 @@ RUN mkdir /build && \
       /build
 
 ## Deploy
-FROM registry.fedoraproject.org/fedora:36
+FROM registry.fedoraproject.org/fedora:38
 COPY --from=build /build /build
 
 ENV SUMMARY="Performance Co-Pilot" \


### PR DESCRIPTION
The github action to build and publish the container will no longer run in forked repositories. Additionally, the container has been updated from fedora 36 to fedora 38.