### PR TITLE
pmdammv: support for empty indoms and export indom help text

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,8 @@ pcp-7.0.0 (31 July 2025)
 	pmdaopenmetrics: allow configuration files with epoch times
 	pmdapodman: fix container name/command handling in new podman
 	pmdahacluster: additional pacemaker node metrics
+	pmdammv: support empty instance domains and dynamic map resets
+	pmdammv: export instance domain help text when requested
     - Server-side utilities and log management scripts:
 	pmlogger, pmproxy: support for a remote archive push webhook;
 	  providing central logging without server-side configuration

--- a/qa/1415.out
+++ b/qa/1415.out
@@ -118,7 +118,8 @@ Cluster    = 0
 Process    = PID
 Flags      = 0x0 (none)
 Bad TOC[0]: invalid entry count 0
-Bad TOC[1]: invalid entry count 0
+
+TOC[1]: offset 56, values offset 72 (0 entries)
 
 == Version 2 interfaces
 MMV file   = $PCP_TMP_DIR/mmv/simple2-PID
@@ -249,7 +250,8 @@ Cluster    = 0
 Process    = PID
 Flags      = 0x0 (none)
 Bad TOC[0]: invalid entry count 0
-Bad TOC[1]: invalid entry count 0
+
+TOC[1]: offset 56, values offset 72 (0 entries)
 
 == Version 3 interfaces
 MMV file   = $PCP_TMP_DIR/mmv/simple3-PID
@@ -408,4 +410,5 @@ Cluster    = 321
 Process    = PID
 Flags      = 0x0 (none)
 Bad TOC[0]: invalid entry count 0
-Bad TOC[1]: invalid entry count 0
+
+TOC[1]: offset 56, values offset 72 (0 entries)

--- a/qa/646.out
+++ b/qa/646.out
@@ -100,7 +100,8 @@ Cluster    = 0
 Process    = PID
 Flags      = 0x0 (none)
 Bad TOC[0]: invalid entry count 0
-Bad TOC[1]: invalid entry count 0
+
+TOC[1]: offset 56, values offset 72 (0 entries)
 MMV file   = $PCP_TMP_DIR/mmv/simple-PID
 Version    = 1
 Generated  = TIMESTAMP
@@ -220,7 +221,8 @@ Cluster    = 0
 Process    = PID
 Flags      = 0x0 (none)
 Bad TOC[0]: invalid entry count 0
-Bad TOC[1]: invalid entry count 0
+
+TOC[1]: offset 56, values offset 72 (0 entries)
 MMV file   = $PCP_TMP_DIR/mmv/simple2-PID
 Version    = 2
 Generated  = TIMESTAMP

--- a/qa/990.out
+++ b/qa/990.out
@@ -446,6 +446,7 @@ ERROR SUMMARY: 0 errors from 0 contexts ...
 [DATESTAMP] pminfo(PID) Debug: mmv: indoms_1: loading client cluster=4 for PMIDs from MMV_STATS_DIR/indoms_1
 [DATESTAMP] pminfo(PID) Debug: mmv: indoms_2: loading client cluster=5 for PMIDs from MMV_STATS_DIR/indoms_2
 [DATESTAMP] pminfo(PID) Debug: mmv: indoms_3: create_indom: serial=2
+[DATESTAMP] pminfo(PID) Debug: mmv: indoms_3: indom serial=2 has no instances
 [DATESTAMP] pminfo(PID) Debug: mmv: indoms_3: loading client cluster=6 for PMIDs from MMV_STATS_DIR/indoms_3
 [DATESTAMP] pminfo(PID) Debug: mmv: indoms_4: loading client cluster=7 for PMIDs from MMV_STATS_DIR/indoms_4
 [DATESTAMP] pminfo(PID) Debug: mmv: indoms_5: loading client cluster=8 for PMIDs from MMV_STATS_DIR/indoms_5
