### PR TITLE
build: For RHEL/Centos Stream drop the unavailable ragel package dependency

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -901,7 +901,11 @@ Summary: Performance Co-Pilot (PCP) metrics from statsd
 URL: https://pcp.io
 Requires: pcp = @package_version@ pcp-libs = @package_version@
 Requires: chan HdrHistogram_c
-BuildRequires: ragel chan-devel HdrHistogram_c-devel
+BuildRequires: chan-devel HdrHistogram_c-devel
+# ragel unavailable on some RHEL and CentOS Stream platforms
+%if 0%{?rhel} == 0
+BuildRequires: ragel
+%endif
 
 %description pmda-statsd
 This package contains the PCP Performance Metrics Domain Agent (PMDA) for


### PR DESCRIPTION
When attempting to do ./Makepkgs on Centos 9 stream and Centos 10 Stream the rpmbuild build would fail because of the unsatisfied dependency on ragel.  There are two places where ragel build dependencies were listed, but only one had a conditional to turn it off on RHEL/Centos.  Added a conditional to the remaining place to allow ./Makepkgs to work on those platforms.