### PR TITLE
pcp-dstat: stop using a nested derived metric in time plugins

### DIFF
--- a/src/pcp/dstat/pcp-dstat.py
+++ b/src/pcp/dstat/pcp-dstat.py
@@ -647,7 +647,7 @@ class DstatTool(object):
                 index = self.timeplugins.index(section)
                 plugin = self.timelist[index]
                 name = 'dstat.' + section + '.' + plugin.name # metric name
-                value = 'event.missed'  # a valid metric that always exists
+                value = '0' # constant expression, always valid as a metric
                 lib.parse_new_verbose_metric(metrics, name, name)
                 lib.parse_verbose_metric_info(metrics, name, 'formula', value)
                 lib.parse_verbose_metric_info(metrics, name, 'label', section)


### PR DESCRIPTION
Recent libpcp changes in derived metrics verifications have meant the pcp-dstat kludge using event.missed as time metric expression no longer functions.  A simpler approach there is to use constant expressions rather than a metric name, and this workaround solves the problem.