### PR TITLE
build: fix multilib installs for pcp-libs-devel packages

### DIFF
--- a/src/include/pcp/config.h.in
+++ b/src/include/pcp/config.h.in
@@ -801,9 +801,3 @@
 #ifndef PM_SIZEOF_TIME_T
 #error Unknown time_t size
 #endif
-
-/* __pmResult padding */
-#undef PM_PAD_RESULT
-
-/* timespec padding */
-#undef PM_PAD_TIMESPEC

--- a/src/include/pcp/config32.h
+++ b/src/include/pcp/config32.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014,2016 Red Hat.
+ * Copyright (c) 2014,2016,2025 Red Hat.
  * Headers for "multilib" support (32-bit and 64-bit packages co-existing)
  *
  * This library is free software; you can redistribute it and/or modify it
@@ -19,5 +19,7 @@
 #define HAVE_32BIT_LONG 1
 #define HAVE_32BIT_PTR 1
 /* #undef HAVE_64BIT_PTR */
+#define PM_PAD_RESULT 4
+#define PM_PAD_TIMESPEC 4
 
 #endif /* PCP_CONFIG32_H */

--- a/src/include/pcp/config64.h
+++ b/src/include/pcp/config64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014,2016 Red Hat.
+ * Copyright (c) 2014,2016,2025 Red Hat.
  * Headers for "multilib" support (32-bit and 64-bit packages co-existing)
  * 
  * This library is free software; you can redistribute it and/or modify it
@@ -19,5 +19,7 @@
 /* #undef HAVE_32BIT_LONG */
 /* #undef HAVE_32BIT_PTR */
 #define HAVE_64BIT_PTR 1
+/* #undef PM_PAD_RESULT */
+/* #undef PM_PAD_TIMESPEC */
 
 #endif /* PCP_CONFIG64_H */

--- a/src/include/pcp/configsz.h.in
+++ b/src/include/pcp/configsz.h.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 Red Hat.
+ * Copyright (c) 2014-2017,2025 Red Hat.
  *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published
@@ -25,5 +25,11 @@
 
 /* pointer size */
 #undef HAVE_64BIT_PTR
+
+/* __pmResult padding */
+#undef PM_PAD_RESULT
+
+/* timespec padding */
+#undef PM_PAD_TIMESPEC
 
 #endif /* PCP_CONFIGSZ_H */

--- a/src/libpcp3/src/include/pcp/config.h.in
+++ b/src/libpcp3/src/include/pcp/config.h.in
@@ -801,9 +801,3 @@
 #ifndef PM_SIZEOF_TIME_T
 #error Unknown time_t size
 #endif
-
-/* __pmResult padding */
-#undef PM_PAD_RESULT
-
-/* timespec padding */
-#undef PM_PAD_TIMESPEC

--- a/src/libpcp3/src/include/pcp/config32.h
+++ b/src/libpcp3/src/include/pcp/config32.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014,2016 Red Hat.
+ * Copyright (c) 2014,2016,2025 Red Hat.
  * Headers for "multilib" support (32-bit and 64-bit packages co-existing)
  *
  * This library is free software; you can redistribute it and/or modify it
@@ -19,5 +19,7 @@
 #define HAVE_32BIT_LONG 1
 #define HAVE_32BIT_PTR 1
 /* #undef HAVE_64BIT_PTR */
+#define PM_PAD_RESULT 4
+#define PM_PAD_TIMESPEC 4
 
 #endif /* PCP_CONFIG32_H */

--- a/src/libpcp3/src/include/pcp/config64.h
+++ b/src/libpcp3/src/include/pcp/config64.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014,2016 Red Hat.
+ * Copyright (c) 2014,2016,2025 Red Hat.
  * Headers for "multilib" support (32-bit and 64-bit packages co-existing)
  * 
  * This library is free software; you can redistribute it and/or modify it
@@ -19,5 +19,7 @@
 /* #undef HAVE_32BIT_LONG */
 /* #undef HAVE_32BIT_PTR */
 #define HAVE_64BIT_PTR 1
+/* #undef PM_PAD_RESULT */
+/* #undef PM_PAD_TIMESPEC */
 
 #endif /* PCP_CONFIG64_H */

--- a/src/libpcp3/src/include/pcp/configsz.h.in
+++ b/src/libpcp3/src/include/pcp/configsz.h.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 Red Hat.
+ * Copyright (c) 2014-2017,2025 Red Hat.
  *
  * This library is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published
@@ -25,5 +25,11 @@
 
 /* pointer size */
 #undef HAVE_64BIT_PTR
+
+/* __pmResult padding */
+#undef PM_PAD_RESULT
+
+/* timespec padding */
+#undef PM_PAD_TIMESPEC
 
 #endif /* PCP_CONFIGSZ_H */


### PR DESCRIPTION
Recently (last year) added PM_PAD_RESULT and PM_PAD_TIMESPEC macro values have 32/64 bit sensitivity so need to reside in the configsz.h.in file rather than config.h.in - this allows us to ship non-conflicting header files with these macros.

Resolves Red Hat bug RHEL-93186.