### PR TITLE
containers: fix broken url in archive-analysis container

### DIFF
--- a/build/containers/archive-analysis/root/usr/bin/archive-import.py
+++ b/build/containers/archive-analysis/root/usr/bin/archive-import.py
@@ -189,7 +189,7 @@ def main():
     parser.add_argument('-p', "--port", type=str)
     parser.add_argument('-Z', "--timezone", type=str)
     args = parser.parse_args()
-    dash = 'http://localhost:3000/d/pcp-archive-analysis/pcp-archive-analysis'
+    dash = 'http://localhost:3000/dashboards'
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     logging.info("Starting Performance Co-Pilot archive import...")
     logging.info("Dashboard: %s (when using default instructions)", dash)


### PR DESCRIPTION
As noted in #2277, the url printed to the console when running the archive-analysis container no longer works. Directly linking the dashboard is not possible as the url changes frequently. Instead, the link is now to the dashboards tab in grafana, where the archive-analysis dashboard can be easily accessed.