### PR TITLE
pmcheck: add service and metric checks for the redis PMDA

### DIFF
--- a/qa/1491.out
+++ b/qa/1491.out
@@ -3,6 +3,7 @@ basic stuff ...
 -- no args --
 pmcd            OK
 pmda-overhead   OK
+pmda-redis      could be activated
 pmda-sample     OK
 pmie            OK
 pmlogger        OK
@@ -11,6 +12,7 @@ zeroconf        OK
 -- -l --
 pmcd           
 pmda-overhead  
+pmda-redis     
 pmda-sample    
 pmie           
 pmlogger       
@@ -19,6 +21,7 @@ zeroconf
 -- -lv --
 pmcd            Performance Metrics Collection Daemon - local source of performance data
 pmda-overhead   overhead PMDA - ...
+pmda-redis      Redis PMDA - metrics from redis-server(1)
 pmda-sample     sample PMDA
 pmie            Inference Engine - rule-based monitoring
 pmlogger        Archive logger - record performance data for subsequent replay
@@ -27,6 +30,7 @@ zeroconf        Zeroconf Package ...
 -- -s --
 pmcd            OK
 pmda-overhead   OK
+pmda-redis      could be activated
 pmda-sample     OK
 pmie            OK
 pmlogger        OK

--- a/qa/913
+++ b/qa/913
@@ -2,7 +2,7 @@
 # PCP QA Test No. 913
 # Exercise the Redis PMDA and metrics.
 #
-# Copyright (c) 2017 Red Hat.
+# Copyright (c) 2017,2024 Red Hat.
 #
 
 seq=`basename $0`
@@ -48,6 +48,10 @@ cd $PCP_PMDAS_DIR/redis
 $sudo ./Remove >>$here/$seq.full 2>&1
 
 echo
+echo "=== $iam check pre-install ==="
+pmcheck pmda-redis
+
+echo
 echo "=== $iam agent installation ==="
 $sudo ./Remove > $tmp.out 2>&1
 
@@ -65,6 +69,10 @@ _filter_pmda_install <$tmp.out \
                                        if ($10 >= 0 && $10 <= 5000) $10 = "Y"
                                      }
                                      { print }'
+
+echo
+echo "=== $iam check post-install ==="
+pmcheck pmda-redis
 
 echo
 echo "=== verify $iam metrics ==="

--- a/qa/913.out
+++ b/qa/913.out
@@ -1,5 +1,8 @@
 QA output created by 913
 
+=== redis check pre-install ===
+pmda-redis      could be activated  
+
 === redis agent installation ===
 Culling the Performance Metrics Name Space ...
 redis ... not found in Name Space, this is OK
@@ -10,6 +13,9 @@ Terminate PMDA if already installed ...
 [...install files, make output...]
 Updating the PMCD control file, and notifying PMCD ...
 Check redis metrics have appeared ... X metrics and Y values
+
+=== redis check post-install ===
+pmda-redis      active              
 
 === verify redis metrics ===
 

--- a/src/pmdas/redis/GNUmakefile
+++ b/src/pmdas/redis/GNUmakefile
@@ -44,9 +44,11 @@ install: default
 	$(INSTALL) -m 755 -d $(PMDACONFIG)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/redis.conf redis.conf $(PMDACONFIG)/redis.conf
 	@$(INSTALL_MAN)
+	$(INSTALL) -m 755 $(IAM).pmcheck $(PCP_SHARE_DIR)/lib/pmcheck/pmda-$(IAM)
 else
 build-me:
-install:
+install: $(TOPDIR)/src/pmcheck/pmda.na.template
+	$(INSTALL) -m 755 $< $(PCP_SHARE_DIR)/lib/pmcheck/pmda-$(IAM)
 endif
 
 default_pcp : default

--- a/src/pmdas/redis/redis.pmcheck
+++ b/src/pmdas/redis/redis.pmcheck
@@ -1,0 +1,45 @@
+#!/bin/sh
+#
+# Redis PMDA "plugin" for pmcheck
+#
+
+. $PCP_DIR/etc/pcp.env || exit 1
+. $PCP_SHARE_DIR/lib/checkproc.sh
+
+_do_args "$@"
+
+_check()
+{
+    test -n "$@" && echo "$@" >> $tmp/out
+    [ "$verbose" -gt 0 -a -s $tmp/out ] && cat $tmp/out
+    [ $status -eq 0 ] || exit
+}
+
+if $lflag
+then
+    [ "$verbose" -gt 0 ] && echo "Redis PMDA - metrics from redis-server(1)"
+elif $sflag
+then
+    status=0  # assume active until proven not to be
+    which redis-server >/dev/null 2>&1 || status=2
+    which redis-cli >/dev/null 2>&1 || status=2
+    _check "redis install status: $status"
+    _ctl_svc state redis || status=$?
+    _check "redis service status: $status"
+    pong=`redis-cli PING`
+    test "$pong" = "PONG" || status=2
+    _check "redis cli PING: $pong"
+    _ctl_pmda state redis || status=1
+    _check "redis PMDA status: $status"
+elif $aflag
+then
+    _ctl_pmda activate redis pmdaredis.pl || status=1
+elif $dflag
+then
+    _ctl_pmda deactivate redis || status=1
+else
+    [ $verbose -gt 0 ] && echo "botch sflag=$sflag aflag=$aflag dflag=$dflag show_me=$show_me verbose=$verbose"
+    status=99
+fi
+
+exit


### PR DESCRIPTION
@kmcdonell here's my first attempt at a pmcheck script, for Redis metrics.

Couple of areas of uncertainty.  I wasn't sure about the protocol for _chk_svc 'state' argument - that one seems to call 'exit' very aggressively (always), which is a problem here because I have other environmental aspects to check too.  I also noticed the use of a local variable called 'exit' in the shell lib code, figured this will end in tears so renamed it to __exit for clarity.  Wondering if all variables in this common file should be updated to use this convention instead of the mixed bag we have currently?

Anyway, please have a look - this seems to do the right thing now for me locally.