### PR TITLE
pcp2elasticsearch: support dynamic mapping

### DIFF
--- a/qa/1130
+++ b/qa/1130
@@ -2,7 +2,7 @@
 # PCP QA Test No. 1130
 # checks basic pcp2elasticsearch functionality
 #
-# Copyright (c) 2017-2019 Red Hat.
+# Copyright (c) 2017-2025 Red Hat.
 #
 seq=`basename $0`
 echo "QA output created by $seq"
@@ -13,7 +13,7 @@ $python -c "from pcp import pmapi" >/dev/null 2>&1
 [ $? -eq 0 ] || _notrun "python pcp pmapi module not installed"
 
 # From Andreas 27 Jul 2022 ...
-# [pcp2elasticsearch] now uses a method='PUT' argument, but this is
+# [pcp2elasticsearch] now uses a method='POST' argument, but this is
 # not available in Python versions before 3.3
 #
 __version=`$python --version 2>&1 | sed -e 's/Python //'`
@@ -90,11 +90,21 @@ wait
 #
 grep -q 'socat.* Remote end closed connection without response' $tmp.socat.err && \
 	_notrun "socat on this platform is not behaving as expected [closed conn]"
-grep -q 'socat.* Connection reset by peer' $tmp.socat.log && \
-	_notrun "socat on this platform is not behaving as expected [reset conn]"
+
+# From Paul 13 Jan 2025 ...
+# Getting reset connection messages with socat even though exporter works
+# correctly meaning the test is not being run. Happens with prior upstream
+# exporter version also:
+#     ... socat[957217] E read(6, 0x558187c97000, 8192): Connection reset by peer
+#
+# Commenting out the check and allowing QA test to run
+#
+#grep -q 'socat.* Connection reset by peer' $tmp.socat.log && \
+#	_notrun "socat on this platform is not behaving as expected [reset conn]"
+
 grep -q 'socat.* Broken pipe' $tmp.socat.log && \
 	_notrun "socat on this platform is not behaving as expected [broken pipe]"
-grep -E -q '^PUT /+pcp HTTP/' $tmp.socat.err
+grep -E -q '^POST /+pcp/_doc HTTP/' $tmp.socat.err
 [ $? -eq 0 ] && echo "Found correct index in output"
 grep -E -q '"hinv": {"ncpu": '$ncpu'}' $tmp.socat.err
 [ $? -eq 0 ] && echo "Found correct value in output"
@@ -108,7 +118,7 @@ $pcp2elasticsearch -t 1 -s 1 -X QAHOST -x INDEX hinv.ncpu >$tmp.p2e.out 2>$tmp.p
 sleep 2
 $signal $pid 2>/dev/null
 wait
-grep -E -q '^PUT /+INDEX HTTP/' $tmp.socat.err
+grep -E -q '^POST /+INDEX/_doc HTTP/' $tmp.socat.err
 [ $? -eq 0 ] && echo "Found correct index in output"
 grep -E -q '"@host-id": "QAHOST"' $tmp.socat.err
 [ $? -eq 0 ] && echo "Found proper hostid in output"
@@ -123,7 +133,7 @@ sleep 2
 $signal $pid 2>/dev/null
 wait
 echo "--- Start of received data ---"
-grep -E '(mappings|slack)' $tmp.socat.err | sed -e 's,< [1-9].*,,g' >$tmp.archive.data
+grep -E '(slack)' $tmp.socat.err | sed -e 's,< [1-9].*,,g' >$tmp.archive.data
 while read -r line
 do
   echo $line | _filter_prec | pmjson | LC_COLLATE=POSIX sort | tr -d ,

--- a/qa/1130.out
+++ b/qa/1130.out
@@ -8,21 +8,6 @@ Found correct index in output
 Found proper hostid in output
 === 3. pcp2elasticsearch full-blown archive replay session ===
 --- Start of received data ---
-                    "type": "epoch_milli"
-                    "type": "string"
-                "@host-id": {
-                "@timestamp": {
-                }
-                }
-            "properties": {
-            }
-        "pcp-metric": {
-        }
-    "ignore": 400
-    "mappings": {
-    }
-{
-}
                     "@id": "000001 /usr/lib/systemd/systemd --switched-root --system --deserialize 21"
                     "@id": "1 minute"
                     "@id": "cpu0"
@@ -84,21 +69,6 @@ Found proper hostid in output
     }
     }
     }
-    }
-{
-}
-                    "type": "epoch_milli"
-                    "type": "string"
-                "@host-id": {
-                "@timestamp": {
-                }
-                }
-            "properties": {
-            }
-        "pcp-metric": {
-        }
-    "ignore": 400
-    "mappings": {
     }
 {
 }
@@ -182,21 +152,6 @@ Found proper hostid in output
     }
 {
 }
-                    "type": "epoch_milli"
-                    "type": "string"
-                "@host-id": {
-                "@timestamp": {
-                }
-                }
-            "properties": {
-            }
-        "pcp-metric": {
-        }
-    "ignore": 400
-    "mappings": {
-    }
-{
-}
                         "@id": "cpu0"
                         "user": 0.0
                     "@id": "000001 /usr/lib/systemd/systemd --switched-root --system --deserialize 21"
@@ -277,21 +232,6 @@ Found proper hostid in output
     }
 {
 }
-                    "type": "epoch_milli"
-                    "type": "string"
-                "@host-id": {
-                "@timestamp": {
-                }
-                }
-            "properties": {
-            }
-        "pcp-metric": {
-        }
-    "ignore": 400
-    "mappings": {
-    }
-{
-}
                         "@id": "cpu0"
                         "user": 9.999
                     "@id": "000001 /usr/lib/systemd/systemd --switched-root --system --deserialize 21"
@@ -369,21 +309,6 @@ Found proper hostid in output
     }
     }
     }
-    }
-{
-}
-                    "type": "epoch_milli"
-                    "type": "string"
-                "@host-id": {
-                "@timestamp": {
-                }
-                }
-            "properties": {
-            }
-        "pcp-metric": {
-        }
-    "ignore": 400
-    "mappings": {
     }
 {
 }


### PR DESCRIPTION
Elasticsearch 7.X removed the concept of mapping types (initially this was depreciated in Elasticsearch 6.X).

Change over to support dynamic mapping by making use of the updated 'POST {server}/{index}/_doc' index API with auto-generated ids by default.

Users can still use the the search type '-p pcp-metric' command line argument on launch to make use of the original pcp-metric mapping name for environments with Elasticsearch 5.X and 6.X, ('POST {server}/{index}/{search_type}' API).

Note: These older versions are considered EOL by Elastic.

This fix addresses github issue #1998.