### PR TITLE
pmlogger, pmproxy: logger push SIGHUP and robustness improvements

### DIFF
--- a/qa/1620
+++ b/qa/1620
@@ -1,6 +1,6 @@
 #!/bin/sh
-# PCP QA Test No. 1611
-# Exercise pmlogger and the logger REST API interfaces.
+# PCP QA Test No. 1620
+# Exercise pmlogger response with a pmproxy SIGHUP.
 #
 # Copyright (c) 2025 Red Hat.  All Rights Reserved.
 #
@@ -48,6 +48,7 @@ _cleanup()
 }
 
 status=0	# success is the default!
+signal=$PCP_BINADM_DIR/pmsignal
 trap "_cleanup; exit \$status" 0 1 2 3 15
 
 _filter()
@@ -57,6 +58,7 @@ _filter()
 	-e "s@$archive_path@ARCHIVE_PATH@g" \
 	-e "s/TMP\.data\./LOCAL_ARCHIVE./g" \
 	-e "s/2[0-9][0-9]*\.[0-9][0-9]\.[0-9][0-9]\./REMOTE_ARCHIVE./g" \
+	-e "s/2[0-9][0-9]*\.[0-9][0-9]\.[0-9][0-9]-[0-9][0-9]\./REMOTE_ARCHIVE./g" \
     # end
 }
 
@@ -66,6 +68,14 @@ _filter_metrics()
 	-e "/^pmcd\.*/d" \
 	-e "/^event\.*/d" \
     | LC_COLLATE=POSIX sort
+}
+
+_save_logs()
+{
+    echo === pmlogger log >> $seq_full
+    cat pmlogger.log >> $seq_full
+    echo === pmproxy log >> $seq_full
+    cat $PCP_LOG_DIR/pmproxy/pmproxy.log >> $seq_full
 }
 
 # real QA test starts here
@@ -100,6 +110,7 @@ $sudo cp $tmp.conf $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 
 if ! _service pmproxy start 2>&1; then _exit 1; fi | _filter_pmproxy_start
 _wait_for_pmproxy || _exit 1
+pmproxy_pid=`cat $PCP_RUN_DIR/pmproxy.pid`
 
 export PCP_DERIVED_CONFIG=""
 
@@ -110,18 +121,18 @@ log mandatory on once {
     hinv.ndisk
 }
 log mandatory on every 1 second {
-    sample.datasize
     disk.all.read
     disk.all.write
     kernel.all.load
     kernel.all.pswitch
 }
 End-Of-File
-common_args="-c $tmp.conf -T 5sec"
+common_args="-c $tmp.conf -T 15sec"
 
 echo
-echo "=== Running pmlogger in both local and remote modes"
+echo "=== Signalling pmlogger in both local and remote modes"
 mixed_mode="$common_args -R http://localhost:44322 $tmp.data"
+((sleep 10; $sudo $signal -s HUP $pmproxy_pid)&) >/dev/null 2>&1
 if $do_valgrind
 then
     _run_valgrind pmlogger $mixed_mode
@@ -129,11 +140,16 @@ else
     pmlogger $mixed_mode
 fi \
 | _filter
+wait # for child signal shell to finish
+
+echo "## checking for pmproxy SIGHUP"
+grep SIGHUP $PCP_LOG_DIR/pmproxy/pmproxy.log | _filter_pmproxy_log
+_save_logs
 
 if [ -d $archive_path ]
 then
-    echo "## Found remote archive files"
-    ls -1 $archive_path | _filter | LC_COLLATE=POSIX sort
+    echo "## found remote archive files" | tee -a $seq_full
+    ls -1 $archive_path | tee -a $seq_full | _filter | LC_COLLATE=POSIX sort
     echo "## with the following metrics"
     pminfo -a $archive_path | _filter_metrics
 else
@@ -143,7 +159,7 @@ else
 fi
 if [ -f $tmp.data.0 ]
 then
-    echo "## Found local archive files"
+    echo "## found local archive files"
     ls -1 $tmp.data.* | _filter | LC_COLLATE=POSIX sort
     echo "## with the following metrics"
     pminfo -a $tmp.data | _filter_metrics
