### PR TITLE
pmproxy, libpcp_web: ensure correct path used for conflict resolution

### DIFF
--- a/qa/1611
+++ b/qa/1611
@@ -72,6 +72,7 @@ _filter_metrics()
 # real QA test starts here
 archive_host=`hostname`
 archive_path=$PCP_REMOTE_ARCHIVE_DIR/$archive_host
+archive_botch=$PCP_LOG_DIR/pmproxy/pmproxy
 
 pmproxy_was_running=false
 [ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
@@ -83,7 +84,7 @@ _save_config $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 _stop_auto_restart pmproxy
 if ! _service pmproxy stop >>$seq_full 2>&1; then _exit 1; fi
 
-$sudo rm -fr $archive_path
+$sudo rm -fr $archive_path $archive_botch
 
 # pmproxy config
 cat >$tmp.conf << End-Of-File
@@ -141,6 +142,12 @@ then
     pminfo -a $archive_path | _filter_metrics
 else
     echo "Archive push failed: $archive_path directory not created"
+    status=1
+    exit
+fi
+if [ -d $archive_botch ]
+then
+    echo "Bad archive path $archive_botch found but should not be"
     status=1
     exit
 fi

--- a/qa/1615
+++ b/qa/1615
@@ -83,7 +83,8 @@ _filter_ls()
 archive=$here/archives/ok-mv-bigbin
 archive_host=moomba
 archive_path=$PCP_REMOTE_ARCHIVE_DIR/$archive_host
-$sudo rm -fr $archive_path
+archive_botch=$PCP_LOG_DIR/pmproxy/pmproxy
+$sudo rm -fr $archive_path $archive_botch
 
 pmproxy_was_running=false
 [ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
@@ -127,6 +128,12 @@ then
     pminfo -a $archive_path | LC_COLLATE=POSIX sort
 else
     echo "Archive push failed: $archive_path directory not created"
+    status=1
+    exit
+fi
+if [ -d $archive_botch ]
+then
+    echo "Bad archive path $archive_botch found but should not be"
     status=1
     exit
 fi

--- a/qa/1617
+++ b/qa/1617
@@ -173,7 +173,8 @@ export PCP_REMOTE_ARCHIVE_DIR=$tmp.pmproxy/pmproxy
 echo "Start test pmproxy ..."
 archive_host=`hostname`
 archive_path=$PCP_REMOTE_ARCHIVE_DIR/$archive_host
-$sudo rm -fr $archive_path
+archive_botch=$PCP_LOG_DIR/pmproxy/pmproxy
+$sudo rm -fr $archive_path $archive_botch
 
 $valgrind_clean_assert pmproxy -Dcontext -f -p $pmproxy_port -U $user -l- -c $tmp.conf >$tmp.valout 2>$tmp.valerr &
 pid=$!
@@ -226,6 +227,14 @@ cat $tmp.valout | tee -a $seq_full | _filter_valgrind
 
 echo "=== valgrind stderr ===" | tee -a $seq_full
 cat $tmp.valerr | tee -a $seq_full | _filter_context_debug | _filter_pmproxy_log | grep -v "Cannot connect to key server" | _filter_pmproxy_port
+
+# final sanity check
+if [ -d $archive_botch ]
+then
+    echo "Bad archive path $archive_botch found but should not be"
+    status=1
+    exit
+fi
 
 # success, all done
 exit

--- a/qa/1620
+++ b/qa/1620
@@ -81,6 +81,7 @@ _save_logs()
 # real QA test starts here
 archive_host=`hostname`
 archive_path=$PCP_REMOTE_ARCHIVE_DIR/$archive_host
+archive_botch=$PCP_LOG_DIR/pmproxy/pmproxy
 
 pmproxy_was_running=false
 [ -f $PCP_RUN_DIR/pmproxy.pid ] && pmproxy_was_running=true
@@ -91,7 +92,7 @@ _save_config $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 _stop_auto_restart pmproxy
 if ! _service pmproxy stop >>$seq_full 2>&1; then _exit 1; fi
 
-$sudo rm -fr $archive_path
+$sudo rm -fr $archive_path $archive_botch
 
 # pmproxy config
 cat >$tmp.conf << End-Of-File
@@ -153,6 +154,12 @@ then
     pminfo -a $archive_path | _filter_metrics
 else
     echo "Archive push failed: $archive_path directory not created"
+    status=1
+    exit
+fi
+if [ -d $archive_botch ]
+then
+    echo "Bad archive path $archive_botch found but should not be"
     status=1
     exit
 fi

--- a/src/libpcp_web/src/loggroup.c
+++ b/src/libpcp_web/src/loggroup.c
@@ -632,9 +632,10 @@ pmLogGroupLabel(pmLogGroupSettings *sp, const char *content, size_t length,
 
     if ((sts = logger_write_labels(pathbuf, &loglabel)) < 0)
 	goto fail;
-    if (sts > 0) /* archive name conflicted - append the iteration count */
-	pmsprintf(pathbuf, sizeof(pathbuf), "%s%c%s%c%s%c%s-%02d", dir, sep,
-		pmGetProgname(), sep, loglabel.hostname, sep, timebuf, sts);
+    if (sts > 0) { /* archive name conflicted - append the iteration count */
+	pmsprintf(timebuf, sizeof(timebuf), "-%02d", sts);
+	pmstrncat(pathbuf, sizeof(pathbuf), timebuf);
+    }
 
     /* wrote two label headers and created one archive - update stats */
     mmv_inc(groups->map, groups->metrics[LOGGROUP_LOGS]);


### PR DESCRIPTION
One location was overlooked on an error path in handling the switch from PCP_LOG_DIR/pmproxy to PCP_REMOTE_ARCHIVE_DIR - fixed here and adjust several tests to detect this breakage (race condition).