### PR TITLE
pmcheck: allow for perl/python script agent checks

### DIFF
--- a/man/man1/pmcheck.1
+++ b/man/man1/pmcheck.1
@@ -354,7 +354,7 @@ or
 and the second argument is the name of the PMDA.
 For the
 .B install
-action, there is a thrird argument for the name of the
+action, there is a third argument for the name of the
 PMDA's executable or DSO and an optional fourth argument
 is the name of a file providing the input required for
 the PMDA's

--- a/src/pmcheck/checkproc.sh
+++ b/src/pmcheck/checkproc.sh
@@ -543,7 +543,7 @@ _ctl_pmda()
 	    echo "need to install the PCP package for the $name PMDA"
 	fi
 	pre=2
-    elif [ "$action" = activate -a -n "$3" -a ! -x "$PCP_VAR_DIR/pmdas/$name/$3" ]
+    elif [ "$action" = activate -a -n "$3" -a ! -f "$PCP_VAR_DIR/pmdas/$name/$3" ]
     then
 	[ "$verbose" -gt 0 ] && echo "need to install the package for the $name PMDA"
 	pre=2


### PR DESCRIPTION
The script agents are not installed executable for reasons, so loosen the pmcheck executable-agent-check to be regular file based instead.

Fix a typo on the man page while there.