### PR TITLE
Update workflows for fedora 40

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
           - {platform: ubuntu1804-i386-container, os: ubuntu-20.04, experimental: false}
           - {platform: ubuntu2004-container,      os: ubuntu-20.04, experimental: false}
           - {platform: ubuntu2204-container,      os: ubuntu-20.04, experimental: false}
-          - {platform: fedora38-container,        os: ubuntu-20.04, experimental: false}
           - {platform: fedora39-container,        os: ubuntu-20.04, experimental: false}
+          - {platform: fedora40-container,        os: ubuntu-20.04, experimental: false}
           - {platform: centos-stream8-container,  os: ubuntu-20.04, experimental: false}
           - {platform: centos-stream9-container,  os: ubuntu-20.04, experimental: false}
 # other platforms that may be used for testing in developer repos

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -30,9 +30,9 @@ jobs:
           - {platform: ubuntu2004,                os: ubuntu-20.04, experimental: false}
           - {platform: ubuntu2204-container,      os: ubuntu-20.04, experimental: false}
           - {platform: ubuntu2204,                os: ubuntu-22.04, experimental: false}
-          - {platform: fedora37-container,        os: ubuntu-20.04, experimental: false}
           - {platform: fedora38-container,        os: ubuntu-20.04, experimental: false}
           - {platform: fedora39-container,        os: ubuntu-20.04, experimental: false}
+          - {platform: fedora40-container,        os: ubuntu-20.04, experimental: false}
           - {platform: fedora-rawhide-container,  os: ubuntu-20.04, experimental: true }
           - {platform: centos6-container,         os: ubuntu-20.04, experimental: false}
           - {platform: centos7-container,         os: ubuntu-20.04, experimental: false}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
           - {platform: ubuntu1804-container,      os: ubuntu-20.04}
           - {platform: ubuntu2004-container,      os: ubuntu-20.04}
           - {platform: ubuntu2204-container,      os: ubuntu-20.04}
-          - {platform: fedora37-container,        os: ubuntu-20.04}
           - {platform: fedora38-container,        os: ubuntu-20.04}
           - {platform: fedora39-container,        os: ubuntu-20.04}
+          - {platform: fedora40-container,        os: ubuntu-20.04}
           - {platform: centos6-container,         os: ubuntu-20.04}
           - {platform: centos7-container,         os: ubuntu-20.04}
           - {platform: centos-stream8-container,  os: ubuntu-20.04}


### PR DESCRIPTION
Fedora rawhide now tracks fedora 41. This has caused the github workflows to no longer run on a fedora 40 container. This PR adds the fedora40 workflows back and removes the workflows for fedora 37 as it is EOL.