### PR TITLE
build: add zstd package as a hard dependency

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -132,7 +132,7 @@ BuildRequires: ncurses-devel
 BuildRequires: readline-devel
 
 # Utilities used indirectly e.g. by scripts we install
-Requires: bash xz gawk sed grep coreutils diffutils findutils
+Requires: bash xz zstd gawk sed grep coreutils diffutils findutils
 %if "%{_vendor}" == "redhat"
 Requires: %{_hostname_executable} %{_ps_executable}
 %endif

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -301,7 +301,7 @@ BuildRequires: qt5-qtsvg-devel
 %endif
 
 # Utilities used indirectly e.g. by scripts we install
-Requires: bash xz gawk sed grep coreutils diffutils findutils
+Requires: bash xz zstd gawk sed grep coreutils diffutils findutils
 Requires: which %{_hostname_executable} %{_ps_executable}
 Requires: pcp-libs = %{version}-%{release}
 

--- a/debian/control.pcp
+++ b/debian/control.pcp
@@ -10,10 +10,10 @@ Standards-Version: 4.7.2
 X-Python3-Version: >= 3.6
 
 Package: pcp
-Depends: ${shlibs:Depends}, ${misc:Depends}, gawk, procps, ?{python-pcp}, ?{python}, libpcp-pmda3 (= ${binary:Version}), libpcp-mmv1 (= ${binary:Version}), libpcp-web1 (= ${binary:Version}), libpcp-archive1 (= ${binary:Version}), libpcp4 (= ${binary:Version}), pcp-conf (= ${binary:Version})
+Depends: ${shlibs:Depends}, ${misc:Depends}, gawk, procps, zstd, ?{python-pcp}, ?{python}, libpcp-pmda3 (= ${binary:Version}), libpcp-mmv1 (= ${binary:Version}), libpcp-web1 (= ${binary:Version}), libpcp-archive1 (= ${binary:Version}), libpcp4 (= ${binary:Version}), pcp-conf (= ${binary:Version})
 Recommends: libpcp-pmda-perl
 Conflicts: pgpool2, dstat, pcp-webapi, pcp-manager
-Suggests: pcp-gui, libpcp-import-perl, ?{bpftrace}, ?{python-bpfcc}, redis-server, zstd
+Suggests: pcp-gui, libpcp-import-perl, ?{bpftrace}, ?{python-bpfcc}, redis-server
 Provides: dstat, pcp-webapi, pcp-manager
 Replaces: dstat, pcp-webapi, pcp-manager
 Architecture: any


### PR DESCRIPTION
A colleague encountered a "corrupt archive" - turned out it was an archive copied from one container to another and the second had PCP but didn't have zstd installed:

```
# pmrep -a 20250902.18.35 kernel.all.load
__pmProcessPipe: child pid=530309 execvp(zstd, ...) failed pmrep: Corrupted record in a PCP archive
```

Which is somewhat cryptic; took me a little while to figure out the root cause, despite it being in the error message - the "corrupted record" bit distracted me I guess.

This commit makes zstd a hard dependency because I think we will see more of this scenario now on (remote) replay hosts since we choose to use this form of compression more often, in recent releases.