### PR TITLE
qa: Enable auditd installation in F43 test env.

### DIFF
--- a/qa/admin/package-lists/Fedora+43+x86_64
+++ b/qa/admin/package-lists/Fedora+43+x86_64
@@ -7,7 +7,7 @@ HdrHistogram_c-devel
 #RediSearch - switch to ValkeySearch when available
 SoQt-devel
 Spreadsheet::Read cpan
-#audit
+audit
 autoconf
 avahi-devel
 avahi-tools


### PR DESCRIPTION
auditd is fixed in the audit-4.1.0-3 build, let's enable it for the F43 test environment (this is a partial revert of the pull request #2235).