### PR TITLE
pmcd: rate-limit connection failure logging in case of bursts

### DIFF
--- a/qa/193
+++ b/qa/193
@@ -22,6 +22,7 @@ _stop_auto_restart pmcd
 
 _cleanup()
 {
+    pmstore pmcd.control.debug 0 >>$seq.full 2>&1 # pdu==1
     _restore_auto_restart pmcd
 }
 
@@ -32,6 +33,7 @@ _wait_for_pmcd
 _wait_for_pmlogger
 
 # real QA test starts here
+pmstore pmcd.control.debug 1 >>$seq.full 2>&1 # pdu==1
 src/crashpmcd
 
 # give pmcd a chance to deal with PDUs from crashpmcd
@@ -43,6 +45,9 @@ _filter_pmcd_log <$PCP_PMCDLOG_PATH \
 | sed \
     -e '1,/ok FD /d' \
     -e '/ok FD /d' \
+    -e '/pmXmitPDU: ERROR/d' \
+    -e '/pmGetPDU: TYPE/d' \
+    -e '/^000:/d' \
     -e 's/fd=[0-9][0-9]*/fd=N/' \
     -e '/HandleClientInput/s/client\[[0-9][0-9]*]/client[N]/' \
     -e 's/len=-1: Connection reset by peer.*/END-OF-FILE/' \

--- a/qa/src/test_pcp_sockets.python
+++ b/qa/src/test_pcp_sockets.python
@@ -1,0 +1,23 @@
+import socket
+import cpmapi as api
+from pcp import pmapi
+
+address = 'localhost'
+port = 44321
+
+c = []
+for i in range(0, 1234):
+    print('context', i)
+    ctx = pmapi.pmContext(api.PM_CONTEXT_HOST, "local:")
+    print('created', i)
+    c.append(ctx)
+
+s = []
+for i in range(0, 1234):
+    sock = socket.socket()
+    print('socket', i)
+    sock.connect((address, port))
+    print('connect', i)
+    sock.send(b"abba\r")  # -- gives a too-large PDU
+    print('send', i)
+    # s.append(sock)  # -- exercise pduread: timeout

--- a/src/pmcd/src/pmcd.c
+++ b/src/pmcd/src/pmcd.c
@@ -745,7 +745,7 @@ HandleReadyAgents(__pmFdSet *readyFds)
 }
 
 static void
-CheckNewClient(__pmFdSet * fdset, int rfd, int family)
+CheckNewClient(__pmFdSet *fdset, int rfd, int family)
 {
     int		s, sts, accepted = 1;
     __uint32_t	challenge;


### PR DESCRIPTION
There have been cases of pmcd.log filling root filesystems with the diagnostics on failure/refusal to accept client connections so now we rate limit these to once-per-minute (with the counter for dropped messages also being logged).

While testing this several cases of verbose socket diagnostics from libpcp/pduread.c __pmGetPDU code were also encountered - these are made conditional via pmDebug.pdu (as in __pmXmitPDU).

Relates to Red Hat bug RHEL-34586
Relates to Github issue #1533