### PR TITLE
pmda.smart Fix potiential UUID collection TOCTOU and QA Fix

### DIFF
--- a/qa/1397.out
+++ b/qa/1397.out
@@ -4284,7 +4284,7 @@ Help:
 Contains the number of read commands completed by the controller
 No value(s) available!
 
-smart.wwid.nvme_attributes.host_write_commands PMID: 150.1255.8 [Contains the number of write commands completed by the controller ]
+smart.wwid.nvme_attributes.host_write_commands PMID: 150.1255.8 [Contains the number of write commands completed by the controller]
     Data Type: 64-bit unsigned int  InDom: 150.1 0x25800001
     Semantics: instant  Units: byte
 Help:
@@ -7178,7 +7178,7 @@ smart.nvme_attributes.host_write_commands PMID: 150.255.8 [Contains the number o
     Data Type: 64-bit unsigned int  InDom: 150.0 0x25800000
     Semantics: instant  Units: byte
 Help:
-Contains the number of write commands completed by the controller
+Contains the number of write commands completed by the controller 
 No value(s) available!
 
 smart.nvme_attributes.media_and_data_integrity_errors PMID: 150.255.13 [Contains the number of error occurances by the controller]
@@ -9675,7 +9675,7 @@ Help:
 Contains the number of read commands completed by the controller
 No value(s) available!
 
-smart.wwid.nvme_attributes.host_write_commands PMID: 150.1255.8 [Contains the number of write commands completed by the controller ]
+smart.wwid.nvme_attributes.host_write_commands PMID: 150.1255.8 [Contains the number of write commands completed by the controller]
     Data Type: 64-bit unsigned int  InDom: 150.1 0x25800001
     Semantics: instant  Units: byte
 Help:
@@ -12231,7 +12231,7 @@ smart.nvme_attributes.host_write_commands PMID: 150.255.8 [Contains the number o
     Data Type: 64-bit unsigned int  InDom: 150.0 0x25800000
     Semantics: instant  Units: byte
 Help:
-Contains the number of write commands completed by the controller
+Contains the number of write commands completed by the controller 
     inst [0 or "nvme0n1"] value 94922330
 
 smart.nvme_attributes.media_and_data_integrity_errors PMID: 150.255.13 [Contains the number of error occurances by the controller]
@@ -14728,11 +14728,11 @@ Help:
 Contains the number of read commands completed by the controller
     inst [0 or "8ce38e0500882b63"] value 77209705
 
-smart.wwid.nvme_attributes.host_write_commands PMID: 150.1255.8 [Contains the number of write commands completed by the controller ]
+smart.wwid.nvme_attributes.host_write_commands PMID: 150.1255.8 [Contains the number of write commands completed by the controller]
     Data Type: 64-bit unsigned int  InDom: 150.1 0x25800001
     Semantics: instant  Units: byte
 Help:
-Contains the number of write commands completed by the controller 
+Contains the number of write commands completed by the controller
     inst [0 or "8ce38e0500882b63"] value 94922330
 
 smart.wwid.nvme_attributes.media_and_data_integrity_errors PMID: 150.1255.13 [Contains the number of error occurances by the controller]
@@ -19772,11 +19772,11 @@ Help:
 Contains the number of read commands completed by the controller
     inst [0 or "8ce38e0500882b63"] value 16961700
 
-smart.wwid.nvme_attributes.host_write_commands PMID: 150.1255.8 [Contains the number of write commands completed by the controller ]
+smart.wwid.nvme_attributes.host_write_commands PMID: 150.1255.8 [Contains the number of write commands completed by the controller]
     Data Type: 64-bit unsigned int  InDom: 150.1 0x25800001
     Semantics: instant  Units: byte
 Help:
-Contains the number of write commands completed by the controller 
+Contains the number of write commands completed by the controller
     inst [0 or "8ce38e0500882b63"] value 170550277
 
 smart.wwid.nvme_attributes.media_and_data_integrity_errors PMID: 150.1255.13 [Contains the number of error occurances by the controller]

--- a/src/pmdas/smart/pmda.c
+++ b/src/pmdas/smart/pmda.c
@@ -2973,7 +2973,7 @@ static int
 uuid_instance_refresh(void)
 {
 	int sts;
-	int n, fd = 0;
+	int fd, n = 0;
 	char buffer[4096], dev_uuid[37], dev_name[128] = {'\0'};
 	char *env_command;
 	FILE *pf;
@@ -2998,44 +2998,42 @@ uuid_instance_refresh(void)
 		/* at this point dev_name contains our device name, we now need to store
 		   this and find out the UUID for the drive. The UUID will be used to
 		   map stats to disk drive instances */
-
+		   
 		if ((env_command = getenv("SMART_SETUP_UUID")) != NULL) {
-			//pmsprintf(buffer, sizeof(buffer), "%s", env_command);
-			sscanf(env_command, "%s", buffer);
-			n = 1;
-		} else {
-	    		n = pmsprintf(buffer, sizeof(buffer), "/sys/block/%s/device/wwid", dev_name);
-	    		if (n <= 0 || access(buffer, F_OK) != 0) /* try alternate path */
-	        		n = pmsprintf(buffer, sizeof(buffer), "/sys/block/%s/wwid", dev_name);
-
-			if (n <= 0 || access(buffer, F_OK) != 0) { /* alternative path also bad */
+			pmsprintf(buffer, sizeof(buffer), env_command);
+			if ((fd = open(buffer, O_RDONLY)) < 0) {
+				/* env_command path fail */
 				pclose(pf);
-				return 0;
+				return -oserror();
+			} 
+		}else {
+			pmsprintf(buffer, sizeof(buffer), "/sys/block/%s/device/wwid", dev_name);
+			if ((fd = open(buffer, O_RDONLY)) < 0) {
+				/* try alternate path */
+				pmsprintf(buffer, sizeof(buffer), "/sys/block/%s/wwid", dev_name);
+				if ((fd = open(buffer, O_RDONLY)) < 0) {
+					/* alternative path also bad */
+					pclose(pf);
+					return -oserror();
+				}
 			}
 		}
+			
+	        n = read(fd, buffer, sizeof(buffer));
+		close(fd);
 
-	    	if (n > 0 && (fd = open(buffer, O_RDONLY)) >= 0) {
-	        	n = read(fd, buffer, sizeof(buffer));
-	        	close(fd);
+		if (n >= 0) {
+			if (strncmp(buffer, "t10.", 4) == 0) {
+				sscanf(buffer, "t10.%s", dev_uuid);	
 
-	        	if (n > 0) {
-		    		buffer[n-1] = '\0';
+			} else if (strncmp(buffer, "eui.", 4) == 0) {
+				sscanf(buffer, "eui.%s", dev_uuid);
 
-				if (strlen(buffer) == 0)
-				    	continue;
-				
-				if (strncmp(buffer, "t10.", 4) == 0) {
-					sscanf(buffer, "t10.%s", dev_uuid);	
+			} else if (strncmp(buffer, "naa.", 4) == 0) {
+				sscanf(buffer, "naa.%s", dev_uuid);
 
-				} else if (strncmp(buffer, "eui.", 4) == 0) {
-				    	sscanf(buffer, "eui.%s", dev_uuid);
-
-				} else if (strncmp(buffer, "naa.", 4) == 0) {
-				    	sscanf(buffer, "naa.%s", dev_uuid);
-
-				} else {
-					sscanf(buffer, "%s", dev_uuid);
-				}
+			} else {
+				sscanf(buffer, "%s", dev_uuid);
 			}
 		}
 


### PR DESCRIPTION
Fix potential TOCTOU issue when collecting drive UUID in PMDA.

Also fix QA/1397 output with spurious space at end of help text for one metrics.