### PR TITLE
Revert "pmdalinux: restore IPC indoms from disk on first access"

### DIFF
--- a/src/pmdas/linux/ipc.c
+++ b/src/pmdas/linux/ipc.c
@@ -177,12 +177,6 @@ refresh_shm_stat(pmInDom shm_indom)
     char		buf[512];
     FILE		*fp;
     int			sts, needsave = 0;
-    static int		setup;
-
-    if (!setup) {
-	pmdaCacheOp(shm_indom, PMDA_CACHE_LOAD);
-	setup = 1;
-    }
 
     pmdaCacheOp(shm_indom, PMDA_CACHE_INACTIVE);
 
@@ -240,12 +234,6 @@ refresh_msg_queue(pmInDom msg_indom)
     char		buf[512];
     FILE		*fp;
     int			sts, needsave = 0;
-    static int		setup;
-
-    if (!setup) {
-	pmdaCacheOp(msg_indom, PMDA_CACHE_LOAD);
-	setup = 1;
-    }
 
     pmdaCacheOp(msg_indom, PMDA_CACHE_INACTIVE);
 
@@ -301,12 +289,6 @@ refresh_sem_array(pmInDom sem_indom)
     char		buf[512];
     FILE		*fp;
     int			sts, needsave = 0;
-    static int		setup;
-
-    if (!setup) {
-	pmdaCacheOp(sem_indom, PMDA_CACHE_LOAD);
-	setup = 1;
-    }
 
     pmdaCacheOp(sem_indom, PMDA_CACHE_INACTIVE);
 


### PR DESCRIPTION
This reverts commit d6e61bdcb8ba14b1e8824961fda81ea78481f466.