### PR TITLE
qa: fix test 1061 with recent versions of python

### DIFF
--- a/qa/1061
+++ b/qa/1061
@@ -29,6 +29,7 @@ pmdalio_filter()
 {
     sed \
 	-e "s/Ran 5 tests in [0-9]\.[0-9][0-9]*[0-9]s/Ran 5 tests in 0.XXXs/" \
+	-e "s/\.ISCSITests\..*) /.ISCSITests) /g" \
 	-e "/^$/d" \
     # end
 }

--- a/qa/admin/package-lists/CentOS+6+x86_64
+++ b/qa/admin/package-lists/CentOS+6+x86_64
@@ -93,6 +93,7 @@ smartmontools
 sqlite
 sysstat
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 xfsprogs

--- a/qa/admin/package-lists/CentOS+7+x86_64
+++ b/qa/admin/package-lists/CentOS+7+x86_64
@@ -136,6 +136,7 @@ sysstat
 systemd-devel
 systemtap-devel
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 xfsprogs

--- a/qa/admin/package-lists/CentOS+8+x86_64
+++ b/qa/admin/package-lists/CentOS+8+x86_64
@@ -124,6 +124,7 @@ sqlite-libs
 sysstat
 systemd-devel
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 xfsprogs

--- a/qa/admin/package-lists/CentOS+Stream10+x86_64
+++ b/qa/admin/package-lists/CentOS+Stream10+x86_64
@@ -130,6 +130,7 @@ systemd-devel
 systemtap-devel
 systemtap-sdt-devel
 systemtap-runtime
+targetcli
 time
 valkey
 valgrind

--- a/qa/admin/package-lists/CentOS+Stream8+x86_64
+++ b/qa/admin/package-lists/CentOS+Stream8+x86_64
@@ -124,6 +124,7 @@ sqlite-libs
 sysstat
 systemd-devel
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 xfsprogs

--- a/qa/admin/package-lists/CentOS+Stream9+x86_64
+++ b/qa/admin/package-lists/CentOS+Stream9+x86_64
@@ -136,6 +136,7 @@ sysstat
 systemd-devel
 systemtap-devel
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 xfsprogs

--- a/qa/admin/package-lists/Debian+10+i686
+++ b/qa/admin/package-lists/Debian+10+i686
@@ -134,6 +134,7 @@ sysstat
 systemtap
 systemtap-runtime
 systemtap-sdt-dev
+targetcli-fb
 time
 unbound
 valgrind

--- a/qa/admin/package-lists/Debian+10+x86_64
+++ b/qa/admin/package-lists/Debian+10+x86_64
@@ -130,6 +130,7 @@ smartmontools
 socat
 sysstat
 systemtap-sdt-dev
+targetcli-fb
 time
 unbound
 valgrind

--- a/qa/admin/package-lists/Debian+11+i686
+++ b/qa/admin/package-lists/Debian+11+i686
@@ -127,6 +127,7 @@ smartmontools
 socat
 sysstat
 systemtap-sdt-dev
+targetcli-fb
 time
 unbound
 valgrind

--- a/qa/admin/package-lists/Debian+11+x86_64
+++ b/qa/admin/package-lists/Debian+11+x86_64
@@ -130,6 +130,7 @@ smartmontools
 socat
 sysstat
 systemtap-sdt-dev
+targetcli-fb
 time
 unbound
 valgrind

--- a/qa/admin/package-lists/Debian+12+i686
+++ b/qa/admin/package-lists/Debian+12+i686
@@ -133,6 +133,7 @@ socat
 sysstat
 systemtap
 systemtap-sdt-dev
+targetcli-fb
 time
 unbound
 valgrind

--- a/qa/admin/package-lists/Debian+12+x86_64
+++ b/qa/admin/package-lists/Debian+12+x86_64
@@ -138,6 +138,7 @@ socat
 sysstat
 systemtap
 systemtap-sdt-dev
+targetcli-fb
 time
 unbound
 valgrind

--- a/qa/admin/package-lists/Fedora+36+x86_64
+++ b/qa/admin/package-lists/Fedora+36+x86_64
@@ -136,6 +136,7 @@ sqlite-libs
 sysstat
 systemd-devel
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 xfsprogs

--- a/qa/admin/package-lists/Fedora+37+x86_64
+++ b/qa/admin/package-lists/Fedora+37+x86_64
@@ -138,6 +138,7 @@ sqlite-libs
 sysstat
 systemd-devel
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 xfsprogs

--- a/qa/admin/package-lists/Fedora+38+x86_64
+++ b/qa/admin/package-lists/Fedora+38+x86_64
@@ -141,6 +141,7 @@ sysstat
 systemd-devel
 systemtap-devel
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 xfsprogs

