### PR TITLE
pmdabpftrace: use notready startup protocol with pmcd

### DIFF
--- a/src/pmdas/bpftrace/GNUmakefile
+++ b/src/pmdas/bpftrace/GNUmakefile
@@ -41,7 +41,7 @@ build-me:	check_domain
 install_pcp install ::	default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
-	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PYSCRIPT) $(PMDAADMDIR)
+	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove Upgrade $(PYSCRIPT) $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/README.md README.md $(PMDAADMDIR)/README.md
 	$(INSTALL) -m 755 -d $(PMDACONFIG)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/$(CONFIG) $(CONFIG) $(PMDACONFIG)/$(CONFIG)

--- a/src/pmdas/bpftrace/Upgrade
+++ b/src/pmdas/bpftrace/Upgrade
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Copyright (c) 2019,2024 Red Hat.
+# Copyright (c) 2024 Red Hat.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -12,22 +12,19 @@
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
 # for more details.
 #
-# Install the bpftrace PMDA
+# Upgrade an older bpftrace PMDA install with missing 'notready' keyword to
+# latest python version.
 #
 
 . $PCP_DIR/etc/pcp.env
-. $PCP_SHARE_DIR/lib/pmdaproc.sh
 
-iam=bpftrace
-domain=151
-python_opt=true
-daemon_opt=false
-
-# See pmcd(1).  Start the PMDA up in the "notready" state.
-# When it has finished starting up, it sends a PM_ERR_PMDAREADY
-# error PDU to PMCD to indicate it's ready to process requests.
-ipc_prot="binary notready"
-
-pmdaSetup
-pmdaInstall
-exit
+if grep -q ^bpftrace "$PCP_PMCDCONF_PATH" 2>/dev/null
+then
+    if grep ^bpftrace "$PCP_PMCDCONF_PATH" | grep -q notready 2>/dev/null
+    then
+	:	# already has the keyword, so nothing to update here
+    else
+	sed -i -e "s,^\(bpftrace.*binary\),\1 notready,g" $PCP_PMCDCONF_PATH
+    fi
+fi
+exit 0


### PR DESCRIPTION
As observed in issue #2026 the bpftrace metrics agent sometimes takes multiple seconds to start up, depending on its persistent configuration and state of the system.

This commit switches it over to use the pmcd 'notready' protocol at startup, like openmetrics and bcc PMDAs do, to address this.

Resolves issue #2029