### PR TITLE
modify uwsgi semantics

### DIFF
--- a/src/pmdas/uwsgi/pmdauwsgi.1
+++ b/src/pmdas/uwsgi/pmdauwsgi.1
@@ -43,8 +43,9 @@ Connect to the uwsgi stats server on the given port.
 .PP
 .PD
 .SH INSTALLATION
-This \s-1PMDA\s0 requires that uwsgi is running on the local host and
-has enabled the stats-http on on \s-1TCP\s0 port 9051.
+This \s-1PMDA\s0 requires that uwsgi is running 
+on the local host with a uwsgi stats server 
+running on \s-1TCP\s0 port 9051 with stats-http enabled.
 .PP
 Install the uwsgi \s-1PMDA\s0 by using the Install script as root:
 .PP

--- a/src/pmdas/uwsgi/pmdauwsgi.python
+++ b/src/pmdas/uwsgi/pmdauwsgi.python
@@ -29,7 +29,9 @@ from cpmapi import (
     PM_INDOM_NULL,
     PM_TYPE_DOUBLE,
     PM_TYPE_U64,
+    PM_TYPE_U32,
     PM_SEM_COUNTER,
+    PM_SEM_INSTANT,
     PM_ERR_AGAIN,
     PM_ERR_INST,
     PM_ERR_PMID
@@ -144,15 +146,15 @@ class UwsgiPMDA(PMDA):
         #           .total_idle_worker_count
         #           .total_pause_worker_count
 
-        self.add_metric(name + '.summary.total_workers', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 0), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER, pmUnits()), "Total number of uwsgi workers")
+        self.add_metric(name + '.summary.total_workers', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 0), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT, pmUnits()), "Total number of uwsgi workers")
         self.add_metric(name + '.summary.avg_response_time_msec', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 1), PM_TYPE_DOUBLE, PM_INDOM_NULL, PM_SEM_COUNTER, pmUnits()), "Average response time across all workers")
         self.add_metric(name + '.summary.total_requests_served', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 2), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER, pmUnits()), "Total requests served across all workers")
-        self.add_metric(name + '.summary.total_workers_accepting_requests', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 3), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER, pmUnits()), "Total number of workers accepting requests")
+        self.add_metric(name + '.summary.total_workers_accepting_requests', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 3), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT, pmUnits()), "Total number of workers accepting requests")
         self.add_metric(name + '.summary.total_exceptions', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 4), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER, pmUnits()), "Total exceptions across all workers")
         self.add_metric(name + '.summary.total_harakiri_count', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 5), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER, pmUnits()), "Total harakiri count across all workers")
-        self.add_metric(name + '.summary.total_busy_worker_count', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 6), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER, pmUnits()), "Total number of busy workers")
-        self.add_metric(name + '.summary.total_idle_worker_count', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 7), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER, pmUnits()), "Total number of idle workers")
-        self.add_metric(name + '.summary.total_pause_worker_count', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 8), PM_TYPE_U64, PM_INDOM_NULL, PM_SEM_COUNTER, pmUnits()), "Total number of pause workers")
+        self.add_metric(name + '.summary.total_busy_worker_count', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 6), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT, pmUnits()), "Total number of busy workers")
+        self.add_metric(name + '.summary.total_idle_worker_count', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 7), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT, pmUnits()), "Total number of idle workers")
+        self.add_metric(name + '.summary.total_pause_worker_count', pmdaMetric(PMDA.pmid(UwsgiPMDA.UWSGI_SUMMARY, 8), PM_TYPE_U32, PM_INDOM_NULL, PM_SEM_INSTANT, pmUnits()), "Total number of pause workers")
 
         # Add the uwsgi worker metrics (metrics per worker)
         # uwsgi.worker


### PR DESCRIPTION
1. Added a bit to the pmdauwsgi man page to clarify setup.

2. Changed the semantics of some of the `uwsgi.summary...` metrics to be instant rather than a counter.

3. Changed type of the total worker metrics to u32 as it is unlikely there will be >4million workers.