### PR TITLE
selinux: add permissions allowing proc_psi_t access

### DIFF
--- a/src/selinux/pcp.if
+++ b/src/selinux/pcp.if
@@ -535,3 +535,23 @@ ifndef(`userdom_manage_tmp_files',`
         ')
     ')
 ')
+
+########################################
+## <summary>
+##      Dummy kernel_read_psi().
+##      Allow caller to set up pressure stall information (PSI),
+##      but if you don't have actual kernel_read_psi() interface
+##      nothing needs to be done.
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </summary> 
+#
+ifndef(`kernel_read_psi',`
+    interface(`kernel_read_psi',`
+        gen_require(`
+            type $1;
+        ')
+    ')
+')

--- a/src/selinux/pcp.te
+++ b/src/selinux/pcp.te
@@ -123,6 +123,7 @@ kernel_read_vm_sysctls(pcp_pmcd_t)
 kernel_read_rpc_sysctls(pcp_pmcd_t)
 kernel_search_network_sysctl(pcp_pmcd_t)
 kernel_read_net_sysctls(pcp_pmcd_t)
+kernel_read_psi(pcp_pmcd_t)
 
 corecmd_exec_bin(pcp_pmcd_t)
 corecmd_exec_shell(pcp_pmcd_t)


### PR DESCRIPTION
Access to /proc/pressure recently became selinux policy protected so we need to allow pcp_pmcd_t to access that as it contains important system level metrics.

Resolves Red Hat bugzilla #2358326.