### PR TITLE
WIP: libpcp_web: Address memory leak in webgroup_scrape_tree()

### DIFF
--- a/src/libpcp_web/src/webgroup.c
+++ b/src/libpcp_web/src/webgroup.c
@@ -1969,13 +1969,13 @@ webgroup_scrape_tree(const char *prefix, struct webscrape *scrape)
 				    scrape->numnames, scrape->names,
 				    scrape->mplist, scrape->pmidlist,
 				    scrape->msg, scrape->arg);
-	for (i = 0; i < scrape->numnames; i++)
-	    sdsfree(scrape->names[i]);
-	scrape->numnames = 0;
     } else {
 	infofmt(*scrape->msg, "'%s' - %s", prefix,
 		pmErrStr_r(sts, err, sizeof(err)));
     }
+    for (i = 0; i < scrape->numnames; i++)
+        sdsfree(scrape->names[i]);
+    scrape->numnames = 0;
 
     if (sts >= 0)
 	sts = (scrape->status < 0) ? scrape->status : 0;


### PR DESCRIPTION
DO NOT MERGE.

The strings in the scrape struct need to be cleaned out even in the case that no matching metrics are found for them in the PMNS (Performance Metric Name Space).

This fix doesn't appear to be quite right and might be papering over a problem. There are definitely names in the scrape struct, but either sts from pmTraversePMNS_r < 0 or one of the earlier runs of webgroup_scrape_batch has set scrape->status < 0.

This doesn't address the other valgrind issues in the redis code:

1695 9s ... - output mismatch (see 1695.out.bad)
13a14,43
> 702 bytes in 9 blocks are definitely lost in loss record 174 of 298
> at 0x4870347: realloc (vg_replace_malloc.c:1801)
> by 0x48D810F: sdsMakeRoomFor (alloc.h:66)
> by 0x48DAF7B: sdscatlen (sds.c:381)
> by 0x48DB40E: sdscatvprintf (sds.c:535)
> by 0x48DBFF9: sdscatprintf (sds.c:560)
> by 0x4902165: webgroup_use_context.isra.0 (webgroup.c:405)
> by 0x48F8958: webgroup_scrape_names (webgroup.c:1913)
> by 0x48F8B3A: webgroup_scrape_batch (webgroup.c:1943)
> by 0x4F1B2FC: TraversePMNS (pmns.c:3133)
> by 0x48F8C1D: webgroup_scrape_tree (webgroup.c:1965)
> by 0x48F8F7E: pmWebGroupScrape (webgroup.c:2050)
> by 0x4EC48A8: ??? (in /usr/lib64/libuv.so.1.0.0)
> {
>    <insert_a_suppression_name_here>
>    Memcheck:Leak
>    match-leak-kinds: definite
>    fun:realloc
>    fun:sdsMakeRoomFor
>    fun:sdscatlen
>    fun:sdscatvprintf
>    fun:sdscatprintf
>    fun:webgroup_use_context.isra.0
>    fun:webgroup_scrape_names
>    fun:webgroup_scrape_batch
>    fun:TraversePMNS
>    fun:webgroup_scrape_tree
>    fun:pmWebGroupScrape
>    obj:/usr/lib64/libuv.so.1.0.0
> }
Check local PMCD is still alive ...
Failures: 1695
Failed 1 of 1 tests