### PR TITLE
build: drop sub-package deps in the testsuite rpm

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -310,110 +310,11 @@ Requires: pcp = @package_version@
 Requires: pcp-libs = @package_version@
 Requires: pcp-libs-devel = @package_version@
 Requires: pcp-devel = @package_version@
-Obsoletes: pcp-gui-testsuite < 3.9.5
-# The following are inherited from pcp-collector and pcp-monitor,
-# both of which are now obsoleted by the base pcp package
-%if "@have_perl@" == "true"
-Requires: pcp-pmda-bonding pcp-pmda-dbping pcp-pmda-ds389 pcp-pmda-ds389log
-Requires: pcp-pmda-gpfs pcp-pmda-gpsd pcp-pmda-lustre pcp-pmda-pdns
-Requires: pcp-pmda-memcache pcp-pmda-named pcp-pmda-netfilter pcp-pmda-news
-Requires: pcp-pmda-redis pcp-pmda-samba pcp-pmda-slurm pcp-pmda-zimbra
-%endif
-Requires: pcp-pmda-apache pcp-pmda-bash pcp-pmda-cisco pcp-pmda-dm
-Requires: pcp-pmda-logger pcp-pmda-mailq pcp-pmda-mounts
-Requires: pcp-pmda-nvidia-gpu pcp-pmda-roomtemp pcp-pmda-sendmail pcp-pmda-shping
-Requires: pcp-pmda-lustrecomm pcp-pmda-docker pcp-pmda-smart pcp-pmda-farm
-Requires: pcp-pmda-hacluster pcp-pmda-sockets pcp-pmda-podman
-%if "@have_python@" == "true"
-Requires: pcp-geolocate pcp-export-pcp2openmetrics pcp-export-pcp2json
-Requires: pcp-export-pcp2spark pcp-export-pcp2xml pcp-export-pcp2zabbix
-Requires: pcp-pmda-gluster pcp-pmda-zswap pcp-pmda-unbound pcp-pmda-mic
-Requires: pcp-pmda-haproxy pcp-pmda-nfsclient pcp-pmda-lmsensors
-Requires: pcp-pmda-netcheck pcp-pmda-rabbitmq pcp-pmda-uwsgi
-Requires: pcp-pmda-openvswitch
-%endif
-%if "@pmda_gfs2@" == "true"
-Requires: pcp-pmda-gfs2
-%endif
-%if "@pmda_statsd@" == "true"
-Requires: pcp-pmda-statsd
-%endif
-%if "@pmda_bcc@" == "true"
-Requires: pcp-pmda-bcc
-%endif
-%if "@pmda_bpf@" == "true"
-Requires: pcp-pmda-bpf
-%endif
-%if "@pmda_bpftrace@" == "true"
-Requires: pcp-pmda-bpftrace
-%endif
-%if "@pmda_json@" == "true"
-Requires: pcp-pmda-json
-%endif
-%if "@pmda_libvirt@" == "true"
-Requires: pcp-pmda-libvirt
-%endif
-%if "@pmda_lio@" == "true"
-Requires: pcp-pmda-lio
-%endif
-%if "@pmda_openmetrics@" == "true"
-Requires: pcp-pmda-openmetrics
-%endif
-%if "@pmda_snmp@" == "true"
-Requires: pcp-pmda-snmp
-%endif
-%if "@pmda_mssql@" == "true"
-Requires: pcp-pmda-mssql
-%endif
-%if "@pmda_mysql@" == "true"
-Requires: pcp-pmda-mysql
-%endif
-%if "@pmda_oracle@" == "true"
-Requires: pcp-pmda-oracle
-%endif
-%if "@pmda_mongodb@" == "true"
-Requires: pcp-pmda-mongodb
-%endif
-%if "@pmda_postgresql@" == "true"
-Requires: pcp-pmda-postgresql
-%endif
-%if "@pmda_nginx@" == "true"
-Requires: pcp-pmda-nginx
-%endif
-%if "@pmda_activemq@" == "true"
-Requires: pcp-pmda-activemq
-%endif
-%if "@pmda_bind2@" == "true"
-Requires: pcp-pmda-bind2
-%endif
-%if "@pmda_nutcracker@" == "true"
-Requires: pcp-pmda-nutcracker
-%endif
-%if "@pmda_elasticsearch@" == "true"
-Requires: pcp-pmda-elasticsearch
-%endif
-%if "@pmda_postfix@" == "true"
-Requires: pcp-pmda-postfix
-%endif
-%if "@pmda_resctrl@" == "true"
-Requires: pcp-pmda-resctrl
-%endif
-%if "@pmda_amdgpu@" == "true"
-Requires: pcp-pmda-amdgpu
-%endif
-Requires: pcp-system-tools
-%if "@enable_qt@" == "true"
-Requires: pcp-gui
-%endif
-Requires: gcc bc bzip2 gzip
+Requires: bc gcc gzip bzip2
 %if "@enable_selinux@" == "true"
 Requires: selinux-policy-devel
 Requires: selinux-policy-targeted