@@ -157,6 +173,7 @@ $sudo rm -fr $archive_path $tmp.data.*
 echo
 echo "=== Running pmlogger in remote only recording mode"
 remote_mode="$common_args -R http://localhost:44322"
+((sleep 10; $sudo $signal -s HUP pmproxy_pid)&) >/dev/null 2>&1
 if $do_valgrind
 then
     _run_valgrind pmlogger $remote_mode
@@ -164,11 +181,16 @@ else
     pmlogger $remote_mode
 fi \
 | _filter
+wait # for child signal shell to finish
+
+echo "## checking for pmproxy SIGHUP"
+grep SIGHUP $PCP_LOG_DIR/pmproxy/pmproxy.log | _filter_pmproxy_log
+_save_logs
 
 if [ -d $archive_path ]
 then
-    echo "## Found remote archive files"
-    ls -1 $archive_path | _filter | LC_COLLATE=POSIX sort
+    echo "## found remote archive files"
+    ls -1 $archive_path | tee -a $seq_full | _filter | LC_COLLATE=POSIX sort
     echo "## with the following metrics"
     pminfo -a $archive_path | _filter_metrics
 else
@@ -182,7 +204,7 @@ then
     status=1
     exit
 else
-    echo "## Found no local archive files"
+    echo "## found no local archive files"
 fi
 
 # success, all done

--- a/qa/1620.out
+++ b/qa/1620.out
@@ -1,0 +1,43 @@
+QA output created by 1620
+
+=== Signalling pmlogger in both local and remote modes
+## checking for pmproxy SIGHUP
+[DATE] pmproxy(PID) Info: pmproxy caught SIGHUP
+## found remote archive files
+REMOTE_ARCHIVE.0
+REMOTE_ARCHIVE.index
+REMOTE_ARCHIVE.meta
+## with the following metrics
+disk.all.read
+disk.all.write
+hinv.ncpu
+hinv.ndisk
+kernel.all.load
+kernel.all.pswitch
+## found local archive files
+LOCAL_ARCHIVE.0
+LOCAL_ARCHIVE.index
+LOCAL_ARCHIVE.meta
+## with the following metrics
+disk.all.read
+disk.all.write
+hinv.ncpu
+hinv.ndisk
+kernel.all.load
+kernel.all.pswitch
+
+=== Running pmlogger in remote only recording mode
+## checking for pmproxy SIGHUP
+[DATE] pmproxy(PID) Info: pmproxy caught SIGHUP
+## found remote archive files
+REMOTE_ARCHIVE.0
+REMOTE_ARCHIVE.index
+REMOTE_ARCHIVE.meta
+## with the following metrics
+disk.all.read
+disk.all.write
+hinv.ncpu
+hinv.ndisk
+kernel.all.load
+kernel.all.pswitch
+## found no local archive files

