### PR TITLE
Fix pmda redis man page

### DIFF
--- a/src/pmdas/redis/pmdaredis.1
+++ b/src/pmdas/redis/pmdaredis.1
@@ -51,17 +51,6 @@ information must be specified in the
 .ft P
 .RE
 .sp 1
-To uninstall, the following must be done as root:
-.sp 1
-.RS +4
-.ft B
-.nf
-# cd $PCP_PMDAS_DIR/redis
-# ./Remove
-.fi
-.ft P
-.RE
-.sp 1
 Once this is setup, you can access the names and values for the
 redis performance metrics by doing the following as root:
 .sp 1


### PR DESCRIPTION
The redis pmda man page currently has two identical sections explaining how to uninstall the pmda. This change drops the first of the two.