### PR TITLE
ci: switch centos7-container over to a more recent Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 #          - {platform: ubuntu2004,                os: ubuntu-latest, experimental: false}
 #          - {platform: ubuntu2204,                os: ubuntu-latest, experimental: false}
 #          - {platform: fedora-rawhide-container,  os: ubuntu-22.04, experimental: true }
-#          - {platform: centos7-container,         os: ubuntu-20.04, experimental: false}
+#          - {platform: centos7-container,         os: ubuntu-22.04, experimental: false}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -36,7 +36,7 @@ jobs:
           - {platform: fedora41-container,        os: ubuntu-22.04, experimental: false}
           - {platform: fedora-rawhide-container,  os: ubuntu-22.04, experimental: true }
           - {platform: centos6-container,         os: ubuntu-latest, experimental: false}
-          - {platform: centos7-container,         os: ubuntu-20.04, experimental: false}
+          - {platform: centos7-container,         os: ubuntu-22.04, experimental: false}
           - {platform: centos-stream8-container,  os: ubuntu-latest, experimental: false}
           - {platform: centos-stream9-container,  os: ubuntu-22.04, experimental: false}
           - {platform: centos-stream10-container, os: ubuntu-22.04, experimental: false}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           - {platform: fedora40-container,        os: ubuntu-22.04}
           - {platform: fedora41-container,        os: ubuntu-22.04}
           - {platform: centos6-container,         os: ubuntu-latest}
-          - {platform: centos7-container,         os: ubuntu-20.04}
+          - {platform: centos7-container,         os: ubuntu-22.04}
           - {platform: centos-stream8-container,  os: ubuntu-latest}
           - {platform: centos-stream9-container,  os: ubuntu-22.04}
           - {platform: centos-stream10-container, os: ubuntu-22.04}


### PR DESCRIPTION
CI has started failing today with this Github runner message: "Ubuntu 20.04 LTS runner will be removed on 2025-04-15."

So we have no choice but to move now and revisit whatever the earlier reason for not moving forward for centos7 was.