### PR TITLE
proc: add amdgpu support

### DIFF
--- a/qa/1222
+++ b/qa/1222
@@ -58,6 +58,8 @@ _filter()
 	-e '/^proc\.id\.container: Missing metric value(s)/d' \
 	-e '/^proc\.psinfo\.labels: No value(s) available/d' \
 	-e '/^proc\.psinfo\.ngid: Metric not supported by this version/d' \
+	-e '/^proc\.fdinfo\..*: Metric not supported/d' \
+	-e '/^proc\.fdinfo\..*: No value(s) available/d' \
 	-e '/pmdaFetch: Fetch callback error from metric PMID 3\.11\.0\[.*]: No data available/d' \
 	-e '/proc\.psinfo\.tty_pgrp: No value(s) available/d' \
 	-e '/ acct: existing pacct file did not grow /d' \
@@ -105,6 +107,7 @@ NF == 0 && seen == 1		{ if (numval == 1) print metric ": 1 value"
 	-e '/^proc\.psinfo\.ngid:/d' \
 	-e '/^proc\.psinfo\.tty_pgrp:/d' \
 	-e '/^proc\.smaps\./d' \
+	-e '/^proc\.fdinfo\./d' \
 	-e '/^Command: /s/,proc_init .*/,proc_init ... metrics .../' \
 	-e '/ERROR SUMMARY/q' \
     # end

--- a/qa/364
+++ b/qa/364
@@ -288,6 +288,7 @@ _filter_linux()
 {
     # pcp-atop uses metrics not supported on some kernels
     # proc.smaps.* metrics are not present for older kernels
+    # proc.fdinfo.* metrics neither
     #
     if [ $PCP_PLATFORM != linux ]
     then
@@ -310,6 +311,7 @@ _filter_linux()
 	    -e '/^proc\.psinfo\.cgroups -12351 Missing metric value(s)/d' \
 	    -e '/^proc\.namespaces\.envid -12350 Metric not supported/d' \
 	    -e '/^hotproc\.namespaces\.envid -12350 Metric not supported/d' \
+	    -e '/^proc\.fdinfo\..* Metric not supported/d' \
 	# linux
     fi
 }

--- a/src/pmdas/linux_proc/clusters.h
+++ b/src/pmdas/linux_proc/clusters.h
@@ -70,8 +70,10 @@
 #define CLUSTER_PID_AUTOGROUP		74 /* /proc/<pid>/autogroup */
 #define CLUSTER_HOTPROC_PID_AUTOGROUP	75 /* /proc/<pid>/autogroup */
 #define CLUSTER_CGROUP2_IRQ_PRESSURE	76
+#define CLUSTER_PID_FDINFO		77 /* /proc/<pid>/fdinfo */
+#define CLUSTER_HOTPROC_PID_FDINFO	78 /* /proc/<pid>/fdinfo */
 
 #define MIN_CLUSTER  8		/* first cluster number we use here */
-#define MAX_CLUSTER 77		/* one more than highest cluster number used */
+#define MAX_CLUSTER 79		/* one more than highest cluster number used */
 
 #endif /* _CLUSTERS_H */

--- a/src/pmdas/linux_proc/help
+++ b/src/pmdas/linux_proc/help
@@ -591,3 +591,4 @@ of accounting information:
   0 inactive (no information available)
   1 system (system level accounting from whatever file accton(8) is using)
   2 private (accounting records from $PCP_VAR_DIR/pmcd/pacct)
+

--- a/src/pmdas/linux_proc/help_text.h
+++ b/src/pmdas/linux_proc/help_text.h
@@ -155,4 +155,18 @@ help_text_t  help_text[] = {
 { .name = "autogroup.enabled",    .shorthelp = "Scheduling autogroup feature for CFS is enabled in the kernel",   .longhelp = "Contents of /proc/sys/kernel/sched_autogroup_enabled as described in sched(7)." },
 { .name = "autogroup.id",    .shorthelp = "Process autogroup identifier from /proc/<pid>/autogroup",   .longhelp = "Process scheduling autogroup identifier as described in sched(7)." },
 { .name = "autogroup.nice",    .shorthelp = "Process autogroup nice level from /proc/<pid>/autogroup",   .longhelp = "Process scheduling autogroup nice level as described in sched(7)." },
+
+{ .name = "fdinfo.drm_memory_cpu",    .shorthelp = "Accumulation of the drm-memory-cpu field from /proc/<pid>/fdinfo/* file descriptors",   .longhelp = "CPU memory which can be used by the GPU to store buffer objects." },
+{ .name = "fdinfo.drm_memory_gtt",    .shorthelp = "Accumulation of the drm-memory-gtt field from /proc/<pid>/fdinfo/* file descriptors",   .longhelp = "GTT memory which can be used by the GPU to store buffer objects." },
+{ .name = "fdinfo.drm_memory_vram",    .shorthelp = "Accumulation of the drm-memory-vram field from /proc/<pid>/fdinfo/* file descriptors",   .longhelp = "VRAM memory which can be used by the GPU to store buffer objects." },
+{ .name = "fdinfo.drm_shared_cpu",    .shorthelp = "Accumulation of the drm-shared-cpu field from /proc/<pid>/fdinfo/* file descriptors",   .longhelp = "CPU memory which can be used by the GPU to store buffer objects, and is shared with another file." },
+{ .name = "fdinfo.drm_shared_gtt",    .shorthelp = "Accumulation of the drm-shared-gtt field from /proc/<pid>/fdinfo/* file descriptors",   .longhelp = "GTT memory which can be used by the GPU to store buffer objects, and is shared with another file." },
+{ .name = "fdinfo.drm_shared_vram",    .shorthelp = "Accumulation of the drm-shared-vram field from /proc/<pid>/fdinfo/* file descriptors",   .longhelp = "VRAM memory which can be used by the GPU to store buffer objects, and is shared with another file." },
+
+{ .name = "fdinfo.amd_evicted_visible_vram",  .shorthelp = "Accumulation of the amd-evicted-visible-vram field from /proc/<pid>/fdinfo/* file descriptors",  .longhelp = "Sum of evicted buffers due to CPU access." },
+{ .name = "fdinfo.amd_evicted_vram",  .shorthelp = "Accumulation of the amd-evicted-vram field from /proc/<pid>/fdinfo/* file descriptors",  .longhelp = "Sum of evicted buffers, includes visible VRAM" },
+{ .name = "fdinfo.amd_memory_visible_vram",  .shorthelp = "Accumulation of the amd-memory-visible-vram field from /proc/<pid>/fdinfo/* file descriptors",  .longhelp = "Current visible VRAM usage" },
+{ .name = "fdinfo.amd_requested_gtt",  .shorthelp = "Accumulation of the amd-requested-gtt field from /proc/<pid>/fdinfo/* file descriptors",  .longhelp = "How much GTT memory userspace asked for" },
+{ .name = "fdinfo.amd_requested_visible_vram",  .shorthelp = "Accumulation of the amd-requested-visible-vram field from /proc/<pid>/fdinfo/* file descriptors",  .longhelp = "How much visible VRAM userspace asked for" },
+{ .name = "fdinfo.amd_requested_vram",  .shorthelp = "Accumulation of the amd-requested-vram field from /proc/<pid>/fdinfo/* file descriptors",  .longhelp = "How much VRAM userspace asked for, includes visible VRAM" },
 };

--- a/src/pmdas/linux_proc/pmda.c
+++ b/src/pmdas/linux_proc/pmda.c
@@ -33,6 +33,7 @@
 #include "../linux/convert.h"
 
 #include <ctype.h>
+#include <sys/syslog.h>
 #include <unistd.h>
 #include <sys/vfs.h>
 #include <sys/stat.h>
@@ -1348,6 +1349,52 @@ static pmdaMetric metrictab[] = {
 /* acct.control.state */
   { NULL, { PMDA_PMID(CLUSTER_ACCT,CONTROL_ACCT_STATE), PM_TYPE_32, PM_INDOM_NULL,
     PM_SEM_DISCRETE, PMDA_PMUNITS(0,0,0,0,0,0) }, },
+
+/*
+ * Fdinfo cluster
+ */
+
+/* proc.fdinfo.drm_memory */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,0), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+/* proc.fdinfo.drm.memory_cpu */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,1), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+/* proc.fdinfo.drm.memory_gtt */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,2), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+/* proc.fdinfo.drm.memory_vram */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,3), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+/* proc.fdinfo.drm.shared_cpu */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,4), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+/* proc.fdinfo.drm.shared_gtt */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,5), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+/* proc.fdinfo.drm.shared_vram */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,6), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+
+/* proc.fdinfo.amd.evicted_visible_vram */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,7), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+/* proc.fdinfo.amd.evicted_vram */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,8), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+/* proc.fdinfo.amd.memory_visible_vram */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,9), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+/* proc.fdinfo.amd.requested_gtt */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,10), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+/* proc.fdinfo.amd.requested_visible_vram */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,11), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+/* proc.fdinfo.amd.requested_vram */
+  { NULL, { PMDA_PMID(CLUSTER_PID_FDINFO,12), PM_TYPE_U64, PROC_INDOM,
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0)}},
+
 };
 
 pmInDom
