### PR TITLE
Osxbuild pythonextensions

### DIFF
--- a/src/python/GNUmakefile
+++ b/src/python/GNUmakefile
@@ -40,7 +40,11 @@ else
 SETUP_PY = distutils-setup.py
 endif
 
+ifeq ($(PCP_PLATFORM),darwin)
+default default_pcp: pre_build build_python3 fix_install_names
+else
 default default_pcp: pre_build build_python3
+endif
 
 ifeq "$(ENABLE_PYTHON3)" "true"
 PY3_BUILD_OPTS = $(SETUP_PY_BUILD_OPTIONS)
@@ -71,6 +75,24 @@ build_python3:	$(TOPDIR)/src/include/pcp/libpcp.h
 #
 pre_build:
 	cd pcp; $(MAKE) default
+
+fix_install_names:
+	@for so in build/lib.macosx-*/c*.so; do \
+		if [ -f "$$so" ]; then \
+			echo "Fixing library references in $$so"; \
+			for lib in $$(otool -L "$$so" | grep -E 'libpcp.*\.dylib' | awk '{print $$1}'); do \
+				if echo "$$lib" | grep -q -v '@rpath'; then \
+					newlib=$$(echo "$$lib" | sed 's|libpcp[^/]*\.dylib|@rpath/libpcp.dylib|'); \
+					newlib=$$(echo "$$newlib" | sed 's|libpcp_pmda[^/]*\.dylib|@rpath/libpcp_pmda.dylib|'); \
+					newlib=$$(echo "$$newlib" | sed 's|libpcp_gui[^/]*\.dylib|@rpath/libpcp_gui.dylib|'); \
+					newlib=$$(echo "$$newlib" | sed 's|libpcp_import[^/]*\.dylib|@rpath/libpcp_import.dylib|'); \
+					newlib=$$(echo "$$newlib" | sed 's|libpcp_mmv[^/]*\.dylib|@rpath/libpcp_mmv.dylib|'); \
+					echo "Changing $$lib to $$newlib"; \
+					install_name_tool -change "$$lib" "$$newlib" "$$so"; \
+				fi; \
+			done; \
+		fi; \
+	done
 
 foo:
 	echo $(CFLAGS)

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -22,17 +22,11 @@ from setuptools import setup, find_packages, Extension
 # To use a consistent encoding
 from codecs import open
 from os import path
-import platform
-
 
 # Get the long description from the README file
 here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
