### PR TITLE
src/selinux/pcp.te: Handle pmlogger perfmon AVCs

### DIFF
--- a/src/selinux/pcp.te
+++ b/src/selinux/pcp.te
@@ -352,6 +352,17 @@ optional_policy(`
     userdom_setattr_user_home_content_files(pcp_pmlogger_t)
 ')
 
+optional_policy(`
+    require {
+	type pcp_pmlogger_t;
+	class capability2 perfmon;
+    }
+
+    #RHBZ2371004
+    # type=AVC msg=audit(N): avc:  denied  { perfmon } for  pid=PID comm="ps" capability=38  scontext=system_u:system_r:pcp_pmlogger_t:s0 tcontext=system_u:system_r:pcp_pmlogger_t:s0 tclass=capability2 permissive=0
+    allow pcp_pmlogger_t self:capability2 perfmon;
+')
+
 ########################################
 #
 # pcp_plugin local  policy


### PR DESCRIPTION
On Fedora running Linux 6.15 kernels started seeing AVCs reported by RHBZ2371004:

type=AVC msg=audit(N): avc:  denied  { perfmon } for  pid=PID comm="ps" capability=38  scontext=system_u:system_r:pcp_pmlogger_t:s0 tcontext=system_u:system_r:pcp_pmlogger_t:s0 tclass=capability2 permissive=0

Added a pcp.te entry to address these AVCs.