### PR TITLE
pmdadm, pmieconf: default to enabling the dmthin pmie rules

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -219,16 +219,6 @@ else
 fi
 }
 
-%global run_pmieconf() %{expand:
-if [ -d "%1" -a -w "%1" -a -w "%1/%2" ]
-then
-    pmieconf -f "%1/%2" -c enable "%3"
-    chown pcp:pcp "%1/%2" 2>/dev/null
-else
-    echo "WARNING: Cannot write to %1/%2, skipping pmieconf enable of %3." >&2
-fi
-}
-
 %if "@enable_selinux@" == "true"
 # rpm boolean dependencies are supported since RHEL 8, but not reliably
 # across all platforms, so be conservative here
@@ -2733,7 +2723,6 @@ exit 0
 PCP_PMDAS_DIR=@pcp_pmdas_dir@
 PCP_SYSCONFIG_DIR=@pcp_sysconfig_dir@
 PCP_PMCDCONF_PATH=@pcp_pmcdconf_path@
-PCP_PMIECONFIG_DIR=@pcp_var_dir@/config/pmie
 # auto-install important PMDAs for RH Support (if not present already)
 needinstall='dm'
 %if "@have_python@" == "true"
@@ -2748,8 +2737,6 @@ for PMDA in $needinstall ; do
 	%{install_file "$PCP_PMDAS_DIR/$PMDA" .NeedInstall}
     fi
 done
-# auto-enable these usually optional pmie rules
-%{run_pmieconf "$PCP_PMIECONFIG_DIR" config.default dmthin}
 # managed via /usr/lib/systemd/system-preset/90-default.preset nowadays:
 %if 0%{?rhel} > 0 && 0%{?rhel} < 10
 %if "@enable_systemd@" == "true"

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -346,7 +346,6 @@ Requires: pcp-selinux = %{version}-%{release}
 %global _pmdasdir       %{_localstatedir}/lib/pcp/pmdas
 %global _pmdasexecdir   %{_libexecdir}/pcp/pmdas
 %global _testsdir       %{_localstatedir}/lib/pcp/testsuite
-%global _ieconfigdir    %{_localstatedir}/lib/pcp/config/pmie
 %global _ieconfdir      %{_localstatedir}/lib/pcp/config/pmieconf
 %global _selinuxdir     %{_datadir}/selinux/packages/targeted
 
@@ -472,16 +471,6 @@ then
     (cd "%1" && ./Rebuild -s && rm -f "%2")
 else
     echo "WARNING: Cannot write to %1, skipping namespace rebuild." >&2
-fi
-}
-
-%global run_pmieconf() %{expand:
-if [ -d "%1" -a -w "%1" -a -w "%1/%2" ]
-then
-    pmieconf -f "%1/%2" -c enable "%3"
-    chown pcp:pcp "%1/%2" 2>/dev/null
-else
-    echo "WARNING: Cannot write to %1/%2, skipping pmieconf enable of %3." >&2
 fi
 }
 
@@ -3215,7 +3204,6 @@ fi
 PCP_PMDAS_DIR=%{_pmdasdir}
 PCP_SYSCONFIG_DIR=%{_sysconfdir}/sysconfig
 PCP_PMCDCONF_PATH=%{_confdir}/pmcd/pmcd.conf
-PCP_PMIECONFIG_DIR=%{_ieconfigdir}
 # auto-install important PMDAs for RH Support (if not present already)
 for PMDA in dm nfsclient openmetrics ; do
     if ! grep -q "$PMDA/pmda$PMDA" "$PCP_PMCDCONF_PATH"
@@ -3223,8 +3211,6 @@ for PMDA in dm nfsclient openmetrics ; do
         %{install_file "$PCP_PMDAS_DIR/$PMDA" .NeedInstall}
     fi
 done
-# auto-enable these usually optional pmie rules
-%{run_pmieconf "$PCP_PMIECONFIG_DIR" config.default dmthin}
 # managed via /usr/lib/systemd/system-preset/90-default.preset nowadays:
 %if 0%{?rhel} > 0 && 0%{?rhel} < 10
 %if !%{disable_systemd}

--- a/debian/pcp-zeroconf.postinst
+++ b/debian/pcp-zeroconf.postinst
@@ -10,7 +10,3 @@ for PMDA in dm nfsclient openmetrics ; do
         fi
     fi
 done
-
-# auto-enable these usually optional pmie rules
-pmieconf -f /var/lib/pcp/config/pmie/config.default -c enable dmthin
-chown pcp:pcp /var/lib/pcp/config/pmie/config.default

--- a/src/pmdas/dm/dmthin.data_high_util.pmie
+++ b/src/pmdas/dm/dmthin.data_high_util.pmie
@@ -12,7 +12,7 @@ rule	dmthin.data_high_util
         > $threshold$
     )
 )"
-	enabled = no
+	enabled = yes
 	version = 1
 	help	=
 "Device Mapper thin pool data utilization percent exceeded

--- a/src/pmdas/dm/dmthin.metadata_high_util.pmie
+++ b/src/pmdas/dm/dmthin.metadata_high_util.pmie
@@ -12,7 +12,7 @@ rule	dmthin.metadata_high_util
         > $threshold$
     )
 )"
-	enabled = no
+	enabled = yes
 	version = 1
 	help	=
 "Device Mapper thin pool metadata utilization percent exceeded


### PR DESCRIPTION
Instead of making dmthin enablement "special" in terms of its pmieconf configuration and pcp-zeroconf, just default enable it (whenever the PMDA is installed) as this simplify things.

Resolves Red Hat bug RHEL-78187