### PR TITLE
pmdaproc: add an access control mechanism for remote sampling

### DIFF
--- a/qa/1770
+++ b/qa/1770
@@ -1,0 +1,235 @@
+#!/bin/sh
+# PCP QA Test No. 1770
+# Exercise different pmdaproc access control settings.
+#
+# Copyright (c) 2024 Red Hat.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+. ./common.secure
+
+_get_libpcp_config
+$authentication || _notrun "No authentication support available"
+
+sasl_notrun_checks saslpasswd2 sasldblistusers2
+$pluginviewer -a | grep 'Plugin "sasldb"' >/dev/null
+test $? -eq 0 || _notrun "SASL sasldb auxprop plugin unavailable"
+$pluginviewer -c | grep 'Plugin "plain"' >/dev/null 2>&1
+test $? -eq 0 || _notrun 'No client support for plain authentication'
+$pluginviewer -s | grep 'Plugin "plain"' >/dev/null 2>&1
+test $? -eq 0 || _notrun 'No server support for plain authentication'
+
+$sudo rm -rf $tmp $tmp.* $seq.full
+
+signal=$PCP_BINADM_DIR/pmsignal
+status=1        # failure is the default!
+need_restore=false
+groupid=`id -g`
+userid=`id -u`
+
+_cleanup()
+{
+    cd $here
+
+    # restore any modified pmcd and pmproxy configuration files
+    if $need_restore 
+    then
+        need_restore=false
+        _restore_config $PCP_SYSCONF_DIR/proc
+        _restore_config $PCP_SYSCONF_DIR/labels
+        _restore_config $PCP_SYSCONF_DIR/pmproxy
+        _restore_config $PCP_SASLCONF_DIR/pmcd.conf
+    fi
+
+    _service pmcd stop >>$seq.full 2>&1
+    _service pmcd start >>$seq.full 2>&1
+    _wait_for_pmcd
+
+    if $pmproxy_was_running
+    then
+        echo "Restart pmproxy ..." >>$here/$seq.full
+        _service pmproxy restart >>$here/$seq.full 2>&1
+        _wait_for_pmproxy
+    else
+        echo "Stopping pmproxy ..." >>$here/$seq.full
+        _service pmproxy stop >>$here/$seq.full 2>&1
+    fi
+
+    $sudo rm -rf $tmp $tmp.*
+}
+
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+full_hostname=`hostname --fqdn`
+
+pmproxy_was_running=false
+[ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
+echo "pmproxy_was_running=$pmproxy_was_running" >>$here/$seq.full
+
+_filter_credentials()
+{
+    sed \
+        -e 's/"groupid": '$groupid',/"groupid": GID/g' \
+        -e 's/"userid": '$userid'/"userid": UID/g' \
+    #end
+}
+
+_filter_username()
+{
+    sed -e "s/user $username/user USER/"
+}
+
+_filter_listusers2()
+{
+    sed \
+        -e "s/^$username/USER/" \
+        -e "s/@$full_hostname:/@HOST:/" \
+        -e "s/@$hostname:/@HOST:/" \
+    #end
+}
+
+_filter_json()
+{
+    tee -a $seq.full | \
+    sed -e 's,"machineid": .*,"machineid": "MACHINEID",g' \
+        -e 's,"context": .*,"context": "CONTEXT",g' \
+        -e 's,"hostname": .*,"hostname": "HOSTNAME",g' \
+        -e 's,"domainname": .*,"domainname": "DOMAINNAME",g' \
+        -e 's,"source": .*,"source": "SOURCE",g' \
+        -e 's,"hostspec": .*,"hostspec": "HOSTSPEC",g' \
+        -e 's,"timestamp": .*,"timestamp": "TIMESTAMP",g' \
+    # end
+}
+
+_filter_values()
+{
+    _filter_json | \
+    $PCP_AWK_PROG '
+BEGIN { instances=0; count=0 }
+/"instances": \[$/    { instances=1; print $0, " ..." }
+/\]/                  { instances=0 }
+                      { if (instances != 1) { print } else { count++ } }
+END { if (count > 1) { print "GOOD VALUES"} else { print "NO VALUES" } }'
+}
+
+_test_log()
+{
+    echo && echo "=== $@ ===" | tee -a $here/$seq.full
+}
+
+_json_log()
+{
+    pmjson | tee -a $here/$seq.full
+}
+
+echo "hostname=$hostname" >>$seq.full
+echo "full_hostname=$full_hostname" >>$seq.full
+
+# real QA test starts here
+_save_config $PCP_SYSCONF_DIR/proc
+_save_config $PCP_SYSCONF_DIR/labels
+_save_config $PCP_SYSCONF_DIR/pmproxy
+_save_config $PCP_SASLCONF_DIR/pmcd.conf
+need_restore=true
+$sudo rm -rf $PCP_SYSCONF_DIR/labels/* $PCP_SYSCONF_DIR/proc/*
+
+# start pmcd in sasldb authenticating mode
+echo 'mech_list: plain' >$tmp.sasl
+echo "sasldb_path: $tmp.passwd.db" >>$tmp.sasl
+$sudo cp $tmp.sasl $PCP_SASLCONF_DIR/pmcd.conf
+$sudo chown pcp:pcp $PCP_SASLCONF_DIR/pmcd.conf
+ls -l $PCP_SASLCONF_DIR/pmcd.conf >>$seq.full
+$sudo -u pcp cat $PCP_SASLCONF_DIR/pmcd.conf >>$seq.full
+
+echo "Creating temporary sasldb, add user running QA to it" | tee -a $seq.full
+echo y | saslpasswd2 -p -a pmcd -f $tmp.passwd.db $username
+
+echo "Verify saslpasswd2 has successfully added a new user" | tee -a $seq.full
+sasldblistusers2 -f $tmp.passwd.db \
+| tee -a $seq.full \
+| _filter_listusers2
+
+echo "Ensure pmcd can read the password file" | tee -a $seq.full
+$sudo chown pcp:pcp $tmp.passwd.db
+ls -l $tmp.passwd.db >>$seq.full
+$sudo -u pcp od -c $tmp.passwd.db >>$seq.full
+
+echo "New pmdaproc config without any authentication" | tee -a $seq.full
+cat >$tmp.nobody <<EOF
+allowed = nobody
+mapped = false
+EOF
+
+echo "New pmdaproc config with remote authentication" | tee -a $seq.full
+cat >$tmp.remote <<EOF
+allowed = bob, $username, root
+mapped = false
+EOF
+
+echo "New pmdaproc config with mapped authentication" | tee -a $seq.full
+cat >$tmp.mapped <<EOF
+allowed = $username
+mapped = true
+EOF
+
+echo "Start pmcd with this shiny new sasldb and no access"
+$sudo cp $tmp.nobody $PCP_SYSCONF_DIR/proc/access.conf
+_service pmcd restart 2>&1 | tee -a $seq.full >$tmp.out
+_wait_for_pmcd
+
+echo "Start pmproxy with mandatory authentication"
+_service pmproxy stop >/dev/null
+_service pmproxy start >>$here/$seq.full 2>&1
+
+test "$PCPQA_SYSTEMD" = yes && $sudo systemctl daemon-reload
+
+_test_log "Establish context for an unauthenticated user"
+response=$(curl -s "http://localhost:44322/pmapi/context")
+echo "${response}" | pmjson | _filter_json | _filter_credentials
+ctx_unauthenticated=$(echo "${response}" | pmpython -c 'import sys,json; print(json.load(sys.stdin)["context"])')
+
+_test_log "I/O metric access using unauthenticated context"
+curl -s "http://localhost:44322/pmapi/$ctx_unauthenticated/fetch?names=proc.io.write_bytes" | _json_log | _filter_values
+echo
+
+echo "Restart pmcd with this sasldb and remote auth mode"
+$sudo cp $tmp.remote $PCP_SYSCONF_DIR/proc/access.conf
+_service pmcd restart 2>&1 | tee -a $seq.full >$tmp.out
+_wait_for_pmcd
+
+_test_log "Establish context for authenticated user"
+response=$(curl -s --user $username:y "http://localhost:44322/pmapi/context")
+echo "${response}" | pmjson | _filter_json | _filter_credentials
+ctx_authenticated=$(echo "${response}" | pmpython -c 'import sys,json; print(json.load(sys.stdin)["context"])')
+
+_test_log "I/O metric access using authenticated context"
+curl -s --user $username:y "http://localhost:44322/pmapi/$ctx_authenticated/fetch?names=proc.io.write_bytes" | _json_log | _filter_values
+echo
+
+echo "Restart pmcd with this sasldb and mapped auth mode"
+$sudo cp $tmp.mapped $PCP_SYSCONF_DIR/proc/access.conf
+_service pmcd restart 2>&1 | tee -a $seq.full >$tmp.out
+_wait_for_pmcd
+
+_test_log "Establish context for authenticated user"
+response=$(curl -s --user $username:y "http://localhost:44322/pmapi/context")
+echo "${response}" | pmjson | _filter_json | _filter_credentials
+ctx_authenticated=$(echo "${response}" | pmpython -c 'import sys,json; print(json.load(sys.stdin)["context"])')
+
+_test_log "I/O metric access using mapped authentication"
+curl -s --user $username:y "http://localhost:44322/pmapi/$ctx_authenticated/fetch?names=proc.io.write_bytes" | _json_log | _filter_values
+echo
+
+echo >>$here/$seq.full
+echo "=== pmcd log ===" >>$here/$seq.full
+cat $PCP_LOG_DIR/pmcd/pmcd.log >>$here/$seq.full
+echo "=== pmproxy log ===" >>$here/$seq.full
+cat $PCP_LOG_DIR/pmproxy/pmproxy.log >>$here/$seq.full
+echo "=== proc PMDA log ===" >>$here/$seq.full
+cat $PCP_LOG_DIR/pmcd/proc.log >>$here/$seq.full
+
+# success, all done
+status=0
+exit

--- a/qa/1770.out
+++ b/qa/1770.out
@@ -1,0 +1,99 @@
+QA output created by 1770
+Creating temporary sasldb, add user running QA to it
+Verify saslpasswd2 has successfully added a new user
+USER@HOST: userPassword
+Ensure pmcd can read the password file
+New pmdaproc config without any authentication
+New pmdaproc config with remote authentication
+New pmdaproc config with mapped authentication
+Start pmcd with this shiny new sasldb and no access
+Start pmproxy with mandatory authentication
+
+=== Establish context for an unauthenticated user ===
+{
+    "context": "CONTEXT"
+    "source": "SOURCE"
+    "hostspec": "HOSTSPEC"
+    "labels": {
+        "domainname": "DOMAINNAME"
+        "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
+    }
+}
+
+=== I/O metric access using unauthenticated context ===
+{
+    "context": "CONTEXT"
+    "timestamp": "TIMESTAMP"
+    "values": [
+        {
+            "pmid": "3.32.5",
+            "name": "proc.io.write_bytes",
+            "instances": [            ]
+        }
+    ]
+}
+NO VALUES
+
+Restart pmcd with this sasldb and remote auth mode
+
+=== Establish context for authenticated user ===
+{
+    "context": "CONTEXT"
+    "source": "SOURCE"
+    "hostspec": "HOSTSPEC"
+    "labels": {
+        "domainname": "DOMAINNAME"
+        "groupid": GID
+        "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
+        "userid": UID
+    }
+}
+
+=== I/O metric access using authenticated context ===
+{
+    "context": "CONTEXT"
+    "timestamp": "TIMESTAMP"
+    "values": [
+        {
+            "pmid": "3.32.5",
+            "name": "proc.io.write_bytes",
+            "instances": [  ...
+            ]
+        }
+    ]
+}
+GOOD VALUES
+
+Restart pmcd with this sasldb and mapped auth mode
+
+=== Establish context for authenticated user ===
+{
+    "context": "CONTEXT"
+    "source": "SOURCE"
+    "hostspec": "HOSTSPEC"
+    "labels": {
+        "domainname": "DOMAINNAME"
+        "groupid": GID
+        "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
+        "userid": UID
+    }
+}
+
+=== I/O metric access using mapped authentication ===
+{
+    "context": "CONTEXT"
+    "timestamp": "TIMESTAMP"
+    "values": [
+        {
+            "pmid": "3.32.5",
+            "name": "proc.io.write_bytes",
+            "instances": [  ...
+            ]
+        }
+    ]
+}
+GOOD VALUES
+

--- a/qa/group
+++ b/qa/group
@@ -2131,6 +2131,7 @@ pmcd.pdu
 1763 pmlogctl local
 1768 pmfind local
 1769 pmda.linux local
+1770 pmda.proc pmcd pmproxy local
 1772 pmda.amdgpu local
 1773 pmseries pmproxy libpcp_web local
 1774 pmlogctl pmlogger logutil

--- a/src/libpcp/src/context.c
+++ b/src/libpcp/src/context.c
@@ -416,22 +416,50 @@ __pmCheckAttribute(__pmAttrKey attr, const char *name)
 		continue;
 	    return -EINVAL;
 	}
+	if (p == name)
+	    return -EINVAL;
+	break;
+
+    case PCP_ATTR_USERNAME:
+	/*
+	 * Check for POSIX user names - alphabetics, digits, period,
+	 * underscore, and hyphen, with the further restriction that
+	 * hyphen is not allowed as first character of a user name.
+	 */
+	if (name[0] == '-' || name[0] == '\0')
+	    return -EINVAL;
+	for (p = name; *p; p++) {
+	    if (isalnum(*p) || *p == '.' || *p == '-' || *p == '_')
+		continue;
+	    return -EINVAL;
+	}
+	break;
+
+    case PCP_ATTR_USERID:
+    case PCP_ATTR_GROUPID:
+    case PCP_ATTR_PROCESSID:
+	/*
+	 * PID, UID or GID must contain numeric characters only.
+	 */
+	for (p = name; *p; p++) {
+	    if (isdigit(*p))
+		continue;
+	    return -EINVAL;
+	}
+	if (p == name)
+	    return -EINVAL;
 	break;
 
     case PCP_ATTR_PROTOCOL:
     case PCP_ATTR_SECURE:
     case PCP_ATTR_COMPRESS:
     case PCP_ATTR_USERAUTH:
-    case PCP_ATTR_USERNAME:
     case PCP_ATTR_AUTHNAME:
     case PCP_ATTR_PASSWORD:
     case PCP_ATTR_METHOD:
     case PCP_ATTR_REALM:
     case PCP_ATTR_UNIXSOCK:
-    case PCP_ATTR_USERID:
-    case PCP_ATTR_GROUPID:
     case PCP_ATTR_LOCAL:
-    case PCP_ATTR_PROCESSID:
     case PCP_ATTR_EXCLUSIVE:
 	break;
 

--- a/src/pmdas/linux_proc/GNUmakefile
+++ b/src/pmdas/linux_proc/GNUmakefile
@@ -75,6 +75,7 @@ install: default
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR) domain.h help help.dir help.pag root root_proc $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDACONFIG)
+	$(INSTALL) -m 644 access.conf $(PMDACONFIG)/access.conf
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/samplehotproc.conf samplehotproc.conf $(PMDACONFIG)/samplehotproc.conf
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(SCRIPTS) $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_proc root_proc $(PCP_PMNSADM_DIR)/root_proc

