### PR TITLE
libpcp: fix memleak on indom instlist seen in pmproxy QA

### DIFF
--- a/src/libpcp/src/logmeta.c
+++ b/src/libpcp/src/logmeta.c
@@ -1249,6 +1249,8 @@ __pmLogUndeltaInDom(pmInDom indom, __pmLogInDom *idp)
 	    }
 	}
 	didp->numinst = numinst;
+	if (didp->alloc & PMLID_INSTLIST)
+	    free(didp->instlist);
 	didp->instlist = instlist;
 	if (didp->alloc & PMLID_NAMELIST)
 	    free(didp->namelist);
@@ -1990,7 +1992,6 @@ __pmFreeLogInDom(__pmLogInDom *lidp)
 	 */
 	memset((void *)lidp, 0, sizeof(*lidp));
     }
-
 }
 
 /*


### PR DESCRIPTION
Picked up by valgrind in pmproxy SIGHUP memory leak tests.