### PR TITLE
Removed hard-coded mappings in pcp dstat; resolves issue #2017

### DIFF
--- a/src/pcp/dstat/pcp-dstat.py
+++ b/src/pcp/dstat/pcp-dstat.py
@@ -444,7 +444,7 @@ class DstatTool(object):
 
         ### Add additional dstat metric specifiers
         dspec = (None, 'printtype', 'colorstep', 'grouptype', 'cullinsts',
-                'plugin', 'valuesets')
+                'plugin', 'valuesets', 'filter')
         mspec = self.pmconfig.metricspec + dspec
         self.pmconfig.metricspec = mspec
 
@@ -686,25 +686,25 @@ class DstatTool(object):
                                 lib.parse_verbose_metric_info(metrics, name, 'label', mkey)
                         lib.parse_verbose_metric_info(metrics, name, spec, value)
 
-                # Instance logic for -C/-D/-L/-M/-P/-I/-N/-S options
-                if section == 'cpu':
-                    plugin.prepare_grouptype(self.cpulist, self.full)
-                elif section in ['disk', 'disk-tps']:
-                    plugin.prepare_grouptype(self.disklist, self.full)
-                elif section in ['dm', 'dm-tps']:
-                    plugin.prepare_grouptype(self.dmlist, self.full)
-                elif section in ['md', 'md-tps']:
-                    plugin.prepare_grouptype(self.mdlist, self.full)
-                elif section in ['part', 'part-tps']:
-                    plugin.prepare_grouptype(self.partlist, self.full)
-                elif section == 'int':
-                    plugin.prepare_grouptype(self.intlist, self.full)
-                elif section == 'net':
-                    plugin.prepare_grouptype(self.netlist, self.full)
-                elif section == 'net-packets':
-                    plugin.prepare_grouptype(self.netpacketlist, self.full)
-                elif section == 'swap':
-                    plugin.prepare_grouptype(self.swaplist, self.full)
+                    if key in ['filter']:
+                        if value == 'cpu':
+                            plugin.prepare_grouptype(self.cpulist, self.full)
+                        elif value == 'disk':
+                            plugin.prepare_grouptype(self.disklist, self.full)
+                        elif value == 'dm':
+                            plugin.prepare_grouptype(self.dmlist, self.full)
+                        elif value == 'md':
+                            plugin.prepare_grouptype(self.mdlist, self.full)
+                        elif value == 'part':
+                            plugin.prepare_grouptype(self.partlist, self.full)
+                        elif value == 'int':
+                            plugin.prepare_grouptype(self.intlist, self.full)
+                        elif value == 'net':
+                            plugin.prepare_grouptype(self.netlist, self.full)
+                        elif value == 'net-packets':
+                            plugin.prepare_grouptype(self.netpacketlist, self.full)
+                        elif value == 'swap':
+                            plugin.prepare_grouptype(self.swaplist, self.full)
 
             for metric in metrics:
                 name = metrics[metric][0]

--- a/src/pcp/dstat/plugins/cpu
+++ b/src/pcp/dstat/plugins/cpu
@@ -3,6 +3,7 @@
 #
 
 [cpu]
+filtertype = cpu
 label = %I usage
 width = 3
 precision = 0
@@ -16,6 +17,7 @@ wai = 100 * rate(kernel.percpu.cpu.wait.total)
 stl = 100 * rate(kernel.percpu.cpu.steal)
 
 [cpu-adv]
+filtertype = cpu
 width = 3
 label = total cpu usage
 precision = 0
@@ -30,6 +32,7 @@ siq = 100 * rate(kernel.all.cpu.irq.soft) / hinv.ncpu
 stl = 100 * rate(kernel.all.cpu.steal) / hinv.ncpu
 
 [cpu-use]
+filtertype = cpu
 width = 3
 label = per cpu usage
 printtype = p

--- a/src/pcp/dstat/plugins/disk
+++ b/src/pcp/dstat/plugins/disk
@@ -3,6 +3,7 @@
 #
 
 [disk]
+filtertype = disk
 label = dsk/%I
 printtype = b
 precision = 0
