### PR TITLE
containers: updates to the archive-analysis container time windowing

### DIFF
--- a/build/containers/archive-analysis/root/usr/bin/archive-import.py
+++ b/build/containers/archive-analysis/root/usr/bin/archive-import.py
@@ -3,12 +3,12 @@ import logging
 import time
 import argparse
 import os
-import sys
 import subprocess
-import cpmapi as api
-from pcp import pmapi
 from pathlib import Path
 from datetime import datetime, UTC
+
+import cpmapi as api
+from pcp import pmapi
 
 POLL_INTERVAL_SEC = 10
 IMPORT_TIMEOUT_SEC = 10 * 60  # 10 minutes
@@ -18,41 +18,65 @@ minimum_start_time = 0.0
 maximum_finish_time = 0.0
 
 
-def format_time(seconds):
+def base_archive_path(path: Path):
+    # From a path, return canonical PMAPI archive context string
+    # (i.e. removing optional compression and .meta suffixes)
+    while len(path.suffixes) != 0:
+        if '.meta' not in path.suffixes:  # stripped too far, bail out now
+            break
+        path = path.with_suffix("")  # strip .meta, optional .gz/.xz/... from path
+    return str(path)
+
+
+def archive_unchanged(archive_path: str, archive_time: float, i: int, count: int):
+    # Test whether we have fully imported this archive already
+    previous_time = imported_archives.get(archive_path)
+    if previous_time and previous_time == archive_time:
+        logging.info("Skipping archive %s (no changes) [%d/%d]", archive_path, i, count)
+        return True
+    return False
+
+
+def format_time(seconds: float):
     # From a floating point number of seconds since the epoch,
     # produce a time string in the format Grafana is expecting.
     string = datetime.fromtimestamp(seconds, UTC).isoformat()
     return string.replace('+00:00', 'Z')
 
 
-def import_archive(path: Path, i: int, count: int):
-    global imported_archives, minimum_start_time, maximum_finish_time
+def setup_grafana(path: Path, i: int, count: int):
+    global minimum_start_time, maximum_finish_time
 
+    archive_path = base_archive_path(path)
     archive_mod_time = os.path.getmtime(path)
-    archive_path = str(path.with_suffix(""))  # strip .meta from path
-
-    prev_mod_time = imported_archives.get(archive_path)
-    if prev_mod_time and prev_mod_time == archive_mod_time:
-        logging.info("Skipping archive %s (no changes) [%d/%d]", archive_path, i, count)
+    if archive_unchanged(archive_path, archive_mod_time, i, count):
         return
 
-    ctx = pmapi.pmContext(api.PM_CONTEXT_ARCHIVE, archive_path)
-    ctx.pmNewZone('UTC')
-
     try:
+        ctx = pmapi.pmContext(api.PM_CONTEXT_ARCHIVE, archive_path)
+        ctx.pmNewZone('UTC')
         label = ctx.pmGetHighResArchiveLabel()
     except pmapi.pmErr:
         logging.info("Skipping archive %s (no context) [%d/%d]", archive_path, i, count)
         return # .meta exists, but not a PCP archive metadata file
     start = float(label.start)
     if minimum_start_time == 0.0 or start < minimum_start_time:
+        logging.info("Updating start to %s from %s [%d/%d]",
+                     format_time(minimum_start_time), archive_path, i, count)
         minimum_start_time = start
-        logging.info("Updated start: %s" % format_time(minimum_start_time))
 
     finish = float(ctx.pmGetHighResArchiveEnd())
     if finish > maximum_finish_time:
+        logging.info("Updating finish to %s from %s [%d/%d]",
+                     format_time(maximum_finish_time), archive_path, i, count)
         maximum_finish_time = finish
-        logging.info("Updated finish: %s" % format_time(maximum_finish_time))
+
+
+def import_archive(path: Path, i: int, count: int):
+    archive_path = base_archive_path(path)
+    archive_mod_time = os.path.getmtime(path)
+    if archive_unchanged(archive_path, archive_mod_time, i, count):
+        return
 
     start_dt = datetime.now()
     try:
@@ -84,10 +108,14 @@ def poll(archives_path: str):
         logging.error("Please use '--security-opt label=disable' when starting the container.")
         return
 
-    archive_paths = list(Path(archives_path).rglob("*.meta"))
+    archive_paths = list(Path(archives_path).rglob("*.meta*"))
     if not archive_paths:
         logging.warning("No archives found.")
     else:
+        # prepare the dashboard with an initial (quick) pass over all archives
+        # because the import_archive process may be loading large data volumes
+        for i, path in enumerate(archive_paths, start=1):
+            setup_grafana(path, i, len(archive_paths))
         for i, path in enumerate(archive_paths, start=1):
             import_archive(path, i, len(archive_paths))
 
@@ -99,7 +127,7 @@ def main():
     dash = 'http://localhost:3000/d/pcp-archive-analysis/pcp-archive-analysis'
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     logging.info("Starting Performance Co-Pilot archive import...")
-    logging.info("Dashboard: %s (when using default instructions)" % dash)
+    logging.info("Dashboard: %s (when using default instructions)", dash)
 
     # ensure archive timestamps for Grafana handled in UTC
     os.environ['TZ'] = 'UTC'


### PR DESCRIPTION
Improvements to the time window calculations in preparation for Sam's dashboard updating code.  Firstly, the switch from .index (optional) to .meta (mandatory) for archive file detection had the unanticipated side-effect of failing to detect compressed archives more often since the index is often not compressed.  This is now addressed by handling compression (any) suffixes following .meta in the filenames.  Second, archive importing can take awhile for large archives so we do Grafana setup in an initial quick pass over the archives before starting that time consuming secondary phase of loading now.  This allows us to get the Grafana dashboard time window configured as early as possible and likely well before the metrics data is available.

Small code cleanups as well, like adding type information into recent function additions.