### PR TITLE
pmproxy: use PCP_REMOTE_ARCHIVE_DIR instead of PCP_LOG_DIR/pmproxy

### DIFF
--- a/qa/1611
+++ b/qa/1611
@@ -43,7 +43,7 @@ _cleanup()
 	_wait_for_pmproxy
 	if [ $? -eq 1 ]
 	then
-	    find $PCP_LOG_DIR/pmproxy >>$seq.full
+	    find $PCP_REMOTE_ARCHIVE_DIR >>$seq.full
 	    cat $PCP_LOG_DIR/pmproxy/pmproxy.log >>$seq_full
 	    cat $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf >>$seq_full
 	fi
@@ -77,7 +77,7 @@ _filter_metrics()
 
 # real QA test starts here
 archive_host=`hostname`
-archive_path=$PCP_LOG_DIR/pmproxy/$archive_host
+archive_path=$PCP_REMOTE_ARCHIVE_DIR/$archive_host
 
 pmproxy_was_running=false
 [ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true

--- a/qa/1615
+++ b/qa/1615
@@ -82,7 +82,7 @@ _filter_ls()
 # real QA test starts here
 archive=$here/archives/ok-mv-bigbin
 archive_host=moomba
-archive_path=$PCP_LOG_DIR/pmproxy/$archive_host
+archive_path=$PCP_REMOTE_ARCHIVE_DIR/$archive_host
 $sudo rm -fr $archive_path
 
 pmproxy_was_running=false

--- a/qa/1617
+++ b/qa/1617
@@ -33,8 +33,8 @@ _cleanup()
     [ -n "$key_server_port" ] && $keys_cli -p $key_server_port shutdown
     [ -d $archive_path ] && $sudo rm -fr $archive_path
 
-    # undo changes to PCP_RUN_DIR PCP_TMP_DIR PCP_LOG_DIR
-    unset PCP_ENV_DONE PCP_RUN_DIR PCP_TMP_DIR PCP_LOG_DIR
+    # undo changes to PCP_RUN_DIR PCP_TMP_DIR PCP_REMOTE_ARCHIVE_DIR
+    unset PCP_ENV_DONE PCP_RUN_DIR PCP_TMP_DIR PCP_REMOTE_ARCHIVE_DIR
     . $PCP_DIR/etc/pcp.env
 
     _restore_auto_restart pmlogger
@@ -168,10 +168,10 @@ End-Of-File
 mkdir -p $tmp.pmproxy/pmproxy
 export PCP_RUN_DIR=$tmp.pmproxy
 export PCP_TMP_DIR=$tmp.pmproxy
-export PCP_LOG_DIR=$tmp.pmproxy/pmproxy
+export PCP_REMOTE_ARCHIVE_DIR=$tmp.pmproxy/pmproxy
 
 echo "Start test pmproxy ..."
-archive_path=$PCP_LOG_DIR/pmproxy/$archive_host
+archive_path=$PCP_REMOTE_ARCHIVE_DIR/$archive_host
 $sudo rm -fr $archive_path
 
 $valgrind_clean_assert pmproxy -Dcontext -f -p $pmproxy_port -U $user -l- -c $tmp.conf >$tmp.valout 2>$tmp.valerr &

--- a/qa/1620
+++ b/qa/1620
@@ -80,7 +80,7 @@ _save_logs()
 
 # real QA test starts here
 archive_host=`hostname`
-archive_path=$PCP_LOG_DIR/pmproxy/$archive_host
+archive_path=$PCP_REMOTE_ARCHIVE_DIR/$archive_host
 
 pmproxy_was_running=false
 [ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
@@ -142,7 +142,7 @@ fi \
 # for sleep 10; send signal; pmproxy to catch signal
 
 echo "## checking for pmproxy SIGHUP"
-grep SIGHUP $PCP_LOG_DIR/pmproxy/pmproxy.log | _filter_pmproxy_log
+grep SIGHUP $PCP_REMOTE_ARCHIVE_DIR/pmproxy.log | _filter_pmproxy_log
 _save_logs
 
 if [ -d $archive_path ]

--- a/src/include/pcp.conf.in
+++ b/src/include/pcp.conf.in
@@ -134,6 +134,10 @@ PCP_RUN_DIR=@pcp_run_dir@
 # Subdirectories: pmcd pmlogger pmie
 PCP_LOG_DIR=@pcp_log_dir@
 
+# parent directory of PCP archives from remote pmloggers
+# Standard path: /var/log/pcp/pmproxy
+PCP_REMOTE_ARCHIVE_DIR=@pcp_log_dir@/pmproxy
+
 # parent directory of PCP archive directories
 # Standard path: /var/log/pcp/pmlogger
 PCP_ARCHIVE_DIR=@pcp_archive_dir@

--- a/src/libpcp_web/src/loggroup.c
+++ b/src/libpcp_web/src/loggroup.c
@@ -614,9 +614,15 @@ pmLogGroupLabel(pmLogGroupSettings *sp, const char *content, size_t length,
     }
 
     sep = pmPathSeparator();
-    dir = pmGetConfig("PCP_LOG_DIR");
-    pmsprintf(pathbuf, sizeof(pathbuf), "%s%c%s%c%s%c%s", dir, sep,
-		pmGetProgname(), sep, loglabel.hostname, sep, timebuf);
+    dir = pmGetConfig("PCP_REMOTE_ARCHIVE_DIR");
+    if (dir) {
+	pmsprintf(pathbuf, sizeof(pathbuf), "%s%c%s%c%s", dir, sep,
+		    loglabel.hostname, sep, timebuf);
+    } else {
+	dir = pmGetConfig("PCP_LOG_DIR");
+	pmsprintf(pathbuf, sizeof(pathbuf), "%s%c%s%c%s%c%s", dir, sep,
+		    pmGetProgname(), sep, loglabel.hostname, sep, timebuf);
+    }
 
     if (cached_only)
 	goto done;

--- a/src/pmlogger/pmlogger_daily.sh
+++ b/src/pmlogger/pmlogger_daily.sh
@@ -1812,7 +1812,7 @@ p
 		else
 		    # pick last (in sort order) uncompressed data volume
 		    #
-		    _last=`ls $PCP_LOG_DIR/pmproxy/$host 2>/dev/null | grep '\.[0-9][0-9]*$' | tail -1`
+		    _last=`ls $PCP_REMOTE_ARCHIVE_DIR/$host 2>/dev/null | grep '\.[0-9][0-9]*$' | tail -1`
 		    current_base=`echo "$_last" | sed -e 's/\.[0-9][0-9]*$//'`
 		    current_vol=`echo "$_last" | sed -e 's/.*\.//'`
 		    $VERY_VERBOSE && echo >&2 "latest archive data volume: $current_base.$current_vol"
@@ -2007,7 +2007,7 @@ then
 else
     # work to be done at the pmproxy end for logpush archives
     #
-    if cd $PCP_LOG_DIR/pmproxy
+    if cd "$PCP_REMOTE_ARCHIVE_DIR"
     then
 	# one-trip guard if there is something to be done
 	#
@@ -2060,7 +2060,7 @@ else
 		[ -f "./control" ] && cat "./control" >>$tmp/control
 		# optional per-host controls next
 		[ -f "$_host/control" ] && cat "$_host/control" >>$tmp/control
-		echo "$_host	n n PCP_LOG_DIR/pmproxy/$_host +" >>$tmp/control
+		echo "$_host	n n PCP_REMOTE_ARCHIVE_DIR/$_host +" >>$tmp/control
 		if $VERY_VERBOSE
 		then
 		    echo >&2 "Synthesized control file ..."

--- a/src/pmlogger/pmlogger_janitor.sh
+++ b/src/pmlogger/pmlogger_janitor.sh
@@ -419,7 +419,7 @@ done
 # pmlogpush ... if found, synthesize a control file for them
 #
 here=`pwd`
-if cd $PCP_LOG_DIR/pmproxy
+if cd "$PCP_REMOTE_ARCHIVE_DIR"
 then
     for _host in *
     do
@@ -433,7 +433,7 @@ then
 	    [ -f "./control" ] && cat "./control" >>$tmp/control
 	    # optional per-host controls next
 	    [ -f "$_host/control" ] && cat "$_host/control" >>$tmp/control
-	    echo "$_host	n n PCP_LOG_DIR/pmproxy/$_host +" >>$tmp/control
+	    echo "$_host	n n PCP_REMOTE_ARCHIVE_DIR/$_host +" >>$tmp/control
 	    if $VERY_VERBOSE
 	    then
 		echo >&2 "Synthesized control file ..."


### PR DESCRIPTION
Allow more end-user control over where the pmlogger push archives will end up, along the lines of the PCP_ARCHIVE_DIR variable for regular pmlogger instances.