### PR TITLE
pmproxy: allow configuration of previously hard-coded HTTP settings

### DIFF
--- a/man/man1/pmproxy.1
+++ b/man/man1/pmproxy.1
@@ -314,6 +314,24 @@ section can be used to explicitly enable or disable each of the
 different protocols.
 .PP
 The
+.I [http]
+section provides fine-tuning over HTTP server settings used by
+.BR pmproxy.
+.I chunksize
+sets the chunked transfer encoding buffer size, and defaults to
+the system pagesize.
+Access control HTTP protocol settings can be adjusted using the
+.I Access-Control-Allow-Headers
+and
+.I Access-Control-Max-Age
+options.
+Discussion of these HTTP protocol headers is beyond the scope of
+this document, but suitable default values are described within
+the
+.I pmproxy.conf
+configuration file.
+.PP
+The
 .I [keys]
 section allows connection information for one or more backing
 key-value server processes to be configured (hostnames and ports).

--- a/qa/1608.out
+++ b/qa/1608.out
@@ -8,7 +8,7 @@ QA output created by 1608
 <html>
 <p><b>unknown servlet</b>: request URL too long</p><hr>
 <p><small><i>PMPROXY/VERSION</i></small></p>
-Access-Control-Allow-Headers: Accept, Accept-Language, Content-Language, Content-Type
+Access-Control-Allow-Headers: Accept, Accept-Language, Content-Language, Content-Type, x-grafana-device-id
 Access-Control-Allow-Origin: *
 Access-Control-Max-Age: 86400
 Content-Length: SIZE

--- a/qa/780.out
+++ b/qa/780.out
@@ -1,7 +1,7 @@
 QA output created by 780
 === Basic
 
-Access-Control-Allow-Headers: Accept, Accept-Language, Content-Language, Content-Type
+Access-Control-Allow-Headers: Accept, Accept-Language, Content-Language, Content-Type, x-grafana-device-id
 Access-Control-Allow-Origin: *
 Access-Control-Max-Age: 86400
 Content-Type: application/json

--- a/src/pmproxy/pmproxy.conf
+++ b/src/pmproxy/pmproxy.conf
@@ -19,9 +19,6 @@
 # delay in seconds for TCP keep-alive (zero to disable)
 #keepalive = 45
 
-# buffer size for chunked transfer encoding (bytes, default pagesize)
-#chunksize = 4096
-
 # support PCP protocol proxying
 pcp.enabled = true
 
@@ -33,6 +30,21 @@ resp.enabled = false
 
 # support SSL/TLS protocol wrapping
 secure.enabled = true
+
+#####################################################################
+## settings related to HTTP server configuration
+#####################################################################
+[http]
+
+# buffer size for chunked transfer encoding (bytes, default pagesize)
+#chunksize = 4096
+
+# append allowed HTTP header values to returned by this HTTP server -
+# extending: Accept, Accept-Language, Content-Language, Content-Type.
+Access-Control-Allow-Headers = x-grafana-device-id
+
+# adjust max page age setting in seconds, default is 86400 (24 hours)
+#Access-Control-Max-Age = 86400
 
 #####################################################################
 ## settings related to RESP key/value server connections


### PR DESCRIPTION
Creates a new, optional [http] section in the pmproxy configuration file, where the following variables can be fine-tuned manually:
- chunksize (chunked transfer encoding buffer size, defaults to the server system page size);
- Access-Control-Allow-Headers (headers accepted from clients);
- Access-Control-Max-Age (set client maximum preflight request page age value, in seconds).

The previous global 'chunksize' setting is moved within [http] in a backwards-compatible way, such that the old name is honoured if it was present before the new setting.