### PR TITLE
pcp-atopsar: fix reporting of new day header for alternate TZ

### DIFF
--- a/src/pcp/atop/atopsar.c
+++ b/src/pcp/atop/atopsar.c
@@ -936,13 +936,15 @@ pratopsaruse(char *myname, pmOptions *opts)
 static time_t
 daylimit(time_t timval)
 {
-	struct tm  *tp = localtime(&timval);
+	struct tm  tt, *tp;
+
+	tp = pmLocaltime(&timval, &tt);
 
 	tp->tm_hour = 23;
 	tp->tm_min  = 59;
 	tp->tm_sec  = 59;
 
-	return mktime(tp);
+	return __pmMktime(tp);
 }
 
 /*


### PR DESCRIPTION
If local doesn't match the recorded archive timezone, we can get confused in pcp-atopsar when detecting day rollover.  We need to use the libpcp time handling routines in this case - make it so and this should tackle the CI qa/1493 failure.