### PR TITLE
pcp-atop: fix units conversion for ipc.shm metric values

### DIFF
--- a/qa/1291.out
+++ b/qa/1291.out
@@ -14,7 +14,7 @@ cpu | sys       1% | user      2% | irq       6% | idle     91% | cpu003 w  0% |
 cpu | sys       1% | user      2% | irq       6% | idle     91% | cpu001 w  0% |
 CPL | numcpu     8 | avg1    0.23 | avg5    0.24 | csw 838830e4 | intr 17700e6 |
 MEM | tot    15.3G | free  286.3M | avail   2.7G | cache 721.6M | slab  624.3M |
-MEM | numnode    1 | shmem 237.9M | shswp   1.1T | pgtab  22.8M | zfarc   0.0M |
+MEM | numnode    1 | shmem 237.9M | shswp   1.1G | pgtab  22.8M | zfarc   0.0M |
 SWP | tot    11.7G | free    3.3G | swcac  34.9M | vmcom  31.6G | vmlim  19.1G |
 PAG | numamig    0 | migrate 76e4 | pgin      12 | pgout   1228 | oomkill    0 |
 LVM | a_shard-root | busy      0% | read 2124419 | write 5583e3 | avio  0.0 ns |
@@ -435,7 +435,7 @@ cpu | sys       0% | user      0% | irq       6% | idle     93% | cpu001 w  0% |
 cpu | sys       0% | user      0% | irq       6% | idle     94% | cpu003 w  0% |
 CPL | numcpu     8 | avg1    0.19 | avg5    0.23 | csw    60604 | intr  182964 |
 MEM | tot    15.3G | free  282.3M | avail   2.7G | cache 721.7M | slab  624.4M |
-MEM | numnode    1 | shmem 237.7M | shswp   1.1T | pgtab  22.8M | zfarc   0.0M |
+MEM | numnode    1 | shmem 237.7M | shswp   1.1G | pgtab  22.8M | zfarc   0.0M |
 SWP | tot    11.7G | free    3.3G | swcac  34.9M | vmcom  31.6G | vmlim  19.1G |
 PAG | numamig    0 | migrate    0 | pgin    4288 | pgout    350 | oomkill    0 |
 LVM | a_shard-root | busy      0% | read       0 | write     13 | avio  0.0 ns |

--- a/src/pcp/atop/drawbar.c
+++ b/src/pcp/atop/drawbar.c
@@ -1777,7 +1777,7 @@ drawmemory(struct perwindow *w, struct sstat *sstat, double nsecs,
 	cachemem	= (sstat->mem.cachemem + sstat->mem.buffermem -
 			   sstat->mem.shmem)  * 1024;
 
-	shmemrss	=  sstat->mem.shmrss  * 1024;
+	shmemrss	=  sstat->mem.shmrss; // in bytes!
 
 	slabmem		=  sstat->mem.slabmem * 1024;
 
@@ -1788,7 +1788,7 @@ drawmemory(struct perwindow *w, struct sstat *sstat, double nsecs,
 
 	totalswp	=  sstat->mem.totswap * 1024;
 
-	shmemswp	=  sstat->mem.shmswp  * 1024;
+	shmemswp	=  sstat->mem.shmswp; // in bytes!
 
 	freeswp		=  sstat->mem.freeswap* 1024;
 
@@ -1800,12 +1800,12 @@ drawmemory(struct perwindow *w, struct sstat *sstat, double nsecs,
 			  (sstat->mem.ltothugepage - sstat->mem.lfreehugepage)
 							* 1024;
 							
-	shmrssreal	= (sstat->mem.shmrss * pagesize) - hugeused;	// in bytes!
+	shmrssreal	= sstat->mem.shmrss - hugeused;	// in bytes!
 
 	if (shmrssreal < 0)	// (partly) wrong assumption about static huge pages
 		shmrssreal = 0;
 
-	tmpfsmem	= (sstat->mem.shmem - sstat->mem.shmswp) * pagesize - shmrssreal / pagesize;
+	tmpfsmem	= (sstat->mem.shmem * 1024) - shmemswp - shmrssreal;
 
 	// determine severity for pagescans, swapouts and oomkills
 	// 'n' - normal,

--- a/src/pcp/atop/photosyst.c
+++ b/src/pcp/atop/photosyst.c
@@ -1,5 +1,5 @@
 /*
-** Copyright (C) 2015-2022 Red Hat.
+** Copyright (C) 2015-2024 Red Hat.
 ** Copyright (C) 2000-2012 Gerlof Langeveld.
 **
 ** This program is free software; you can redistribute it and/or modify it
@@ -528,9 +528,9 @@ photosyst(struct sstat *si)
 	si->mem.ksmshared = extract_count_t(result, descs, MEM_KSMSHARED);
 	si->mem.ksmsharing = extract_count_t(result, descs, MEM_KSMSHARING);
 
-	/* shmctl(2) */
-	si->mem.shmrss = extract_count_t(result, descs, MEM_SHMRSS) * 1024;
-	si->mem.shmswp = extract_count_t(result, descs, MEM_SHMSWP) * 1024;
+	/* shmctl(2) values in bytes */
+	si->mem.shmrss = extract_count_t(result, descs, MEM_SHMRSS);
+	si->mem.shmswp = extract_count_t(result, descs, MEM_SHMSWP);
 
 	/* /proc/net/dev */
 	insts = NULL; /* silence coverity */


### PR DESCRIPTION
Resolves a strange rendering of the atop bar-mode display when values went negative incorrectly.