### PR TITLE
pmdabpftrace: Adjust event loop code to work with Python 3.14

### DIFF
--- a/src/pmdas/bpftrace/bpftrace/process_manager.py
+++ b/src/pmdas/bpftrace/bpftrace/process_manager.py
@@ -22,8 +22,8 @@ class ScriptTasks:
 
 class ProcessManager():
 
-    def __init__(self, loop: asyncio.AbstractEventLoop, config: PMDAConfig, logger: Logger, pipe: multiprocessing.Pipe, runtime_info: RuntimeInfo):
-        self.loop = loop
+    def __init__(self, config: PMDAConfig, logger: Logger, pipe: multiprocessing.Pipe, runtime_info: RuntimeInfo):
+        self.loop = asyncio.new_event_loop()
         self.loop.set_exception_handler(self.handle_exception)
         self.config = config
         self.logger = logger
@@ -322,6 +322,7 @@ class ProcessManager():
         else:
             self.logger.info(f"manager: using bpftrace {self.runtime_info.bpftrace_version_str}")
 
+        asyncio.set_event_loop(self.loop)
         asyncio.ensure_future(self.expiry_timer())
         self.loop.run_until_complete(self.main_loop())
 

--- a/src/pmdas/bpftrace/bpftrace/service.py
+++ b/src/pmdas/bpftrace/bpftrace/service.py
@@ -1,13 +1,12 @@
 from typing import Optional, List
-import asyncio
 import multiprocessing
 from .models import Script, PMDAConfig, RuntimeInfo, Logger, BPFtraceError
 from .process_manager import ProcessManager
 from .utils import get_bpftrace_version
 
 
-def process_manager_main(loop: asyncio.AbstractEventLoop, config: PMDAConfig, logger: Logger, pipe: multiprocessing.Pipe, runtime_info: RuntimeInfo):
-    ProcessManager(loop, config, logger, pipe, runtime_info).run()
+def process_manager_main(config: PMDAConfig, logger: Logger, pipe: multiprocessing.Pipe, runtime_info: RuntimeInfo):
+    ProcessManager(config, logger, pipe, runtime_info).run()
 
 
 class BPFtraceService():
@@ -15,7 +14,6 @@ class BPFtraceService():
     def __init__(self, config: PMDAConfig, logger: Logger):
         self.config = config
         self.logger = logger
-        self.loop = asyncio.new_event_loop()
         self.pipe, self.child_pipe = multiprocessing.Pipe()
         self.process = None
 
@@ -49,7 +47,7 @@ class BPFtraceService():
         runtime_info = self.gather_runtime_info()
         self.process = multiprocessing.Process(name="pmdabpftrace process manager",
                                                target=process_manager_main,
-                                               args=(self.loop, self.config,
+                                               args=(self.config,
                                                      self.logger, self.child_pipe,
                                                      runtime_info),
                                                daemon=True)


### PR DESCRIPTION
Unlike earlier versions, Python 3.14 asyncio.get_running_loop() throws an RuntimeError if there is no running event loop. To simplify code the setup and handling of the event loop has been moved completely inside the ProcessManager class.  The event loop is now explicity started.  These changes allow the bpftrace PMDA to work with Python 3.14, 11 of the 12 pmda.pftrace tests pass with this patch.  The failure in 1703 appears to have an unrelated issue which causes a coredump.