### PR TITLE
build: Enable amdgpu pmda for rhel 9

### DIFF
--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -236,7 +236,7 @@ ExcludeArch: %{ix86}
 %global disable_xlsx 1
 %endif
 
-%if 0%{?fedora} >= 40 || 0%{?rhel} >= 10
+%if 0%{?fedora} >= 40 || 0%{?rhel} >= 9
 %global disable_amdgpu 0
 %else
 %global disable_amdgpu 1


### PR DESCRIPTION
Since the minimum library requirement is available in RHEL 9, enable the amdgpu pmda.