### PR TITLE
pmproxy: add OpenTelemetry output format for /metrics REST API

### DIFF
--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -16,9 +16,9 @@ info:
 servers:
 - url: http://localhost:44322/
 tags:
-- name: OPEN METRICS
+- name: OPEN METRICS AND OPEN TELEMETRY
   description: |
-    Exporting of live performance metrics in an Open Metrics compatible format (as described at https://openmetrics.io and popularized by the https://prometheus.io project) is available.
+    Exporting of live performance metrics in [Open Metrics](https://openmetrics.io/) and [Open Telemetry](https://opentelemetry.io/) formats is available.
 - name: SCALABLE TIME SERIES
   description: |
     The fast, scalable time series query capabilities provided by the [pmseries](https://man7.org/linux/man-pages/man1/pmseries.1.html)(1) command are also available through a REST API. These queries provide access to performance data (metric metadata and values) from multiple hosts simultaneously, and in a fashion suited to efficient retrieval by any number of web applications.
@@ -54,24 +54,58 @@ paths:
   /metrics:
     get:
       tags:
-      - OPEN METRICS
+      - OPEN METRICS AND OPEN TELEMETRY
       summary: Fetches current values and metadata 
       description: |
         `Get Metrics` fetches current values and metadata for all metrics, or only metrics indicated by a comma-separated list of *names*.
         
-        For all numeric metrics with the given NAME prefixes, create an Open Metrics (Prometheus) text export format giving their current value and related metadata.
-        
-        The response has plain text type rather than JSON commonly used elsewhere in the REST API. This format can be injested by many open source monitoring tools, 
-        including Prometheus and [pmdaopenmetrics](https://man7.org/linux/man-pages/man1/pmdaopenmetrics.1.html)(1).
-        
-        The native PCP metric metadata (metric name, type, indom, semantics and units) is first output for each metric with **\# PCP** prefix. The metadata reported 
-        is of the form described on [pmTypeStr](https://man7.org/linux/man-pages/man3/pmtypestr.3.html)(3), [pmInDomStr](https://man7.org/linux/man-pages/man3/pmindomstr.3.html)(3), 
+        For all numeric metrics with the given NAME prefixes, create either an Open Telemetry (JSON) or Open Metrics (text) export format giving their current value and related metadata.
+ 
+        The default response has plain text type, however JSON can be requested instead by setting the HTTP request **Accept** header to **application/json**.
+        These formats can be injested by many open source monitoring tools, including Prometheus,
+        [pmdaopenmetrics](https://man7.org/linux/man-pages/man1/pmdaopenmetrics.1.html)(1) and
+        [pmdaopentelemetry](https://man7.org/linux/man-pages/man1/pmdaopentelemetry.1.html)(1).
+
+      In the Open Telemetry JSON response form, sample timestamps are always present and reported using nanosecond precision.  The PCP context labels are presented once, as resource attributes, and metric labels are presented as dataPoints attributes.  Unit strings conform to the [Unified Code for Units of Measure](https://ucum.org/) specification.
+
+        ```bash
+        $ curl -s -H Accept:application/json http://localhost:44322/metrics?names=names=disk.dev,filesys | pmjson
+          {
+              "resourceMetrics": [
+                  {
+                      "resource": {
+                          "attributes": [ ... ]
+                      },
+                      "scopeMetrics": [
+                          {
+                              "scope": { ... },
+                              "metrics": [
+                                  {
+                                      "name": "disk_dev_total_bytes",
+                                      "description": "per-disk count of total bytes read and written",
+                                      "unit": "KiBy",
+                                      "sum": {
+                                          "aggregationTemporality": "CUMULATIVE",
+                                          "isMonotonic": true,
+                                          "dataPoints": [
+                                              {
+                                                  "attributes": [ ... ]
+                                                  "timeUnixNano": "1753934255798173",
+                                                  "asInt": "68927569"
+                                              }
+                                          ]
+                                      }
+                                  },
+                                  ...
+        ```
+
+        In the Open Metrics (Prometheus) text response form, the native PCP metric metadata (metric name, type, indom, semantics and units) is first output for each metric with **\# PCP** prefix.
+        The metadata reported is of the form described on [pmTypeStr](https://man7.org/linux/man-pages/man3/pmtypestr.3.html)(3), [pmInDomStr](https://man7.org/linux/man-pages/man3/pmindomstr.3.html)(3), 
         [pmSemStr](https://man7.org/linux/man-pages/man3/pmsemstr.3.html)(3) and [pmUnitsStr](https://man7.org/linux/man-pages/man3/pmunitsstr.3.html)(3) respectively. If the [pmUnitsStr](https://man7.org/linux/man-pages/man3/pmunitsstr.3.html)(3) 
         units string is empty, then **none** is output. The units metadata string may contain spaces and extends to the end of the line.
-        
+
         PCP metric names are mapped so that the **.** separators are exchanged with **_** (':' in back-compatibility mode, where "# PCP" is the identifying line suffix). 
-        Both metric labels and instances are represented as Prometheus labels, with external instance names being quoted and the flattened PCP metric hierarchy being 
-        presented with each value.
+        Both metric labels and instances are represented as Prometheus labels, with external instance names being quoted and the flattened PCP metric hierarchy being presented with each value.
 
         ```bash
           $ curl -s http://localhost:44322/metrics?names=proc.nprocs,kernel.pernode.cpu.intr,filesys.blocksize
@@ -110,7 +144,7 @@ paths:
           type: string
       - name: times
         in: query
-        description: Append sample times (milliseconds since epoch)
+        description: Append sample times (milliseconds since epoch), only relevent for the text response form as JSON response form includes times (nanoseconds since epoch) by default.
         schema:
           type: boolean
 
@@ -1523,7 +1557,7 @@ paths:
       - PMAPI HOST SERVICES
       summary: Allows a web context identifier to be passed as a parameter
       description: | 
-        This request is a subset of the style described in the ``OPEN METRICS`` section, allowing a web context identifier to be passed as a parameter. It is 
+        This request is a subset of the style described in the ``OPEN METRICS and OPEN TELEMETRY`` section, allowing a web context identifier to be passed as a parameter. It is 
         otherwise very similar in terms of parameters and response handling, please refer to the earlier section for details.
 
         **Reference:** [pmLookupDesc](https://man7.org/linux/man-pages/man3/pmLookupDesc.3.html)(3),

--- a/man/man3/pmwebapi.3
+++ b/man/man3/pmwebapi.3
@@ -84,13 +84,12 @@ The examples in the scalable time series section use
 historical data recorded by the
 .BR pmlogger (1)
 service, in conjunction with a local key-value server/
-.SH OPEN METRICS
-Exporting of live performance metrics in an Open Metrics
-compatible format (as described at
-.I https://openmetrics.io
-and popularized by the
-.I https://prometheus.io
-project) is available.
+.SH OPEN METRICS AND OPEN TELEMETRY
+Exporting of live performance metrics in either Open Metrics (\c
+.IR https://openmetrics.io )
+or Open Telemetry (\c
+.IR https://opentelemetry.io )
+formats is available.
 .PP
 All requests are performed on the web server host by default,
 unless a
@@ -116,17 +115,54 @@ metrics indicated by a comma-separated list of
 .IR names .
 .PP
 For all numeric metrics with the given NAME prefixes, create
-an Open Metrics (Prometheus) text export format giving their
-current value and related metadata.
+an open text export format giving their current value and
+related metadata.
 .PP
-The response has plain text type rather than JSON commonly
-used elsewhere in the REST API.
-This format can be ingested by many open source monitoring
-tools, including Prometheus and
-.BR pmdaopenmetrics (1).
+Choice of output format is selected using the HTTP
+.I Accept
+header.
+With no header, the default response format is Open Metrics
+.IR text .
+Using the header with value
+.I application/json
+switches the response to the Open Telemetry JSON format.
 .PP
-The native PCP metric metadata (metric name, type, indom,
-semantics and units) is first output for each metric with
+In Open Telemetry response mode, sample timestamps are always
+included and are reported using nanosecond precision.
+.SAMPLE
+$ curl -H Accept:application/json -s http://localhost:44322/metrics?names=disk.dev,filesys | pmjson
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [ ... ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": { ... },
+                    "metrics": [
+                        {
+                            "name": "disk_dev_total_bytes",
+                            "description": "per-disk count of total bytes read and written",
+                            "unit": "KiBy",
+                            "sum": {
+                                "aggregationTemporality": "CUMULATIVE",
+                                "isMonotonic": true,
+                                "dataPoints": [
+                                    {
+                                        "attributes": [ ... ]
+                                        "timeUnixNano": "1753934255798173",
+                                        "asInt": "68927569"
+                                    }
+                                ]
+                            }
+                        },
+                        ...
+.ESAMPLE
+.PP
+In Open Metrics response mode, the native PCP metric metadata
+(metric name, type, indom, semantics and units) is first output
+for each metric with
 .B # PCP
 prefix.
 The metadata reported is of the form described on
@@ -1226,8 +1262,8 @@ client	string	Request identifier sent back with response
 .TE
 .P
 This request is a subset of the style described in the
-``OPEN METRICS'' section, allowing a web context
-identifier to be passed as a parameter.
+``OPEN METRICS AND OPEN TELEMETRY'' section, allowing a web
+context identifier to be passed as a parameter.
 It is otherwise very similar in terms of parameters
 and response handling, please refer to the earlier section
 for details.

--- a/qa/1543
+++ b/qa/1543
@@ -114,14 +114,20 @@ _filter_json()
     if [ $status -eq 0 ]; then
 	cat $tmp.filtered | \
 	sed \
-	    -e '/"machineid": .*/d' \
+	    -e 's,"machineid": .*,"machineid": "MACHINEID",g' \
 	    -e 's,"series": .*,"series": "SERIES",g' \
 	    -e 's,"source": .*,"source": "SOURCE",g' \
 	    -e 's,"context": .*,"context": "CONTEXT",g' \
+	    -e 's,"version": ".*","version": "VERSION",g' \
 	    -e 's,"hostname": .*,"hostname": "HOSTNAME",g' \
 	    -e 's,"hostspec": .*,"hostname": "HOSTNAME",g' \
 	    -e 's,"domainname": .*,"domainname": "DOMAINNAME",g' \
 	    -e 's,"timestamp": [0-9][0-9]*.[0-9][0-9]*,"timestamp": TIME,g' \
+	    -e 's,"stringValue": "'$machineid'","stringValue": "MACHINEID",g' \
+	    -e 's,"stringValue": "'$domainname'","stringValue: "DOMAINNAME",g' \
+	    -e 's,"stringValue": "'$hostname'","stringValue": "HOSTNAME",g' \
+	    -e 's,"timeUnixNano": "[0-9][0-9]*","timeUnixNano": NANOSECONDS,g' \
+	    -e 's,"asInt": "[0-9][0-9]*","asInt": "INTEGER",g' \
 	    -e 's,"msec": [0-9][0-9]*,"msec": MILLISECONDS,g' \
 	    -e 's,"usec": [0-9][0-9]*,"usec": MICROSECONDS,g' \
 	    -e 's,"nsec": [0-9][0-9]*,"nsec": NANOSECONDS,g' \
@@ -133,6 +139,17 @@ _filter_json()
 	echo "Invalid JSON: $status"
 	cat $tmp.unfiltered
 	rm -f $tmp.context $tmp.series
+    fi
+}
+
+_check_pmproxy()
+{
+    echo "== check pmproxy is running =="
+    pminfo -v -h localhost@localhost:$port hinv.ncpu
+    if [ $? -eq 0 ]; then
+	echo "pmproxy check passed"
+    else
+	echo "pmproxy check failed"
     fi
 }
 
@@ -399,17 +416,12 @@ curl -s  --compressed "http://localhost:$port/metrics?name=sample.long.one" \
 	| _filter_text "small curl compression command"
 curl -s  --compressed "http://localhost:$port/metrics?name=sample,sampledso" \
 	| _filter_text "large curl compression command" | head -8
+
 echo "== scrape all metrics =="
 curl -s "http://localhost:$port/metrics" \
 	> /dev/null	# checking pmproxy remains up here (too much to filter)
 echo "done full scrape"
-echo "== check pmproxy is running =="
-pminfo -v -h localhost@localhost:$port hinv.ncpu
-if [ $? -eq 0 ]; then
-    echo "pmproxy check passed"
-else
-    echo "pmproxy check failed"
-fi
+_check_pmproxy
 
 # Filtering options
 curl -s "http://localhost:$port/metrics?name=sample.long.one,sample.long.ten&filter=*ten" \
@@ -420,6 +432,27 @@ curl -s "http://localhost:$port/metrics?name=sample.long.one,sample.long.ten&fil
 	| _filter_text "good filter regex"
 curl -s "http://localhost:$port/metrics?name=sample.long.one,sample.long.ten&filter=ten&match=dummy" \
 	| _filter_text "bad filter match param"
+
+# alternate JSON output (OpenTelemetry instead of OpenMetrics)
+json_request="-H Accept:application/json"
+curl -s $json_request "http://localhost:$port/pmapi/metrics?target=sample.long.one" \
+	| _filter_json "scrape one metric"
+curl -s $json_request "http://localhost:$port/metrics?names=sample.long.one,sample.long.ten" \
+	| _filter_json "scrape two metrics"
+curl -s $json_request "http://localhost:$port/metrics?names=no.such.metric" \
+	| _filter_json "scrape bad metric name"
+curl -s $json_request "http://localhost:$port/pmapi/metrics?target=sample.long" \
+	| _filter_json "scrape one metric tree"
+curl -s $json_request "http://localhost:$port/pmapi/metrics?target=sample.colour" \
+	| _filter_json "scrape metric instances"
+curl -s $json_request --compressed "http://localhost:$port/metrics?name=sample.long.one" \
+	| _filter_json "small curl compression command"
+
+echo "== scrape all metrics (JSON) =="
+curl -s $json_request "http://localhost:$port/metrics" \
+	> /dev/null	# checking pmproxy remains up here (too much to filter)
+echo "done full scrape (JSON)"
+_check_pmproxy
 
 # No clue why or how, but on vm21 (Debian 11) this sleep makes the test
 # reliably pass, rather than 

--- a/qa/1543.out
+++ b/qa/1543.out
@@ -10,6 +10,7 @@ QA output created by 1543
     "labels": {
         "domainname": "DOMAINNAME"
         "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
     }
 }
 == Check hostname parameter ==
@@ -20,6 +21,7 @@ QA output created by 1543
     "labels": {
         "domainname": "DOMAINNAME"
         "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
     }
 }
 == Check hostspec parameter ==
@@ -30,6 +32,7 @@ QA output created by 1543
     "labels": {
         "domainname": "DOMAINNAME"
         "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
     }
 }
 == Pinging active context via URL ==
@@ -40,6 +43,7 @@ QA output created by 1543
     "labels": {
         "domainname": "DOMAINNAME"
         "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
     }
 }
 Context ping success
@@ -51,6 +55,7 @@ Context ping success
     "labels": {
         "domainname": "DOMAINNAME"
         "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
     }
 }
 == Pinging now-expired context via URL ==
@@ -61,6 +66,7 @@ Context ping success
     "labels": {
         "domainname": "DOMAINNAME"
         "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
     }
 }
 Context successfully expired
@@ -72,6 +78,7 @@ Context successfully expired
     "labels": {
         "domainname": "DOMAINNAME"
         "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
     }
 }
 Context successfully expired
@@ -94,6 +101,7 @@ Context successfully expired
                 "cluster": "zero",
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
                 "role": "testing"
             },
             "text-oneline": "10 as a 32-bit integer",
@@ -119,6 +127,7 @@ Series checked (single)
                 "cluster": "zero",
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
                 "role": "testing"
             },
             "text-oneline": "like sample.bin but type 32",
@@ -143,6 +152,7 @@ Series checked (indom)
                 "cluster": "zero",
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
                 "role": "testing"
             },
             "text-oneline": "1 as a 32-bit integer",
@@ -160,6 +170,7 @@ Series checked (indom)
                 "cluster": "zero",
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
                 "role": "testing"
             },
             "text-oneline": "10 as a 32-bit integer",
@@ -177,6 +188,7 @@ Series checked (indom)
                 "cluster": "zero",
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
                 "role": "testing"
             },
             "text-oneline": "100 as a 32-bit integer",
@@ -194,6 +206,7 @@ Series checked (indom)
                 "cluster": "zero",
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
                 "role": "testing"
             },
             "text-oneline": "1000000 as a 32-bit integer",
@@ -211,6 +224,7 @@ Series checked (indom)
                 "cluster": "zero",
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
                 "role": "testing"
             },
             "text-oneline": "a 32-bit integer that can be modified",
@@ -229,6 +243,7 @@ Series checked (indom)
                 "cluster": "zero",
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
                 "role": "testing"
             },
             "text-oneline": "like sample.bin but type 32",
@@ -247,6 +262,7 @@ Series checked (indom)
                 "cluster": "zero",
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
                 "role": "testing"
             },
             "text-oneline": "like sample.bin but type 32, SEM_COUNTER and SPACE_KBYTE",
@@ -276,6 +292,7 @@ Series checked (indom)
                 "cluster": "zero",
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
                 "role": "testing"
             },
             "text-oneline": "10 as a 32-bit integer",
@@ -304,6 +321,7 @@ Series checked (indom)
                 "cluster": "zero",
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
                 "role": "testing"
             },
             "text-oneline": "1 as a 32-bit integer",
@@ -321,6 +339,7 @@ Series checked (indom)
                 "cluster": "zero",
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
                 "role": "testing"
             },
             "text-oneline": "10 as a 32-bit integer",
@@ -482,6 +501,7 @@ Series checked (indom)
     "labels": {
         "domainname": "DOMAINNAME"
         "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
     },
     "text-oneline": "Instance domain \u0022bin\u0022 for sample PMDA",
     "text-help": "Universally 9 instances numbered 100 .. 900 in steps of 100, and named\u000A\u0022bin-100\u0022 .. \u0022bin-900\u0022",
@@ -492,6 +512,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -500,6 +521,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -508,6 +530,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -516,6 +539,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -524,6 +548,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -532,6 +557,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -540,6 +566,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -548,6 +575,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -556,6 +584,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         }
     ]
@@ -567,6 +596,7 @@ Series checked (indom)
     "labels": {
         "domainname": "DOMAINNAME"
         "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
     },
     "text-oneline": "Instance domain \u0022bin\u0022 for sample PMDA",
     "text-help": "Universally 9 instances numbered 100 .. 900 in steps of 100, and named\u000A\u0022bin-100\u0022 .. \u0022bin-900\u0022",
@@ -577,6 +607,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -585,6 +616,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -593,6 +625,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -601,6 +634,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -609,6 +643,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -617,6 +652,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -625,6 +661,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -633,6 +670,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -641,6 +679,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         }
     ]
@@ -658,6 +697,7 @@ Series checked (indom)
     "labels": {
         "domainname": "DOMAINNAME"
         "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
     },
     "instances": [    ]
 }
@@ -677,6 +717,7 @@ Series checked (indom)
     "labels": {
         "domainname": "DOMAINNAME"
         "hostname": "HOSTNAME"
+        "machineid": "MACHINEID"
     },
     "text-oneline": "Instance domain \u0022bin\u0022 for sample PMDA",
     "text-help": "Universally 9 instances numbered 100 .. 900 in steps of 100, and named\u000A\u0022bin-100\u0022 .. \u0022bin-900\u0022",
@@ -687,6 +728,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         },
         {
@@ -695,6 +737,7 @@ Series checked (indom)
             "labels": {
                 "domainname": "DOMAINNAME"
                 "hostname": "HOSTNAME"
+                "machineid": "MACHINEID"
             }
         }
     ]
@@ -1052,6 +1095,2451 @@ sample_long_ten{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero"
 sample_long_one{role="testing",agent="sample",hostname="HOSTNAME",cluster="zero",domainname="DOMAINNAME",machineid="MACHINEID"} 1
 == bad filter match param ==
 {"context":CONTEXT,"message":"dummy - invalid 'match' parameter value","success":false}
+== scrape one metric ==
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "hostname",
+                        "value": {
+                            "stringValue": "HOSTNAME"
+                        }
+                    },
+                    {
+                        "key": "machineid",
+                        "value": {
+                            "stringValue": "MACHINEID"
+                        }
+                    },
+                    {
+                        "key": "domainname",
+                        "value": {
+                            "stringValue: "DOMAINNAME"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "performance-co-pilot",
+                        "version": "VERSION"
+                    },
+                    "metrics": [
+                        {
+                            "name": "sample_long_one",
+                            "description": "1 as a 32-bit integer",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+== scrape two metrics ==
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "hostname",
+                        "value": {
+                            "stringValue": "HOSTNAME"
+                        }
+                    },
+                    {
+                        "key": "machineid",
+                        "value": {
+                            "stringValue": "MACHINEID"
+                        }
+                    },
+                    {
+                        "key": "domainname",
+                        "value": {
+                            "stringValue: "DOMAINNAME"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "performance-co-pilot",
+                        "version": "VERSION"
+                    },
+                    "metrics": [
+                        {
+                            "name": "sample_long_one",
+                            "description": "1 as a 32-bit integer",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sample_long_ten",
+                            "description": "10 as a 32-bit integer",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+== scrape bad metric name ==
+{
+    "context": "CONTEXT"
+    "message": "'no.such.metric' - Unknown metric name",
+    "success": false
+}
+== scrape one metric tree ==
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "hostname",
+                        "value": {
+                            "stringValue": "HOSTNAME"
+                        }
+                    },
+                    {
+                        "key": "machineid",
+                        "value": {
+                            "stringValue": "MACHINEID"
+                        }
+                    },
+                    {
+                        "key": "domainname",
+                        "value": {
+                            "stringValue: "DOMAINNAME"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "performance-co-pilot",
+                        "version": "VERSION"
+                    },
+                    "metrics": [
+                        {
+                            "name": "sample_long_one",
+                            "description": "1 as a 32-bit integer",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sample_long_ten",
+                            "description": "10 as a 32-bit integer",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sample_long_hundred",
+                            "description": "100 as a 32-bit integer",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sample_long_million",
+                            "description": "1000000 as a 32-bit integer",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sample_long_write_me",
+                            "description": "a 32-bit integer that can be modified",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "changed",
+                                                "value": {
+                                                    "stringValue": "true"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sample_dupnames_five_long_bin",
+                            "description": "like sample.bin but type 32",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 100
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-100"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "100"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 200
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-200"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "200"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 300
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-300"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "300"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 400
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-400"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "400"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 500
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-500"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "500"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 600
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-600"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "600"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 700
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-700"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "700"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 800
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-800"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "800"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 900
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-900"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "900"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sample_long_bin",
+                            "description": "like sample.bin but type 32",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 100
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-100"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "100"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 200
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-200"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "200"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 300
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-300"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "300"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 400
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-400"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "400"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 500
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-500"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "500"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 600
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-600"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "600"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 700
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-700"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "700"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 800
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-800"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "800"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 900
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-900"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "900"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sample_long_bin_ctr",
+                            "description": "like sample.bin but type 32, SEM_COUNTER and SPACE_KBYTE",
+                            "unit": "KiBy",
+                            "sum": {
+                                "aggregationTemporality": "CUMULATIVE",
+                                "isMonotonic": true,
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "counter"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 100
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-100"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "100"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "counter"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 200
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-200"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "200"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "counter"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 300
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-300"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "300"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "counter"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 400
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-400"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "400"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "counter"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 500
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-500"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "500"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "counter"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 600
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-600"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "600"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "counter"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 700
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-700"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "700"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "counter"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 800
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-800"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "800"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "counter"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 900
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "bin-900"
+                                                }
+                                            },
+                                            {
+                                                "key": "bin",
+                                                "value": {
+                                                    "stringValue": "900"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+== scrape metric instances ==
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "hostname",
+                        "value": {
+                            "stringValue": "HOSTNAME"
+                        }
+                    },
+                    {
+                        "key": "machineid",
+                        "value": {
+                            "stringValue": "MACHINEID"
+                        }
+                    },
+                    {
+                        "key": "domainname",
+                        "value": {
+                            "stringValue: "DOMAINNAME"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "performance-co-pilot",
+                        "version": "VERSION"
+                    },
+                    "metrics": [
+                        {
+                            "name": "sample_dupnames_four_colour",
+                            "description": "Metrics with a \"saw-tooth\" trend over time",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "model",
+                                                "value": {
+                                                    "stringValue": "RGB"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 0
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "red"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "model",
+                                                "value": {
+                                                    "stringValue": "RGB"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 1
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "green"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "model",
+                                                "value": {
+                                                    "stringValue": "RGB"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 2
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "blue"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "name": "sample_colour",
+                            "description": "Metrics with a \"saw-tooth\" trend over time",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "model",
+                                                "value": {
+                                                    "stringValue": "RGB"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 0
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "red"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "model",
+                                                "value": {
+                                                    "stringValue": "RGB"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 1
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "green"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    },
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "model",
+                                                "value": {
+                                                    "stringValue": "RGB"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            },
+                                            {
+                                                "key": "instid",
+                                                "value": {
+                                                    "intValue": 2
+                                                }
+                                            },
+                                            {
+                                                "key": "instname",
+                                                "value": {
+                                                    "stringValue": "blue"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+== small curl compression command ==
+{
+    "resourceMetrics": [
+        {
+            "resource": {
+                "attributes": [
+                    {
+                        "key": "hostname",
+                        "value": {
+                            "stringValue": "HOSTNAME"
+                        }
+                    },
+                    {
+                        "key": "machineid",
+                        "value": {
+                            "stringValue": "MACHINEID"
+                        }
+                    },
+                    {
+                        "key": "domainname",
+                        "value": {
+                            "stringValue: "DOMAINNAME"
+                        }
+                    }
+                ]
+            },
+            "scopeMetrics": [
+                {
+                    "scope": {
+                        "name": "performance-co-pilot",
+                        "version": "VERSION"
+                    },
+                    "metrics": [
+                        {
+                            "name": "sample_long_one",
+                            "description": "1 as a 32-bit integer",
+                            "unit": "1",
+                            "gauge": {
+                                "dataPoints": [
+                                    {
+                                        "attributes": [
+                                            {
+                                                "key": "semantics",
+                                                "value": {
+                                                    "stringValue": "instant"
+                                                }
+                                            },
+                                            {
+                                                "key": "type",
+                                                "value": {
+                                                    "stringValue": "32"
+                                                }
+                                            },
+                                            {
+                                                "key": "role",
+                                                "value": {
+                                                    "stringValue": "testing"
+                                                }
+                                            },
+                                            {
+                                                "key": "agent",
+                                                "value": {
+                                                    "stringValue": "sample"
+                                                }
+                                            },
+                                            {
+                                                "key": "cluster",
+                                                "value": {
+                                                    "stringValue": "zero"
+                                                }
+                                            }
+                                        ],
+                                        "timeUnixNano": NANOSECONDS,
+                                        "asInt": "INTEGER"
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+== scrape all metrics (JSON) ==
+done full scrape (JSON)
+== check pmproxy is running ==
+pmproxy check passed
 
 *****   GET and POST /pmapi/derive   *****
 

--- a/qa/1695
+++ b/qa/1695
@@ -86,6 +86,7 @@ else
 fi
 
 params="polltimeout=20"
+jsonreq="-H Accept:application/json"
 
 if which fuser >/dev/null
 then
@@ -102,6 +103,11 @@ fi
 date >>$seq_full
 echo "=== checking metric scrape operation ===" | tee -a $seq_full
 curl -Gs "http://localhost:$port/metrics?$params" >$tmp.tmp 2>&1
+grep "^curl" $tmp.tmp
+cat $tmp.tmp >>$seq_full
+
+echo "=== checking metric scrape JSON operation ===" | tee -a $seq_full
+curl -Gs $jsonreq "http://localhost:$port/metrics?$params" >$tmp.tmp 2>&1
 grep "^curl" $tmp.tmp
 cat $tmp.tmp >>$seq_full
 

--- a/qa/1695.out
+++ b/qa/1695.out
@@ -3,6 +3,7 @@ Start test key server ...
 PING
 PONG
 === checking metric scrape operation ===
+=== checking metric scrape JSON operation ===
 === checking short-fuse scrape operation ===
 === checking repeated scrape operation ===
 === checking one client making multiple requests ===

--- a/src/pmproxy/src/GNUmakefile
+++ b/src/pmproxy/src/GNUmakefile
@@ -34,8 +34,10 @@ PCPLIB_LDFLAGS += \
 ifeq "$(HAVE_LIBUV)" "true"
 LCFLAGS += $(LIBUVCFLAGS) -DHAVE_LIBUV=1
 SERVLETS = search.c series.c webapi.c logger.c
-CFILES += openmetrics.c server.c http.c pcp.c uv_callback.c keys.c $(SERVLETS)
-HFILES += openmetrics.h server.h http.h pcp.h uv_callback.h
+CFILES += server.c http.c pcp.c uv_callback.c keys.c $(SERVLETS)
+HFILES += server.h http.h pcp.h uv_callback.h
+CFILES += openmetrics.c opentelemetry.c
+HFILES += openmetrics.h opentelemetry.h
 ifeq "$(HAVE_OPENSSL)" "true"
 LCFLAGS += $(OPENSSLCFLAGS) -DHAVE_OPENSSL=1
 CFILES += secure.c

--- a/src/pmproxy/src/http.h
+++ b/src/pmproxy/src/http.h
@@ -36,6 +36,8 @@ typedef enum http_flags {
     HTTP_FLAG_HTML	= (1<<2),
     HTTP_FLAG_UTF8	= (1<<3),
     HTTP_FLAG_UTF16	= (1<<4),
+    HTTP_FLAG_REQ_JSON	= (1<<5),
+    /* insert new flags here */
     HTTP_FLAG_NO_BODY	= (1<<11),
     HTTP_FLAG_GZIP	= (1<<12),
     HTTP_FLAG_DEFLATE	= (1<<13),

--- a/src/pmproxy/src/openmetrics.h
+++ b/src/pmproxy/src/openmetrics.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Red Hat.
+ * Copyright (c) 2019,2025 Red Hat.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published
@@ -17,9 +17,6 @@
 #include "pmwebapi.h"
 #include "dict.h"
 
-/* check if PCP metric type has valid Open Metrics form */
-extern int open_metrics_type_check(sds);
-
 /* convert PCP metric name to Open Metrics form */
 extern sds open_metrics_name(sds, int);
 
@@ -27,6 +24,6 @@ extern sds open_metrics_name(sds, int);
 extern sds open_metrics_semantics(sds);
 
 /* convert an array of PCP labelsets into Open Metrics form */
-extern void open_metrics_labels(pmWebLabelSet *, dict *);
+extern void open_metrics_labels(pmWebLabelSet *);
 
 #endif	/* OPEN_METRICS_H */

--- a/src/pmproxy/src/opentelemetry.c
+++ b/src/pmproxy/src/opentelemetry.c
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) 2025 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ */
+#include "opentelemetry.h"
+#include "libpcp.h"
+#include "util.h"
+
+static void
+labelname(const pmLabel *lp, const char *json, __pmHashCtl *lc,
+		const char **name, int *length)
+{
+    __pmHashNode	*hp;
+
+    if (!(lp->flags & PM_LABEL_COMPOUND) || lc == NULL ||
+	(hp = __pmHashSearch(lp->name, lc)) == NULL) {
+	*name = json + lp->name;
+	*length = lp->namelen;
+    } else {
+	*name = hp->data;       /* compound "a.b.c" style label name */
+	*length = strlen(hp->data);
+    }
+}
+
+static void
+labelvalue(const pmLabel *lp, const char *json, const char **value, int *length)
+{
+    const char		*offset;
+    int			bytes;
+
+    bytes = lp->valuelen;
+    offset = json + lp->value;
+    if (*offset == '\"' && bytes >= 2 && offset[bytes-1] == '\"') {
+	bytes -= 2;
+	offset++;
+    }
+    *value = offset;
+    *length = bytes;
+}
+
+static void
+labeladd(void *arg, const struct dictEntry *entry)
+{
+    sds			*buffer = (sds *)arg;
+    sds			value = entry->v.val;
+    const char		*type;
+
+    if (value[0] == '"')
+	type = "stringValue";
+    else if (strchr(value, '.'))
+	type = "doubleValue";
+    else
+	type = "intValue";
+
+    if (*buffer)
+	*buffer = sdscatfmt(*buffer,
+				",{\"key\":\"%S\",\"value\":{\"%s\":%S}}",
+				entry->key, type, value);
+    else /* first label: alloc empty start string, and no leading comma */
+	*buffer = sdscatfmt(sdsempty(),
+				"{\"key\":\"%S\",\"value\":{\"%s\":%S}}",
+				entry->key, type, value);
+}
+
+/* convert an array of PCP labelsets into Open Telemetry form */
+void
+open_telemetry_labels(pmWebLabelSet *labels, struct dict **context, sds *buffer)
+{
+    unsigned long	cursor = 0;
+    pmLabelSet		*labelset;
+    pmLabel		*label;
+    dictEntry		*entry;
+    const char		*offset;
+    static sds		instname, instid;
+    struct dict		*labeldict = *context;
+    struct dict		*metric_labels;
+    sds			key, value;
+    int			i, j, length;
+
+    if (instname == NULL)
+	instname = sdsnewlen("instname", 8);
+    if (instid == NULL)
+	instid = sdsnewlen("instid", 6);
+
+    /* setup resource attributues based on the PCP context labels */
+    if (labeldict == NULL) {
+	labeldict = dictCreate(&sdsOwnDictCallBacks, NULL);
+	labelset = labels->sets[0];	/* context labels */
+	for (j = 0; j < labelset->nlabels; j++) {
+	    label = &labelset->labels[j];
+
+	    /* extract the label name */
+	    labelname(label, labelset->json, labelset->hash, &offset, &length);
+	    key = sdsnewlen(offset, length);
+
+	    /* extract the label value without any surrounding quotes */
+	    labelvalue(label, labelset->json, &offset, &length);
+	    value = sdscatrepr(sdsempty(), offset, length);
+
+	    dictAdd(labeldict, key, value);	/* new entry */
+	}
+	*context = labeldict;
+    }
+
+    metric_labels = dictCreate(&sdsOwnDictCallBacks, NULL);
+
+    /* walk remaining labelsets in order adding labels to */
+    for (i = 1; i < labels->nsets; i++) {
+	labelset = labels->sets[i];
+	for (j = 0; j < labelset->nlabels; j++) {
+	    label = &labelset->labels[j];
+
+	    /* extract the label name */
+	    labelname(label, labelset->json, labelset->hash, &offset, &length);
+	    key = sdsnewlen(offset, length);
+
+	    /* extract the label value without any surrounding quotes */
+	    labelvalue(label, labelset->json, &offset, &length);
+	    value = sdscatrepr(sdsempty(), offset, length);
+
+	    /* overwrite entries from earlier passes: label hierarchy */
+	    if ((entry = dictFind(metric_labels, key)) == NULL) {
+		dictAdd(metric_labels, key, value);	/* new entry */
+	    } else {
+		sdsfree(key);
+		sdsfree(dictGetVal(entry));
+		dictSetVal(metric_labels, entry, value);
+	    }
+	}
+    }
+
+    /* if an instance with instname or instid labels missing, add them now */
+    if (labels->instname && dictFind(metric_labels, instname) == NULL) {
+	key = sdsdup(instname);
+	value = labels->instname;
+	value = sdscatrepr(sdsempty(), value, sdslen(value));
+	dictAdd(metric_labels, key, value);	/* new entry */
+    }
+    if (labels->instid != PM_IN_NULL && dictFind(metric_labels, instid) == NULL) {
+	key = sdsdup(instid);
+	value = sdscatfmt(sdsempty(), "%u", labels->instid);
+	dictAdd(metric_labels, key, value);	/* new entry */
+    }
+
+    /* finally produce the merged set of labels in the desired format */
+    sdsfree(*buffer);
+    *buffer = NULL;
+    do {
+	cursor = dictScan(metric_labels, cursor, labeladd, NULL, buffer);
+    } while (cursor);
+    dictRelease(metric_labels);
+}
+
+/* convert PCP metric name to Open Telemetry form */
+sds
+open_telemetry_name(sds metric)
+{
+    sds		p, name = sdsdup(metric);
+
+    /* swap dots with underscores in name */
+    for (p = name; p && *p; p++)
+	if (*p == '.')
+	    *p = '_';
+    return name;
+}
+
+/* convert PCP metric semantics to Open Telemetry form */
+const char *
+open_telemetry_semantics(sds sem)
+{
+    if (strncmp(sem, "instant", 7) == 0 || strncmp(sem, "discrete", 8) == 0)
+	return "gauge";
+    return "sum";
+}
+
+/* convert PCP metric type has valid Open Telemetry form */
+const char *
+open_telemetry_type(sds type)
+{
+    static const char * const	asInt[] = { "u64", "64", "u32", "32" };
+    static const char * const	asDouble[] = { "double", "float" };
+    int		i;
+
+    for (i = 0; i < sizeof(asDouble) / sizeof(asDouble[0]); i++)
+	if (strcmp(type, asDouble[i]) == 0)
+	    return "asDouble";
+    for (i = 0; i < sizeof(asInt) / sizeof(asInt[0]); i++)
+	if (strcmp(type, asInt[i]) == 0)
+	    return "asInt";
+    return NULL;
+}
+
+/*
+ * Mapping Unified Code for Units of Measure (UCUM) to PCP pmUnits.
+ * OpenTelemetry mandates the specification of units in UCUM form.
+ */
+
+/* Space unit prefixes (powers of 1024 for "binary" units) */
+static const char *
+UCUM_space_prefix(unsigned int scale)
+{
+    /* UCUM uses "Ki", "Mi", "Gi" for powers of 1024 */
+    switch (scale) {
+    case PM_SPACE_BYTE:  return "";   /* base bytes */
+    case PM_SPACE_KBYTE: return "Ki"; /* Kibibyte */
+    case PM_SPACE_MBYTE: return "Mi"; /* Mebibyte */
+    case PM_SPACE_GBYTE: return "Gi"; /* Gibibyte */
+    case PM_SPACE_TBYTE: return "Ti"; /* Tebibyte */
+    case PM_SPACE_PBYTE: return "Pi"; /* Pebibyte */
+    case PM_SPACE_EBYTE: return "Ei"; /* Exbibyte */
+    case PM_SPACE_ZBYTE: return "Zi"; /* Zebibyte */
+    case PM_SPACE_YBYTE: return "Yi"; /* Yobibyte */
+    default:	/* should never happen */
+	break;
+    }
+    return NULL;
+}
+
+/* Time unit prefixes */
+static const char *
+UCUM_time_prefix(unsigned int scale)
+{
+    switch (scale) {
+    case PM_TIME_NSEC: return "n";  /* nano */
+    case PM_TIME_USEC: return "u";  /* micro */
+    case PM_TIME_MSEC: return "m";  /* milli */
+    case PM_TIME_SEC:  return "";   /* base second */
+    case PM_TIME_MIN:  return "min"; /* minute */
+    case PM_TIME_HOUR: return "h";   /* hour */
+    default:	/* should never happen */
+	break;
+    }
+    return NULL;
+}
+
+/* Count unit prefixes (powers of 10) */
+static const char*
+UCUM_count_prefix(signed int scale)
+{
+    switch (scale) {
+    case -24: return "y"; /* yocto */
+    case -21: return "z"; /* zepto */
+    case -18: return "a"; /* atto */
+    case -15: return "f"; /* femto */
+    case -12: return "p"; /* pico */
+    case -9:  return "n"; /* nano */
+    case -6:  return "u"; /* micro */
+    case -3:  return "m"; /* milli */
+    case 0:   return "";  /* no prefix (PM_COUNT_ONE) */
+    case 3:   return "k"; /* kilo */
+    case 6:   return "M"; /* mega */
+    case 9:   return "G"; /* giga */
+    case 12:  return "T"; /* tera */
+    case 15:  return "P"; /* peta */
+    case 18:  return "E"; /* exa */
+    case 21:  return "Z"; /* zetta */
+    case 24:  return "Y"; /* yotta */
+    default:
+	break;
+    }
+    return NULL;
+}
+
+/*
+ * Convert pmUnits struct to UCUM string using a user-supplied bytes buffer
+ * of at least 42 bytes.
+ *
+ * Maximum reasonable length for a UCUM string:
+ * e.g.  'YiBy.h-3.{count}6'
+ * Prefixes (2-3 chars), base units (2-4 chars), exponents (2-3 chars),
+ *	 and multiplicating dot '.' (1 char)
+ * So, 3 components * (3+4+3+1) + null terminator = ~30-40 chars.
+ */
+static char *
+pmUnits_to_UCUM(pmUnits pmunits, char *ucum_string, size_t bytes)
+{
+    const char*	prefix = UCUM_space_prefix(pmunits.scaleSpace);
+    char	component[32]; /* temporary buffer for each component */
+    int		first_unit = 1;
+
+    if (bytes < 42)
+	return NULL;
+
+    ucum_string[0] = '\0';
+
+    /* Process the space dimension */
+    if (pmunits.dimSpace != 0) {
+	if (!first_unit)
+	    strcat(ucum_string, "."); /* multiplication dot */
+	first_unit = 0;
+
+	prefix = UCUM_space_prefix(pmunits.scaleSpace);
+	snprintf(component, sizeof(component), "%sBy", prefix);
+
+	strcat(ucum_string, component);
+	if (pmunits.dimSpace != 1) { /* add exponent if not 1 */
+	    snprintf(component, sizeof(component), "%d", pmunits.dimSpace);
+	    strcat(ucum_string, component);
+	}
+    }
+
+    /* Process the time dimension */
+    if (pmunits.dimTime != 0) {
+	if (!first_unit)
+	    strcat(ucum_string, "."); /* multiplication dot */
+	first_unit = 0;
+
+	prefix = UCUM_time_prefix(pmunits.scaleTime);
+	/*
+	 * UCUM base time units: s, min, h (seconds, minutes, hours),
+	 * and n, u, m (nano, micro, milli) are standard s prefixes.
+	 */
+	if (pmunits.scaleTime <= PM_TIME_SEC)
+	    snprintf(component, sizeof(component), "%ss", prefix);
+	else /* min, h (minutes, hours) are standalone UCUM units */
+	    snprintf(component, sizeof(component), "%s", prefix);
+	strcat(ucum_string, component);
+	if (pmunits.dimTime != 1) { /* add exponent if not 1 */
+	    snprintf(component, sizeof(component), "%d", pmunits.dimTime);
+	    strcat(ucum_string, component);
+	}
+    }
+
+    /* Process the count dimension */
+    if (pmunits.dimCount != 0) {
+	if (!first_unit)
+	    strcat(ucum_string, "."); /* multiplication dot */
+	first_unit = 0;
+
+	prefix = UCUM_count_prefix(pmunits.scaleCount);
+	/*
+	 * For count, UCUM can use "{count}" or similar annotations for base,
+	 * then standard prefixes if applicable (e.g. "M{count}" for a million).
+	 * As scaleCount specifies powers of 10, apply the prefix to "{count}".
+	 * For powers of 10 that aren't in the standard prefixes: "10^X".
+	 */
+	if (prefix == NULL)
+	    snprintf(component, sizeof(component), "10^%u", pmunits.scaleCount);
+	else
+	     snprintf(component, sizeof(component), "%s{count}", prefix);
+
+	strcat(ucum_string, component);
+	if (pmunits.dimCount != 1) { /* add exponent if not 1 */
+	    snprintf(component, sizeof(component), "%d", pmunits.dimCount);
+	    strcat(ucum_string, component);
+	}
+    }
+
+    /* Finally, handle the dimensionless case */
+    if (first_unit)
+	strcpy(ucum_string, "1"); /* UCUM standard for dimensionless */
+
+    return ucum_string;
+}
+
+/* convert PCP metric units to Open Telemetry form */
+sds
+open_telemetry_units(sds units)
+{
+    pmUnits	pmunits;
+    double	unused;
+    char	*error;
+    char	buffer[64];
+
+    if (pmParseUnitsStr(units, &pmunits, &unused, &error) == 0)
+	return sdsnew(pmUnits_to_UCUM(pmunits, buffer, sizeof(buffer)));
+    free(error);
+    return sdsnew("1");
+}

--- a/src/pmproxy/src/opentelemetry.h
+++ b/src/pmproxy/src/opentelemetry.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ */
+#ifndef OPEN_TELEMETRY_H
+#define OPEN_TELEMETRY_H
+
+#include "pmwebapi.h"
+#include "dict.h"
+
+/* convert PCP metric name to Open Telemetry form */
+extern sds open_telemetry_name(sds);
+
+/* convert PCP metric semantics to Open Telemetry form */
+const char *open_telemetry_semantics(sds);
+
+/* convert PCP metric type to Open Telemetry form */
+const char *open_telemetry_type(sds);
+
+/* convert PCP metric units to Open Telemetry form */
+extern sds open_telemetry_units(sds);
+
+/* convert an array of PCP labelsets into Open Telemetry form */
+extern void open_telemetry_labels(pmWebLabelSet *, dict **, sds *);
+
+#endif	/* OPEN_TELEMETRY_H */


### PR DESCRIPTION
Access this functionality through the Accept HTTP header, which specifies the clients preference for output content-type, e.g.:

  # curl -H "Accept: application/json" localhost:44322/metrics?name=kernel.all | pmjson

Docs and QA to follow, committing this early for discussion and comparion points for pcp2opentelemetry and pmdaopentelemetry.

Resolves Red Hat issue RHEL-85456