### PR TITLE
systemd: defer to system-preset for pmcd/pmie/pmlogger autostart

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -2749,9 +2749,11 @@ for PMDA in $needinstall ; do
 done
 # auto-enable these usually optional pmie rules
 %{run_pmieconf "$PCP_PMIECONFIG_DIR" config.default dmthin}
+# managed via /usr/lib/systemd/system-preset/90-default.preset nowadays:
+%if 0%{?rhel} > 0 && 0%{?rhel} < 10
 %if "@enable_systemd@" == "true"
-    systemctl restart pcp-reboot-init pmcd pmlogger pmie >/dev/null 2>&1
-    systemctl enable pcp-reboot-init pmcd pmlogger pmie >/dev/null 2>&1
+    systemctl restart pmcd pmlogger pmie >/dev/null 2>&1
+    systemctl enable pmcd pmlogger pmie >/dev/null 2>&1
 %else
     /sbin/chkconfig --add pmcd >/dev/null 2>&1
     /sbin/chkconfig --add pmlogger >/dev/null 2>&1
@@ -2759,6 +2761,11 @@ done
     /sbin/service pmcd condrestart
     /sbin/service pmlogger condrestart
     /sbin/service pmie condrestart
+%endif
+%endif
+%if "@enable_systemd@" == "true"
+    systemctl restart pcp-reboot-init >/dev/null 2>&1
+    systemctl enable pcp-reboot-init >/dev/null 2>&1
 %endif
 
 %if "@pmda_systemd@" == "true"

--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -2698,6 +2698,7 @@ semodule -r pcpqa >/dev/null 2>&1 || true
 %selinux_relabel_post -s targeted
 %endif
 chown -R pcpqa:pcpqa @pcp_var_dir@/testsuite 2>/dev/null
+%{install_file "$PCP_PMDAS_DIR/sample" .NeedInstall}
 # inherited from %post for pcp-collector
 %if "@enable_systemd@" == "true"
     systemctl restart pcp-reboot-init pmcd pmlogger >/dev/null 2>&1

--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -2763,10 +2763,6 @@ done
     /sbin/service pmie condrestart
 %endif
 %endif
-%if "@enable_systemd@" == "true"
-    systemctl restart pcp-reboot-init >/dev/null 2>&1
-    systemctl enable pcp-reboot-init >/dev/null 2>&1
-%endif
 
 %if "@pmda_systemd@" == "true"
 %preun pmda-systemd
@@ -3084,6 +3080,8 @@ PCP_SA_DIR=@pcp_sa_dir@
 %if "@enable_systemd@" == "true"
     # clean up any stale symlinks for deprecated pm*-poll services
     rm -f %{_sysconfdir}/systemd/system/pm*.requires/pm*-poll.* >/dev/null 2>&1 || true
+    systemctl restart pcp-reboot-init >/dev/null 2>&1
+    systemctl enable pcp-reboot-init >/dev/null 2>&1
 
     %systemd_postun_with_restart pmcd.service
     %systemd_post pmcd.service

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -3239,10 +3239,6 @@ done
     /sbin/service pmie condrestart
 %endif
 %endif
-%if !%{disable_systemd}
-    systemctl restart pcp-reboot-init >/dev/null 2>&1
-    systemctl enable pcp-reboot-init >/dev/null 2>&1
-%endif
 
 %post
 PCP_PMNS_DIR=%{_pmnsdir}
@@ -3252,6 +3248,8 @@ PCP_LOG_DIR=%{_logsdir}
 %if !%{disable_systemd}
     # clean up any stale symlinks for deprecated pm*-poll services
     rm -f %{_sysconfdir}/systemd/system/pm*.requires/pm*-poll.* >/dev/null 2>&1 || true
+    systemctl restart pcp-reboot-init >/dev/null 2>&1
+    systemctl enable pcp-reboot-init >/dev/null 2>&1
 
     %systemd_postun_with_restart pmcd.service
     %systemd_post pmcd.service

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -3225,10 +3225,11 @@ for PMDA in dm nfsclient openmetrics ; do
 done
 # auto-enable these usually optional pmie rules
 %{run_pmieconf "$PCP_PMIECONFIG_DIR" config.default dmthin}
-%if 0%{?rhel} <= 9
+# managed via /usr/lib/systemd/system-preset/90-default.preset nowadays:
+%if 0%{?rhel} > 0 && 0%{?rhel} < 10
 %if !%{disable_systemd}
-    systemctl restart pcp-reboot-init pmcd pmlogger pmie >/dev/null 2>&1
-    systemctl enable pcp-reboot-init pmcd pmlogger pmie >/dev/null 2>&1
+    systemctl restart pmcd pmlogger pmie >/dev/null 2>&1
+    systemctl enable pmcd pmlogger pmie >/dev/null 2>&1
 %else
     /sbin/chkconfig --add pmcd >/dev/null 2>&1
     /sbin/chkconfig --add pmlogger >/dev/null 2>&1
@@ -3237,6 +3238,10 @@ done
     /sbin/service pmlogger condrestart
     /sbin/service pmie condrestart
 %endif
+%endif
+%if !%{disable_systemd}
+    systemctl restart pcp-reboot-init >/dev/null 2>&1
+    systemctl enable pcp-reboot-init >/dev/null 2>&1
 %endif
 
 %post

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -2893,6 +2893,7 @@ semodule -r pcpqa >/dev/null 2>&1 || true
 %selinux_relabel_post -s targeted
 %endif
 chown -R pcpqa:pcpqa %{_testsdir} 2>/dev/null
+%{install_file "$PCP_PMDAS_DIR/sample" .NeedInstall}
 %if 0%{?rhel}
 %if !%{disable_systemd}
     systemctl restart pcp-reboot-init pmcd pmlogger >/dev/null 2>&1


### PR DESCRIPTION
Change pcp-zeroconf on RHEL 10 and later to match Fedora, where state from /usr/lib/systemd/system-preset/90-default.preset is used to determine service enabled state centrally for sysadmins rather than hard-coding this in the PCP spec file.

Resolves Red Hat issue RHEL-22723