### PR TITLE
qa/valgrind-suppress: external libbpf.so does not fully initialize attr

### DIFF
--- a/qa/1900
+++ b/qa/1900
@@ -46,6 +46,39 @@ _filter_logs()
     # end
 }
 
+cat >$tmp.suppress <<End-of-File
+# The libbpf probes to test for whether the kernel supports certain features
+# do not fully initialize the attr struct passed in the syscall.
+# This is outside the control of PCP.  There is an upstream libbpf issue filed:
+#
+#   https://github.com/libbpf/libbpf/issues/845
+#
+# The following suppressions are for qa/1900
+{
+   libbpf missing attr missing expected_attach_type field initialization
+   Memcheck:Param
+   bpf(attr->expected_attach_type)
+   fun:syscall
+   fun:sys_bpf
+   fun:sys_bpf_fd
+   fun:sys_bpf_prog_load
+   fun:probe_kern_prog_name
+   fun:kernel_supports
+   ...
+}
+{
+   libbpf missing attr missing prog_ifindex field initialization
+   Memcheck:Param
+   bpf(attr->prog_ifindex)
+   fun:syscall
+   fun:sys_bpf
+   fun:sys_bpf_fd
+   fun:sys_bpf_prog_load
+   fun:probe_kern_prog_name
+   fun:kernel_supports
+   ...
+}
+End-of-File
 
 # preliminaries ...
 # - install bpf PMDA so we get bpf in the default PMNS
@@ -57,6 +90,7 @@ _pmdabpf_wait_for_metric
 
 pmda=$PCP_PMDAS_DIR/bpf/pmda_bpf,bpf_init
 
+grind_extra="--suppressions=$tmp.suppress"
 echo && echo "== Running pmdabpf with valgrind"
 _run_valgrind --sudo pminfo -L -K clear -K add,157,$pmda -dmtT bpf.disk bpf.runq 2>&1 \
 | _filter_logs

--- a/qa/triaged
+++ b/qa/triaged
@@ -81,12 +81,6 @@
 1740	vm21		acct(2) just seems broken here
 1724	Fedora 38	bpftrace PMDA is broken here, check-flakey passes
 			(sometimes)
-1900	Fedora.*	valgrind uninitialised data failure deep inside libbpf
-1900	CentOS Stream9	ditto
-1900	Debian 12	ditto
-1900	openSUSE Leap 15.[56]	ditto
-1900	MX 23.[23]	ditto
-1900	Ubuntu 24\.04	ditto
 1973	Ubuntu 16\.04	Python here is 3.5.2 and there a bunch of what look like
 			dict ordering and/or cacheing sequence differences
 			and some arithmetic rounding differences ... not


### PR DESCRIPTION
The qa/1900 test makes use of libbpf.  When libbpf probes the linux kernel to check which features are available one of the probes does not fully initialize all the members of the attr struct. Adding suppression entries to qa/valgrind-suppress to catch those specific cases.  An upstream issue has been filed on libbpf to get this addressed:

   https://github.com/libbpf/libbpf/issues/845