-
-# Darwin specific linker options, which expects Homebrew to be there and sets the library search path to help find libpcp etc
-extra_link_args = ['-Wl,-rpath,/usr/local/lib']
-#if platform.system() == 'Darwin' and path.exists('/opt/homebrew/lib') else []
 
 setup(name = 'pcp',
     version = '7.0',
@@ -45,11 +39,11 @@ setup(name = 'pcp',
     url = 'https://pcp.io',
     packages = find_packages(),
     ext_modules = [
-        Extension('cpmapi', ['pmapi.c'], libraries = ['pcp'], extra_link_args=extra_link_args),
-        Extension('cpmda', ['pmda.c'], libraries = ['pcp_pmda', 'pcp'], extra_link_args=extra_link_args),
-        Extension('cpmgui', ['pmgui.c'], libraries = ['pcp_gui', 'pcp'], extra_link_args=extra_link_args),
-        Extension('cpmi', ['pmi.c'], libraries = ['pcp_import', 'pcp'], extra_link_args=extra_link_args),
-        Extension('cmmv', ['mmv.c'], libraries = ['pcp_mmv', 'pcp'], extra_link_args=extra_link_args),
+        Extension('cpmapi', ['pmapi.c'], libraries = ['pcp']),
+        Extension('cpmda', ['pmda.c'], libraries = ['pcp_pmda', 'pcp']),
+        Extension('cpmgui', ['pmgui.c'], libraries = ['pcp_gui', 'pcp']),
+        Extension('cpmi', ['pmi.c'], libraries = ['pcp_import', 'pcp']),
+        Extension('cmmv', ['mmv.c'], libraries = ['pcp_mmv', 'pcp']),
     ],
     keywords = ['performance', 'analysis', 'monitoring' ],
     platforms = [ 'Windows', 'Linux', 'FreeBSD', 'NetBSD', 'OpenBSD', 'Solaris', 'Mac OS X', 'AIX' ],

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -22,11 +22,17 @@ from setuptools import setup, find_packages, Extension
 # To use a consistent encoding
 from codecs import open
 from os import path
+import platform
+
 
 # Get the long description from the README file
 here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
+
+# Darwin specific linker options, which expects Homebrew to be there and sets the library search path to help find libpcp etc
+extra_link_args = ['-Wl,-rpath,/usr/local/lib']
+#if platform.system() == 'Darwin' and path.exists('/opt/homebrew/lib') else []
 
 setup(name = 'pcp',
     version = '7.0',
@@ -39,11 +45,11 @@ setup(name = 'pcp',
     url = 'https://pcp.io',
     packages = find_packages(),
     ext_modules = [
-        Extension('cpmapi', ['pmapi.c'], libraries = ['pcp']),
-        Extension('cpmda', ['pmda.c'], libraries = ['pcp_pmda', 'pcp']),
-        Extension('cpmgui', ['pmgui.c'], libraries = ['pcp_gui', 'pcp']),
-        Extension('cpmi', ['pmi.c'], libraries = ['pcp_import', 'pcp']),
-        Extension('cmmv', ['mmv.c'], libraries = ['pcp_mmv', 'pcp']),
+        Extension('cpmapi', ['pmapi.c'], libraries = ['pcp'], extra_link_args=extra_link_args),
+        Extension('cpmda', ['pmda.c'], libraries = ['pcp_pmda', 'pcp'], extra_link_args=extra_link_args),
+        Extension('cpmgui', ['pmgui.c'], libraries = ['pcp_gui', 'pcp'], extra_link_args=extra_link_args),
+        Extension('cpmi', ['pmi.c'], libraries = ['pcp_import', 'pcp'], extra_link_args=extra_link_args),
+        Extension('cmmv', ['mmv.c'], libraries = ['pcp_mmv', 'pcp'], extra_link_args=extra_link_args),
     ],
     keywords = ['performance', 'analysis', 'monitoring' ],
     platforms = [ 'Windows', 'Linux', 'FreeBSD', 'NetBSD', 'OpenBSD', 'Solaris', 'Mac OS X', 'AIX' ],


### PR DESCRIPTION
This change tweaks the Python make file so as to re-link the generated `.so` files. 

Prior to this, the `pmrep` command would fail with:

```
pcp@pcps-Virtual-Machine pcp % pmrep
Traceback (most recent call last):
  File "/usr/local/bin/pmrep", line 40, in <module>
    from pcp import pmapi, pmi, pmconfig
  File "/opt/homebrew/lib/python3.13/site-packages/pcp/pmapi.py", line 104, in <module>
    import cpmapi as c_api
ImportError: dlopen(/opt/homebrew/lib/python3.13/site-packages/cpmapi.cpython-313-darwin.so, 0x0002): Library not loaded: libpcp.4.dylib
  Referenced from: <AFA4F539-0CDD-386F-BD06-4973ECA04FB6> /opt/homebrew/lib/python3.13/site-packages/cpmapi.cpython-313-darwin.so
  Reason: tried: 'libpcp.4.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibpcp.4.dylib' (no such file), 'libpcp.4.dylib' (no such file), '/Users/pcp/pcp/libpcp.4.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/pcp/pcp/libpcp.4.dylib' (no such file), '/Users/pcp/pcp/libpcp.4.dylib' (no such file)
```

There's likely a better way to do this, but this is the one I came up with...