### PR TITLE
pmdauwsgi: support older versions of python (3.5), reduce logging

### DIFF
--- a/src/pmdas/uwsgi/pmdauwsgi.python
+++ b/src/pmdas/uwsgi/pmdauwsgi.python
@@ -178,7 +178,7 @@ class UwsgiPMDA(PMDA):
     def refresh_all(self):
         try:
             stats = requests.get(self.url, timeout=self.timeout).json()
-            self.log(f"stats: {stats}")
+            #self.log("refresh_all stats:", str(stats))
         except Exception:
             return
 


### PR DESCRIPTION
The f-format style string formatting wasn't available in earlier versions of python, so switch a log call to a simpler interface. Also reduce verbosity of the agent by default as that log() call is on a frequently used (fetch) code path.