### PR TITLE
python API: fix return value from pmLoadDerivedConfig

### DIFF
--- a/qa/1684
+++ b/qa/1684
@@ -1,0 +1,61 @@
+#!/bin/sh
+# PCP QA Test No. 1684
+# Exercise python derived metrics interface.
+#
+# Copyright (c) 2024 Red Hat.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+. ./common.python
+
+$sudo rm -rf $tmp $tmp.* $seq.full
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=0	# success is the default!
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_filter()
+{
+    sed \
+	-e "s@$tmp@TMP@g" \
+    # end
+}
+
+mkdir $tmp
+echo "x = no-such-metric" >$tmp/a
+echo "y = sample.lights" >>$tmp/a
+echo "z = hinv.ncpu + hinv.ndisk" >>$tmp/a
+
+echo "a = sample.lights" >$tmp/b
+echo "b = bozo}" >>$tmp/b
+echo "c=sample.bin*hinv.ncpu" >>$tmp/b
+echo "d = +" >>$tmp/b
+
+# Don't load any global derived metric configs by default
+export PCP_DERIVED_CONFIG=""
+
+# real QA test starts here
+echo "## Missing file - outright failure"
+src/test_pcp_derived.py no-such-file >$tmp/out 2>&1
+[ $? -eq 1 ] || status=1  # expect a failure
+_filter < $tmp/out
+echo
+echo "## Valid metrics - outright success"
+src/test_pcp_derived.py $tmp/a >$tmp/out 2>&1
+[ $? -eq 0 ] || status=1  # expect success
+_filter < $tmp/out
+echo
+echo "## Mix of metrics - partial success"
+src/test_pcp_derived.py $tmp/b >$tmp/out 2>&1
+[ $? -eq 0 ] || status=1  # expect success
+_filter < $tmp/out
+
+# success, all done
+exit

--- a/qa/1684.out
+++ b/qa/1684.out
@@ -1,0 +1,20 @@
+QA output created by 1684
+## Missing file - outright failure
+Loading derived metrics from no-such-file
+Failed to load: No such file or directory
+
+## Valid metrics - outright success
+Loading derived metrics from TMP/a
+Successfully loaded 3 derived metrics
+
+## Mix of metrics - partial success
+[TMP/b:2] Error: pmRegisterDerived(b, ...) syntax error
+ bozo}
+     ^
+Illegal character
+[TMP/b:4] Error: pmRegisterDerived(d, ...) syntax error
+ +
+ ^
+Unexpected initial '+'
+Loading derived metrics from TMP/b
+Successfully loaded 2 derived metrics

--- a/qa/group
+++ b/qa/group
@@ -2027,6 +2027,7 @@ x11
 1680 openvswitch local
 1681 pmrep pcp2xxx pmlogconf local
 1682 pmrep pcp2xxx pmlogconf valgrind local
+1684 python derive local
 1688 pmieconf local
 1689 pmproxy libpcp_web local
 1690 pmseries local

--- a/qa/src/GNUlocaldefs
+++ b/qa/src/GNUlocaldefs
@@ -141,6 +141,7 @@ PYTHONFILES = \
 	test_pcp.python test_pmcc.python \
 	test_pmi.python check_import.python \
 	test_mmv.python test_webapi.python \
+	test_pcp_derived.python \
 	test_pcp_options.python test_pcp_getopts.python \
 	test_pcp_time.python test_pmnswalk.python \
 	pmapi_exceptions.python pmapi_daemon.python \

--- a/qa/src/test_pcp_derived.python
+++ b/qa/src/test_pcp_derived.python
@@ -1,0 +1,39 @@
+#!/usr/bin/env pmpython
+#
+# Copyright (C) 2024 Red Hat.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+
+""" Exercise PMAPI derived metrics interfaces """
+
+import sys
+from pcp import pmapi
+
+context = pmapi.pmContext()
+
+def check_load_from_file(file):
+    print('Loading derived metrics from', file)
+    try:
+        count = context.pmLoadDerivedConfig(file)
+    except pmapi.pmErr as err:
+        print('Failed to load:', str(err))
+        return 1  # exit status
+    print('Successfully loaded', count, 'derived metrics')
+    return 0  # success
+
+if __name__ == '__main__':
+    sts = 2  # failure code
+    if (len(sys.argv) == 2):
+        sts = check_load_from_file(sys.argv[1])
+    else:
+        print("Usage: " + sys.argv[0] + " load-file")
+    sys.exit(sts)

--- a/src/python/pcp/pmapi.py
+++ b/src/python/pcp/pmapi.py
@@ -1744,12 +1744,13 @@ class pmContext(object):
         """
         if not isinstance(fname, bytes):
             fname = fname.encode('utf-8')
-        status = LIBPCP.pmLoadDerivedConfig(fname)
+        status = count = LIBPCP.pmLoadDerivedConfig(fname)
         if status < 0:
             raise pmErr(status)
         status = LIBPCP.pmReconnectContext(self.ctx)
         if status < 0:
             raise pmErr(status)
+        return count
 
     # Deprecated, no longer needed, py wrapper uses pmRegisterDerivedMetric(3)
     # and the exception encodes a more complete error message as a result.


### PR DESCRIPTION
Add test qa/1684 to exercise derived metrics handling in the python wrapper using a test_pcp_derived.python helper utility.

Resolves: #1963