### PR TITLE
Fix unreliable tests in `configure.ac`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2509,6 +2509,11 @@ AC_SUBST([rdynamic_flag])
 
 dnl check if argument to user's select() method in scandir call is const
 AC_MSG_CHECKING([whether const arg for scandir() select method])
+save_CFLAGS="$CFLAGS"
+dnl Using -Werror to make the compiler fail on purpose if scandir()
+dnl on this system does not support `const struct dirent *' for
+dnl callbacks.
+CFLAGS="-Werror"
 cat <<End-of-File >conftest.c
 #include <stdlib.h>
 #include <unistd.h>
@@ -2518,14 +2523,16 @@ my_select(const struct dirent *foo) { return 0; }
 int main() { struct dirent **list; return scandir(".", &list, my_select, NULL); }
 End-of-File
 (eval $ac_compile) 2>conftest.out
+_ret=$?
 cat conftest.out >&5
-if test -s conftest.out
+if test $_ret != 0
 then
     AC_MSG_RESULT(no)
 else
     AC_DEFINE(HAVE_CONST_DIRENT, [1], [const arg for scandir() select method])
     AC_MSG_RESULT(yes)
 fi
+CFLAGS="$save_CFLAGS"
 rm -f conftest.*
 
 dnl check if struct dirent has a d_off (directory offset) field
@@ -2537,8 +2544,9 @@ cat <<End-of-File >conftest.c
 int main() { struct dirent d; d.d_off = 0; }
 End-of-File
 (eval $ac_compile) 2>conftest.out
+_ret=$?
 cat conftest.out >&5
-if test -s conftest.out
+if test $_ret != 0
 then
     AC_MSG_RESULT(no)
 else

--- a/configure.ac
+++ b/configure.ac
@@ -563,7 +563,7 @@ AC_MSG_CHECKING([__pmResult padding])
 ans=`sed <conftest.out -n -e '/__pmResult pad/s/.* //p'`
 if test -n "$ans"
 then
-    AC_DEFINE_UNQUOTED(PM_PAD_RESULT, $ans, [])
+    AC_DEFINE_UNQUOTED(PM_PAD_RESULT, $ans, [__pmResult padding])
     AC_MSG_RESULT($ans)
 else
     AC_MSG_RESULT([no])
@@ -572,7 +572,7 @@ AC_MSG_CHECKING([timespec padding])
 ans=`sed <conftest.out -n -e '/timespec pad/s/.* //p'`
 if test -n "$ans"
 then
-    AC_DEFINE_UNQUOTED(PM_PAD_TIMESPEC, $ans, [])
+    AC_DEFINE_UNQUOTED(PM_PAD_TIMESPEC, $ans, [timespec padding])
     AC_MSG_RESULT($ans)
 else
     AC_MSG_RESULT([no])


### PR DESCRIPTION
Two tests in `configure.ac` should not rely on whether the compiler emitted warnings, but should instead rely on whether the compilation failed. Unintended warnings (triggered by certain combination of CFLAGS) emitted by compiler will disrupt the test result, resulting in FTBFS.

For the `scandir()` test, with some combination of CFLAGS, the compiler may emit some warnings, failing the test, but in reality the `scandir()` call must use `const struct dirent *` for the callbacks.

