### PR TITLE
Rename all /var/run file context entries to /run

### DIFF
--- a/src/selinux/pcp.fc
+++ b/src/selinux/pcp.fc
@@ -29,4 +29,4 @@
 
 /var/log/pcp(/.*)?		gen_context(system_u:object_r:pcp_log_t,s0)
 
-/var/run/pcp(/.*)?		gen_context(system_u:object_r:pcp_var_run_t,s0)
+/run/pcp(/.*)?		gen_context(system_u:object_r:pcp_var_run_t,s0)


### PR DESCRIPTION
With the 1f76e522a ("Rename all /var/run file context entries to /run") selinux-policy commit, all /var/run file context entries moved to /run and the equivalency was inverted. Subsequently, changes in pcp.fc need to be done, too, in a similar manner.