### PR TITLE
qa/1616: mirror change to qa/1611

### DIFF
--- a/qa/1616.out
+++ b/qa/1616.out
@@ -22,7 +22,7 @@ hinv.ncpu
 hinv.ndisk
 kernel.all.load
 kernel.all.pswitch
-mem.util.free
+sample.datasize
 ## Found local archive files
 LOCAL_ARCHIVE.0
 LOCAL_ARCHIVE.index
@@ -34,7 +34,7 @@ hinv.ncpu
 hinv.ndisk
 kernel.all.load
 kernel.all.pswitch
-mem.util.free
+sample.datasize
 
 === Running pmlogger in remote only recording mode
 === std out ===
@@ -57,5 +57,5 @@ hinv.ncpu
 hinv.ndisk
 kernel.all.load
 kernel.all.pswitch
-mem.util.free
+sample.datasize
 ## Found no local archive files


### PR DESCRIPTION
I noticed some failures in the daily QA run that look like issues with the .out files rather than issues with pcp code. The tests are 1616, 1617, and 1618.

I changed 1616.out to mirror the recent change to 1611 and 1611.out, as 1616 is just 1611 run with --valgrind.

I looked into updating 1617.out and 1618.out, specifically the different timestamp causing the test to fail. After some investigation, I noticed the timestamp is not consistent across architectures. I'm not certain how we want to fix this. One thought I have is to change the _filter_values function run under the "pmseries value check", but I'd like a different set of eyes to take a look in case there is something I am missing with this.