### PR TITLE
pmdauwsgi: fix failure when no uwsgi values available

### DIFF
--- a/qa/1992
+++ b/qa/1992
@@ -36,11 +36,18 @@ pmdauwsgi_install()
     echo
     echo "=== uwsgi agent installation ==="
     $sudo ./Install </dev/null >$tmp.out 2>&1
-    # Check metrics have appeared ... X metrics and Y values
+    # Check metrics have appeared ... X metrics and Y values (or)
+    # Check metrics have appeared ... N warnings, X metrics and 0 values
     _filter_pmda_install <$tmp.out \
     | $PCP_AWK_PROG '
-    /Check uwsgi metrics have appeared/  { if ($7 == 15) $7 = "X"
-                                           if ($10 >= 0 || $10 == 0) $10 = "Y"
+    /Check uwsgi metrics have appeared/  { if ($NF > 10) {
+                                             if ($8 == "warnings,") $7 = $8 = ""
+                                             if ($9 >= 9) $9 = "X"
+                                             if ($12 == 0) $12 = "Y"
+                                           } else {
+                                             if ($7 >= 15) $7 = "X"
+                                             if ($10 >= 0) $10 = "Y"
+                                           }
                                          }
                                          { print }'
 }

--- a/src/pmdas/uwsgi/pmdauwsgi.python
+++ b/src/pmdas/uwsgi/pmdauwsgi.python
@@ -30,6 +30,7 @@ from cpmapi import (
     PM_TYPE_DOUBLE,
     PM_TYPE_U64,
     PM_SEM_COUNTER,
+    PM_ERR_AGAIN,
     PM_ERR_INST,
     PM_ERR_PMID
 )
@@ -262,7 +263,10 @@ class UwsgiPMDA(PMDA):
 
         item_lookup = [summary_attr[0] for summary_attr in UWSGISUMMARY._fields_]
         if 0 <= item <= (len(UWSGISUMMARY._fields_) - 1):
-            return [getattr(self.summary, item_lookup[item]), 1]
+            try:
+                return [getattr(self.summary, item_lookup[item]), 1]
+            except AttributeError:  # most likely GET failed
+                return [PM_ERR_AGAIN, 0]
         else:
             return [PM_ERR_INST, 0]
 


### PR DESCRIPTION
Make the ussgi PMDA more resilient in the presence of no values available, currently this trips an exception in the fetch code.

Similarly, the QA test 1992 needs additional handling for this case as the Install script (correctly) generates warnings about the missing values.