--- a/qa/1621
+++ b/qa/1621
@@ -1,0 +1,36 @@
+#!/bin/sh
+# PCP QA Test No. 1621
+# pmlogger push testing
+#
+# valgrind variant, see qa/1620 for the non-valgrind variant
+#
+# check-group-include: pmlogger pmproxy pmlogpush
+#
+# Copyright (c) 2025 Red Hat.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+_check_valgrind
+
+_cleanup()
+{
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=0	# success is the default!
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+# real QA test starts here
+export seq
+./1620 --valgrind
+
+# success, all done
+exit

--- a/qa/1621.out
+++ b/qa/1621.out
@@ -1,0 +1,62 @@
+QA output created by 1621
+QA output created by 1620 --valgrind
+
+=== Signalling pmlogger in both local and remote modes
+=== std out ===
+=== std err ===
+=== filtered valgrind report ===
+Memcheck, a memory error detector
+Command: pmlogger -c TMP.conf -T 15sec -R http://localhost:44322 TMP.data
+LEAK SUMMARY:
+definitely lost: 0 bytes in 0 blocks
+indirectly lost: 0 bytes in 0 blocks
+ERROR SUMMARY: 0 errors from 0 contexts ...
+## checking for pmproxy SIGHUP
+[DATE] pmproxy(PID) Info: pmproxy caught SIGHUP
+## found remote archive files
+REMOTE_ARCHIVE.0
+REMOTE_ARCHIVE.index
+REMOTE_ARCHIVE.meta
+## with the following metrics
+disk.all.read
+disk.all.write
+hinv.ncpu
+hinv.ndisk
+kernel.all.load
+kernel.all.pswitch
+## found local archive files
+LOCAL_ARCHIVE.0
+LOCAL_ARCHIVE.index
+LOCAL_ARCHIVE.meta
+## with the following metrics
+disk.all.read
+disk.all.write
+hinv.ncpu
+hinv.ndisk
+kernel.all.load
+kernel.all.pswitch
+
+=== Running pmlogger in remote only recording mode
+=== std out ===
+=== std err ===
+=== filtered valgrind report ===
+Memcheck, a memory error detector
+Command: pmlogger -c TMP.conf -T 15sec -R http://localhost:44322
+LEAK SUMMARY:
+definitely lost: 0 bytes in 0 blocks
+indirectly lost: 0 bytes in 0 blocks
+ERROR SUMMARY: 0 errors from 0 contexts ...
+## checking for pmproxy SIGHUP
+[DATE] pmproxy(PID) Info: pmproxy caught SIGHUP
+## found remote archive files
+REMOTE_ARCHIVE.0
+REMOTE_ARCHIVE.index
+REMOTE_ARCHIVE.meta
+## with the following metrics
+disk.all.read
+disk.all.write
+hinv.ncpu
+hinv.ndisk
+kernel.all.load
+kernel.all.pswitch
+## found no local archive files

--- a/qa/group
+++ b/qa/group
@@ -2112,6 +2112,8 @@ pmcd.pdu
 1617 pmproxy pmseries pmlogpush libpcp_web local
 1618 pmproxy pmseries pmlogpush libpcp_web local valgrind
 1619 pmcd local
+1620 pmlogger pmproxy pmlogpush libpcp_web local
+1621 pmlogger pmproxy pmlogpush libpcp_web local valgrind
 1622:retired local
 1623 libpcp_import local pmlogdump collectl2pcp pmrep
 1626 pmproxy libpcp_web local

--- a/src/include/pcp/pmwebapi.h
+++ b/src/include/pcp/pmwebapi.h
@@ -418,6 +418,8 @@ extern int pmLogGroupSetup(pmLogGroupModule *);
 extern int pmLogGroupSetEventLoop(pmLogGroupModule *, void *);
 extern int pmLogGroupSetConfiguration(pmLogGroupModule *, struct dict *);
 extern int pmLogGroupSetMetricRegistry(pmLogGroupModule *, struct mmv_registry *);
+extern int pmLogPathsSetMetricRegistry(pmLogGroupModule *, struct mmv_registry *);
+extern void pmLogPathsReset(pmLogGroupModule *);
 extern void pmLogGroupClose(pmLogGroupModule *);
 
 /*

--- a/src/libpcp_web/src/exports
+++ b/src/libpcp_web/src/exports
@@ -280,4 +280,6 @@ PCP_WEB_1.22 {
     pmLogGroupSetConfiguration;
     pmLogGroupSetEventLoop;
     pmLogGroupSetMetricRegistry;
+    pmLogPathsReset;
+    pmLogPathsSetMetricRegistry;
 } PCP_WEB_1.21;

--- a/src/libpcp_web/src/webgroup.c
+++ b/src/libpcp_web/src/webgroup.c
@@ -319,9 +319,9 @@ webgroup_garbage_collect(struct webgroups *groups)
 	iterator = dictGetSafeIterator(groups->contexts);
 	for (entry = dictNext(iterator); entry;) {
 	    cp = (context_t *)dictGetVal(entry);
+	    entry = dictNext(iterator);
 	    if (cp->privdata != groups)
 		continue;
-	    entry = dictNext(iterator);
 	    if (cp->garbage)
 		garbageset++;
 	    if (cp->inactive && cp->refcount == 0)

--- a/src/pmproxy/src/http.c
+++ b/src/pmproxy/src/http.c
@@ -1289,6 +1289,16 @@ setup_http_module(struct proxy *proxy)
 }
 
 void
+reset_http_module(struct proxy *proxy)
+{
+    struct servlet	*servlet;
+
+    for (servlet = proxy->servlets; servlet != NULL; servlet = servlet->next)
+	if (servlet->reset)
+	    servlet->reset(proxy);
+}
+
+void
 close_http_module(struct proxy *proxy)
 {
     struct servlet	*servlet;

--- a/src/pmproxy/src/http.h
+++ b/src/pmproxy/src/http.h
@@ -75,6 +75,7 @@ extern sds http_get_buffer(struct client *);
 extern void http_set_buffer(struct client *, sds, http_flags_t);
 
 typedef void (*httpSetupCallBack)(struct proxy *);
+typedef void (*httpResetCallBack)(struct proxy *);
 typedef void (*httpCloseCallBack)(struct proxy *);
 typedef int (*httpHeadersCallBack)(struct client *, struct dict *);
 typedef int (*httpUrlCallBack)(struct client *, sds, struct dict *);
@@ -86,6 +87,7 @@ typedef struct servlet {
     const char * const	name;
     struct servlet	*next;
     httpSetupCallBack	setup;
+    httpResetCallBack	reset;
     httpCloseCallBack	close;
     httpUrlCallBack	on_url;
     httpHeadersCallBack	on_headers;

--- a/src/pmproxy/src/keys.c
+++ b/src/pmproxy/src/keys.c
@@ -274,6 +274,13 @@ get_keys_module(struct proxy *proxy)
 }
 
 void
+reset_keys_module(struct proxy *proxy)
+{
+    /* SIGHUP: no-op */
+    (void)proxy;
+}
+
+void
 close_keys_module(struct proxy *proxy)
 {
     if (proxy->slots) {

--- a/src/pmproxy/src/pcp.c
+++ b/src/pmproxy/src/pcp.c
@@ -297,6 +297,13 @@ setup_pcp_module(struct proxy *proxy)
 }
 
 void
+reset_pcp_module(struct proxy *proxy)
+{
+    /* SIGHUP: no-op */
+    (void)proxy;
+}
+
+void
 close_pcp_module(struct proxy *proxy)
 {
     proxymetrics_close(proxy, METRICS_PCP);

--- a/src/pmproxy/src/secure.c
+++ b/src/pmproxy/src/secure.c
@@ -352,6 +352,13 @@ setup_secure_module(struct proxy *proxy)
 }
 
 void
+reset_secure_module(struct proxy *proxy)
+{
+    /* SIGHUP: no-op */
+    (void)proxy;
+}
+
+void
 close_secure_module(struct proxy *proxy)
 {
     if (proxy->ssl) {

--- a/src/pmproxy/src/server.h
+++ b/src/pmproxy/src/server.h
@@ -45,6 +45,7 @@ typedef enum proxy_registry {
     METRICS_WEBGROUP,
     METRICS_SEARCH,
     METRICS_LOGGROUP,
+    METRICS_LOGPATHS,
     NUM_REGISTRY
 } proxy_registry_t;
 
@@ -228,6 +229,7 @@ extern void on_pcp_client_close(struct client *);
 #ifdef HAVE_OPENSSL
 extern void flush_secure_module(struct proxy *);
 extern void setup_secure_module(struct proxy *);
+extern void reset_secure_module(struct proxy *);
 extern void close_secure_module(struct proxy *);
 #else
 #define flush_secure_module(p)	do { (void)(p); } while (0)
@@ -236,13 +238,16 @@ extern void close_secure_module(struct proxy *);
 #endif
 
 extern void setup_http_module(struct proxy *);
+extern void reset_http_module(struct proxy *);
 extern void close_http_module(struct proxy *);
 
 extern void setup_keys_module(struct proxy *);
+extern void reset_keys_module(struct proxy *);
 extern void * get_keys_module(struct proxy *);
 extern void close_keys_module(struct proxy *);
 
 extern void setup_pcp_module(struct proxy *);
+extern void reset_pcp_module(struct proxy *);
 extern void close_pcp_module(struct proxy *);
 
 extern void setup_modules(struct proxy *);


### PR DESCRIPTION
To support the daily logging scripts requirements, pmproxy will now respond to SIGHUP by closing all active loggers.  Additionally when a conflicing (same minute) remote archive push path is required, we now use the -NN suffix handling in pmproxy (up to 100 alternates).