### PR TITLE
macos: add plist files for pmproxy, pmie and pmlogger

### DIFF
--- a/build/mac/GNUmakefile
+++ b/build/mac/GNUmakefile
@@ -79,13 +79,17 @@ idb: $(DIST_MANIFEST)
 	  echo "f 755 root wheel $$bdir/install-pcp install-pcp replace"; \
 	  echo "f 755 root wheel $$bdir/uninstall-pcp uninstall-pcp replace") >> idb
 	@echo "f 644 root wheel Library/LaunchDaemons/io.pcp.pmcd.plist io.pcp.pmcd.plist replace" >> idb
+	@echo "f 644 root wheel Library/LaunchDaemons/io.pcp.pmie.plist io.pcp.pmie.plist replace" >> idb
+	@echo "f 644 root wheel Library/LaunchDaemons/io.pcp.pmlogger.plist io.pcp.pmlogger.plist replace" >> idb
+	@echo "f 644 root wheel Library/LaunchDaemons/io.pcp.pmproxy.plist io.pcp.pmlogger.plist replace" >> idb
 	@echo idb created
 
 extrabits: idb
-	DIST_MANIFEST= $(INSTALL) -m 755 idb install-pcp uninstall-pcp \
-		$(PCP_BINADM_DIR)
-	DIST_MANIFEST= $(INSTALL) -m 644 io.pcp.pmcd.plist \
-		Library/LaunchDaemons/io.pcp.pmcd.plist
+	DIST_MANIFEST= $(INSTALL) -m 755 idb install-pcp uninstall-pcp $(PCP_BINADM_DIR)
+	DIST_MANIFEST= $(INSTALL) -m 644 io.pcp.pmcd.plist Library/LaunchDaemons/io.pcp.pmcd.plist
+	DIST_MANIFEST= $(INSTALL) -m 644 io.pcp.pmie.plist Library/LaunchDaemons/io.pcp.pmie.plist
+	DIST_MANIFEST= $(INSTALL) -m 644 io.pcp.pmlogger.plist Library/LaunchDaemons/io.pcp.pmlogger.plist
+	DIST_MANIFEST= $(INSTALL) -m 644 io.pcp.pmproxy.plist Library/LaunchDaemons/io.pcp.pmproxy.plist
 
 
 include $(BUILDRULES)

--- a/build/mac/io.pcp.pmie.plist
+++ b/build/mac/io.pcp.pmie.plist
@@ -3,10 +3,10 @@
 <plist version="1.0">
     <dict>
         <key>Label</key>
-        <string>io.pcp.pmcd</string>
+        <string>io.pcp.pmie</string>
         <key>ProgramArguments</key>
         <array>
-            <string>/etc/init.d/pmcd</string>
+            <string>/etc/init.d/pmie</string>
             <string>start</string>
         </array>
         <key>Disabled</key>
@@ -22,8 +22,8 @@
         <key>RunAtLoad</key>
         <true/>
         <key>StandardErrorPath</key>
-        <string>/var/log/pcp/pmcd/plist.stderr</string>
+        <string>/var/log/pcp/pmie/plist.stderr</string>
         <key>StandardOutPath</key>
-        <string>/var/log/pcp/pmcd/plist.stdout</string>
+        <string>/var/log/pcp/pmie/plist.stdout</string>
     </dict>
 </plist>

--- a/build/mac/io.pcp.pmlogger.plist
+++ b/build/mac/io.pcp.pmlogger.plist
@@ -3,10 +3,10 @@
 <plist version="1.0">
     <dict>
         <key>Label</key>
-        <string>io.pcp.pmcd</string>
+        <string>io.pcp.pmlogger</string>
         <key>ProgramArguments</key>
         <array>
-            <string>/etc/init.d/pmcd</string>
+            <string>/etc/init.d/pmlogger</string>
             <string>start</string>
         </array>
         <key>Disabled</key>
@@ -22,8 +22,8 @@
         <key>RunAtLoad</key>
         <true/>
         <key>StandardErrorPath</key>
-        <string>/var/log/pcp/pmcd/plist.stderr</string>
+        <string>/var/log/pcp/pmlogger/plist.stderr</string>
         <key>StandardOutPath</key>
-        <string>/var/log/pcp/pmcd/plist.stdout</string>
+        <string>/var/log/pcp/pmlogger/plist.stdout</string>
     </dict>
 </plist>

--- a/build/mac/io.pcp.pmproxy.plist
+++ b/build/mac/io.pcp.pmproxy.plist
@@ -3,10 +3,10 @@
 <plist version="1.0">
     <dict>
         <key>Label</key>
-        <string>io.pcp.pmcd</string>
+        <string>io.pcp.pmproxy</string>
         <key>ProgramArguments</key>
         <array>
-            <string>/etc/init.d/pmcd</string>
+            <string>/etc/init.d/pmproxy</string>
             <string>start</string>
         </array>
         <key>Disabled</key>
@@ -22,8 +22,8 @@
         <key>RunAtLoad</key>
         <true/>
         <key>StandardErrorPath</key>
-        <string>/var/log/pcp/pmcd/plist.stderr</string>
+        <string>/var/log/pcp/pmproxy/plist.stderr</string>
         <key>StandardOutPath</key>
-        <string>/var/log/pcp/pmcd/plist.stdout</string>
+        <string>/var/log/pcp/pmproxy/plist.stdout</string>
     </dict>
 </plist>


### PR DESCRIPTION
Also switch from logging plist output in /tmp to somewhere with more appropriate directory permissions for logs.