### PR TITLE
build: drop dependency on bpftool as local version used nowadays

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -1547,7 +1547,7 @@ Requires: libbpf1
 %else
 Requires: libbpf
 %endif
-BuildRequires: libbpf-devel clang llvm bpftool
+BuildRequires: libbpf-devel clang llvm
 %description pmda-bpf
 This package contains the PCP Performance Metrics Domain Agent (PMDA) for
 extracting performance metrics from eBPF ELF modules.

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -1532,7 +1532,7 @@ Summary: Performance Co-Pilot (PCP) metrics from eBPF ELF modules
 URL: https://pcp.io
 Requires: pcp = %{version}-%{release} pcp-libs = %{version}-%{release}
 Requires: libbpf
-BuildRequires: libbpf-devel clang llvm bpftool
+BuildRequires: libbpf-devel clang llvm
 %description pmda-bpf
 This package contains the PCP Performance Metrics Domain Agent (PMDA) for
 extracting performance metrics from eBPF ELF modules.

--- a/qa/admin/other-packages/manifest
+++ b/qa/admin/other-packages/manifest
@@ -527,10 +527,9 @@ S_pkg?	/usr/lib/python3.*/*-packages/*/bcc.py	[N/A (build optional)]
 slackpkg?	/usr/lib*/python*/*-packages/*/*/bcc.py	[N/A (build optional)]
 pacman?	/usr/lib/python3.*/*-packages/bcc.py	[python-bcc (build optional)]
 brew?	/usr/local/lib/python3.*/*-packages/bcc/bcc.py	[pip3(bcc) (build optional)]
-# -- bpftrace and bpftool
+# -- bpftrace
 dpkg?	bpftrace	[bpftrace (build optional)]
 rpm?	bpftrace	[bpftrace (build optional)]
-rpm?	bpftool		[bpftool (build optional)]
 # -- python pillow
 dpkg?	/usr/lib/python3/*-packages/PIL/Image.py	[python3-pil (QA optional)]
 rpm?	/usr/lib*/python3.*/*-packages/PIL/Image.py	[python3-pillow or python3-Pillow or python36-pillow (QA optional)]

--- a/qa/admin/package-lists/CentOS+Stream9+x86_64
+++ b/qa/admin/package-lists/CentOS+Stream9+x86_64
@@ -14,7 +14,6 @@ bc
 bcc-tools
 bind-utils
 bison
-bpftool
 bpftrace
 clang
 # in CI CentOS container already has coreutils-single installed and this

--- a/qa/admin/package-lists/Fedora+36+x86_64
+++ b/qa/admin/package-lists/Fedora+36+x86_64
@@ -16,7 +16,6 @@ bc
 bcc-tools
 bind-utils
 bison
-bpftool
 bpftrace
 chan-devel
 clang

--- a/qa/admin/package-lists/Fedora+37+x86_64
+++ b/qa/admin/package-lists/Fedora+37+x86_64
@@ -16,7 +16,6 @@ bc
 bcc-tools
 bind-utils
 bison
-bpftool
 bpftrace
 chan-devel
 clang

--- a/qa/admin/package-lists/Fedora+38+x86_64
+++ b/qa/admin/package-lists/Fedora+38+x86_64
@@ -16,7 +16,6 @@ bc
 bcc-tools
 bind-utils
 bison
-bpftool
 bpftrace
 chan-devel
 clang

--- a/qa/admin/package-lists/Fedora+39+x86_64
+++ b/qa/admin/package-lists/Fedora+39+x86_64
@@ -16,7 +16,6 @@ bc
 bcc-tools
 bind-utils
 bison
-bpftool
 bpftrace
 chan-devel
 clang

--- a/qa/admin/package-lists/Fedora+40+x86_64
+++ b/qa/admin/package-lists/Fedora+40+x86_64
@@ -16,7 +16,6 @@ bc
 bcc-tools
 bind-utils
 bison
-bpftool
 bpftrace
 chan-devel
 clang

--- a/qa/admin/package-lists/openSUSE+15.5+x86_64
+++ b/qa/admin/package-lists/openSUSE+15.5+x86_64
@@ -22,7 +22,6 @@ bc
 bcc-tools
 bind-utils
 bison
-bpftool
 bpftrace
 ccache
 clang

--- a/qa/admin/package-lists/openSUSE+15.6+x86_64
+++ b/qa/admin/package-lists/openSUSE+15.6+x86_64
@@ -22,7 +22,6 @@ bc
 bcc-tools
 bind-utils
 bison
-bpftool
 bpftrace
 ccache
 clang


### PR DESCRIPTION
Fedora rawhide has recently removed this package, so this resolves the CI fallout as well as removing a historical build dep.