### PR TITLE
pcp-htop: fix header build race condition

### DIFF
--- a/src/pcp/htop/GNUmakefile
+++ b/src/pcp/htop/GNUmakefile
@@ -224,6 +224,7 @@ default:	build-me
 include $(BUILDRULES)
 
 ifeq "$(HAVE_NCURSESW)" "true"
+$(OBJECTS): $(HFILES)
 build-me: $(TOPXFILES) $(SUBXFILES) $(CFGXFILES) $(CMDTARGET) $(DISTLINKS) $(MAN_PAGES)
 
 install: default


### PR DESCRIPTION
.c and .h files are soft-linked before being compiled. Under heavy load or a build with a high CPU count, the compilation can start before header files are softlinked, resulting in a build error: 
```
| pcp-htop.c:13:10: fatal error: CommandLine.h: No such file or directory
|    13 | #include "CommandLine.h"
|       |          ^~~~~~~~~~~~~~~
```
Fix this by adding the make dependency between object files and the headers.