### PR TITLE
pmcd, pmdaproc: allow non-local username connection attributes

### DIFF
--- a/qa/1770
+++ b/qa/1770
@@ -142,10 +142,11 @@ $sudo chown pcp:pcp $PCP_SASLCONF_DIR/pmcd.conf
 ls -l $PCP_SASLCONF_DIR/pmcd.conf >>$seq_full
 $sudo -u pcp cat $PCP_SASLCONF_DIR/pmcd.conf >>$seq_full
 
-echo "Creating temporary sasldb, add user running QA to it" | tee -a $seq_full
+echo "Creating temporary sasldb, add some usernames to it" | tee -a $seq_full
 echo y | saslpasswd2 -p -a pmcd -f $tmp.passwd.db $username
+echo y | saslpasswd2 -p -a pmcd -f $tmp.passwd.db remoteuser
 
-echo "Verify saslpasswd2 has successfully added a new user" | tee -a $seq_full
+echo "Verify saslpasswd2 has successfully added new users" | tee -a $seq_full
 sasldblistusers2 -f $tmp.passwd.db \
 | tee -a $seq_full \
 | _filter_listusers2
@@ -157,20 +158,20 @@ $sudo -u pcp od -c $tmp.passwd.db >>$seq_full
 
 echo "New pmdaproc config without any authentication" | tee -a $seq_full
 cat >$tmp.nobody <<EOF
-allowed = nobody
-mapped = false
+allowed: nobody
+mapped: false
 EOF
 
 echo "New pmdaproc config with remote authentication" | tee -a $seq_full
 cat >$tmp.remote <<EOF
-allowed = bob, $username, root
-mapped = false
+allowed: remoteuser, $username, root
+mapped: false
 EOF
 
 echo "New pmdaproc config with mapped authentication" | tee -a $seq_full
 cat >$tmp.mapped <<EOF
-allowed = $username
-mapped = true
+allowed: $username
+mapped: true
 EOF
 
 echo "Start pmcd with this shiny new sasldb and no access"
@@ -198,13 +199,22 @@ $sudo cp $tmp.remote $PCP_SYSCONF_DIR/proc/access.conf
 if ! _service pmcd restart 2>&1; then _exit 1; fi | tee -a $seq_full >$tmp.out
 _wait_for_pmcd || _exit 1
 
-_test_log "Establish context for authenticated user"
+_test_log "Establish context for authenticated local user"
 response=$(curl -s --user $username:y "http://localhost:44322/pmapi/context")
 echo "${response}" | pmjson | _filter_json | _filter_credentials
 ctx_authenticated=$(echo "${response}" | pmpython -c 'import sys,json; print(json.load(sys.stdin)["context"])')
 
-_test_log "I/O metric access using authenticated context"
+_test_log "I/O metric local user access using authenticated context"
 curl -s --user $username:y "http://localhost:44322/pmapi/$ctx_authenticated/fetch?names=proc.io.write_bytes" | _json_log | _filter_values
+echo
+
+_test_log "Establish context for authenticated remote user"
+response=$(curl -s --user remoteuser:y "http://localhost:44322/pmapi/context")
+echo "${response}" | pmjson | _filter_json | _filter_credentials
+ctx_authenticated=$(echo "${response}" | pmpython -c 'import sys,json; print(json.load(sys.stdin)["context"])')
+
+_test_log "I/O metric remote user access using authenticated context"
+curl -s --user remoteuser:y "http://localhost:44322/pmapi/$ctx_authenticated/fetch?names=proc.io.write_bytes" | _json_log | _filter_values
 echo
 
 echo "Restart pmcd with this sasldb and mapped auth mode"

--- a/qa/1770.out
+++ b/qa/1770.out
@@ -1,7 +1,8 @@
 QA output created by 1770
-Creating temporary sasldb, add user running QA to it
-Verify saslpasswd2 has successfully added a new user
+Creating temporary sasldb, add some usernames to it
+Verify saslpasswd2 has successfully added new users
 USER@HOST: userPassword
+remoteuser@HOST: userPassword
 Ensure pmcd can read the password file
 New pmdaproc config without any authentication
 New pmdaproc config with remote authentication
@@ -37,7 +38,7 @@ NO VALUES
 
 Restart pmcd with this sasldb and remote auth mode
 
-=== Establish context for authenticated user ===
+=== Establish context for authenticated local user ===
 {
     "context": "CONTEXT"
     "source": "SOURCE"
@@ -51,7 +52,35 @@ Restart pmcd with this sasldb and remote auth mode
     }
 }
 
