### PR TITLE
fix(statsd): prevent uncommitted metrics from being mapped to PCP

### DIFF
--- a/src/pmdas/statsd/src/aggregator-metric-counter.c
+++ b/src/pmdas/statsd/src/aggregator-metric-counter.c
@@ -24,7 +24,11 @@
 #include "utils.h"
 
 /**
- * Creates counter value in given dest
+ * Creates counter value in given destination
+ * @arg config - Config
+ * @arg datagram - Data to extract value from
+ * @arg out - Dest pointer
+ * @return 1 on success, 0 on fail. Should NOT allocate "out" when 0 is returned
  */
 int
 create_counter_value(struct agent_config* config, struct statsd_datagram* datagram, void** out) {

--- a/src/pmdas/statsd/src/aggregator-metric-duration.c
+++ b/src/pmdas/statsd/src/aggregator-metric-duration.c
@@ -26,7 +26,11 @@
 #include "utils.h"
 
 /**
- * Creates duration value in given dest
+ * Creates duration value in given destination
+ * @arg config - Config from which we know what duration
+ * @arg datagram - Data to extract value from
+ * @arg out - Dest pointer
+ * @return 1 on success, 0 on fail. Should NOT allocate "out" when 0 is returned
  */
 int 
 create_duration_value(struct agent_config* config, struct statsd_datagram* datagram, void** out) {

--- a/src/pmdas/statsd/src/aggregator-metric-gauge.c
+++ b/src/pmdas/statsd/src/aggregator-metric-gauge.c
@@ -24,11 +24,11 @@
 #include "utils.h"
 
 /**
- * Creates gauge value in given dest
- * @arg config - Config from which we know what gauge
+ * Creates gauge value in given destination
+ * @arg config - Config
  * @arg datagram - Data to extract value from
  * @arg out - Dest pointer
- * @return 1 on success, 0 on fail
+ * @return 1 on success, 0 on fail. Should NOT allocate "out" when 0 is returned
  */
 int
 create_gauge_value(struct agent_config* config, struct statsd_datagram* datagram, void** out) {

--- a/src/pmdas/statsd/src/aggregator-metric-labels.c
+++ b/src/pmdas/statsd/src/aggregator-metric-labels.c
@@ -41,11 +41,11 @@ create_labels_dict(
      * Callbacks for metrics hashtable
      */
     static dictType metric_label_dict_callbacks = {
-        .hashFunction	= str_hash_callback,
-        .keyCompare		= str_compare_callback,
-        .keyDup		    = str_duplicate_callback,
-        .keyDestructor	= str_hash_free_callback,
-        .valDestructor	= metric_label_free_callback,
+        .hashFunction   = str_hash_callback,
+        .keyCompare     = str_compare_callback,
+        .keyDup	        = str_duplicate_callback,
+        .keyDestructor  = str_hash_free_callback,
+        .valDestructor  = metric_label_free_callback,
     };
     labels* children = dictCreate(&metric_label_dict_callbacks, container->metrics_privdata);
     item->children = children;
@@ -224,8 +224,9 @@ create_label(
         default:
             status = 0;
     }
-    (*out)->type = item->type;
-    if (!status) {
+    if (status) {
+        (*out)->type = item->type;
+    } else {
         free_metric_label(config, label);
     }    
     return status;

--- a/src/pmdas/statsd/src/aggregator-metrics.c
+++ b/src/pmdas/statsd/src/aggregator-metrics.c
@@ -132,11 +132,11 @@ process_metric(struct agent_config* config, struct pmda_metrics_container* conta
                     if (!label_success) {
                         remove_metric(container, metric_key);
                     } else {
-                        mark_metric_as_pernament(container, item);
+                        mark_metric_as_committed(container, item);
                         status = 1;
                     }
                 } else {
-                    mark_metric_as_pernament(container, item);
+                    mark_metric_as_committed(container, item);
                 }
             } else {
                 METRIC_PROCESSING_ERR_LOG("%s %s, REASON: semantically incorrect values.", throwing_away_msg, datagram->name);
@@ -292,7 +292,7 @@ find_metric_by_name(struct pmda_metrics_container* container, char* key, struct 
  * @arg config - Agent config
  * @arg datagram - Datagram with data that should populate new metric
  * @arg out - Placeholder metric
- * @return 1 on success, 0 on fail - fails before allocating anything to "out"
+ * @return 1 on success, 0 on fail
  */
 int
 create_metric(struct agent_config* config, struct statsd_datagram* datagram, struct metric** out) {
@@ -305,8 +305,8 @@ create_metric(struct agent_config* config, struct statsd_datagram* datagram, str
     strncpy((*out)->name, datagram->name, len);
     (*out)->meta = create_metric_meta(datagram);
     (*out)->children = NULL;
+    (*out)->committed = 0;
     int status = 0; 
-    (*out)->type = datagram->type;
     (*out)->value = NULL;
     // this metric doesn't have root value
     if (datagram->tags != NULL) {
@@ -327,7 +327,9 @@ create_metric(struct agent_config* config, struct statsd_datagram* datagram, str
                 status = 0;
         }
     }
-    if (!status) {
+    if (status) {
+        (*out)->type = datagram->type;
+    } else {
         free_metric(config, item);
     }
     return status;
@@ -514,8 +516,8 @@ free_metric_metadata(struct metric_metadata* meta) {
  * Synchronized by mutex on pmda_metrics_container struct
  */
 void
-mark_metric_as_pernament(struct pmda_metrics_container* container, struct metric* item) {
+mark_metric_as_committed(struct pmda_metrics_container* container, struct metric* item) {
     pthread_mutex_lock(&container->mutex);
-    item->pernament = 1;
+    item->committed = 1;
     pthread_mutex_unlock(&container->mutex);
 }

--- a/src/pmdas/statsd/src/aggregator-metrics.h
+++ b/src/pmdas/statsd/src/aggregator-metrics.h
@@ -68,7 +68,7 @@ typedef struct metric_label {
 
 typedef struct metric {
     char* name;
-    int pernament;
+    int committed;
     struct metric_metadata* meta;
     labels* children;
     enum METRIC_TYPE type;
@@ -247,6 +247,6 @@ print_metric_meta(FILE* f, struct metric_metadata* meta);
  * Synchronized by mutex on pmda_metrics_container struct
  */
 extern void
-mark_metric_as_pernament(struct pmda_metrics_container* container, struct metric* item);
+mark_metric_as_committed(struct pmda_metrics_container* container, struct metric* item);
 
 #endif

--- a/src/pmdas/statsd/src/pmda-callbacks.c
+++ b/src/pmdas/statsd/src/pmda-callbacks.c
@@ -355,7 +355,7 @@ update_pcp_metric_instance_domain(char* key, struct metric* item, pmdaExt* pmda)
 static void
 map_metric(char* key, struct metric* item, void* pmda) {
     // skip metric if its still being processed (case when new metric gets added and datagram has only label, but metric addition and label appending are 2 separate actions)
-    if (item->pernament == 0) return;
+    if (item->committed == 0) return;
     // this prevents creating of metrics/labels that have tags as we don't deal with those yet
     struct pmda_data_extension* data = (struct pmda_data_extension*)pmdaExtGetData((pmdaExt*)pmda);
     // lets check if metric already has pmid assigned, if not create new metric for it (including new pmid)


### PR DESCRIPTION
Because of uninitialized "committed" flag of internal representation of statsd metric in aggregator-metrics.c `int create_metric(struct agent_config* config, struct statsd_datagram* datagram, struct metric** out)`, counterpart pmdaMetric* could have been created for it in pmda-callbacks.c "create_pcp_metric `static void create_pcp_metric(char* key, struct metric* item, pmdaExt* pmda)`, cause it may have passed the check at pmda-callbacks.c `static void map_metric(char* key, struct metric* item, void* pmda)`.

Internal representation of the statsd metric is the "struct metric* item" argument.

Processing a statsd metric happens in multiple steps, relevant for this is part of thread responsible for aggregation:

<img width="1528" alt="Screenshot 2024-09-15 at 1 14 40" src="https://github.com/user-attachments/assets/bb4fee7a-a199-4881-bc6c-acb456125ea0">

add_metric, process_labeled_datagram, remove_metric and mark_metric_as_comitted (excuse grammar) are all synchronized by single mutex which is also contested by the thread handling the pcp callbacks. This mutex is unlocked before each of them returns.

In the thread handling pcp callbacks:

<img width="1037" alt="Screenshot 2024-09-15 at 1 20 46" src="https://github.com/user-attachments/assets/69fe24b8-91d5-47a2-b660-22ded4686238">

need_reload read and statsd_map_stats contest same mutex mentioned above. Hence there may be the following sequence of calls that results in metrics being mapped into PCP representation (pmdaMetric*) whose internal representation is struct metric*, even though it never should have and since its data can be freed/removed at an arbitrary later point (with pmdaMetric pointing to some of it), I imagine this can cause issues. 

Such a sequence may be:

create_metric (aggregator) -> add_metric (aggregator) -> statsd_possible_reload determines that reload is needed (handling pcp callbacks) -> statsd_map_stats maps the internal metrics to pcp ones (handling pcp callbacks) -> process_labeled_datagram (agregator) -> remove_metric (aggregator)

datagram received which may trigger such a sequence is:

"metric_name,x=1:-2|c"

(parsing succeeds, but -2 is invalid value for a counter type, so process_labeled_datagram returns 0 and metric will be cleaned up with remove_metric)

I wasn't able to simulate a segmentation error in the pmdaRehash and I wasn't able to run 1720 qa test due to some issues with python, CI should run it and won't find an issue, hopefully.

Other changes are related to other errors I was able to simulate, eg.: metric above would lead to freeing a memory that wasn't alocated with malloc.

As noted in Slack @natoscott if you got some clue as to how to verify the correctness of the above, I would be grateful for a consultation as well as overall review, cause I have not written or read an ounce of C in quite a while.

Likely related #2062 