### PR TITLE
pmproxy: disable Redis protocol proxying by default

### DIFF
--- a/src/pmproxy/pmproxy.conf
+++ b/src/pmproxy/pmproxy.conf
@@ -29,7 +29,7 @@ pcp.enabled = true
 http.enabled = true
 
 # support Redis protocol proxying
-redis.enabled = true
+redis.enabled = false
 
 # support SSL/TLS protocol wrapping
 secure.enabled = true


### PR DESCRIPTION
If a redis-server has been locked down in terms of connections, we want to prevent pmproxy from being allowed to send arbitrary RESP commands to it.

This protocol proxying doesn't affect PCP functionality at all, its more of a developer/sysadmin convenience when Redis used in cluster mode (relatively uncommon compared to localhost mode).