### PR TITLE
Remove all references to the lockdown class from SELinux policy

### DIFF
--- a/src/selinux/pcp.te
+++ b/src/selinux/pcp.te
@@ -521,15 +521,6 @@ optional_policy(`
 
 optional_policy(`
     require {
-	class lockdown { integrity };
-    }
-    # pmda.kvm
-    # type=AVC msg=audit(YYY.101): avc: denied { integrity } for pid=PID comm="pmdakvm" lockdown_reason="debugfs access" scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:system_r:pcp_pmcd_t:s0 tclass=lockdown permissive=0
-    allow pcp_pmcd_t self:lockdown integrity;
-')
-
-optional_policy(`
-    require {
 	class rawip_socket { create getopt setopt read write };
     }
     # pmda.netcheck


### PR DESCRIPTION
A comprehensive fix for all the problems caused by the lockdown SELinux class was rejected by Linus and for the lack of a better option, the consensus upstream was to just remove the class entirely and stop checking anything in the lockdown hook.

This commit is a follow-up to selinux-policy commit 12f821c731b2 ("Remove the lockdown-class rules from the policy").