### PR TITLE
pmseries_import: use a datetime UTC interface from python3.6

### DIFF
--- a/build/containers/archive-analysis/root/usr/bin/archive-import.py
+++ b/build/containers/archive-analysis/root/usr/bin/archive-import.py
@@ -144,7 +144,7 @@ def import_archive(path: Path, i: int, count: int, no_op: bool, import_timeout: 
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     check=True,
-                    text=True,
+                    universal_newlines=True,
                     timeout=import_timeout,
                 )
     except subprocess.CalledProcessError as e:

--- a/build/containers/archive-analysis/root/usr/bin/archive-import.py
+++ b/build/containers/archive-analysis/root/usr/bin/archive-import.py
@@ -22,7 +22,7 @@ import os
 import subprocess
 import json
 from pathlib import Path
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 
 import cpmapi as api
 from pcp import pmapi
@@ -54,7 +54,7 @@ def archive_unchanged(archive_path: str, archive_time: float, i: int, count: int
 def format_time(seconds: float):
     # From a floating point number of seconds since the epoch,
     # produce a time string in the format Grafana is expecting.
-    string = datetime.fromtimestamp(seconds, UTC).isoformat()
+    string = datetime.fromtimestamp(seconds, timezone.utc).isoformat()
     return string.replace('+00:00', 'Z')
 
 


### PR DESCRIPTION
Resolves an issue Ken reported running tests in the QA farm, which is due to use of an interface from more-recent-python: https://github.com/python/cpython/pull/91973