### PR TITLE
Fix Fedora base image location

### DIFF
--- a/build/containers/archive-analysis/Dockerfile
+++ b/build/containers/archive-analysis/Dockerfile
@@ -1,5 +1,5 @@
 ## Build
-FROM registry.fedoraproject.org/fedora:38 AS build
+FROM quay.io/fedora/fedora:latest AS build
 COPY . /usr/src/pcp
 
 WORKDIR /usr/src/pcp
@@ -18,7 +18,7 @@ RUN mkdir /build && \
       /build
 
 ## Deploy
-FROM registry.fedoraproject.org/fedora:38
+FROM quay.io/fedora/fedora:latest
 COPY --from=build /build /build
 
 RUN dnf install -y --setopt=tsflags=nodocs procps-ng gettext /build/*.rpm redis grafana grafana-pcp && \

--- a/build/containers/pcp/Dockerfile
+++ b/build/containers/pcp/Dockerfile
@@ -1,5 +1,5 @@
 ## Build
-FROM registry.fedoraproject.org/fedora:38 AS build
+FROM quay.io/fedora/fedora:latest AS build
 COPY . /usr/src/pcp
 
 WORKDIR /usr/src/pcp
@@ -25,7 +25,7 @@ RUN mkdir /build && \
       /build
 
 ## Deploy
-FROM registry.fedoraproject.org/fedora:38
+FROM quay.io/fedora/fedora:latest
 COPY --from=build /build /build
 
 ENV SUMMARY="Performance Co-Pilot" \


### PR DESCRIPTION
Fedora has moved its primary repository for container images to Quay.io. This commit reflects the relocation.