### PR TITLE
libpcp_web: remove accidental timespec nsec sign extension

### DIFF
--- a/qa/1617
+++ b/qa/1617
@@ -155,7 +155,7 @@ pmsignal $pid
 
 # while that happens, check state of the key server
 echo "=== pmseries value check ==="
-pmseries -c $tmp.conf 'sample.milliseconds[count:1,timezone:"UTC"]' | _filter_values
+pmseries -c $tmp.conf -Z UTC 'sample.milliseconds[count:1,timezone:"UTC"]' | _filter_values
 
 echo "=== pmseries labels check ==="
 pmseries -c $tmp.conf -l | LC_COLLATE=POSIX sort

--- a/src/libpcp_web/src/util.c
+++ b/src/libpcp_web/src/util.c
@@ -68,10 +68,10 @@ zfree(void *ptr)
 const char *
 timespec_stream_str(struct timespec *stamp, char *buffer, int buflen)
 {
-    __uint64_t	millipart;
-    __uint64_t	fractions;
-    __uint64_t	crossover = stamp->tv_nsec / 1000000;
+    __uint64_t	millipart, fractions, crossover;
+    __uint32_t	nanoseconds = (__uint32_t)stamp->tv_nsec;
 
+    crossover = (__uint64_t)nanoseconds / 1000000;
     millipart = ((__uint64_t)stamp->tv_sec) * 1000;
     millipart += crossover;
     fractions = stamp->tv_nsec % 1000000 / 1000;


### PR DESCRIPTION
QA tests 1617 and 1618 are sometimes failing as a result of this issue, which is a result of the tv_nsec field of struct timespec being sign extended when converted to u64 for a key (time) xstream conversion calculation within libpcp_web.