### PR TITLE
riscv: config pmdabpf_arch value

### DIFF
--- a/configure
+++ b/configure
@@ -9135,7 +9135,7 @@ llvm_strip=$LLVM_STRIP
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking BPF CO-RE architecture identifier" >&5
 printf %s "checking BPF CO-RE architecture identifier... " >&6; }
-pmdabpf_arch=`uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/' | sed 's/s390x/s390/'`
+pmdabpf_arch=`uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/' | sed 's/s390x/s390/' | sed 's/riscv.*/riscv/'`
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $pmdabpf_arch" >&5
 printf "%s\n" "$pmdabpf_arch" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -1179,7 +1179,7 @@ AC_SUBST(llvm_strip)
 
 dnl Get BPF CO-RE arch identifier
 AC_MSG_CHECKING([BPF CO-RE architecture identifier])
-pmdabpf_arch=`uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/' | sed 's/s390x/s390/'`
+pmdabpf_arch=`uname -m | sed 's/x86_64/x86/' | sed 's/aarch64/arm64/' | sed 's/ppc64le/powerpc/' | sed 's/mips.*/mips/' | sed 's/s390x/s390/' | sed 's/riscv.*/riscv/'`
 AC_SUBST(pmdabpf_arch)
 AC_MSG_RESULT($pmdabpf_arch)
 


### PR DESCRIPTION
Configure scripts use pmdabpf_arch to refer to architecture directory of iovisor/bcc/libbpf-tools, which hold kernel vmlinux.h. For RISC-V, the unique directory name is 'riscv'. We need to sed uname's value riscv64 etc. to adapt this.