### PR TITLE
qa: relax the checks on parent directories permissions

### DIFF
--- a/qa/common
+++ b/qa/common
@@ -937,10 +937,10 @@ else
 	__prot=`ls -ldL "$__x" | sed -e 's/[ 	].*//'`
 	case $__prot
 	in
-	    dr?xr?xr?[xt]*)
+	    dr?x*)
 		;;
 	    *)
-		echo "Warning: parent directory $__x (mode:$__prot) not world readable and searchable"
+		echo "Warning: parent directory $__x (mode:$__prot) not owner readable and searchable"
 		;;
 	esac
 	__x=`dirname $__x`


### PR DESCRIPTION
Current releases of Fedora have tighter default settings for home directory permissions, which is tripping common script warning code when running QA tests; e.g.

Warning: parent directory /home/nathans (mode:drwx------.) not world readable and searchable

AFAICT this sseems to be too strict however and checking for owner read/exec suffices.