### PR TITLE
pmapi.py : fix for struct_time() day of year out of range on yyyy-01-01

### DIFF
--- a/src/python/pcp/pmapi.py
+++ b/src/python/pcp/pmapi.py
@@ -330,7 +330,7 @@ class tm(Structure):
             pywday = 6
         stlist = [self.tm_year + 1900, self.tm_mon + 1, self.tm_mday,
                   self.tm_hour, self.tm_min, self.tm_sec,
-                  pywday, self.tm_yday - 1, self.tm_isdst]
+                  pywday, self.tm_yday + 1, self.tm_isdst]
         return time.struct_time(stlist)
 
     def __str__(self):


### PR DESCRIPTION
Fix for `day of year out of range` on 2024-01-01, due to self.tm_yday - 1, which returns `[2024, 1, 1, 2, 3, 0, 0, -1, 0]`. The range for tm_yday should be [1, 366]. Related RH case #03734598.

https://docs.python.org/3.6/library/time.html#time.struct_time

```
# timedatectl set-ntp false
# timedatectl set-time "2022-01-01 00:00:00"
# /usr/libexec/pcp/bin/pcp-mpstat -P ALL -t 1 -s 2
Traceback (most recent call last):
  File "/usr/libexec/pcp/bin/pcp-mpstat", line 710, in <module>
    sts = manager.run()
  File "/usr/lib64/python3.9/site-packages/pcp/pmcc.py", line 687, in run
    self._printer.report(self)
  File "/usr/libexec/pcp/bin/pcp-mpstat", line 661, in report
    self.print_machine_info(group, manager)
  File "/usr/libexec/pcp/bin/pcp-mpstat", line 615, in print_machine_info
    time_string = time.strftime("%x", timestamp.struct_time())
ValueError: day of year out of range

# timedatectl set-time "2022-01-02 00:00:00"
# /usr/libexec/pcp/bin/pcp-mpstat -P ALL -t 1 -s 2
Linux  5.14.0-362.18.1.el9_3.x86_64  (ip-172-31-34-188.ec2.internal)  01/02/22  x86_64    (2 CPU)

Timestamp 	CPU	%usr 	%nice 	%sys 	%iowait 	%irq 	%soft 	%steal 	%guest 	%nice 	%idle
00:00:01  	all	0.0  	0.0   	0.0  	0.0     	0.0  	0.0   	0.0    	0.0    	0.0   	99.8
00:00:01  	0  	0.0  	0.0   	0.0  	0.0     	0.0  	0.0   	0.0    	0.0    	0.0   	99.8
00:00:01  	1  	0.0  	0.0   	0.0  	0.0     	0.0  	0.0   	0.0    	0.0    	0.0   	99.8
```
```
# timedatectl set-ntp false
# timedatectl set-time "2024-01-01 00:00:00"
# /usr/libexec/pcp/bin/pcp-mpstat -P ALL -t 1 -s 2
Traceback (most recent call last):
  File "/usr/libexec/pcp/bin/pcp-mpstat", line 653, in <module>
    sts = manager.run()
  File "/usr/lib64/python3.6/site-packages/pcp/pmcc.py", line 687, in run
    self._printer.report(self)
  File "/usr/libexec/pcp/bin/pcp-mpstat", line 606, in report
    self.print_machine_info(group, manager)
  File "/usr/libexec/pcp/bin/pcp-mpstat", line 585, in print_machine_info
    time_string = time.strftime("%x", timestamp.struct_time())
ValueError: day of year out of range

# with print(stlist)

# /usr/libexec/pcp/bin/pcp-pidstat
[2024, 1, 1, 2, 6, 46, 0, -1, 0]
Traceback (most recent call last):
  File "/usr/libexec/pcp/bin/pcp-pidstat", line 1029, in <module>
    sts = manager.run()
  File "/usr/lib64/python3.6/site-packages/pcp/pmcc.py", line 687, in run
    self._printer.report(self)
  File "/usr/libexec/pcp/bin/pcp-pidstat", line 942, in report
    self.print_machine_info(group, manager)
  File "/usr/libexec/pcp/bin/pcp-pidstat", line 918, in print_machine_info
    time_string = time.strftime("%x", timestamp.struct_time())
ValueError: day of year out of range

# with self.tm_yday + 1

# /usr/libexec/pcp/bin/pcp-mpstat -P ALL -t 1 -s 2
[2024, 1, 1, 2, 11, 6, 0, 1, 0]
Linux  4.18.0-513.11.1.el8_9.x86_64  (ip-10-10-11-90.ec2.internal)  01/01/24  x86_64    (2 CPU)

Timestamp 	CPU	%usr 	%nice 	%sys 	%iowait 	%irq 	%soft 	%steal 	%guest 	%nice 	%idle
02:11:06  	all	0.0  	0.0   	0.0  	0.0     	0.0  	0.0   	0.0    	0.0    	0.0   	99.81
02:11:06  	0  	0.0  	0.0   	0.0  	0.0     	0.0  	0.0   	0.0    	0.0    	0.0   	99.81
02:11:06  	1  	1.0  	0.0   	0.0  	0.0     	0.0  	0.0   	0.0    	0.0    	0.0   	99.81
```