### PR TITLE
qa/1900: Eliminate the need for libbpf debuginfo

### DIFF
--- a/qa/1900
+++ b/qa/1900
@@ -59,11 +59,6 @@ cat >$tmp.suppress <<End-of-File
    Memcheck:Param
    bpf(attr->expected_attach_type)
    fun:syscall
-   fun:sys_bpf
-   fun:sys_bpf_fd
-   fun:sys_bpf_prog_load
-   fun:probe_kern_prog_name
-   fun:kernel_supports
    ...
 }
 {
@@ -71,11 +66,6 @@ cat >$tmp.suppress <<End-of-File
    Memcheck:Param
    bpf(attr->prog_ifindex)
    fun:syscall
-   fun:sys_bpf
-   fun:sys_bpf_fd
-   fun:sys_bpf_prog_load
-   fun:probe_kern_prog_name
-   fun:kernel_supports
    ...
 }
 End-of-File


### PR DESCRIPTION
If the libbpf debuginfo is not installed, valgrind returns a backtrace of hexadecimal numbers. Those numbers do not match the symbolic functions names used in qa/1900 valgrind suppression file.  Limiting the backtrace matching in the valgrind suppress file to just the syscall function to avoid failures when the libbpf debuginfo is not installed.