--- a/src/pmdas/linux_proc/access.conf
+++ b/src/pmdas/linux_proc/access.conf
@@ -1,0 +1,19 @@
+# access.conf
+#
+# Comments are the hash-to-end-of-line variety and all comma
+# and whitespace characters are removed prior to pmdaproc(1)
+# making use of the names here.
+# 
+# Names of users permitted access to per-process metrics when
+# authenticated.  These usernames must be registered with the
+# SASL mechanism that pmcd(1) has been configured to use.
+#
+#allowed: bob, jenny, procfsreader
+
+#
+# Enforce requirement that allowed username must have a local
+# account and that account will be used for sampling procfs.
+# Default behaviour is 'false' and the user account the proc
+# PMDA runs under will be used (typically 'root' or 'pcp').
+#
+#mapped: true

--- a/src/pmdas/linux_proc/contexts.h
+++ b/src/pmdas/linux_proc/contexts.h
@@ -1,17 +1,16 @@
 /*
- * Copyright (c) 2013,2015 Red Hat.
- * 
+ * Copyright (c) 2013,2015,2024 Red Hat.
+ *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
  * Free Software Foundation; either version 2 of the License, or (at your
  * option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but
  * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
  * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
  * for more details.
  */
-
 #ifndef _CONTEXTS_H
 #define _CONTEXTS_H
 
