### PR TITLE
Add filter parameter for the pmwebapi openmetrics 

### DIFF
--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -98,6 +98,16 @@ paths:
         description: Comma-separated list of metric names
         schema:
           type: string
+      - name: filter
+        in: query
+        description: Comma-separated list of filters
+        schema:
+          type: string
+      - name: match
+        in: query
+        description: Pattern matching style (exact, glob or regex)
+        schema:
+          type: string
       - name: times
         in: query
         description: Append sample times (milliseconds since epoch)

--- a/man/man3/pmwebapi.3
+++ b/man/man3/pmwebapi.3
@@ -95,6 +95,7 @@ lf(CR) | l | l.
 Parameters	Type	Explanation
 _
 names	string	Comma-separated list of metric names
+filter	string	Comma-separated list of excluded metric names
 times	boolean	Append sample times (milliseconds since epoch)
 _
 hostspec	string	Host specification as described in \f(CBPCPIntro\fR(1)

--- a/man/man3/pmwebapi.3
+++ b/man/man3/pmwebapi.3
@@ -95,7 +95,8 @@ lf(CR) | l | l.
 Parameters	Type	Explanation
 _
 names	string	Comma-separated list of metric names
-filter	string	Comma-separated list of excluded metric names
+filter	string	Comma-separated list of excluded metric names (default glob matching)
+match	string	Pattern matching style (exact, glob or regex)
 times	boolean	Append sample times (milliseconds since epoch)
 _
 hostspec	string	Host specification as described in \f(CBPCPIntro\fR(1)

--- a/qa/1543
+++ b/qa/1543
@@ -90,6 +90,7 @@ _filter_text()
 	-e "s/hostname=\"$hostname\"/hostname=\"HOSTNAME\"/g" \
 	-e "s/machineid=\"$machineid\"/machineid=\"MACHINEID\"/g" \
 	-e "s/domainname=\"$domainname\"/domainname=\"DOMAINNAME\"/g" \
+	-e "s/\"context\":[0-9][0-9]*/\"context\":CONTEXT/g" \
     #end
 }
 
@@ -406,6 +407,16 @@ if [ $? -eq 0 ]; then
 else
     echo "pmproxy check failed"
 fi
+
+# Filtering options
+curl -s "http://localhost:$port/metrics?name=sample.long.one,sample.long.ten&filter=*ten" \
+	| _filter_text "good filter globbing"
+curl -s "http://localhost:$port/metrics?name=sample.long.one,sample.long.ten&filter=*ten&match=exact" \
+	| _filter_text "good filter exact match"
+curl -s "http://localhost:$port/metrics?name=sample.long.one,sample.long.ten&filter=ten&match=regex" \
+	| _filter_text "good filter regex"
+curl -s "http://localhost:$port/metrics?name=sample.long.one,sample.long.ten&filter=ten&match=dummy" \
+	| _filter_text "bad filter match param"
 
 # No clue why or how, but on vm21 (Debian 11) this sleep makes the test
 # reliably pass, rather than 

--- a/qa/1543.out
+++ b/qa/1543.out
@@ -1031,6 +1031,23 @@ sample_control{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",
 done full scrape
 == check pmproxy is running ==
 pmproxy check passed
+== good filter globbing ==
+# PCP5 sample.long.one 29.0.10 32 PM_INDOM_NULL instant none
+# HELP sample_long_one 1 as a 32-bit integer
+# TYPE sample_long_one gauge
+sample_long_one{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAINNAME",machineid="MACHINEID"} 1
+== good filter exact match ==
+# PCP5 sample.long.one 29.0.10 32 PM_INDOM_NULL instant none
+# HELP sample_long_one 1 as a 32-bit integer
+# TYPE sample_long_one gauge
+sample_long_one{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAINNAME",machineid="MACHINEID"} 1
+== good filter regex ==
+# PCP5 sample.long.one 29.0.10 32 PM_INDOM_NULL instant none
+# HELP sample_long_one 1 as a 32-bit integer
+# TYPE sample_long_one gauge
+sample_long_one{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAINNAME",machineid="MACHINEID"} 1
+== bad filter match param ==
+{"context":CONTEXT,"message":"dummy - invalid 'match' parameter value","success":false}
 
 *****   GET and POST /pmapi/derive   *****
 


### PR DESCRIPTION
The names parameter for pmwebapi get metrics operation pulls in all the names in the performance metric tree that match its comma separate list.  There may be cases where particular individual metrics that are found during the search should be excluded from the results.  For example one may want to exclude specific metrics that have instances for all the process running on the system, but include all the other related metrics in that area of the performance metric name tree.  Rather than enumerating the names in the names parameter one could just name the node in the tree that contains all the names and then use the filter parameter to exclude the unwanted metrics.