### PR TITLE
qa: Enable python3-elasticsearch installation in F43 test env.

### DIFF
--- a/qa/admin/package-lists/Fedora+43+x86_64
+++ b/qa/admin/package-lists/Fedora+43+x86_64
@@ -102,7 +102,7 @@ psmisc
 python3
 python3-bcc
 python3-devel
-#python3-elasticsearch
+python3-elasticsearch
 python3-libs
 python3-libvirt
 python3-lxml


### PR DESCRIPTION
python3-elasticsearch is already fixed in F43 distro. Let's enable it for the test environment (this is
a partial revert of the pull request performancecopilot#2235).