@@ -13,6 +14,7 @@ writes = disk.dev.write_bytes
 writes.label = writ
 
 [disk-avgqu]
+filtertype = disk
 label = %I
 width = 4
 grouptype = 1
@@ -21,6 +23,7 @@ colorstep = 10
 avgqu = disk.dev.aveq
 
 [disk-avgrq]
+filtertype = disk
 label = %I
 width = 4
 grouptype = 1
@@ -29,6 +32,7 @@ colorstep = 10
 avgrq = (delta(disk.dev.read_bytes) + delta(disk.dev.write_bytes)) / (delta(disk.dev.read) + delta(disk.dev.write))
 
 [disk-svctm]
+filtertype = disk
 label = %I
 width = 4
 grouptype = 1
@@ -37,6 +41,7 @@ colorstep = 1
 svctm = (delta(disk.dev.avactive) / 1000 / 2) / (delta(disk.dev.read) + delta(disk.dev.write))
 
 [disk-tps]
+filtertype = disk
 label = dsk/%I
 width = 5
 printtype = d
@@ -47,6 +52,7 @@ writes = disk.dev.write
 writes.label = #writ
 
 [disk-util]
+filtertype = disk
 label = %I
 width = 4
 grouptype = 1
@@ -55,6 +61,7 @@ colorstep = 34
 util = 100 * rate(disk.dev.avactive)
 
 [disk-wait]
+filtertype = disk
 label = %I
 width = 4
 grouptype = 1

--- a/src/pcp/dstat/plugins/dm
+++ b/src/pcp/dstat/plugins/dm
@@ -3,6 +3,7 @@
 #
 
 [dm]
+filtertype = dm
 label = %I
 printtype = b
 precision = 0
@@ -13,6 +14,7 @@ writes = disk.dm.write_bytes
 writes.label = writ
 
 [dm-avgqu]
+filtertype = dm
 label = %I
 width = 4
 grouptype = 1
@@ -21,6 +23,7 @@ colorstep = 10
 avgqu = disk.dm.aveq
 
 [dm-avgrq]
+filtertype = dm
 label = %I
 width = 4
 grouptype = 1
@@ -29,6 +32,7 @@ colorstep = 10
 avgrq = (delta(disk.dm.read_bytes) + delta(disk.dm.write_bytes)) / (delta(disk.dm.read) + delta(disk.dm.write))
 
 [dm-svctm]
+filtertype = dm
 label = %I
 width = 4
 grouptype = 1
@@ -37,6 +41,7 @@ colorstep = 1
 svctm = (delta(disk.dm.avactive) / 1000 / 2) / (delta(disk.dm.read) + delta(disk.dm.write))
 
 [dm-tps]
+filtertype = dm
 label = %I
 width = 5
 printtype = d
@@ -47,6 +52,7 @@ writes = disk.dm.write
 writes.label = #writ
 
 [dm-util]
+filtertype = dm
 label = %I
 width = 4
 grouptype = 1
@@ -55,6 +61,7 @@ colorstep = 34
 util = 100 * rate(disk.dm.avactive)
 
 [dm-wait]
+filtertype = dm
 label = %I
 width = 4
 grouptype = 1

--- a/src/pcp/dstat/plugins/int
+++ b/src/pcp/dstat/plugins/int
@@ -3,6 +3,7 @@
 #
 
 [int]
+filtertype = int
 label = interrupts
 width = 4
 printtype = d

--- a/src/pcp/dstat/plugins/md
+++ b/src/pcp/dstat/plugins/md
@@ -3,6 +3,7 @@
 #
 
 [md]
+filtertype = md
 label = dsk/%I
 printtype = b
 precision = 0
@@ -13,6 +14,7 @@ writes = disk.md.write_bytes
 writes.label = writ
 
 [md-avgqu]
+filtertype = md
 label = %I
 width = 4
 grouptype = 1
@@ -21,6 +23,7 @@ colorstep = 10
 avgqu = disk.md.aveq
 
 [md-avgrq]
+filtertype = md
 label = %I
 width = 4
 grouptype = 1
