### PR TITLE
fix(statsd): keep correct track of pmns mapped metric count

### DIFF
--- a/src/pmdas/statsd/src/pmda-callbacks.c
+++ b/src/pmdas/statsd/src/pmda-callbacks.c
@@ -134,6 +134,7 @@ create_pcp_metric(char* key, struct metric* item, pmdaExt* pmda) {
         "STATSD: adding metric %s %s from %s\n", item->meta->pcp_name, pmIDStr(item->meta->pmid), item->name
     );
     item->meta->pcp_metric_index = i;
+    data->pcp_metric_count += 1;
 }
 
 /***
@@ -366,7 +367,6 @@ map_metric(char* key, struct metric* item, void* pmda) {
     if (item->meta->pcp_instance_change_requested == 1) {
         update_pcp_metric_instance_domain(key, item, (pmdaExt*)pmda);
     }
-    data->pcp_metric_count += 1;
     process_stat(data->config, data->stats_storage, STAT_TRACKED_METRIC, (void*)item->type);
     VERBOSE_LOG(1, "Populated PMNS with %d, %s .", item->meta->pmid, item->meta->pcp_name);
     pmdaTreeInsert(data->pcp_pmns, item->meta->pmid, item->meta->pcp_name);


### PR DESCRIPTION
Likely related #2062.

This is likely it, no race conditions, just me not being able to count well. I am kind of surprised that it took such large metric counts

> It seems tome the rehash was slowly happening at a time some other thread updated the hash table (the for (m = 0; m < pmda->e_nmetrics; m++) { was processing 4992th metric out of 5091)?

for it to segfault when it indexed out of bounds in pmdaRehash. Especially cause across multiple passes roughly speaking even after half of that number you would start reaching into memory I didn't allocate.