@@ -468,7 +469,6 @@ ERROR SUMMARY: 0 errors from 0 contexts ...
 [DATESTAMP] pminfo(PID) Error: mmv: indoms_6: indom[0] offset: 185 < 200
 [DATESTAMP] pminfo(PID) Info: pminfo: 4 metrics and 1 indoms after reload
 [DATESTAMP] pminfo(PID) Warning: mmv: contents_3: metrics count: 0
-[DATESTAMP] pminfo(PID) Warning: mmv: indoms_3: indom serial=2 has no instances
 
 mmv.control.metrics
     value 0
@@ -548,6 +548,7 @@ mmv.metrics_2.badmmv: Unknown or illegal instance identifier
 [DATESTAMP] pminfo(PID) Debug: mmv: indoms_1: loading client cluster=4 for PMIDs from MMV_STATS_DIR/indoms_1
 [DATESTAMP] pminfo(PID) Debug: mmv: indoms_2: loading client cluster=5 for PMIDs from MMV_STATS_DIR/indoms_2
 [DATESTAMP] pminfo(PID) Debug: mmv: indoms_3: create_indom: serial=2
+[DATESTAMP] pminfo(PID) Debug: mmv: indoms_3: indom serial=2 has no instances
 [DATESTAMP] pminfo(PID) Debug: mmv: indoms_3: loading client cluster=6 for PMIDs from MMV_STATS_DIR/indoms_3
 [DATESTAMP] pminfo(PID) Debug: mmv: indoms_4: loading client cluster=7 for PMIDs from MMV_STATS_DIR/indoms_4
 [DATESTAMP] pminfo(PID) Debug: mmv: indoms_5: loading client cluster=8 for PMIDs from MMV_STATS_DIR/indoms_5
@@ -589,7 +590,6 @@ mmv.metrics_2.badmmv: Unknown or illegal instance identifier
 [DATESTAMP] pminfo(PID) Error: mmv: metrics_6: values offset: 209 < 224
 [DATESTAMP] pminfo(PID) Info: pminfo: 9 metrics and 1 indoms after reload
 [DATESTAMP] pminfo(PID) Warning: mmv: contents_3: metrics count: 0
-[DATESTAMP] pminfo(PID) Warning: mmv: indoms_3: indom serial=2 has no instances
 
 mmv.control.metrics
     value 5

--- a/src/include/pcp/mmv_stats.h
+++ b/src/include/pcp/mmv_stats.h
@@ -144,6 +144,7 @@ extern int mmv_stats_add_instance_label(mmv_registry_t *,
 		int, int, const char *, const char *, mmv_value_type_t, int);
 
 extern void * mmv_stats_start(mmv_registry_t *);
+extern void mmv_stats_reset(mmv_registry_t *);
 extern void mmv_stats_free(mmv_registry_t *);
 
 extern pmAtomValue * mmv_lookup_value_desc(void *, const char *, const char *);

--- a/src/libpcp_mmv/src/exports
+++ b/src/libpcp_mmv/src/exports
@@ -56,3 +56,8 @@ PCP_MMV_1.4 {
     mmv_inc;
     mmv_set;
 } PCP_MMV_1.3;
+
+PCP_MMV_1.5 {
+  global:
+    mmv_stats_reset;
+} PCP_MMV_1.4;

--- a/src/pmdas/mmv/mmvdump.c
+++ b/src/pmdas/mmv/mmvdump.c
@@ -655,7 +655,8 @@ dump(const char *file, void *addr, size_t size)
 	count = toc[i].count;
 	offset = toc[i].offset;
 
-	if ((__int32_t)count < 1) {
+	if ((__int32_t)count < 1 &&
+	    type != MMV_TOC_INSTANCES && type != MMV_TOC_VALUES) {
 	    printf("Bad TOC[%d]: invalid entry count %d\n", i, (__int32_t)count);
 	    continue;
 	}


### PR DESCRIPTION
Exporting InDom help text appears to have been missing in the PMDA forever, but its there now.  Extensions to pmproxy (next commit) need more dynamic instance domain handling - this has been implemented via a mmap resetting mechanism, which allows for a more dynamic instance domain experience including empty sets.