### PR TITLE
build: ensure pmie config.default created with correct ownership

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -220,11 +220,12 @@ fi
 }
 
 %global run_pmieconf() %{expand:
-if [ -w "%1" ]
+if [ -d "%1" -a -w "%1" -a -w "%1/%2" ]
 then
-    pmieconf -c enable "%2"
+    pmieconf -f "%1/%2" -c enable "%3"
+    chown pcp:pcp "%1/%2" 2>/dev/null
 else
-    echo "WARNING: Cannot write to %1, skipping pmieconf enable of %2." >&2
+    echo "WARNING: Cannot write to %1/%2, skipping pmieconf enable of %3." >&2
 fi
 }
 
@@ -2747,7 +2748,7 @@ for PMDA in $needinstall ; do
     fi
 done
 # auto-enable these usually optional pmie rules
-%{run_pmieconf "$PCP_PMIECONFIG_DIR" dmthin}
+%{run_pmieconf "$PCP_PMIECONFIG_DIR" config.default dmthin}
 %if "@enable_systemd@" == "true"
     systemctl restart pcp-reboot-init pmcd pmlogger pmie >/dev/null 2>&1
     systemctl enable pcp-reboot-init pmcd pmlogger pmie >/dev/null 2>&1

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -476,11 +476,12 @@ fi
 }
 
 %global run_pmieconf() %{expand:
-if [ -w "%1" ]
+if [ -d "%1" -a -w "%1" -a -w "%1/%2" ]
 then
-    pmieconf -c enable "%2"
+    pmieconf -f "%1/%2" -c enable "%3"
+    chown pcp:pcp "%1/%2" 2>/dev/null
 else
-    echo "WARNING: Cannot write to %1, skipping pmieconf enable of %2." >&2
+    echo "WARNING: Cannot write to %1/%2, skipping pmieconf enable of %3." >&2
 fi
 }
 
@@ -3223,7 +3224,7 @@ for PMDA in dm nfsclient openmetrics ; do
     fi
 done
 # auto-enable these usually optional pmie rules
-%{run_pmieconf "$PCP_PMIECONFIG_DIR" dmthin}
+%{run_pmieconf "$PCP_PMIECONFIG_DIR" config.default dmthin}
 %if 0%{?rhel} <= 9
 %if !%{disable_systemd}
     systemctl restart pcp-reboot-init pmcd pmlogger pmie >/dev/null 2>&1

--- a/debian/pcp-zeroconf.postinst
+++ b/debian/pcp-zeroconf.postinst
@@ -12,4 +12,5 @@ for PMDA in dm nfsclient openmetrics ; do
 done
 
 # auto-enable these usually optional pmie rules
-pmieconf -c enable dmthin
+pmieconf -f /var/lib/pcp/config/pmie/config.default -c enable dmthin
+chown pcp:pcp /var/lib/pcp/config/pmie/config.default


### PR DESCRIPTION
When the pcp-zeroconf package install creates config.default for pmie (rather than updating it) ensure correct pcp:pcp ownership.

Resolves Red Hat issue RHEL-59366