-=== I/O metric access using authenticated context ===
+=== I/O metric local user access using authenticated context ===
+{
+    "context": "CONTEXT"
+    "timestamp": "TIMESTAMP"
+    "values": [
+        {
+            "pmid": "3.32.5",
+            "name": "proc.io.write_bytes",
+            "instances": [  ...
+            ]
+        }
+    ]
+}
+GOOD VALUES
+
+
+=== Establish context for authenticated remote user ===
+{
+    "context": "CONTEXT"
+    "source": "SOURCE"
+    "hostspec": "HOSTSPEC"
+    "labels": {
+        "domainname": "DOMAINNAME"
+        "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
+    }
+}
+
+=== I/O metric remote user access using authenticated context ===
 {
     "context": "CONTEXT"
     "timestamp": "TIMESTAMP"

--- a/src/include/pcp/pmda.h
+++ b/src/include/pcp/pmda.h
@@ -293,7 +293,7 @@ typedef struct pmdaInterface {
 #define PMDA_FLAG_CONTAINER	(1<<6)	/* container name support */
 
 /* communication attributes (mirrored from libpcp.h) */
-#define PMDA_ATTR_USERNAME   5  /* username (sasl) */
+#define PMDA_ATTR_USERNAME	5	/* username (sasl) */
 #define PMDA_ATTR_USERID	11	/* uid - user identifier (posix) */
 #define PMDA_ATTR_GROUPID	12	/* gid - group identifier (posix) */
 #define PMDA_ATTR_PROCESSID	14	/* pid - process identifier (posix) */

--- a/src/libpcp/src/accounts.c
+++ b/src/libpcp/src/accounts.c
@@ -623,15 +623,17 @@ __pmGetUserIdentity(const char *username, uid_t *uid, gid_t *gid, int mode)
 
     sts = getpwnam_r(username, &pwd, buf, sizeof(buf), &pw);
     if (sts < 0) {
-	pmNotifyErr(LOG_CRIT, "getpwnam_r(%s) failed: %s\n",
-		username, pmErrStr_r(sts, buf, sizeof(buf)));
+	if (mode == PM_FATAL_ERR || pmDebugOptions.access)
+	    pmNotifyErr(LOG_CRIT, "getpwnam_r(%s) failed: %s\n",
+		    username, pmErrStr_r(sts, buf, sizeof(buf)));
 	if (mode == PM_FATAL_ERR)
 	    exit(1);
 	return -ENOENT;
     }
     else if (pw == NULL) {
-	pmNotifyErr(LOG_CRIT,
-		"cannot find the %s user to switch to\n", username);
+	if (mode == PM_FATAL_ERR || pmDebugOptions.access)
+	    pmNotifyErr(LOG_CRIT,
+		    "cannot find the %s user to switch to\n", username);
 	if (mode == PM_FATAL_ERR)
 	    exit(1);
 	return -ENOENT;
@@ -653,16 +655,18 @@ __pmGetUserIdentity(const char *username, uid_t *uid, gid_t *gid, int mode)
     pw = getpwnam(username);		/* THREADSAFE */
     if (pw == NULL) {
 	PM_UNLOCK(__pmLock_extcall);
-	pmNotifyErr(LOG_CRIT,
-		"cannot find the %s user to switch to\n", username);
+	if (mode == PM_FATAL_ERR || pmDebugOptions.access)
+	    pmNotifyErr(LOG_INFO,
+		    "cannot find the %s user to switch to\n", username);
 	if (mode == PM_FATAL_ERR)
 	    exit(1);
 	return -ENOENT;
     }
     else if (oserror() != 0) {
 	PM_UNLOCK(__pmLock_extcall);
-	pmNotifyErr(LOG_CRIT, "getpwnam(%s) failed: %s\n",
-		username, pmErrStr_r(oserror(), errmsg, sizeof(errmsg)));
+	if (mode == PM_FATAL_ERR || pmDebugOptions.access)
+	     pmNotifyErr(LOG_CRIT, "getpwnam(%s) failed: %s\n",
+		    username, pmErrStr_r(oserror(), errmsg, sizeof(errmsg)));
 	if (mode == PM_FATAL_ERR)
 	    exit(1);
 	return -ENOENT;

--- a/src/libpcp/src/secureserver.c
+++ b/src/libpcp/src/secureserver.c
@@ -284,8 +284,10 @@ __pmSetUserGroupAttributes(const char *username, __pmHashCtl *attrs)
 	    return -ENOMEM;
 	return 0;
     }
-    pmNotifyErr(LOG_ERR, "Authenticated user %s not found\n", username);
-    return -ESRCH;
+
+    if (pmDebugOptions.auth)
+        pmNotifyErr(LOG_INFO, "Authenticated user %s not local\n", username);
+    return 0;
 }
 
 static int
@@ -426,10 +428,10 @@ __pmAuthServerNegotiation(int fd, int ssf, __pmHashCtl *attrs)
 	    char	strbuf[20];
 	    char	errmsg[PM_MAXERRMSGLEN];
 	    if (sts < 0)
-		fprintf(stderr, "__pmSecureClientHandshake: PM_ERR_IPC: expecting PDU_AUTH but__pmGetPDU returns %d (%s)\n",
+		fprintf(stderr, "__pmSecureClientHandshake: PM_ERR_IPC: expecting PDU_AUTH but __pmGetPDU returns %d (%s)\n",
 		    sts, pmErrStr_r(sts, errmsg, sizeof(errmsg)));
 	    else
-		fprintf(stderr, "__pmSecureClientHandshake: PM_ERR_IPC: expecting PDU_AUTH but__pmGetPDU returns %d (type=%s)\n",
+		fprintf(stderr, "__pmSecureClientHandshake: PM_ERR_IPC: expecting PDU_AUTH but __pmGetPDU returns %d (type=%s)\n",
 		    sts, __pmPDUTypeStr_r(sts, strbuf, sizeof(strbuf)));
 	}
 	sts = PM_ERR_IPC;
@@ -479,10 +481,10 @@ __pmAuthServerNegotiation(int fd, int ssf, __pmHashCtl *attrs)
 		char	strbuf[20];
 		char	errmsg[PM_MAXERRMSGLEN];
 		if (sts < 0)
-		    fprintf(stderr, "__pmAuthServerNegotiation: PM_ERR_IPC: expecting PDU_AUTH but__pmGetPDU returns %d (%s)\n",
+		    fprintf(stderr, "__pmAuthServerNegotiation: PM_ERR_IPC: expecting PDU_AUTH but __pmGetPDU returns %d (%s)\n",
 			sts, pmErrStr_r(sts, errmsg, sizeof(errmsg)));
 		else
-		    fprintf(stderr, "__pmAuthServerNegotiation: PM_ERR_IPC: expecting PDU_AUTH but__pmGetPDU returns %d (type=%s)\n",
+		    fprintf(stderr, "__pmAuthServerNegotiation: PM_ERR_IPC: expecting PDU_AUTH but __pmGetPDU returns %d (type=%s)\n",
 			sts, __pmPDUTypeStr_r(sts, strbuf, sizeof(strbuf)));
 	    }
 	    sts = PM_ERR_IPC;

--- a/src/pmcd/src/dopdus.c
+++ b/src/pmcd/src/dopdus.c
@@ -1527,7 +1527,8 @@ DoCreds(ClientInfo *cp, __pmPDU *pb)
      * account authentication successful (if needed) and/or other attributes
      * have been given - in these cases, we need to inform interested PMDAs.
      */
-    else if (sts > 0 || (flags & PDU_FLAG_CONTAINER)) {
+    else if (sts > 0 ||
+	    (sts == 0 && (flags & (PDU_FLAG_CONTAINER|PDU_FLAG_AUTH)))) {
 	sts = AgentsAttributes(cp - client);
 	if (sts < 0 && (pmDebugOptions.auth || pmDebugOptions.attr))
 	    fprintf(stderr, "DoCreds: AgentsAttributes returns %d: %s\n",

--- a/src/pmdas/linux_proc/contexts.c
+++ b/src/pmdas/linux_proc/contexts.c
@@ -75,9 +75,9 @@ proc_ctx_set_userid(int ctx, const char *value)
 static int
 proc_ctx_allow_username(const char *value)
 {
-   char *username;
+    char *username;
 
-   if (!ctxusers)
+    if (!ctxusers)
 	return 0; /* no allowed usernames, denied */
     for (username = *ctxusers; username; username++)
 	if (strcmp(username, value) == 0)
@@ -299,6 +299,8 @@ proc_ctx_access(int ctx)
     if (pp->state == CTX_INACTIVE)
 	return accessible;
 
+    if (pp->state & CTX_USERNAME)
+	return 1;
     if (pp->state & CTX_GROUPID) {
 	accessible++;
 	if (basegid != pp->gid) {
@@ -319,8 +321,6 @@ proc_ctx_access(int ctx)
 	    }
 	}
     }
-    if (pp->state & CTX_USERNAME)
-	return 1;
     return (accessible > 1);
 }
 
@@ -333,6 +333,8 @@ proc_ctx_revert(int ctx)
 	return 0;
     pp = &ctxtab[ctx];
     if (pp->state == CTX_INACTIVE)
+	return 0;
+    if (pp->state & CTX_USERNAME)
 	return 0;
 
     if ((pp->state & CTX_USERID) && baseuid != pp->uid) {


### PR DESCRIPTION
Allows authenticated users to access the proc metric values even when there is no local account for the users name, via the /etc/pcp/proc/access.conf configuration file.

Related issue #2089