### PR TITLE
pmcheck: postgresql service detection and agent recommendation

### DIFF
--- a/src/pmdas/postgresql/GNUmakefile
+++ b/src/pmdas/postgresql/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2020 Red Hat.
+# Copyright (c) 2018-2020,2024 Red Hat.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -47,9 +47,11 @@ install_pcp install: default
 	$(INSTALL) -m 755 -d $(LOGCONFDIR)
 	$(INSTALL) -m 755 -d $(LOGCONFVARDIR)
 	$(INSTALL) -m 644 -t $(LOGCONFVARDIR)/summary pmlogconf.summary $(LOGCONFDIR)/summary
+	$(INSTALL) -m 755 $(IAM).pmcheck $(PCP_SHARE_DIR)/lib/pmcheck/pmda-$(IAM)
 else
 build-me:
-install_pcp install:
+install_pcp install: $(TOPDIR)/src/pmcheck/pmda.na.template
+	$(INSTALL) -m 755 $< $(PCP_SHARE_DIR)/lib/pmcheck/pmda-$(IAM)
 	@$(INSTALL_MAN)
 endif
 

--- a/src/pmdas/postgresql/pmdapostgresql.python
+++ b/src/pmdas/postgresql/pmdapostgresql.python
@@ -1087,6 +1087,10 @@ class POSTGRESQLPMDA(PMDA):
         # success
         return self.cur
 
+    def domain_probe(self):
+        """ return True if postgresql is available and monitorable """
+        return self.conn is not None
+
     def debug(self, msg):
         """ print diagnostic message if verbose logging is enabled """
         if self.verbose:

--- a/src/pmdas/postgresql/postgresql.pmcheck
+++ b/src/pmdas/postgresql/postgresql.pmcheck
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Postgresql PMDA "plugin" for pmcheck
+#
+
+. $PCP_DIR/etc/pcp.env || exit 1
+. $PCP_SHARE_DIR/lib/checkproc.sh
+
+_do_args "$@"
+
+_check()
+{
+    test -n "$@" && echo "$@" >> $tmp/out
+    [ "$verbose" -gt 0 -a -s $tmp/out ] && cat $tmp/out
+    [ $status -eq 0 ] || exit
+}
+
+if $lflag
+then
+    [ "$verbose" -gt 0 ] && echo "Postgresql PMDA - metrics from postgresql-server(1)"
+elif $sflag
+then
+    status=0  # assume active until proven not to be
+    _ctl_svc state postgresql || status=$?
+    _check "postgresql service status: $status"
+    _ctl_pmda state postgresql || status=$?
+    PCP_PYTHON_PROBE=1 $PCP_PYTHON_PROG \
+    $PCP_PMDAS_DIR/postgresql/pmdapostgresql.python || status=$?
+    _check "postgresql PMDA status: $status"
+elif $aflag
+then
+    _ctl_pmda activate postgresql pmdapostgresql || status=1
+elif $dflag
+then
+    _ctl_pmda deactivate postgresql || status=1
+else
+    [ $verbose -gt 0 ] && echo "botch sflag=$sflag aflag=$aflag dflag=$dflag show_me=$show_me verbose=$verbose"
+    status=99
+fi
+
+exit

--- a/src/python/pcp/pmda.py
+++ b/src/python/pcp/pmda.py
@@ -20,6 +20,7 @@
 # pylint: disable=too-many-arguments,consider-using-dict-items,no-member
 
 import os
+import sys
 
 import cpmapi
 import cpmda
@@ -455,6 +456,15 @@ class PMDA(MetricDispatch):
     ##
     # general PMDA class methods
 
+    def domain_probe(self):
+        """
+        Probe the domain to see if the PMDA could be activated
+        Used by pmcheck(1).  Default is None (unknown) but any
+        subclass that overrides should return True on success
+        or False if the target domain is unavailable locally.
+        """
+        return None
+
     def domain_write(self):
         """
         Write out the domain.h file (used during installation)
@@ -492,13 +502,18 @@ class PMDA(MetricDispatch):
     def run(self):
         """
         All the real work happens herein; we can be called in one of three
-        situations, determined by environment variables.  First couple are
-        during the agent Install process, where the domain.h and namespace
-        files need to be created.  The third case is the real mccoy, where
-        an agent is actually being started by pmcd/dbpmda and makes use of
-        libpcp_pmda to talk PCP protocol.
+        situations, determined by environment variables.  First one is for
+        pmcheck(1), next two are part of the agent Install process (where
+        the domain.h and namespace files need to be created).  The fourth
+        case is the real mccoy, where an agent is actually being started
+        by pmcd/dbpmda and makes use of libpcp_pmda to talk PCP protocol.
         """
-        if 'PCP_PYTHON_DOMAIN' in os.environ:
+        if 'PCP_PYTHON_PROBE' in os.environ:
+            result = self.domain_probe()
+            if isinstance(result, int):
+                sys.exit(int(result))
+            sys.exit(2)
+        elif 'PCP_PYTHON_DOMAIN' in os.environ:
             self.domain_write()
         elif 'PCP_PYTHON_PMNS' in os.environ:
             self.pmns_write(os.environ['PCP_PYTHON_PMNS'])


### PR DESCRIPTION
This commit adds an interface allowing any python PMDA script to be called by its corresponding pmcheck plugin to probe and see if it could be enabled.