### PR TITLE
add fedora 40 container testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
           - {platform: ubuntu1804-i386-container, os: ubuntu-20.04, experimental: false}
           - {platform: ubuntu2004-container,      os: ubuntu-20.04, experimental: false}
           - {platform: ubuntu2204-container,      os: ubuntu-20.04, experimental: false}
-          - {platform: fedora38-container,        os: ubuntu-20.04, experimental: false}
           - {platform: fedora39-container,        os: ubuntu-20.04, experimental: false}
+          - {platform: fedora40-container,        os: ubuntu-20.04, experimental: false}
           - {platform: centos-stream8-container,  os: ubuntu-20.04, experimental: false}
           - {platform: centos-stream9-container,  os: ubuntu-20.04, experimental: false}
 # other platforms that may be used for testing in developer repos

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -30,9 +30,9 @@ jobs:
           - {platform: ubuntu2004,                os: ubuntu-20.04, experimental: false}
           - {platform: ubuntu2204-container,      os: ubuntu-20.04, experimental: false}
           - {platform: ubuntu2204,                os: ubuntu-22.04, experimental: false}
-          - {platform: fedora37-container,        os: ubuntu-20.04, experimental: false}
           - {platform: fedora38-container,        os: ubuntu-20.04, experimental: false}
           - {platform: fedora39-container,        os: ubuntu-20.04, experimental: false}
+          - {platform: fedora40-container,        os: ubuntu-20.04, experimental: false}
           - {platform: fedora-rawhide-container,  os: ubuntu-20.04, experimental: true }
           - {platform: centos6-container,         os: ubuntu-20.04, experimental: false}
           - {platform: centos7-container,         os: ubuntu-20.04, experimental: false}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,9 @@ jobs:
           - {platform: ubuntu1804-container,      os: ubuntu-20.04}
           - {platform: ubuntu2004-container,      os: ubuntu-20.04}
           - {platform: ubuntu2204-container,      os: ubuntu-20.04}
-          - {platform: fedora37-container,        os: ubuntu-20.04}
           - {platform: fedora38-container,        os: ubuntu-20.04}
           - {platform: fedora39-container,        os: ubuntu-20.04}
+          - {platform: fedora40-container,        os: ubuntu-20.04}
           - {platform: centos6-container,         os: ubuntu-20.04}
           - {platform: centos7-container,         os: ubuntu-20.04}
           - {platform: centos-stream8-container,  os: ubuntu-20.04}

--- a/build/ci/platforms/fedora40-container.yml
+++ b/build/ci/platforms/fedora40-container.yml
@@ -1,0 +1,43 @@
+type: container
+
+artifactory:
+  package_type: rpm
+  deploy_path: /fedora/39/x86_64/pcp
+
+container:
+  containerfile: |
+    FROM registry.fedoraproject.org/fedora:39
+    RUN dnf install -y systemd
+    RUN useradd --create-home pcpbuild
+    RUN echo 'pcpbuild ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/pcpbuild
+    CMD ["/usr/sbin/init"]
+
+tasks:
+  setup: |
+    sudo dnf install -y which hostname
+    sudo dnf -y install $(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
+  build: |
+    ./Makepkgs --verbose --check
+    rpm -qp --requires $(echo pcp-*/build/rpm/pcp-*.src.rpm | sed 's/src/x86_64/') | grep -q libuv.so
+  copy_build_artifacts: |
+    cp pcp-*/build/rpm/*.rpm ../artifacts/build
+  install: |
+    sudo rpm -Uv pcp-*/build/rpm/*.rpm
+    echo 'pcpqa ALL=(ALL) NOPASSWD: ALL' | sudo tee /etc/sudoers.d/pcpqa
+  init_qa: |
+    sudo systemctl start redis
+    sudo -i -u pcpqa ./check 002
+  qa_sanity: |
+    set -o pipefail
+    sudo -i -u pcpqa ./check -TT -g sanity -x not_in_ci -x not_in_container |& tee ../artifacts/test/test.log
+  qa: |
+    set -o pipefail
+    DEFAULT_PCP_QA_ARGS="-x x11 -x remote -x not_in_ci -x not_in_container"
+    sudo -i -u pcpqa ./check -TT ${PCP_QA_ARGS:-${DEFAULT_PCP_QA_ARGS}} |& tee ../artifacts/test/test.log
+  copy_test_artifacts: |
+    cp /var/lib/pcp/testsuite/check.timings ../artifacts/test
+    # add current timestamp if the last QA test got stuck
+    [ $(awk 'END{print NF}' ../artifacts/test/check.timings) = 2 ] && date '+%s' >> ../artifacts/test/check.timings
+    shopt -s nullglob
+    for test in /var/lib/pcp/testsuite/*.out.bad; do cp $test ../artifacts/test; [ -f ${test/.out.bad/.full} ] && cp ${test/.out.bad/.full} ../artifacts/test; done
+    [ -x /var/lib/pcp/testsuite/admin/whatami ] && /var/lib/pcp/testsuite/admin/whatami >../artifacts/test/whatami


### PR DESCRIPTION
With the recent change of fedora rawhide becoming fedora 41, the github actions are now missing fedora 40. This patch handles adding back fedora 40 testing and removes fedora 37 testing as that is EOL.