### PR TITLE
pcp-meminfo: added timestamp string to make it similar to other utility

### DIFF
--- a/qa/1988.out
+++ b/qa/1988.out
@@ -2,7 +2,7 @@ QA output created by 1988
 
 pcp-meminfo output : Display default output
 Linux  5.4.17-2136.300.7.el8uek.x86_64  (Mohit-OL8u5-vm1)  09/08/23  x86_64    (2 CPU)
-07:06:54
+Timestamp         : 09/08/2023 07:06:54
 MemTotal          : 1734892 kB
 MemFree           : 244744 kB
 MemAvailable      : 860616 kB
@@ -51,7 +51,7 @@ DirectMap4k       : 362340 kB
 DirectMap2M       : 1734656 kB
 DirectMap1G       : 0 kB
 
-07:06:56
+Timestamp         : 09/08/2023 07:06:56
 MemTotal          : 1734892 kB
 MemFree           : 244272 kB
 MemAvailable      : 860544 kB
@@ -100,7 +100,7 @@ DirectMap4k       : 362340 kB
 DirectMap2M       : 1734656 kB
 DirectMap1G       : 0 kB
 
-07:06:58
+Timestamp         : 09/08/2023 07:06:58
 MemTotal          : 1734892 kB
 MemFree           : 243028 kB
 MemAvailable      : 859744 kB
@@ -149,7 +149,7 @@ DirectMap4k       : 362340 kB
 DirectMap2M       : 1734656 kB
 DirectMap1G       : 0 kB
 
-07:07:00
+Timestamp         : 09/08/2023 07:07:00
 MemTotal          : 1734892 kB
 MemFree           : 243232 kB
 MemAvailable      : 860464 kB
@@ -201,7 +201,7 @@ DirectMap1G       : 0 kB
 
 pcp-meminfo output : Display output when given specified number of samples
 Linux  5.4.17-2136.300.7.el8uek.x86_64  (Mohit-OL8u5-vm1)  09/08/23  x86_64    (2 CPU)
-07:06:54
+Timestamp         : 09/08/2023 07:06:54
 MemTotal          : 1734892 kB
 MemFree           : 244744 kB
 MemAvailable      : 860616 kB
@@ -250,7 +250,7 @@ DirectMap4k       : 362340 kB
 DirectMap2M       : 1734656 kB
 DirectMap1G       : 0 kB
 
-07:06:56
+Timestamp         : 09/08/2023 07:06:56
 MemTotal          : 1734892 kB
 MemFree           : 244272 kB
 MemAvailable      : 860544 kB
@@ -299,7 +299,7 @@ DirectMap4k       : 362340 kB
 DirectMap2M       : 1734656 kB
 DirectMap1G       : 0 kB
 
-07:06:58
+Timestamp         : 09/08/2023 07:06:58
 MemTotal          : 1734892 kB
 MemFree           : 243028 kB
 MemAvailable      : 859744 kB

--- a/src/pcp/meminfo/pcp-meminfo.py
+++ b/src/pcp/meminfo/pcp-meminfo.py
@@ -177,7 +177,7 @@ class MeminfoReport(pmcc.MetricGroupPrinter):
 
         t_s = group.contextCache.pmLocaltime(int(group.timestamp))
         time_string = time.strftime(MeminfoOptions.timefmt, t_s.struct_time())
-        print(time_string)
+        print("Timestamp".ljust(18) + ": " + time_string)
 
         idx = 0
         for metric in METRICS:
@@ -201,7 +201,7 @@ class MeminfoReport(pmcc.MetricGroupPrinter):
 
 class MeminfoOptions(pmapi.pmOptions):
     context = None
-    timefmt = "%H:%M:%S"
+    timefmt = "%m/%d/%Y %H:%M:%S"
 
     def __init__(self):
         pmapi.pmOptions.__init__(self, "a:s:S:T:z:A:t:")


### PR DESCRIPTION
changed timestamp format as well to print date along with time
Signed-off-by: sagar sagar <sagar.sagar@oracle.com>