-%if 0%{?fedora} >= 19 || 0%{?rhel} >= 6 || 0%{?suse_version} >= 1200
 Requires: setools-console
-%else
-Requires: setools
-%endif
 %endif
 
 %description testsuite

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -568,81 +568,12 @@ Requires: pcp = %{version}-%{release}
 Requires: pcp-libs = %{version}-%{release}
 Requires: pcp-libs-devel = %{version}-%{release}
 Requires: pcp-devel = %{version}-%{release}
-Obsoletes: pcp-gui-testsuite < 3.9.5
-# The following are inherited from pcp-collector and pcp-monitor,
-# both of which are now obsoleted by the base pcp package
-Requires: pcp-pmda-activemq pcp-pmda-bonding pcp-pmda-dbping pcp-pmda-ds389 pcp-pmda-ds389log
-Requires: pcp-pmda-elasticsearch pcp-pmda-gpfs pcp-pmda-gpsd pcp-pmda-lustre
-Requires: pcp-pmda-memcache pcp-pmda-named pcp-pmda-netfilter pcp-pmda-news
-Requires: pcp-pmda-nginx pcp-pmda-nfsclient pcp-pmda-pdns pcp-pmda-postfix pcp-pmda-postgresql pcp-pmda-oracle
-Requires: pcp-pmda-samba pcp-pmda-slurm pcp-pmda-zimbra
-Requires: pcp-pmda-dm pcp-pmda-apache
-Requires: pcp-pmda-bash pcp-pmda-cisco pcp-pmda-mailq pcp-pmda-mounts
-Requires: pcp-pmda-nvidia-gpu pcp-pmda-roomtemp pcp-pmda-sendmail pcp-pmda-shping pcp-pmda-smart pcp-pmda-farm
-Requires: pcp-pmda-hacluster pcp-pmda-lustrecomm pcp-pmda-logger pcp-pmda-denki pcp-pmda-docker pcp-pmda-bind2
-Requires: pcp-pmda-sockets pcp-pmda-podman
-%if !%{disable_gfs2}
-Requires: pcp-pmda-gfs2
-%endif
-%if !%{disable_statsd}
-Requires: pcp-pmda-statsd
-%endif
-%if !%{disable_nutcracker}
-Requires: pcp-pmda-nutcracker
-%endif
-%if !%{disable_bcc}
-Requires: pcp-pmda-bcc
-%endif
-%if !%{disable_bpf}
-Requires: pcp-pmda-bpf
-%endif
-%if !%{disable_bpftrace}
-Requires: pcp-pmda-bpftrace
-%endif
-%if !%{disable_python2} || !%{disable_python3}
-Requires: pcp-geolocate pcp-export-pcp2openmetrics pcp-export-pcp2json
-Requires: pcp-export-pcp2spark pcp-export-pcp2xml pcp-export-pcp2zabbix
-Requires: pcp-pmda-gluster pcp-pmda-zswap pcp-pmda-unbound pcp-pmda-mic
-Requires: pcp-pmda-libvirt pcp-pmda-lio pcp-pmda-openmetrics pcp-pmda-haproxy
-Requires: pcp-pmda-lmsensors pcp-pmda-netcheck pcp-pmda-rabbitmq pcp-pmda-uwsgi
-Requires: pcp-pmda-openvswitch
-%endif
-%if !%{disable_mongodb}
-Requires: pcp-pmda-mongodb
-%endif
-%if !%{disable_mssql}
-Requires: pcp-pmda-mssql 
-%endif
-%if !%{disable_mysql}
-Requires: pcp-pmda-mysql 
-%endif
-%if !%{disable_snmp}
-Requires: pcp-pmda-snmp
-%endif
-%if !%{disable_json}
-Requires: pcp-pmda-json
-%endif
-%if !%{disable_resctrl}
-Requires: pcp-pmda-resctrl
-%endif
-Requires: pcp-pmda-summary pcp-pmda-trace pcp-pmda-weblog
-%if !%{disable_amdgpu}
-Requires: pcp-pmda-amdgpu
-%endif
-Requires: pcp-system-tools
-%if !%{disable_qt}
-Requires: pcp-gui
-%endif
 Requires: bc gcc gzip bzip2
 Requires: redhat-rpm-config
 %if !%{disable_selinux}
 Requires: selinux-policy-devel
 Requires: selinux-policy-targeted
-%if 0%{?rhel} == 5
 Requires: setools
-%else
-Requires: setools-console
-%endif
 %endif
 
 %description testsuite


### PR DESCRIPTION
These were added originally at the request of our QE folk, but now they've requested to drop these as its causing some unexpected (distro-build-related, not PCP) fallout.

Related to Red Hat issue RHELMISC-10534