### PR TITLE
pmproxy: drop the systemd unit dep between pmproxy and pmcd

### DIFF
--- a/src/pmproxy/pmproxy.service.in
+++ b/src/pmproxy/pmproxy.service.in
@@ -3,7 +3,6 @@ Description=Proxy for Performance Metrics Collector Daemon
 Documentation=man:pmproxy(1)
 After=network-online.target valkey.service redis.service avahi-daemon.service pmcd.service
 BindsTo=pmproxy_check.timer pmproxy_daily.timer
-Wants=pmcd.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
This was recently added, but there are a number of pmproxy deployment scenarios (incl. the archive-analysis container) where no such dependency is required, nor wanted.

The downside of this is the user must be aware of any such dependency, potentially.  In practice, deployments where a pmlogger push pmproxy server is present, is very likely to have pmcd running.  This is also the pcp-zeroconf default.