### PR TITLE
pmdaopenmetrics: add default exporter ports for Ceph and DCGM

### DIFF
--- a/src/pmdas/openmetrics/GNUmakefile
+++ b/src/pmdas/openmetrics/GNUmakefile
@@ -21,8 +21,8 @@ PYSCRIPT = pmda$(IAM).python
 LDIRT	= domain.h root pmns $(IAM).log
 DOMAIN	= $(IAM)
 # common endpoint URLs (on: enabled, off: available)
-ONURLS	= grafana.url kepler.url vllm.url
-OFFURLS	= collectd.url etcd.url spark.url vmware.url
+ONURLS	= grafana.url ceph.url dcgm.url etcd.url vllm.url
+OFFURLS	= collectd.url kepler.url spark.url vmware.url
 
 MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)

--- a/src/pmdas/openmetrics/ceph.url
+++ b/src/pmdas/openmetrics/ceph.url
@@ -1,0 +1,1 @@
+http://localhost:9283/metrics

--- a/src/pmdas/openmetrics/dcgm.url
+++ b/src/pmdas/openmetrics/dcgm.url
@@ -1,0 +1,1 @@
+http://localhost:9400/metrics


### PR DESCRIPTION
Adds important scrapers for technologies underlying major open source and Red Hat projects (esp. Kubernetes, OpenShift).