### PR TITLE
addition of files for new openmetrics derived metric: openmetrics.grafana.go_memstats_last_gc_since_start_time_seconds

### DIFF
--- a/debian/pcp-conf.install
+++ b/debian/pcp-conf.install
@@ -1,11 +1,15 @@
 etc/pcp.conf
 etc/pcp/derived/cpu-util.conf
+etc/pcp/derived/denki.conf
 etc/pcp/derived/iostat.conf
 etc/pcp/derived/mssql.conf
+etc/pcp/derived/openmetrics.conf
 etc/pcp/derived/proc.conf
 usr/include/pcp/builddefs
 usr/include/pcp/buildrules
 var/lib/pcp/config/derived/cpu-util.conf
+var/lib/pcp/config/derived/denki.conf
 var/lib/pcp/config/derived/iostat.conf
 var/lib/pcp/config/derived/mssql.conf
+var/lib/pcp/config/derived/openmetrics.conf
 var/lib/pcp/config/derived/proc.conf

--- a/src/derived/openmetrics.conf
+++ b/src/derived/openmetrics.conf
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2024, Red Hat.
+#
+# This file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.
+# 
+# This file is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+#
+# OpenMetrics derived metrics
+# These derived metrics complete calculation of those metrics requiring
+# client-side computation using multiple base metrics from OpenMetrics.
+#
+
+openmetrics.grafana.go_memstats_last_gc_since_start_time_seconds = ( openmetrics.grafana.go_memstats_last_gc_time_seconds - openmetrics.grafana.process_start_time_seconds)
+openmetrics.grafana.go_memstats_last_gc_since_start_time_seconds(oneline) = Number of seconds since start time of last garbage collection
+openmetrics.grafana.go_memstats_last_gc_since_start_time_seconds(helptext) = '\
+Difference of go_memstats_last_gc_time_seconds and process_start_time.
+Difference of the number of seconds since unix epoch of last garbage
+collection and of the start time of the process since unix epoch.'


### PR DESCRIPTION
Addition of two files to support new derived metric: addition of files for new openmetrics derived metric: openmetrics.grafana.go_memstats_last_gc_since_start_time_seconds. 