--- a/qa/admin/package-lists/Fedora+39+x86_64
+++ b/qa/admin/package-lists/Fedora+39+x86_64
@@ -143,6 +143,7 @@ sysstat
 systemd-devel
 systemtap-devel
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 xfsprogs

--- a/qa/admin/package-lists/Fedora+40+x86_64
+++ b/qa/admin/package-lists/Fedora+40+x86_64
@@ -142,6 +142,7 @@ sysstat
 systemd-devel
 systemtap-devel
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 valkey

--- a/qa/admin/package-lists/Fedora+41+x86_64
+++ b/qa/admin/package-lists/Fedora+41+x86_64
@@ -146,6 +146,7 @@ systemtap
 systemtap-runtime
 systemtap-devel
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 valkey

--- a/qa/admin/package-lists/Fedora+42+x86_64
+++ b/qa/admin/package-lists/Fedora+42+x86_64
@@ -144,6 +144,7 @@ sysstat
 systemd-devel
 systemtap-devel
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 valkey

--- a/qa/admin/package-lists/Fedora+43+x86_64
+++ b/qa/admin/package-lists/Fedora+43+x86_64
@@ -144,6 +144,7 @@ sysstat
 systemd-devel
 systemtap-devel
 systemtap-sdt-devel
+targetcli
 time
 valgrind
 valkey

--- a/qa/admin/package-lists/RHEL+6+x86_64
+++ b/qa/admin/package-lists/RHEL+6+x86_64
@@ -100,6 +100,7 @@ socat
 sqlite
 sysstat
 systemtap-sdt-devel
+targetcli-fb
 time
 valgrind
 xkeyboard-config

--- a/qa/admin/package-lists/RHEL+7+x86_64
+++ b/qa/admin/package-lists/RHEL+7+x86_64
@@ -116,6 +116,7 @@ sysstat
 systemd-devel
 systemtap-devel
 systemtap-sdt-devel
+targetcli-fb
 time
 valgrind
 xfsprogs

--- a/qa/admin/package-lists/RHEL+8+x86_64
+++ b/qa/admin/package-lists/RHEL+8+x86_64
@@ -126,6 +126,7 @@ systemd-devel
 systemtap
 systemtap-devel
 systemtap-sdt-devel
+targetcli-fb
 time
 valkey
 valgrind

--- a/qa/admin/package-lists/RHEL+9+x86_64
+++ b/qa/admin/package-lists/RHEL+9+x86_64
@@ -137,6 +137,7 @@ sysstat
 systemd-devel
 systemtap-devel
 systemtap-sdt-devel
+targetcli-fb
 time
 valgrind
 valkey

--- a/qa/admin/package-lists/Ubuntu+16.04+x86_64
+++ b/qa/admin/package-lists/Ubuntu+16.04+x86_64
@@ -122,6 +122,7 @@ socat
 sysstat
 systemtap
 systemtap-sdt-dev
+targetcli-fb
 time
 unbound
 valgrind

--- a/qa/admin/package-lists/Ubuntu+18.04+i686
+++ b/qa/admin/package-lists/Ubuntu+18.04+i686
@@ -128,6 +128,7 @@ smartmontools
 socat
 sysstat
 systemtap-sdt-dev
+targetcli-fb
 time
 unbound
 valgrind

--- a/qa/admin/package-lists/Ubuntu+18.04+x86_64
+++ b/qa/admin/package-lists/Ubuntu+18.04+x86_64
@@ -129,6 +129,7 @@ socat
 sysstat
 systemtap
 systemtap-sdt-dev
+targetcli-fb
 time
 unbound
 valgrind

--- a/qa/admin/package-lists/Ubuntu+20.04+x86_64
+++ b/qa/admin/package-lists/Ubuntu+20.04+x86_64
@@ -134,6 +134,7 @@ socat
 sysstat
 systemtap
 systemtap-sdt-dev
+targetcli-fb
 time
 unbound
 valgrind

--- a/qa/admin/package-lists/Ubuntu+22.04+x86_64
+++ b/qa/admin/package-lists/Ubuntu+22.04+x86_64
@@ -136,6 +136,7 @@ socat
 sysstat
 systemtap
 systemtap-sdt-dev
+targetcli-fb
 time
 unbound
 valgrind

--- a/qa/admin/package-lists/Ubuntu+24.04+x86_64
+++ b/qa/admin/package-lists/Ubuntu+24.04+x86_64
@@ -135,6 +135,7 @@ socat
 sysstat
 systemtap
 systemtap-sdt-dev
+targetcli-fb
 time
 unbound
 valkey-server


### PR DESCRIPTION
Fix filter to handle changes to test object name reporting. Add targetcli package to QA/CI package lists to ensure this test is run on more test platforms.

Resolves #2137