### PR TITLE
pcp-iostat: fixed broken pipe issue in pcp-iostat utility.

### DIFF
--- a/src/pcp/iostat/pcp-iostat.py
+++ b/src/pcp/iostat/pcp-iostat.py
@@ -461,5 +461,7 @@ if __name__ == '__main__':
     except pmapi.pmUsageErr as usage:
         usage.message()
         sys.exit(1)
+    except IOError:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
```
sagar@localhost:~/Desktop/pcp/upstream/src/pcp/iostat$ pcp iostat | head -5
# Device      rrqm/s  wrqm/s     r/s    w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await   %util
sda             0.00    0.00    0.00   0.00     0.00     0.00    0.000    0.000    0.00    0.00    0.00    0.00
sda             0.00    0.00    0.00   0.00     0.00     0.00    0.000    0.000    0.00    0.00    0.00    0.00
sda             0.00    0.00    0.00   5.98     0.00    43.89    7.333    0.006    1.00    0.00    1.00    0.30
sda             0.00    0.00    0.00   0.00     0.00     0.00    0.000    0.000    0.00    0.00    0.00    0.00
Traceback (most recent call last):
  File "/usr/libexec/pcp/bin/pcp-iostat", line 457, in <module>
    sts = manager.run()
  File "/usr/local/lib64/python3.6/site-packages/pcp/pmcc.py", line 687, in run
    self._printer.report(self)
  File "/usr/libexec/pcp/bin/pcp-iostat", line 309, in report
    w_await,utilspace,precision, util))
BrokenPipeError: [Errno 32] Broken pipe
sagar@localhost:~/Desktop/pcp/upstream/src/pcp/iostat$ 
```
