### PR TITLE
Fixed crash of pcp-ss when using -t/-u option

### DIFF
--- a/src/pcp/ss/pcp-ss.py
+++ b/src/pcp/ss/pcp-ss.py
@@ -253,10 +253,10 @@ class SS(object):
         elif self.args.udp and netid == "udp":
             state = self.valuesD["state"][inst]
             ret = bool(state != "UNCONN" or self.args.listening)
-        elif self.args.unix and netid == "unix":
-            ret = True
-        elif self.args.raw and netid == "raw":
-            ret = True
+        #elif self.args.unix and netid == "unix":
+        #    ret = True
+        #elif self.args.raw and netid == "raw":
+        #    ret = True
         return ret
 
     def filter_ipv46(self, inst):


### PR DESCRIPTION
Cleanup of remained code for unix and raw sockets causing `pcp-ss` to crash, generating a traceback.

This pull request fixes crash of  `pcp-ss` when it is run with `-t` or `-u` option:

```
# pcp ss -u
# Time: 2023-12-13 10:41:44.509127 Filter: state all
Netid  State  Recv-Q Send-Q        Local Address:Port Peer Address:Port          Process
udp   ESTAB         0     0      10.0.185.202%eth0:68 10.0.187.254:67          
Traceback (most recent call last):
  File "/usr/libexec/pcp/bin/pcp-ss", line 374, in <module>
    ss.report()
  File "/usr/libexec/pcp/bin/pcp-ss", line 299, in report
    if not self.filter_netid(inst) or not self.filter_listening(inst):
  File "/usr/libexec/pcp/bin/pcp-ss", line 256, in filter_netid
    elif self.args.unix and netid == "unix":
AttributeError: 'Namespace' object has no attribute 'unix'
```
