### PR TITLE
libpcp_web: fix a race in webgroup context teardown on timeout

### DIFF
--- a/src/libpcp_web/src/load.h
+++ b/src/libpcp_web/src/load.h
@@ -42,8 +42,9 @@ typedef struct context {
     unsigned int	setup	: 1;	/* context established */
     unsigned int	cached	: 1;	/* context/source in cache */
     unsigned int	garbage	: 1;	/* context pending removal */
+    unsigned int	inactive: 1;	/* context removal deferred */
     unsigned int	updated : 1;	/* context labels are updated */
-    unsigned int	padding : 4;	/* zero-filled struct padding */
+    unsigned int	padding : 3;	/* zero-filled struct padding */
     unsigned int	refcount : 16;	/* currently-referenced counter */
     unsigned int	timeout;	/* context timeout in milliseconds */
     uv_timer_t		timer;


### PR DESCRIPTION
Resolves a race condition on client teardown when an unusually long-held connection reference interferes with the client state management during a timeout.  We have been unable to reproduce this through targetted testing programs, but this survived for a full day of testing on a machine that previously was reliably leaking file descriptors every once in a while, with no leaks anymore at all (according to pmcd.openfds and log file audits).

Resolves #1533