### PR TITLE
python: pass help text result as string not bytes

### DIFF
--- a/qa/1131
+++ b/qa/1131
@@ -48,7 +48,6 @@ _filter_pcp2openmetrics()
     -e '/groupid=/s/groupid="*[0-9][0-9]*"*/groupid="GROUPID"/' \
     -e '/userid=/s/userid="*[0-9][0-9]*"*/userid="USERID"/' \
     -e '/hostname=/s/'$hostname'/HOST/' \
-    -e "s/b'\([^'][^']*\)'/\1/" \
     -e 's/\(.*}\).*/\1 NCPU/' \
     | LC_COLLATE=POSIX sort
 }

--- a/qa/1827
+++ b/qa/1827
@@ -1,5 +1,5 @@
 #!/bin/sh
-# PCP QA Test No. 1589
+# PCP QA Test No. 1827
 # Exercise pcp2openmetrics HTTP POST functionality.
 #
 # Copyright (c) 2024 Red Hat.  All Rights Reserved.

--- a/src/python/pcp/pmapi.py
+++ b/src/python/pcp/pmapi.py
@@ -1846,7 +1846,7 @@ class pmContext(object):
             raise pmErr(status)
         text = buf.value
         LIBC.free(buf)
-        return text
+        return str(text.decode())
 
     ##
     # PMAPI Instance Domain Services


### PR DESCRIPTION
Resolves an issue reporting the HELP line in pcp2openmetrics.