### PR TITLE
dstat top-io.top should be calculated rchar+wchar.

### DIFF
--- a/src/pcp/dstat/plugins/topio
+++ b/src/pcp/dstat/plugins/topio
@@ -4,7 +4,7 @@
 
 [top-io]
 label = most expensive
-top = rate(proc.io.rchar) + rate(proc.io.rchar)
+top = rate(proc.io.rchar) + rate(proc.io.wchar)
 top.label = I/O process
 width = 24
 grouptype = 4


### PR DESCRIPTION
It seems simple typo. It should be sum of read and write.

top = rate(proc.io.rchar) + rate(proc.io.wchar)

closes #1913 