@@ -25,13 +24,14 @@
  */
 
 enum {
-    CTX_INACTIVE = 0,
-    CTX_ACTIVE   = (1<<0),
-    CTX_USERID   = (1<<1),
-    CTX_GROUPID  = (1<<2),
-    CTX_THREADS  = (1<<3),
-    CTX_CGROUPS  = (1<<4),
-    CTX_CONTAINER= (1<<5),
+    CTX_INACTIVE  = 0,
+    CTX_ACTIVE    = (1<<0),
+    CTX_USERID    = (1<<1),
+    CTX_GROUPID   = (1<<2),
+    CTX_THREADS   = (1<<3),
+    CTX_CGROUPS   = (1<<4),
+    CTX_USERNAME  = (1<<5),
+    CTX_CONTAINER = (1<<6),
 };
 
 typedef struct {
@@ -49,7 +49,8 @@ typedef struct {
     proc_container_t	container;
 } proc_perctx_t;
 
-extern void proc_ctx_init(void);
+extern void proc_context_init(void);
+
 extern int proc_ctx_attrs(int, int, const char *, int, pmdaExt *);
 extern void proc_ctx_end(int);
 extern int proc_ctx_getuid(int);

--- a/src/pmdas/linux_proc/pmda.c
+++ b/src/pmdas/linux_proc/pmda.c
@@ -3979,7 +3979,7 @@ proc_init(pmdaInterface *dp)
     hotproc_init();
     init_hotproc_pid(&hotproc_pid);
 
-    proc_ctx_init();
+    proc_context_init();
     proc_dynamic_init(metrictab, nmetrics);
 
     indomtab[ACCT_INDOM].it_indom = ACCT_INDOM;

--- a/src/pmdas/linux_proc/pmdaproc.1
+++ b/src/pmdas/linux_proc/pmdaproc.1
@@ -56,8 +56,11 @@ command line options follows:
 .B \-A
 Disables use of the credentials provided by
 .B PMAPI
-client tools,
-and simply runs everything under the "root" account.
+client tools and simply runs everything under the "root" account.
+Refer to the ACCESS CONFIGURATION section below for finer grained
+control when using
+.BR pmcd (1)
+with remote client authentication.
 Only enable this option if you understand the risks involved, and
 are sure that all remote accesses will be from benevolent users.
 If enabled, unauthenticated remote
@@ -263,7 +266,7 @@ predicate.
 .SH DYNAMIC CONFIGURATION
 The
 .B hot
-metrics can also be configured at runtime through the
+process metrics can also be configured at runtime through the
 .BR pmstore (1)
 interface (and, implicitly, the
 .BR pmStore (3)
@@ -275,6 +278,37 @@ Examples
 .TP
 To force the config file to be reloaded:
   pmstore hotproc.control.reload_config "1"
+.SH ACCESS CONFIGURATION
+Access to per-process metrics is controlled by several factors.
+.PP
+When using automatically authenticating local connections, such
+as through the "unix:" or "local:" style context, then client
+tools will have full access to these metrics as if sampling the
+metrics directly as the user running the client tool.
+.PP
+When using
+.B pmcd
+with remote, authenticated clients it is possible to specify a
+set of user names that are allowed access to the process metrics.
+.PP
+A configuration file
+.B $PCP_SYSCONF_DIR/proc/access.conf
+can be used to fine-tune this behaviour, and it supports two
+keywords:
+.TP
+.B allowed
+A comma-separated list of authenticated user names that will be
+allowed access to per-process metrics.
+Sampling is performed as the root user.
+.TP
+.B mapped
+A boolean value, when true indicating that authenticated user
+names will be mapped to local system user account names (this
+requires a one-to-one user name mapping between the account and
+the SASL-based authenticated user name enforced by
+.BR pmcd (1)).
+Sampling is performed as that local user.
+.PP
 .SH INSTALLATION
 The
 .B proc
@@ -338,6 +372,9 @@ simple sample hotproc configuration
 .TP 10
 .B $PCP_PMDAS_DIR/proc/hotproc.conf
 default hotproc configuration file
+.TP 10
+.B $PCP_SYSCONF_DIR/proc/access.conf
+default access control configuration file
 .PD
 .SH "PCP ENVIRONMENT"
 Environment variables with the prefix


### PR DESCRIPTION
Allows authenticated users to access the proc metric values, through the new /etc/pcp/proc/access.conf configuration file.

Resolves issue #2089