### PR TITLE
pmdaopenmetrics: add vLLM metrics support by default

### DIFF
--- a/src/pmdas/openmetrics/GNUmakefile
+++ b/src/pmdas/openmetrics/GNUmakefile
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2017 Ronak Jain.
-# Copyright (c) 2017,2019-2020,2023 Red Hat.
+# Copyright (c) 2017,2019-2020,2023-2024 Red Hat.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -21,7 +21,7 @@ PYSCRIPT = pmda$(IAM).python
 LDIRT	= domain.h root pmns $(IAM).log
 DOMAIN	= $(IAM)
 # common endpoint URLs (on: enabled, off: available)
-ONURLS	= grafana.url kepler.url
+ONURLS	= grafana.url kepler.url vllm.url
 OFFURLS	= collectd.url etcd.url spark.url vmware.url
 
 MAN_SECTION = 1

--- a/src/pmdas/openmetrics/vllm.url
+++ b/src/pmdas/openmetrics/vllm.url
@@ -1,0 +1,1 @@
+http://localhost:8000/metrics

--- a/src/pmlogconf/openmetrics/localdefs
+++ b/src/pmlogconf/openmetrics/localdefs
@@ -1,1 +1,1 @@
-FILES = kepler
+FILES = kepler vllm

--- a/src/pmlogconf/openmetrics/vllm
+++ b/src/pmlogconf/openmetrics/vllm
@@ -1,0 +1,5 @@
+#pmlogconf-setup 2.0
+ident	vLLM stats
+probe	openmetrics.vllm values ? include : available
+delta	60 seconds
+	openmetrics.vllm


### PR DESCRIPTION
Exports the following metrics when vLLM is monitored: https://docs.vllm.ai/en/latest/serving/metrics.html