@@ -1444,6 +1491,7 @@ proc_refresh(pmdaExt *pmda, int *need_refresh)
 	need_refresh[CLUSTER_PID_CWD] ||
 	need_refresh[CLUSTER_PID_EXE] ||
 	need_refresh[CLUSTER_PID_FD] ||
+	need_refresh[CLUSTER_PID_FDINFO] ||
 	need_refresh[CLUSTER_PROC_RUNQ]) {
 	refresh_proc_pid(&proc_pid,
 		need_refresh[CLUSTER_PROC_RUNQ]? &proc_runq : NULL,
@@ -1464,6 +1512,7 @@ proc_refresh(pmdaExt *pmda, int *need_refresh)
         need_refresh[CLUSTER_HOTPROC_PID_CWD] ||
         need_refresh[CLUSTER_HOTPROC_PID_EXE] ||
         need_refresh[CLUSTER_HOTPROC_PID_FD] ||
+        need_refresh[CLUSTER_HOTPROC_PID_FDINFO] ||
         need_refresh[CLUSTER_HOTPROC_GLOBAL] ||
         need_refresh[CLUSTER_HOTPROC_PRED]){
         refresh_hotproc_pid(&hotproc_pid,
@@ -1495,6 +1544,7 @@ proc_instance(pmInDom indom, int inst, char *name, pmInResult **result, pmdaExt 
         need_refresh[CLUSTER_PID_CWD]++;
         need_refresh[CLUSTER_PID_IO]++;
         need_refresh[CLUSTER_PID_FD]++;
+        need_refresh[CLUSTER_PID_FDINFO]++;
 	break;
     case HOTPROC_INDOM:
         need_refresh[CLUSTER_HOTPROC_PID_STAT]++;
@@ -1511,6 +1561,7 @@ proc_instance(pmInDom indom, int inst, char *name, pmInResult **result, pmdaExt 
         need_refresh[CLUSTER_HOTPROC_PID_FD]++;
         need_refresh[CLUSTER_HOTPROC_GLOBAL]++;
         need_refresh[CLUSTER_HOTPROC_PRED]++;
+        need_refresh[CLUSTER_HOTPROC_PID_FDINFO]++;
         break;
 
     case CGROUP_CPUSET_INDOM:
@@ -3430,6 +3481,59 @@ proc_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
 	}
 	break;
 
+    case CLUSTER_HOTPROC_PID_FDINFO:
+	active_proc_pid = &hotproc_pid;
+	/*FALLTHROUGH*/
+    case CLUSTER_PID_FDINFO:
+	if (!have_access)
+	  return PM_ERR_PERMISSION;
+	if ((entry = fetch_proc_pid_fdinfo(inst, active_proc_pid, &sts)) == NULL)
+	  return sts;
+	if (!(entry->success & PROC_PID_FLAG_FDINFO))
+	  return 0;
+
+	switch (item) {
+	  case 0: /* proc.fdinfo.drm.memory_cpu */
+	    atom->ull = entry->fdinfo.drm_memory_cpu;
+	    break;
+	  case 1: /* proc.fdinfo.drm.memory_gtt */
+	    atom->ull = entry->fdinfo.drm_memory_gtt;
+	    break;
+	  case 2: /* proc.fdinfo.drm.memory_vram */
+	    atom->ull = entry->fdinfo.drm_memory_vram;
+	    break;
+	  case 3: /* proc.fdinfo.drm.shared_cpu */
+	    atom->ull = entry->fdinfo.drm_shared_cpu;
+	    break;
+	  case 4: /* proc.fdinfo.drm.shared_gtt */
+	    atom->ull = entry->fdinfo.drm_shared_gtt;
+	    break;
+	  case 5: /* proc.fdinfo.drm.shared_vram */
+	    atom->ull = entry->fdinfo.drm_shared_vram;
+	    break;
+
+	  case 6: /* proc.fdinfo.amd.evicted_visible_vram */
+	    atom->ull = entry->fdinfo.amd_evicted_visible_vram;
+	    break;
+	  case 7: /* proc.fdinfo.amd.evicted_vram */
+	    atom->ull = entry->fdinfo.amd_evicted_vram;
+	    break;
+	  case 8: /* proc.fdinfo.amd.memory_visible_vram */
+	    atom->ull = entry->fdinfo.amd_memory_visible_vram;
+	    break;
+	  case 9: /* proc.fdinfo.amd.requested_gtt */
+	    atom->ull = entry->fdinfo.amd_requested_gtt;
+	    break;
+	  case 10: /* proc.fdinfo.amd.requested_visible_vram */
+	    atom->ull = entry->fdinfo.amd_requested_visible_vram;
+	    break;
+	  case 11: /* proc.fdinfo.amd.requested_vram */
+	    atom->ull = entry->fdinfo.amd_requested_vram;
+	    break;
+	  default: /* unknown cluster */
+	    return PM_ERR_PMID;
+	}
+	break;
     default: /* unknown cluster */
 	return PM_ERR_PMID;
     }

--- a/src/pmdas/linux_proc/proc_dynamic.c
+++ b/src/pmdas/linux_proc/proc_dynamic.c
@@ -40,6 +40,7 @@ enum {
     DYNPROC_GROUP_NAMESPACE,
     DYNPROC_GROUP_SMAPS,
     DYNPROC_GROUP_AUTOGROUP,
+    DYNPROC_GROUP_FDINFO,
 
     NUM_DYNPROC_GROUPS
 };
@@ -69,6 +70,7 @@ static int proc_hotproc_cluster_list[][2] = {
 	{ CLUSTER_PID_EXE,	    CLUSTER_HOTPROC_PID_EXE },
 	{ CLUSTER_PID_CWD,	    CLUSTER_HOTPROC_PID_CWD },
 	{ CLUSTER_PID_AUTOGROUP,    CLUSTER_HOTPROC_PID_AUTOGROUP },
+	{ CLUSTER_PID_FDINFO,	    CLUSTER_HOTPROC_PID_FDINFO },
 };
 
 
@@ -257,6 +259,21 @@ static dynproc_metric_t smaps_metrics[] = {
 	{ .name = "pss_dirty",       .cluster = CLUSTER_PID_SMAPS,  .item=20 },
 };
 
+static dynproc_metric_t fdinfo_metrics[] = {
+	{ .name = "drm_memory_cpu",             .cluster = CLUSTER_PID_FDINFO, .item=0 },
+	{ .name = "drm_memory_gtt",             .cluster = CLUSTER_PID_FDINFO, .item=1 },
+	{ .name = "drm_memory_vram",            .cluster = CLUSTER_PID_FDINFO, .item=2 },
+	{ .name = "drm_shared_cpu",             .cluster = CLUSTER_PID_FDINFO, .item=3 },
+	{ .name = "drm_shared_gtt",             .cluster = CLUSTER_PID_FDINFO, .item=4 },
+	{ .name = "drm_shared_vram",            .cluster = CLUSTER_PID_FDINFO, .item=5 },
+	{ .name = "amd_evicted_visible_vram",   .cluster = CLUSTER_PID_FDINFO, .item=6 },
+	{ .name = "amd_evicted_vram",           .cluster = CLUSTER_PID_FDINFO, .item=7 },
+	{ .name = "amd_memory_visible_vram",    .cluster = CLUSTER_PID_FDINFO, .item=8 },
+	{ .name = "amd_requested_gtt",          .cluster = CLUSTER_PID_FDINFO, .item=9 },
+	{ .name = "amd_requested_visible_vram", .cluster = CLUSTER_PID_FDINFO, .item=10 },
+	{ .name = "amd_requested_vram",         .cluster = CLUSTER_PID_FDINFO, .item=11 },
+};
+
 static dynproc_group_t dynproc_groups[] = {
 	[DYNPROC_GROUP_PSINFO]    = { .name = "psinfo",	    .metrics = psinfo_metrics,	    .nmetrics = sizeof(psinfo_metrics)/sizeof(dynproc_metric_t)},
 	[DYNPROC_GROUP_ID]	  = { .name = "id",	    .metrics = id_metrics,	    .nmetrics = sizeof(id_metrics)/sizeof(dynproc_metric_t)},
@@ -267,6 +284,7 @@ static dynproc_group_t dynproc_groups[] = {
 	[DYNPROC_GROUP_NAMESPACE] = { .name = "namespaces", .metrics = namespace_metrics,   .nmetrics = sizeof(namespace_metrics)/sizeof(dynproc_metric_t) },
 	[DYNPROC_GROUP_SMAPS]     = { .name = "smaps",	    .metrics = smaps_metrics,	    .nmetrics = sizeof(smaps_metrics)/sizeof(dynproc_metric_t)},
 	[DYNPROC_GROUP_AUTOGROUP] = { .name = "autogroup", .metrics = autogroup_metrics,   .nmetrics = sizeof(autogroup_metrics)/sizeof(dynproc_metric_t) },
+	[DYNPROC_GROUP_FDINFO]    = { .name = "fdinfo",	    .metrics = fdinfo_metrics,	    .nmetrics = sizeof(fdinfo_metrics)/sizeof(dynproc_metric_t) },
 };
 
 /*

--- a/src/pmdas/linux_proc/proc_pid.c
+++ b/src/pmdas/linux_proc/proc_pid.c
@@ -19,9 +19,12 @@
 #include "pmapi.h"
 #include "libpcp.h"
 #include "pmda.h"
+#include <stdio.h>
+#include <string.h>
 #include <ctype.h>
 #include <dirent.h>
 #include <sys/stat.h>
+#include <sys/syslog.h>
 #include <sys/types.h>
 #include <pwd.h>
 #include <grp.h>
@@ -2289,5 +2292,208 @@ fetch_proc_pid_autogroup(int id, proc_pid_t *proc_pid, int *sts)
 	*sts = refresh_proc_pid_autogroup(ep);
 	ep->fetched |= PROC_PID_FLAG_AUTOGROUP;
     }
+    return (*sts < 0) ? NULL : ep;
+}
+
+static void
+parse_proc_fdinfo(proc_pid_fdinfo_t *fdinfo, size_t buflen, char *buf)
+{
+    char		*curline = buf;
+
+    /*
+    * drm-driver:	amdgpu
+    * drm-client-id:	422
+    * drm-pdev:	0000:0c:00.0
+    * drm-memory-vram:	0 KiB
+    * [...]
+    * amd-requested-gtt:	2048 KiB
+    */
+    while (curline) {
+	switch (curline[0]) {
+	case 'd':
+	  if (strncmp(curline, "drm-driver:", 11) == 0) {
+	      char *c = curline + 11;
+	      char const *n = index(curline, '\n');
+	      size_t size = sizeof(fdinfo->drm_driver) - 1;
+
+	      while (isspace(*c))
+		++c;
+	      if (n && (n - c <= size))
+		size = n - c;
+
+	      strncpy(fdinfo->drm_driver, c, size);
+	  }
+	  else if (strncmp(curline, "drm-client-id:", 14) == 0)
+	      fdinfo->drm_client_id = strtoull(curline + 14, &curline, 0);
+	  else if (strncmp(curline, "drm-pdev:", 9) == 0) {
+	      char *c = curline + 9;
+	      char const *n = index(curline, '\n');
+	      size_t size = sizeof(fdinfo->drm_driver) - 1;
+
+	      while (isspace(*c))
+		++c;
+	      if (n && (n - c <= size))
+		size = n - c;
+
+	      strncpy(fdinfo->drm_pdev, c, size);
+	  }
+	  else if (strncmp(curline, "drm-memory-vram:", 16) == 0)
+	      fdinfo->drm_memory_vram = strtoull(curline + 16, &curline, 0);
+	  else if (strncmp(curline, "drm-memory-gtt:", 15) == 0)
+	      fdinfo->drm_memory_gtt = strtoull(curline + 15, &curline, 0);
+	  else if (strncmp(curline, "drm-memory-cpu:", 15) == 0)
+	      fdinfo->drm_memory_cpu = strtoull(curline + 15, &curline, 0);
+	  else
+	      goto nomatch;
+	  break;
+	case 'a':
+	  if (strncmp(curline, "amd-memory-visible-vram:", 24) == 0)
+	    fdinfo->amd_memory_visible_vram = strtoull(curline + 24, &curline, 0);
+	  else if (strncmp(curline, "amd-evicted-vram:", 17) == 0)
+	    fdinfo->amd_evicted_vram = strtoull(curline + 17, &curline, 0);
+	  else if (strncmp(curline, "amd-evicted-visible-vram:", 25) == 0)
+	    fdinfo->amd_evicted_visible_vram = strtoull(curline + 25, &curline, 0);
+	  else if (strncmp(curline, "amd-requested-vram:", 19) == 0)
+	    fdinfo->amd_requested_vram = strtoull(curline + 19, &curline, 0);
+	  else if (strncmp(curline, "amd-requested-visible-vram:", 27) == 0)
+	    fdinfo->amd_requested_visible_vram = strtoull(curline + 27, &curline, 0);
+	  else if (strncmp(curline, "amd-requested-gtt:", 18) == 0)
+	    fdinfo->amd_requested_gtt = strtoull(curline + 18,&curline, 0);
+	  else
+	      goto nomatch;
+	  break;
+	default:
+	nomatch:
+	    if (pmDebugOptions.appl1 && pmDebugOptions.desperate) {
+		char	*p;
+		fprintf(stderr, "%s: skip ", "fetch_proc_pid_fdinfo.");
+		for (p = curline; *p && *p != '\n'; p++)
+		    fputc(*p, stderr);
+		fputc('\n', stderr);
+	    }
+	}
+	curline = index(curline, '\n');	/* skips any kiB suffix */
+	if (curline != NULL) curline++;
+    }
+}
+
+static void
+accumulate_proc_fdinfo(proc_pid_entry_t *ep, proc_pid_fdinfo_t fdinfo)
+{
+    /* Generic DRM data */
+    ep->fdinfo.drm_memory_cpu += fdinfo.drm_memory_cpu;
+    ep->fdinfo.drm_memory_gtt += fdinfo.drm_memory_gtt;
+    ep->fdinfo.drm_memory_vram += fdinfo.drm_memory_vram;
+    ep->fdinfo.drm_shared_cpu += fdinfo.drm_shared_cpu;
+    ep->fdinfo.drm_shared_gtt += fdinfo.drm_shared_gtt;
+    ep->fdinfo.drm_shared_vram += fdinfo.drm_shared_vram;
+    /* AMD GPU specific data */
+    ep->fdinfo.amd_evicted_visible_vram += fdinfo.amd_evicted_visible_vram;
+    ep->fdinfo.amd_evicted_vram += fdinfo.amd_evicted_vram;
+    ep->fdinfo.amd_memory_visible_vram += fdinfo.amd_memory_visible_vram;
+    ep->fdinfo.amd_requested_gtt += fdinfo.amd_requested_gtt;
+    ep->fdinfo.amd_requested_visible_vram += fdinfo.amd_requested_visible_vram;
+    ep->fdinfo.amd_requested_vram += fdinfo.amd_requested_vram;
+}
+
+static int
+refresh_proc_pid_fdinfo(proc_pid_entry_t *ep)
+{
+    DIR			*dirp;
+    struct dirent const	*dp;
+    int			sts = -1;
+    proc_pid_fdinfo_t	*fdinfos;
+    int			fd_count = 0;
+    int			fd_it = 0;
+
+    if (ep->success & PROC_PID_FLAG_FDINFO)
+	return 0;
+
+    if ((dirp = proc_opendir("fdinfo", ep)) == NULL)
+	return maperr();
+
+    while ((dp = readdir(dirp)) != NULL)
+	fd_count++;
+
+    if (!fd_count)
+	return 0;
+
+    fdinfos = calloc(fd_count, sizeof(*fdinfos));
+    if (!fdinfos)
+	return maperr();
+
+    rewinddir(dirp);
+
+    while ((dp = readdir(dirp)) != NULL) {
+	int fd = -1;
+	int duplicate = 0;
+	proc_pid_fdinfo_t fdinfo = { 0 };
+	char fname[] = "fdinfo/xxxxx";
+
+	if (!isdigit((int)dp->d_name[0]))
+	    continue;
+
+	pmsprintf(fname, sizeof(fname), "fdinfo/%s", dp->d_name);
+
+	if ((fd = proc_open(fname, ep)) < 0) {
+	    free(fdinfos);
+	    return maperr();
+	}
+
+	if ((sts = read_proc_entry(fd, &procbuflen, &procbuf)) >= 0)
+	    parse_proc_fdinfo(&fdinfo, procbuflen, procbuf);
+
+	close(fd);
+
+	/* We only support AMD GPUs for now */
+	if (!fdinfo.drm_driver[0] ||
+	    strncmp(fdinfo.drm_driver, "amdgpu", 6) ||
+	    !fdinfo.drm_client_id)
+	    continue;
+
+	/* Skip duplicate data */
+	for (int i = 0; i < fd_it; i++) {
+	    if (fdinfo.drm_client_id == fdinfos[i].drm_client_id) {
+		duplicate = 1;
+		break;
+	    }
+	}
+
+	if (!duplicate)
+	    fdinfos[fd_it++] = fdinfo;
+    }
+
+    /* Reset any previous data, before accumulation.
+     * If we wanted to keep all infos separated, we could simply
+     * attach fdinfos there.
+     */
+    memset(&ep->fdinfo, 0, sizeof(ep->fdinfo));
+
+    for (int i = 0; i < fd_it; i++)
+	accumulate_proc_fdinfo(ep, fdinfos[i]);
+
+    ep->success |= PROC_PID_FLAG_FDINFO;
+    free(fdinfos);
+
+    return sts;
+}
+
+/*
+ * fetch data from proc/<pid>/fdinfo/ entries for pid
+ */
+proc_pid_entry_t *
+fetch_proc_pid_fdinfo(int id, proc_pid_t *proc_pid, int *sts)
+{
+    proc_pid_entry_t	*ep = proc_pid_entry_lookup(id, proc_pid);
+
+    *sts = 0;
+    if (!ep)
+	return NULL;
+
+    if (!(ep->fetched & PROC_PID_FLAG_FDINFO)) {
+	*sts = refresh_proc_pid_fdinfo(ep);
+	ep->fetched |= PROC_PID_FLAG_FDINFO;
+    }
+
     return (*sts < 0) ? NULL : ep;
 }

--- a/src/pmdas/linux_proc/proc_pid.h
+++ b/src/pmdas/linux_proc/proc_pid.h
@@ -202,6 +202,29 @@ typedef struct {
     uint64_t	locked;
 } proc_pid_smaps_t;
 
+/*
+ * metrics in /proc/<pid>/fdinfo/
+ */
+typedef struct {
+    /* Generic DRM data */
+    char	drm_driver[32];
+    uint64_t	drm_client_id;
+    char	drm_pdev[32];
+    uint64_t	drm_memory_vram;
+    uint64_t	drm_memory_gtt;
+    uint64_t	drm_memory_cpu;
+    uint64_t	drm_shared_vram;
+    uint64_t	drm_shared_gtt;
+    uint64_t	drm_shared_cpu;
+    /* AMD GPU specific data */
+    uint64_t	amd_memory_visible_vram;
+    uint64_t	amd_evicted_vram;
+    uint64_t	amd_evicted_visible_vram;
+    uint64_t	amd_requested_vram;
+    uint64_t	amd_requested_visible_vram;
+    uint64_t	amd_requested_gtt;
+} proc_pid_fdinfo_t;
+
 enum {
     PROC_PID_FLAG_VALID		= 1<<0,
 
@@ -221,6 +244,7 @@ enum {
     PROC_PID_FLAG_CWD		= 1<<14,
     PROC_PID_FLAG_EXE		= 1<<15,
     PROC_PID_FLAG_AUTOGROUP	= 1<<16,
+    PROC_PID_FLAG_FDINFO	= 1<<17,
 };
 
 typedef struct {
@@ -286,6 +310,9 @@ typedef struct {
     /* /proc/<pid>/autogroup cluster */
     uint32_t		autogroup_id;
     int32_t		autogroup_nice;
+
+    /* /proc/<pid>/fdinfo cluster */
+    proc_pid_fdinfo_t	fdinfo;
 } proc_pid_entry_t;
 
 typedef struct {
@@ -371,5 +398,8 @@ extern proc_pid_entry_t *fetch_proc_pid_exe(int, proc_pid_t *, int *);
 
 /* fetch a proc/<pid>/autogroup entry for pid */
 extern proc_pid_entry_t *fetch_proc_pid_autogroup(int, proc_pid_t *, int *);
+
+/* fetch data from proc/<pid>/fdinfo/ entry for pid */
+extern proc_pid_entry_t *fetch_proc_pid_fdinfo(int, proc_pid_t *, int *);
 
 #endif /* _PROC_PID_H */

--- a/src/pmdas/linux_proc/root_proc
+++ b/src/pmdas/linux_proc/root_proc
@@ -449,6 +449,7 @@ proc {
     io			PROC:*:*
     schedstat		PROC:*:*
     fd			PROC:*:*
+    fdinfo		PROC:*:*
     namespaces		PROC:*:*
     smaps		PROC:*:*
     autogroup		PROC:*:*
@@ -463,6 +464,7 @@ hotproc {
     io			PROC:*:*
     schedstat		PROC:*:*
     fd			PROC:*:*
+    fdinfo		PROC:*:*
     namespaces		PROC:*:*
     smaps		PROC:*:*
     autogroup		PROC:*:*


### PR DESCRIPTION
This is a first shot for new AMD GPU process metrics.
This patch collects information retrieved from `/proc/<pid>/fdinfo`.

The current implementation accumulates data for each process, walking through all file descriptors and looking for drm and amd entries.

A future patch may be considered to separate the data per drm client ID.

