### PR TITLE
pmfg: allow for not preserving discrete metric values

### DIFF
--- a/man/man3/pmfetchgroup.3
+++ b/man/man3/pmfetchgroup.3
@@ -481,6 +481,9 @@ pmValueSet.numval==0), then the last seen valid value (if any) is
 retained.
 This is intended to ease the processing of sets of archives with a
 mixture of once- and repeatedly-sampled metrics.
+The environment variable
+.B PCP_PMFG_NO_PRESERVE
+may be set to disable this feature.
 .SS Clearing a fetchgroup
 .ft 3
 .nf


### PR DESCRIPTION
Existing QA and C (pmclient_fg) and Python (pmrep et al) clients all work as before, the next commit will make the Python clients to use the feature and add appropriate QA.

Related to issue #2175