### PR TITLE
pmproxy, libpcp_web: fix QA valgrind issue with new source leak

### DIFF
--- a/src/include/pcp/pmwebapi.h
+++ b/src/include/pcp/pmwebapi.h
@@ -207,6 +207,8 @@ typedef struct pmDiscoverModule {
 } pmDiscoverModule;
 
 typedef void (*pmDiscoverSourceCallBack)(pmDiscoverEvent *, void *);
+typedef void (*pmDiscoverResetCallBack)(pmDiscoverEvent *,
+		pmLabelSet *, void *);
 typedef void (*pmDiscoverClosedCallBack)(pmDiscoverEvent *, void *);
 typedef void (*pmDiscoverLabelsCallBack)(pmDiscoverEvent *,
 		int, int, pmLabelSet *, int, void *);
@@ -221,6 +223,7 @@ typedef void (*pmDiscoverTextCallBack)(pmDiscoverEvent *,
 
 typedef struct pmDiscoverCallBacks {
     pmDiscoverSourceCallBack	on_source;	/* metric source discovered */
+    pmDiscoverResetCallBack	on_reset;	/* metric source changed ID */
     pmDiscoverClosedCallBack	on_closed;	/* end of discovery updates */
     pmDiscoverLabelsCallBack	on_labels;	/* new labelset discovered */
     pmDiscoverMetricCallBack	on_metric;	/* metric descriptor, names */

--- a/src/libpcp_web/src/discover.h
+++ b/src/libpcp_web/src/discover.h
@@ -93,6 +93,8 @@ typedef struct pmDiscover {
 } pmDiscover;
 
 extern void pmSeriesDiscoverSource(pmDiscoverEvent *, void *);
+extern void pmSeriesDiscoverReset(pmDiscoverEvent *,
+				pmLabelSet *, void *);
 extern void pmSeriesDiscoverClosed(pmDiscoverEvent *, void *);
 
 extern void pmSeriesDiscoverLabels(pmDiscoverEvent *,
@@ -113,7 +115,8 @@ extern void pmSearchDiscoverInDom(pmDiscoverEvent *,
 extern void pmSearchDiscoverText(pmDiscoverEvent *,
 				int, int, char *, void *);
 
-extern pmDiscover *pmDiscoverStreamLabel(const char *, __pmLogLabel *, pmDiscoverModule *, void *);
+extern pmDiscover *pmDiscoverStreamLogLabel(const char *, __pmLogLabel *,
+				pmDiscoverModule *, void *);
 extern int pmDiscoverStreamMeta(pmDiscover *, const char *, size_t);
 extern int pmDiscoverStreamData(pmDiscover *, const char *, size_t);
 extern void pmDiscoverStreamEnd(const char *);

--- a/src/libpcp_web/src/exports
+++ b/src/libpcp_web/src/exports
@@ -282,4 +282,6 @@ PCP_WEB_1.22 {
     pmLogGroupSetMetricRegistry;
     pmLogPathsReset;
     pmLogPathsSetMetricRegistry;
+
+    pmSeriesDiscoverReset;
 } PCP_WEB_1.21;

--- a/src/pmproxy/src/keys.c
+++ b/src/pmproxy/src/keys.c
@@ -24,6 +24,7 @@ static int archive_push;
 
 static pmDiscoverCallBacks key_server_series = {
     .on_source		= pmSeriesDiscoverSource,
+    .on_reset		= pmSeriesDiscoverReset,
     .on_closed		= pmSeriesDiscoverClosed,
     .on_labels		= pmSeriesDiscoverLabels,
     .on_metric		= pmSeriesDiscoverMetric,


### PR DESCRIPTION
When new context labels arrive after establishing a metrics source, SHA1 identifiers change; handling this correctly requires different mechanisms for resetting a context vs setting up a new one.

While there, improve the locking around lookup for a new archive context by removing a small race between what was previously two hash table lookups in loggroup_new_archive.