### PR TITLE
libdrm: Increase minimum version to 2.4.77

### DIFF
--- a/configure
+++ b/configure
@@ -12200,19 +12200,19 @@ fi
 
 
 pkg_failed=no
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libdrm >= 2.0" >&5
-printf %s "checking for libdrm >= 2.0... " >&6; }
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libdrm >= 2.4.77" >&5
+printf %s "checking for libdrm >= 2.4.77... " >&6; }
 
 if test -n "$libdrm_CFLAGS"; then
     pkg_cv_libdrm_CFLAGS="$libdrm_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libdrm >= 2.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libdrm >= 2.0") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libdrm >= 2.4.77\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libdrm >= 2.4.77") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_libdrm_CFLAGS=`$PKG_CONFIG --cflags "libdrm >= 2.0" 2>/dev/null`
+  pkg_cv_libdrm_CFLAGS=`$PKG_CONFIG --cflags "libdrm >= 2.4.77" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -12224,12 +12224,12 @@ if test -n "$libdrm_LIBS"; then
     pkg_cv_libdrm_LIBS="$libdrm_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libdrm >= 2.0\""; } >&5
-  ($PKG_CONFIG --exists --print-errors "libdrm >= 2.0") 2>&5
+    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libdrm >= 2.4.77\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libdrm >= 2.4.77") 2>&5
   ac_status=$?
   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
-  pkg_cv_libdrm_LIBS=`$PKG_CONFIG --libs "libdrm >= 2.0" 2>/dev/null`
+  pkg_cv_libdrm_LIBS=`$PKG_CONFIG --libs "libdrm >= 2.4.77" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
 else
   pkg_failed=yes
@@ -12250,9 +12250,9 @@ else
         _pkg_short_errors_supported=no
 fi
         if test $_pkg_short_errors_supported = yes; then
-                libdrm_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libdrm >= 2.0" 2>&1`
+                libdrm_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libdrm >= 2.4.77" 2>&1`
         else
-                libdrm_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libdrm >= 2.0" 2>&1`
+                libdrm_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libdrm >= 2.4.77" 2>&1`
         fi
         # Put the nasty error message in config.log where it belongs
         echo "$libdrm_PKG_ERRORS" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -2087,7 +2087,7 @@ then
 fi
 AC_SUBST(enable_secure)
 
-PKG_CHECK_MODULES([libdrm], [libdrm >= 2.0], [have_drm=true], [have_drm=false])
+PKG_CHECK_MODULES([libdrm], [libdrm >= 2.4.77], [have_drm=true], [have_drm=false])
 if $have_drm
 then
 	PKG_CHECK_MODULES([libdrm_amdgpu], [libdrm_amdgpu >= 1], [have_amdgpu=true], [have_amdgpu=false])


### PR DESCRIPTION
Some needed API were not available before 2.4.77, increasing the minimum version in configure.