### PR TITLE
selinux: additional policy needed for pcp_pmie_t using ps(1)

### DIFF
--- a/src/selinux/pcp.te
+++ b/src/selinux/pcp.te
@@ -247,7 +247,7 @@ optional_policy(`
 #
 # pcp_pmie local  policy
 #
-allow pcp_pmie_t self:capability { chown fsetid sys_ptrace };
+allow pcp_pmie_t self:capability { chown fsetid sys_admin sys_ptrace };
 allow pcp_pmie_t self:cap_userns sys_ptrace;
 allow pcp_pmie_t self:netlink_route_socket { create_socket_perms nlmsg_read };
 allow pcp_pmie_t self:unix_dgram_socket { create_socket_perms sendto };


### PR DESCRIPTION
Resolves Fedora BZ 2363903.