### PR TITLE
libpcp: auto-load the proc PMDA in local context mode

### DIFF
--- a/src/libpcp/src/connectlocal.c
+++ b/src/libpcp/src/connectlocal.c
@@ -125,6 +125,19 @@ build_dsotab(void)
 	     */
 	    goto eatline;
 	}
+	if (strncmp(p, "proc", 4) == 0) {
+	    /*
+	     * the proc PMDA is an exception now too ... we run it as root
+	     * (daemon) but we still want to make the DSO available for any
+	     * local context users.  We add this explicitly below.
+	     */
+	    domain = 3;
+	    init = "proc_init";
+	    pmsprintf(pathbuf, sizeof(pathbuf), "%s/proc/pmda_proc.so", pmdas);
+	    name = pathbuf;
+	    peekc = *p;
+	    goto dsoload;
+	}
 	if (strncmp(p, "linux", 5) == 0) {
 	    /*
 	     * the Linux PMDA is an exception now too ... we run it as root


### PR DESCRIPTION
We can treat pmda_proc.so the same as pmda_linux.so in the local context auto-loading code paths since its in exactly the same boat when it comes to default pmcd.conf state.

This resolves a problem report where pcp-htop reports some kernel metrics but the per-process stats are missing, when its fallback-to-local-without-pmcd mode occurs.