@@ -29,6 +32,7 @@ colorstep = 10
 avgrq = (delta(disk.md.read_bytes) + delta(disk.md.write_bytes)) / (delta(disk.md.read) + delta(disk.md.write))
 
 [md-svctm]
+filtertype = md
 label = %I
 width = 4
 grouptype = 1
@@ -37,6 +41,7 @@ colorstep = 1
 svctm = (delta(disk.md.avactive) / 1000 / 2) / (delta(disk.md.read) + delta(disk.md.write))
 
 [md-tps]
+filtertype = md
 label = dsk/%I
 width = 5
 printtype = d
@@ -47,6 +52,7 @@ writes = disk.md.write
 writes.label = #writ
 
 [md-util]
+filtertype = md
 label = %I
 width = 4
 grouptype = 1
@@ -55,6 +61,7 @@ colorstep = 34
 util = 100 * rate(disk.md.avactive)
 
 [md-wait]
+filtertype = md
 label = %I
 width = 4
 grouptype = 1

--- a/src/pcp/dstat/plugins/net
+++ b/src/pcp/dstat/plugins/net
@@ -3,6 +3,7 @@
 #
 
 [net]
+filtertype = net
 label = net/%I
 width = 5
 printtype = b
@@ -13,6 +14,7 @@ bits_out.label = send
 bits_out = network.interface.out.bytes
 
 [net-packets]
+filtertype = net
 label = pkt/%I
 width = 5
 printtype = d
@@ -23,10 +25,12 @@ pkts_out.label = #send
 pkts_out = network.interface.out.packets
 
 [raw]
+filtertype = net
 width = 4
 raw = network.rawconn.count + network.rawconn6.count
 
 [udp]
+filtertype = net
 width = 4
 listen = network.udpconn.listen + network.udpconn6.listen
 listen.label = lis
@@ -34,6 +38,7 @@ active = network.udpconn.established + network.udpconn6.established
 active.label = act
 
 [unix]
+filtertype = net
 width = 4
 datagram.label = dgm
 datagram = network.unix.datagram.count

--- a/src/pcp/dstat/plugins/part
+++ b/src/pcp/dstat/plugins/part
@@ -3,6 +3,7 @@
 #
 
 [part]
+filtertype = part
 label = dsk/%I
 printtype = b
 precision = 0
@@ -13,6 +14,7 @@ writes = disk.partitions.write_bytes
 writes.label = writ
 
 [part-avgqu]
+filtertype = part
 label = %I
 width = 4
 grouptype = 1
@@ -21,6 +23,7 @@ colorstep = 10
 avgqu = disk.partitions.aveq
 
 [part-avgrq]
+filtertype = part
 label = %I
 width = 4
 grouptype = 1
@@ -29,6 +32,7 @@ colorstep = 10
 avgrq = (delta(disk.partitions.read_bytes) + delta(disk.partitions.write_bytes)) / (delta(disk.partitions.read) + delta(disk.partitions.write))
 
 [part-svctm]
+filtertype = part
 label = %I
 width = 4
 grouptype = 1
@@ -37,6 +41,7 @@ colorstep = 1
 svctm = (delta(disk.partitions.avactive) / 1000 / 2) / (delta(disk.partitions.read) + delta(disk.partitions.write))
 
 [part-tps]
+filtertype = part
 label = dsk/%I
 width = 5
 printtype = d
@@ -47,6 +52,7 @@ writes = disk.partitions.write
 writes.label = #writ
 
 [part-util]
+filtertype = part
 label = %I
 width = 4
 grouptype = 1
@@ -55,6 +61,7 @@ colorstep = 34
 util = 100 * rate(disk.partitions.avactive)
 
 [part-wait]
+filtertype = part
 label = %I
 width = 4
 grouptype = 1

--- a/src/pcp/dstat/plugins/swap
+++ b/src/pcp/dstat/plugins/swap
@@ -3,6 +3,7 @@
 #
 
 [swap]
+filtertype = swap
 label = %I
 used = swapdev.length - swapdev.free
 free = swapdev.free


### PR DESCRIPTION
Resolves git issue #2017

Updated pcp dstat tool to not rely on hard coded mappings between instance filtering command line options and the specific plugin they apply to