### PR TITLE
qa: disable array bounds warnings as this causes qa failures

### DIFF
--- a/configure
+++ b/configure
@@ -4878,6 +4878,13 @@ then :
   PCFLAGS="$PCFLAGS -Wshadow"
 fi
 fi
+if ! echo "$CFLAGS" | grep -- -Wno-array-bound >/dev/null
+then
+    if test "x$cc_is_gcc" = xyes
+then :
+  PCFLAGS="$PCFLAGS -Wno-array-bound"
+fi
+fi
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking sizeof off_t" >&5
 printf %s "checking sizeof off_t... " >&6; }
 cat <<End-of-File >conftest.c

--- a/configure.ac
+++ b/configure.ac
@@ -433,6 +433,11 @@ if ! echo "$CFLAGS" | grep -- -Wshadow >/dev/null
 then
     AS_IF([test "x$cc_is_gcc" = xyes ],[PCFLAGS="$PCFLAGS -Wshadow"])
 fi
+dnl Disable array bounds as pmResult is often mischaracterised
+if ! echo "$CFLAGS" | grep -- -Wno-array-bound >/dev/null
+then
+    AS_IF([test "x$cc_is_gcc" = xyes ],[PCFLAGS="$PCFLAGS -Wno-array-bound"])
+fi
 dnl and we need to worry about off_t ... we need it to be 64-bits for V3 archives
 AC_MSG_CHECKING([sizeof off_t])
 cat <<End-of-File >conftest.c


### PR DESCRIPTION
Subtleties of the pmResult handling result in confusion from gcc -Warray-bounds checks - disable it now as its causing QA failures on rawhide when PMDA sample is built from source.