### PR TITLE
pmdaopentelemetry: QA failure fixes

### DIFF
--- a/qa/1632
+++ b/qa/1632
@@ -14,8 +14,6 @@ echo "QA output created by $seq"
 
 _pmdaopentelemetry_check || _notrun "opentelemetry pmda and/or load generator not installed"
 
-_notrun "currently failing, needs analysis and updates"
-
 status=1        # failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 totalendpoints=5 #total queue to work through

--- a/qa/1632.out
+++ b/qa/1632.out
@@ -3,8 +3,8 @@ QA output created by 1632
 === opentelemetry agent installation ===
 Fetch and desc opentelemetry metrics: success
 
-opentelemetry.source1.sample_counter0001 []
-    Data Type: double  InDom: 88.6145 0x16001801
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6145 0x29001801
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 340410788
@@ -17,8 +17,8 @@ opentelemetry.source1.sample_counter0001 []
     inst [8 or "8 inst-8"] value 2723286300
     inst [9 or "9 inst-9"] value 3063697090
 
-opentelemetry.source1.sample_counter0023 []
-    Data Type: double  InDom: 88.6153 0x16001809
+opentelemetry.source1.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6153 0x29001809
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1021232360
@@ -31,8 +31,8 @@ opentelemetry.source1.sample_counter0023 []
     inst [8 or "8 inst-8"] value 8169858910
     inst [9 or "9 inst-9"] value 9191091280
 
-opentelemetry.source1.sample_counter0045 []
-    Data Type: double  InDom: 88.6161 0x16001811
+opentelemetry.source1.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6161 0x29001811
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1702053940
@@ -45,8 +45,8 @@ opentelemetry.source1.sample_counter0045 []
     inst [8 or "8 inst-8"] value 13616431500
     inst [9 or "9 inst-9"] value 15318485500
 
-opentelemetry.source1.sample_counter0067 []
-    Data Type: double  InDom: 88.6169 0x16001819
+opentelemetry.source1.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6169 0x29001819
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2382875520
@@ -59,8 +59,8 @@ opentelemetry.source1.sample_counter0067 []
     inst [8 or "8 inst-8"] value 19063004100
     inst [9 or "9 inst-9"] value 21445879600
 
-opentelemetry.source1.sample_counter0089 []
-    Data Type: double  InDom: 88.6177 0x16001821
+opentelemetry.source1.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6177 0x29001821
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3063697090
@@ -73,8 +73,8 @@ opentelemetry.source1.sample_counter0089 []
     inst [8 or "8 inst-8"] value 24509576700
     inst [9 or "9 inst-9"] value 27573273800
 
-opentelemetry.source1.sample_counter0111 []
-    Data Type: double  InDom: 88.6185 0x16001829
+opentelemetry.source1.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6185 0x29001829
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3744518670
@@ -87,8 +87,8 @@ opentelemetry.source1.sample_counter0111 []
     inst [8 or "8 inst-8"] value 29956149300
     inst [9 or "9 inst-9"] value 33700668000
 
-opentelemetry.source1.sample_counter0133 []
-    Data Type: double  InDom: 88.6193 0x16001831
+opentelemetry.source1.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6193 0x29001831
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4425340240
@@ -101,8 +101,8 @@ opentelemetry.source1.sample_counter0133 []
     inst [8 or "8 inst-8"] value 35402722000
     inst [9 or "9 inst-9"] value 39828062200
 
-opentelemetry.source1.sample_counter0155 []
-    Data Type: double  InDom: 88.6201 0x16001839
+opentelemetry.source1.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6201 0x29001839
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5106161820
@@ -115,8 +115,8 @@ opentelemetry.source1.sample_counter0155 []
     inst [8 or "8 inst-8"] value 40849294600
     inst [9 or "9 inst-9"] value 45955456400
 
-opentelemetry.source1.sample_counter0177 []
-    Data Type: double  InDom: 88.6209 0x16001841
+opentelemetry.source1.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6209 0x29001841
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5786983400
@@ -129,8 +129,8 @@ opentelemetry.source1.sample_counter0177 []
     inst [8 or "8 inst-8"] value 46295867200
     inst [9 or "9 inst-9"] value 52082850600
 
-opentelemetry.source1.sample_counter0199 []
-    Data Type: double  InDom: 88.6217 0x16001849
+opentelemetry.source1.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6217 0x29001849
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6467804970
@@ -143,8 +143,8 @@ opentelemetry.source1.sample_counter0199 []
     inst [8 or "8 inst-8"] value 51742439800
     inst [9 or "9 inst-9"] value 58210244700
 
-opentelemetry.source1.sample_counter0221 []
-    Data Type: double  InDom: 88.6225 0x16001851
+opentelemetry.source1.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6225 0x29001851
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7148626550
@@ -157,8 +157,8 @@ opentelemetry.source1.sample_counter0221 []
     inst [8 or "8 inst-8"] value 57189012400
     inst [9 or "9 inst-9"] value 64337638900
 
-opentelemetry.source1.sample_counter0243 []
-    Data Type: double  InDom: 88.6233 0x16001859
+opentelemetry.source1.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6233 0x29001859
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7829448120
@@ -171,8 +171,8 @@ opentelemetry.source1.sample_counter0243 []
     inst [8 or "8 inst-8"] value 62635585000
     inst [9 or "9 inst-9"] value 70465033100
 
-opentelemetry.source1.sample_counter0265 []
-    Data Type: double  InDom: 88.6241 0x16001861
+opentelemetry.source1.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6241 0x29001861
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8510269700
@@ -185,8 +185,8 @@ opentelemetry.source1.sample_counter0265 []
     inst [8 or "8 inst-8"] value 68082157600
     inst [9 or "9 inst-9"] value 76592427300
 
-opentelemetry.source1.sample_counter0287 []
-    Data Type: double  InDom: 88.6249 0x16001869
+opentelemetry.source1.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6249 0x29001869
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9191091280
@@ -199,8 +199,8 @@ opentelemetry.source1.sample_counter0287 []
     inst [8 or "8 inst-8"] value 73528730200
     inst [9 or "9 inst-9"] value 82719821500
 
-opentelemetry.source1.sample_counter0309 []
-    Data Type: double  InDom: 88.6257 0x16001871
+opentelemetry.source1.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6257 0x29001871
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9871912850
@@ -213,8 +213,8 @@ opentelemetry.source1.sample_counter0309 []
     inst [8 or "8 inst-8"] value 78975302800
     inst [9 or "9 inst-9"] value 88847215700
 
-opentelemetry.source1.sample_counter0331 []
-    Data Type: double  InDom: 88.6265 0x16001879
+opentelemetry.source1.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6265 0x29001879
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10552734400
@@ -227,8 +227,8 @@ opentelemetry.source1.sample_counter0331 []
     inst [8 or "8 inst-8"] value 84421875400
     inst [9 or "9 inst-9"] value 94974609900
 
-opentelemetry.source1.sample_counter0353 []
-    Data Type: double  InDom: 88.6273 0x16001881
+opentelemetry.source1.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6273 0x29001881
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11233556000
@@ -241,8 +241,8 @@ opentelemetry.source1.sample_counter0353 []
     inst [8 or "8 inst-8"] value 89868448000
     inst [9 or "9 inst-9"] value 101102004000
 
-opentelemetry.source1.sample_counter0375 []
-    Data Type: double  InDom: 88.6281 0x16001889
+opentelemetry.source1.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6281 0x29001889
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11914377600
@@ -255,8 +255,8 @@ opentelemetry.source1.sample_counter0375 []
     inst [8 or "8 inst-8"] value 95315020600
     inst [9 or "9 inst-9"] value 107229398000
 
-opentelemetry.source1.sample_counter0397 []
-    Data Type: double  InDom: 88.6289 0x16001891
+opentelemetry.source1.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6289 0x29001891
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12595199200
@@ -269,8 +269,8 @@ opentelemetry.source1.sample_counter0397 []
     inst [8 or "8 inst-8"] value 100761593000
     inst [9 or "9 inst-9"] value 113356792000
 
-opentelemetry.source1.sample_gauge0000 []
-    Data Type: double  InDom: 88.6144 0x16001800
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6144 0x29001800
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12.1
@@ -283,8 +283,8 @@ opentelemetry.source1.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 96.8
     inst [9 or "9 inst-9"] value 108.9
 
-opentelemetry.source1.sample_gauge0022 []
-    Data Type: double  InDom: 88.6152 0x16001808
+opentelemetry.source1.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6152 0x29001808
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 60.5
@@ -297,8 +297,8 @@ opentelemetry.source1.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 484
     inst [9 or "9 inst-9"] value 544.5
 
-opentelemetry.source1.sample_gauge0044 []
-    Data Type: double  InDom: 88.6160 0x16001810
+opentelemetry.source1.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6160 0x29001810
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 108.9
@@ -311,8 +311,8 @@ opentelemetry.source1.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 871.2
     inst [9 or "9 inst-9"] value 980.1
 
-opentelemetry.source1.sample_gauge0066 []
-    Data Type: double  InDom: 88.6168 0x16001818
+opentelemetry.source1.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6168 0x29001818
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 157.3
@@ -325,8 +325,8 @@ opentelemetry.source1.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1258.4
     inst [9 or "9 inst-9"] value 1415.7
 
-opentelemetry.source1.sample_gauge0088 []
-    Data Type: double  InDom: 88.6176 0x16001820
+opentelemetry.source1.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6176 0x29001820
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 205.7
@@ -339,8 +339,8 @@ opentelemetry.source1.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 1645.6
     inst [9 or "9 inst-9"] value 1851.3
 
-opentelemetry.source1.sample_gauge0110 []
-    Data Type: double  InDom: 88.6184 0x16001828
+opentelemetry.source1.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6184 0x29001828
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 254.1
@@ -353,8 +353,8 @@ opentelemetry.source1.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2032.8
     inst [9 or "9 inst-9"] value 2286.9
 
-opentelemetry.source1.sample_gauge0132 []
-    Data Type: double  InDom: 88.6192 0x16001830
+opentelemetry.source1.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6192 0x29001830
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 302.5
@@ -367,8 +367,8 @@ opentelemetry.source1.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2420
     inst [9 or "9 inst-9"] value 2722.5
 
-opentelemetry.source1.sample_gauge0154 []
-    Data Type: double  InDom: 88.6200 0x16001838
+opentelemetry.source1.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6200 0x29001838
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 350.9
@@ -381,8 +381,8 @@ opentelemetry.source1.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 2807.2
     inst [9 or "9 inst-9"] value 3158.1
 
-opentelemetry.source1.sample_gauge0176 []
-    Data Type: double  InDom: 88.6208 0x16001840
+opentelemetry.source1.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6208 0x29001840
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 399.3
@@ -395,8 +395,8 @@ opentelemetry.source1.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3194.4
     inst [9 or "9 inst-9"] value 3593.7
 
-opentelemetry.source1.sample_gauge0198 []
-    Data Type: double  InDom: 88.6216 0x16001848
+opentelemetry.source1.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6216 0x29001848
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 447.7
@@ -409,8 +409,8 @@ opentelemetry.source1.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 3581.6
     inst [9 or "9 inst-9"] value 4029.3
 
-opentelemetry.source1.sample_gauge0220 []
-    Data Type: double  InDom: 88.6224 0x16001850
+opentelemetry.source1.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6224 0x29001850
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 496.1
@@ -423,8 +423,8 @@ opentelemetry.source1.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 3968.8
     inst [9 or "9 inst-9"] value 4464.9
 
-opentelemetry.source1.sample_gauge0242 []
-    Data Type: double  InDom: 88.6232 0x16001858
+opentelemetry.source1.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6232 0x29001858
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 544.5
@@ -437,8 +437,8 @@ opentelemetry.source1.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4356
     inst [9 or "9 inst-9"] value 4900.5
 
-opentelemetry.source1.sample_gauge0264 []
-    Data Type: double  InDom: 88.6240 0x16001860
+opentelemetry.source1.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6240 0x29001860
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 592.9
@@ -451,8 +451,8 @@ opentelemetry.source1.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 4743.2
     inst [9 or "9 inst-9"] value 5336.1
 
-opentelemetry.source1.sample_gauge0286 []
-    Data Type: double  InDom: 88.6248 0x16001868
+opentelemetry.source1.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6248 0x29001868
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 641.3
@@ -465,8 +465,8 @@ opentelemetry.source1.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5130.4
     inst [9 or "9 inst-9"] value 5771.7
 
-opentelemetry.source1.sample_gauge0308 []
-    Data Type: double  InDom: 88.6256 0x16001870
+opentelemetry.source1.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6256 0x29001870
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 689.7
@@ -479,8 +479,8 @@ opentelemetry.source1.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 5517.6
     inst [9 or "9 inst-9"] value 6207.3
 
-opentelemetry.source1.sample_gauge0330 []
-    Data Type: double  InDom: 88.6264 0x16001878
+opentelemetry.source1.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6264 0x29001878
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 738.1
@@ -493,8 +493,8 @@ opentelemetry.source1.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 5904.8
     inst [9 or "9 inst-9"] value 6642.9
 
-opentelemetry.source1.sample_gauge0352 []
-    Data Type: double  InDom: 88.6272 0x16001880
+opentelemetry.source1.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6272 0x29001880
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 786.5
@@ -507,8 +507,8 @@ opentelemetry.source1.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6292
     inst [9 or "9 inst-9"] value 7078.5
 
-opentelemetry.source1.sample_gauge0374 []
-    Data Type: double  InDom: 88.6280 0x16001888
+opentelemetry.source1.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6280 0x29001888
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 834.9
@@ -521,8 +521,8 @@ opentelemetry.source1.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 6679.2
     inst [9 or "9 inst-9"] value 7514.1
 
-opentelemetry.source1.sample_gauge0396 []
-    Data Type: double  InDom: 88.6288 0x16001890
+opentelemetry.source1.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6288 0x29001890
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 883.3
@@ -535,8 +535,8 @@ opentelemetry.source1.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7066.4
     inst [9 or "9 inst-9"] value 7949.7
 
-opentelemetry.source1.sample_histogram0012 []
-    Data Type: double  InDom: 88.6149 0x16001805
+opentelemetry.source1.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6149 0x29001805
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 23780
@@ -550,18 +550,18 @@ opentelemetry.source1.sample_histogram0012 []
     inst [9 or "le=18"] value 214020
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0012_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0012_sum []
+opentelemetry.source1.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0034 []
-    Data Type: double  InDom: 88.6157 0x1600180d
+opentelemetry.source1.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6157 0x2900180d
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 47560
@@ -575,18 +575,18 @@ opentelemetry.source1.sample_histogram0034 []
     inst [9 or "le=18"] value 428040
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0034_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0034_sum []
+opentelemetry.source1.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0056 []
-    Data Type: double  InDom: 88.6165 0x16001815
+opentelemetry.source1.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6165 0x29001815
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 71340
@@ -600,18 +600,18 @@ opentelemetry.source1.sample_histogram0056 []
     inst [9 or "le=18"] value 642060
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0056_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0056_sum []
+opentelemetry.source1.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0078 []
-    Data Type: double  InDom: 88.6173 0x1600181d
+opentelemetry.source1.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6173 0x2900181d
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 95120
@@ -625,18 +625,18 @@ opentelemetry.source1.sample_histogram0078 []
     inst [9 or "le=18"] value 856080
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0078_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0078_sum []
+opentelemetry.source1.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0100 []
-    Data Type: double  InDom: 88.6181 0x16001825
+opentelemetry.source1.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6181 0x29001825
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 118900
@@ -650,18 +650,18 @@ opentelemetry.source1.sample_histogram0100 []
     inst [9 or "le=18"] value 1070100
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0100_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0100_sum []
+opentelemetry.source1.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0122 []
-    Data Type: double  InDom: 88.6189 0x1600182d
+opentelemetry.source1.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6189 0x2900182d
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 142680
@@ -675,18 +675,18 @@ opentelemetry.source1.sample_histogram0122 []
     inst [9 or "le=18"] value 1284120
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0122_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0122_sum []
+opentelemetry.source1.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0144 []
-    Data Type: double  InDom: 88.6197 0x16001835
+opentelemetry.source1.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6197 0x29001835
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 166460
@@ -700,18 +700,18 @@ opentelemetry.source1.sample_histogram0144 []
     inst [9 or "le=18"] value 1498140
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0144_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0144_sum []
+opentelemetry.source1.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0166 []
-    Data Type: double  InDom: 88.6205 0x1600183d
+opentelemetry.source1.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6205 0x2900183d
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 190240
@@ -725,18 +725,18 @@ opentelemetry.source1.sample_histogram0166 []
     inst [9 or "le=18"] value 1712160
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0166_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0166_sum []
+opentelemetry.source1.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0188 []
-    Data Type: double  InDom: 88.6213 0x16001845
+opentelemetry.source1.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6213 0x29001845
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 214020
@@ -750,18 +750,18 @@ opentelemetry.source1.sample_histogram0188 []
     inst [9 or "le=18"] value 1926180
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0188_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0188_sum []
+opentelemetry.source1.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0210 []
-    Data Type: double  InDom: 88.6221 0x1600184d
+opentelemetry.source1.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6221 0x2900184d
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 237800
@@ -775,18 +775,18 @@ opentelemetry.source1.sample_histogram0210 []
     inst [9 or "le=18"] value 2140200
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0210_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0210_sum []
+opentelemetry.source1.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0232 []
-    Data Type: double  InDom: 88.6229 0x16001855
+opentelemetry.source1.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6229 0x29001855
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 261580
@@ -800,18 +800,18 @@ opentelemetry.source1.sample_histogram0232 []
     inst [9 or "le=18"] value 2354220
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0232_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0232_sum []
+opentelemetry.source1.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0254 []
-    Data Type: double  InDom: 88.6237 0x1600185d
+opentelemetry.source1.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6237 0x2900185d
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 285360
@@ -825,18 +825,18 @@ opentelemetry.source1.sample_histogram0254 []
     inst [9 or "le=18"] value 2568240
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0254_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0254_sum []
+opentelemetry.source1.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0276 []
-    Data Type: double  InDom: 88.6245 0x16001865
+opentelemetry.source1.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6245 0x29001865
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 309140
@@ -850,18 +850,18 @@ opentelemetry.source1.sample_histogram0276 []
     inst [9 or "le=18"] value 2782260
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0276_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0276_sum []
+opentelemetry.source1.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0298 []
-    Data Type: double  InDom: 88.6253 0x1600186d
+opentelemetry.source1.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6253 0x2900186d
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 332920
@@ -875,18 +875,18 @@ opentelemetry.source1.sample_histogram0298 []
     inst [9 or "le=18"] value 2996280
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0298_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0298_sum []
+opentelemetry.source1.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0320 []
-    Data Type: double  InDom: 88.6261 0x16001875
+opentelemetry.source1.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6261 0x29001875
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 356700
@@ -900,18 +900,18 @@ opentelemetry.source1.sample_histogram0320 []
     inst [9 or "le=18"] value 3210300
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0320_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0320_sum []
+opentelemetry.source1.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0342 []
-    Data Type: double  InDom: 88.6269 0x1600187d
+opentelemetry.source1.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6269 0x2900187d
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 380480
@@ -925,18 +925,18 @@ opentelemetry.source1.sample_histogram0342 []
     inst [9 or "le=18"] value 3424320
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0342_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0342_sum []
+opentelemetry.source1.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0364 []
-    Data Type: double  InDom: 88.6277 0x16001885
+opentelemetry.source1.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6277 0x29001885
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 404260
@@ -950,18 +950,18 @@ opentelemetry.source1.sample_histogram0364 []
     inst [9 or "le=18"] value 3638340
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0364_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0364_sum []
+opentelemetry.source1.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_histogram0386 []
-    Data Type: double  InDom: 88.6285 0x1600188d
+opentelemetry.source1.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: 164.6285 0x2900188d
     Semantics: counter  Units: none
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 428040
@@ -975,19 +975,19 @@ opentelemetry.source1.sample_histogram0386 []
     inst [9 or "le=18"] value 3852360
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0386_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.source1.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 181350
 
-opentelemetry.source1.sample_histogram0386_sum []
+opentelemetry.source1.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
     value 451570
 
-opentelemetry.source1.sample_summary0002 []
-    Data Type: double  InDom: 88.6146 0x16001802
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6146 0x29001802
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.000478869
     inst [2 or "quantile: 0.5"] value 0.0009577380000000001
@@ -999,19 +999,19 @@ opentelemetry.source1.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.003830952
     inst [9 or "quantile: 2.25"] value 0.004309821
 
-opentelemetry.source1.sample_summary0002_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 5454
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 4.17362
 
-opentelemetry.source1.sample_summary0024 []
-    Data Type: double  InDom: 88.6154 0x1600180a
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6154 0x2900180a
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001117361
     inst [2 or "quantile: 0.5"] value 0.002234722
@@ -1023,19 +1023,19 @@ opentelemetry.source1.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.008938888000000001
     inst [9 or "quantile: 2.25"] value 0.010056249
 
-opentelemetry.source1.sample_summary0024_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 12726
 
-opentelemetry.source1.sample_summary0024_sum []
+opentelemetry.source1.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 9.738447000000001
 
-opentelemetry.source1.sample_summary0046 []
-    Data Type: double  InDom: 88.6162 0x16001812
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6162 0x29001812
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001755853
     inst [2 or "quantile: 0.5"] value 0.003511706
@@ -1047,19 +1047,19 @@ opentelemetry.source1.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.014046824
     inst [9 or "quantile: 2.25"] value 0.015802677
 
-opentelemetry.source1.sample_summary0046_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 19998
 
-opentelemetry.source1.sample_summary0046_sum []
+opentelemetry.source1.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 15.303274
 
-opentelemetry.source1.sample_summary0068 []
-    Data Type: double  InDom: 88.6170 0x1600181a
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6170 0x2900181a
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002394345
     inst [2 or "quantile: 0.5"] value 0.00478869
@@ -1071,19 +1071,19 @@ opentelemetry.source1.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.01915476
     inst [9 or "quantile: 2.25"] value 0.021549105
 
-opentelemetry.source1.sample_summary0068_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 27270
 
-opentelemetry.source1.sample_summary0068_sum []
+opentelemetry.source1.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 20.868102
 
-opentelemetry.source1.sample_summary0090 []
-    Data Type: double  InDom: 88.6178 0x16001822
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6178 0x29001822
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003032837
     inst [2 or "quantile: 0.5"] value 0.006065674
@@ -1095,19 +1095,19 @@ opentelemetry.source1.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.024262696
     inst [9 or "quantile: 2.25"] value 0.027295533
 
-opentelemetry.source1.sample_summary0090_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 34542
 
-opentelemetry.source1.sample_summary0090_sum []
+opentelemetry.source1.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 26.432929
 
-opentelemetry.source1.sample_summary0112 []
-    Data Type: double  InDom: 88.6186 0x1600182a
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6186 0x2900182a
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003671329
     inst [2 or "quantile: 0.5"] value 0.007342658
@@ -1119,19 +1119,19 @@ opentelemetry.source1.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.029370632
     inst [9 or "quantile: 2.25"] value 0.033041961
 
-opentelemetry.source1.sample_summary0112_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 41814
 
-opentelemetry.source1.sample_summary0112_sum []
+opentelemetry.source1.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 31.997756
 
-opentelemetry.source1.sample_summary0134 []
-    Data Type: double  InDom: 88.6194 0x16001832
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6194 0x29001832
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004309821
     inst [2 or "quantile: 0.5"] value 0.008619642
@@ -1143,19 +1143,19 @@ opentelemetry.source1.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.034478568
     inst [9 or "quantile: 2.25"] value 0.03878838900000001
 
-opentelemetry.source1.sample_summary0134_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 49086
 
-opentelemetry.source1.sample_summary0134_sum []
+opentelemetry.source1.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 37.562583
 
-opentelemetry.source1.sample_summary0156 []
-    Data Type: double  InDom: 88.6202 0x1600183a
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6202 0x2900183a
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004948313
     inst [2 or "quantile: 0.5"] value 0.009896626
@@ -1167,19 +1167,19 @@ opentelemetry.source1.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.039586504
     inst [9 or "quantile: 2.25"] value 0.044534817
 
-opentelemetry.source1.sample_summary0156_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 56358
 
-opentelemetry.source1.sample_summary0156_sum []
+opentelemetry.source1.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 43.12741
 
-opentelemetry.source1.sample_summary0178 []
-    Data Type: double  InDom: 88.6210 0x16001842
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6210 0x29001842
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005586805
     inst [2 or "quantile: 0.5"] value 0.01117361
@@ -1191,19 +1191,19 @@ opentelemetry.source1.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.04469444
     inst [9 or "quantile: 2.25"] value 0.050281245
 
-opentelemetry.source1.sample_summary0178_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 63630
 
-opentelemetry.source1.sample_summary0178_sum []
+opentelemetry.source1.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 48.692237
 
-opentelemetry.source1.sample_summary0200 []
-    Data Type: double  InDom: 88.6218 0x1600184a
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6218 0x2900184a
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006225297
     inst [2 or "quantile: 0.5"] value 0.012450594
@@ -1215,19 +1215,19 @@ opentelemetry.source1.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.049802376
     inst [9 or "quantile: 2.25"] value 0.05602767300000001
 
-opentelemetry.source1.sample_summary0200_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 70902
 
-opentelemetry.source1.sample_summary0200_sum []
+opentelemetry.source1.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 54.257064
 
-opentelemetry.source1.sample_summary0222 []
-    Data Type: double  InDom: 88.6226 0x16001852
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6226 0x29001852
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006863789
     inst [2 or "quantile: 0.5"] value 0.013727578
@@ -1239,19 +1239,19 @@ opentelemetry.source1.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.054910312
     inst [9 or "quantile: 2.25"] value 0.061774101
 
-opentelemetry.source1.sample_summary0222_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 78174
 
-opentelemetry.source1.sample_summary0222_sum []
+opentelemetry.source1.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 59.821891
 
-opentelemetry.source1.sample_summary0244 []
-    Data Type: double  InDom: 88.6234 0x1600185a
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6234 0x2900185a
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007502281
     inst [2 or "quantile: 0.5"] value 0.015004562
@@ -1263,19 +1263,19 @@ opentelemetry.source1.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.060018248
     inst [9 or "quantile: 2.25"] value 0.06752052900000001
 
-opentelemetry.source1.sample_summary0244_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 85446
 
-opentelemetry.source1.sample_summary0244_sum []
+opentelemetry.source1.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 65.386718
 
-opentelemetry.source1.sample_summary0266 []
-    Data Type: double  InDom: 88.6242 0x16001862
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6242 0x29001862
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008140773
     inst [2 or "quantile: 0.5"] value 0.016281546
@@ -1287,19 +1287,19 @@ opentelemetry.source1.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.065126184
     inst [9 or "quantile: 2.25"] value 0.07326695700000001
 
-opentelemetry.source1.sample_summary0266_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 92718
 
-opentelemetry.source1.sample_summary0266_sum []
+opentelemetry.source1.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 70.951545
 
-opentelemetry.source1.sample_summary0288 []
-    Data Type: double  InDom: 88.6250 0x1600186a
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6250 0x2900186a
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008779265000000001
     inst [2 or "quantile: 0.5"] value 0.01755853
@@ -1311,19 +1311,19 @@ opentelemetry.source1.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.07023412000000001
     inst [9 or "quantile: 2.25"] value 0.07901338500000001
 
-opentelemetry.source1.sample_summary0288_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 99990
 
-opentelemetry.source1.sample_summary0288_sum []
+opentelemetry.source1.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 76.516372
 
-opentelemetry.source1.sample_summary0310 []
-    Data Type: double  InDom: 88.6258 0x16001872
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6258 0x29001872
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009417757000000001
     inst [2 or "quantile: 0.5"] value 0.018835514
@@ -1335,19 +1335,19 @@ opentelemetry.source1.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.075342056
     inst [9 or "quantile: 2.25"] value 0.084759813
 
-opentelemetry.source1.sample_summary0310_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 107262
 
-opentelemetry.source1.sample_summary0310_sum []
+opentelemetry.source1.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 82.081199
 
-opentelemetry.source1.sample_summary0332 []
-    Data Type: double  InDom: 88.6266 0x1600187a
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6266 0x2900187a
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010056249
     inst [2 or "quantile: 0.5"] value 0.020112498
@@ -1359,19 +1359,19 @@ opentelemetry.source1.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.08044999200000001
     inst [9 or "quantile: 2.25"] value 0.090506241
 
-opentelemetry.source1.sample_summary0332_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 114534
 
-opentelemetry.source1.sample_summary0332_sum []
+opentelemetry.source1.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 87.646027
 
-opentelemetry.source1.sample_summary0354 []
-    Data Type: double  InDom: 88.6274 0x16001882
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6274 0x29001882
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010694741
     inst [2 or "quantile: 0.5"] value 0.021389482
@@ -1383,19 +1383,19 @@ opentelemetry.source1.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.08555792800000001
     inst [9 or "quantile: 2.25"] value 0.09625266900000001
 
-opentelemetry.source1.sample_summary0354_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 121806
 
-opentelemetry.source1.sample_summary0354_sum []
+opentelemetry.source1.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 93.210854
 
-opentelemetry.source1.sample_summary0376 []
-    Data Type: double  InDom: 88.6282 0x1600188a
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6282 0x2900188a
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011333233
     inst [2 or "quantile: 0.5"] value 0.022666466
@@ -1407,19 +1407,19 @@ opentelemetry.source1.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.09066586400000001
     inst [9 or "quantile: 2.25"] value 0.101999097
 
-opentelemetry.source1.sample_summary0376_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 129078
 
-opentelemetry.source1.sample_summary0376_sum []
+opentelemetry.source1.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 98.77568100000001
 
-opentelemetry.source1.sample_summary0398 []
-    Data Type: double  InDom: 88.6290 0x16001892
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6290 0x29001892
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011971725
     inst [2 or "quantile: 0.5"] value 0.02394345
@@ -1431,17 +1431,17 @@ opentelemetry.source1.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.09577380000000001
     inst [9 or "quantile: 2.25"] value 0.107745525
 
-opentelemetry.source1.sample_summary0398_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 136350
 
-opentelemetry.source1.sample_summary0398_sum []
+opentelemetry.source1.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 104.340508
 
-opentelemetry.source0.sample_counter0001 []
+opentelemetry.source0.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 170205394
     inst [2 or "2 inst-2"] value 340410788
@@ -1453,7 +1453,7 @@ opentelemetry.source0.sample_counter0001 []
     inst [8 or "8 inst-8"] value 1361643150
     inst [9 or "9 inst-9"] value 1531848550
 
-opentelemetry.source0.sample_counter0023 []
+opentelemetry.source0.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 851026970
     inst [2 or "2 inst-2"] value 1702053940
@@ -1465,7 +1465,7 @@ opentelemetry.source0.sample_counter0023 []
     inst [8 or "8 inst-8"] value 6808215760
     inst [9 or "9 inst-9"] value 7659242730
 
-opentelemetry.source0.sample_counter0045 []
+opentelemetry.source0.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1531848550
     inst [2 or "2 inst-2"] value 3063697090
@@ -1477,7 +1477,7 @@ opentelemetry.source0.sample_counter0045 []
     inst [8 or "8 inst-8"] value 12254788400
     inst [9 or "9 inst-9"] value 13786636900
 
-opentelemetry.source0.sample_counter0067 []
+opentelemetry.source0.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -1489,7 +1489,7 @@ opentelemetry.source0.sample_counter0067 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source0.sample_counter0089 []
+opentelemetry.source0.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -1501,7 +1501,7 @@ opentelemetry.source0.sample_counter0089 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source0.sample_counter0111 []
+opentelemetry.source0.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -1513,7 +1513,7 @@ opentelemetry.source0.sample_counter0111 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source0.sample_counter0133 []
+opentelemetry.source0.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -1525,7 +1525,7 @@ opentelemetry.source0.sample_counter0133 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source0.sample_counter0155 []
+opentelemetry.source0.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -1537,7 +1537,7 @@ opentelemetry.source0.sample_counter0155 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source0.sample_counter0177 []
+opentelemetry.source0.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -1549,7 +1549,7 @@ opentelemetry.source0.sample_counter0177 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source0.sample_counter0199 []
+opentelemetry.source0.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -1561,7 +1561,7 @@ opentelemetry.source0.sample_counter0199 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source0.sample_counter0221 []
+opentelemetry.source0.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -1573,7 +1573,7 @@ opentelemetry.source0.sample_counter0221 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source0.sample_counter0243 []
+opentelemetry.source0.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -1585,7 +1585,7 @@ opentelemetry.source0.sample_counter0243 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source0.sample_counter0265 []
+opentelemetry.source0.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -1597,7 +1597,7 @@ opentelemetry.source0.sample_counter0265 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source0.sample_counter0287 []
+opentelemetry.source0.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -1609,7 +1609,7 @@ opentelemetry.source0.sample_counter0287 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source0.sample_counter0309 []
+opentelemetry.source0.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -1621,7 +1621,7 @@ opentelemetry.source0.sample_counter0309 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source0.sample_counter0331 []
+opentelemetry.source0.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -1633,7 +1633,7 @@ opentelemetry.source0.sample_counter0331 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source0.sample_counter0353 []
+opentelemetry.source0.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -1645,7 +1645,7 @@ opentelemetry.source0.sample_counter0353 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source0.sample_counter0375 []
+opentelemetry.source0.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -1657,7 +1657,7 @@ opentelemetry.source0.sample_counter0375 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source0.sample_counter0397 []
+opentelemetry.source0.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -1669,7 +1669,7 @@ opentelemetry.source0.sample_counter0397 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source0.sample_gauge0000 []
+opentelemetry.source0.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 0
     inst [2 or "2 inst-2"] value 0
@@ -1681,7 +1681,7 @@ opentelemetry.source0.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 0
     inst [9 or "9 inst-9"] value 0
 
-opentelemetry.source0.sample_gauge0022 []
+opentelemetry.source0.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 48.4
     inst [2 or "2 inst-2"] value 96.8
@@ -1693,7 +1693,7 @@ opentelemetry.source0.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 387.2
     inst [9 or "9 inst-9"] value 435.6
 
-opentelemetry.source0.sample_gauge0044 []
+opentelemetry.source0.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 96.8
     inst [2 or "2 inst-2"] value 193.6
@@ -1705,7 +1705,7 @@ opentelemetry.source0.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 774.4
     inst [9 or "9 inst-9"] value 871.2
 
-opentelemetry.source0.sample_gauge0066 []
+opentelemetry.source0.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -1717,7 +1717,7 @@ opentelemetry.source0.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source0.sample_gauge0088 []
+opentelemetry.source0.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -1729,7 +1729,7 @@ opentelemetry.source0.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source0.sample_gauge0110 []
+opentelemetry.source0.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -1741,7 +1741,7 @@ opentelemetry.source0.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source0.sample_gauge0132 []
+opentelemetry.source0.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -1753,7 +1753,7 @@ opentelemetry.source0.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source0.sample_gauge0154 []
+opentelemetry.source0.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -1765,7 +1765,7 @@ opentelemetry.source0.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source0.sample_gauge0176 []
+opentelemetry.source0.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -1777,7 +1777,7 @@ opentelemetry.source0.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source0.sample_gauge0198 []
+opentelemetry.source0.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -1789,7 +1789,7 @@ opentelemetry.source0.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source0.sample_gauge0220 []
+opentelemetry.source0.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -1801,7 +1801,7 @@ opentelemetry.source0.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source0.sample_gauge0242 []
+opentelemetry.source0.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -1813,7 +1813,7 @@ opentelemetry.source0.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source0.sample_gauge0264 []
+opentelemetry.source0.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -1825,7 +1825,7 @@ opentelemetry.source0.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source0.sample_gauge0286 []
+opentelemetry.source0.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -1837,7 +1837,7 @@ opentelemetry.source0.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source0.sample_gauge0308 []
+opentelemetry.source0.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -1849,7 +1849,7 @@ opentelemetry.source0.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source0.sample_gauge0330 []
+opentelemetry.source0.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -1861,7 +1861,7 @@ opentelemetry.source0.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source0.sample_gauge0352 []
+opentelemetry.source0.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -1873,7 +1873,7 @@ opentelemetry.source0.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source0.sample_gauge0374 []
+opentelemetry.source0.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -1885,7 +1885,7 @@ opentelemetry.source0.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source0.sample_gauge0396 []
+opentelemetry.source0.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -1897,7 +1897,7 @@ opentelemetry.source0.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source0.sample_histogram0012 []
+opentelemetry.source0.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 17835
     inst [2 or "le=4"] value 35670
@@ -1910,13 +1910,13 @@ opentelemetry.source0.sample_histogram0012 []
     inst [9 or "le=18"] value 160515
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0012_count []
+opentelemetry.source0.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0012_sum []
+opentelemetry.source0.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0034 []
+opentelemetry.source0.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 41615
     inst [2 or "le=4"] value 83230
@@ -1929,13 +1929,13 @@ opentelemetry.source0.sample_histogram0034 []
     inst [9 or "le=18"] value 374535
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0034_count []
+opentelemetry.source0.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0034_sum []
+opentelemetry.source0.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0056 []
+opentelemetry.source0.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 65395
     inst [2 or "le=4"] value 130790
@@ -1948,13 +1948,13 @@ opentelemetry.source0.sample_histogram0056 []
     inst [9 or "le=18"] value 588555
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0056_count []
+opentelemetry.source0.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0056_sum []
+opentelemetry.source0.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0078 []
+opentelemetry.source0.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 89175
     inst [2 or "le=4"] value 178350
@@ -1967,13 +1967,13 @@ opentelemetry.source0.sample_histogram0078 []
     inst [9 or "le=18"] value 802575
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0078_count []
+opentelemetry.source0.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0078_sum []
+opentelemetry.source0.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0100 []
+opentelemetry.source0.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 112955
     inst [2 or "le=4"] value 225910
@@ -1986,13 +1986,13 @@ opentelemetry.source0.sample_histogram0100 []
     inst [9 or "le=18"] value 1016595
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0100_count []
+opentelemetry.source0.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0100_sum []
+opentelemetry.source0.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0122 []
+opentelemetry.source0.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 136735
     inst [2 or "le=4"] value 273470
@@ -2005,13 +2005,13 @@ opentelemetry.source0.sample_histogram0122 []
     inst [9 or "le=18"] value 1230615
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0122_count []
+opentelemetry.source0.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0122_sum []
+opentelemetry.source0.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0144 []
+opentelemetry.source0.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 160515
     inst [2 or "le=4"] value 321030
@@ -2024,13 +2024,13 @@ opentelemetry.source0.sample_histogram0144 []
     inst [9 or "le=18"] value 1444635
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0144_count []
+opentelemetry.source0.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0144_sum []
+opentelemetry.source0.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0166 []
+opentelemetry.source0.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 184295
     inst [2 or "le=4"] value 368590
@@ -2043,13 +2043,13 @@ opentelemetry.source0.sample_histogram0166 []
     inst [9 or "le=18"] value 1658655
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0166_count []
+opentelemetry.source0.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0166_sum []
+opentelemetry.source0.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0188 []
+opentelemetry.source0.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 208075
     inst [2 or "le=4"] value 416150
@@ -2062,13 +2062,13 @@ opentelemetry.source0.sample_histogram0188 []
     inst [9 or "le=18"] value 1872675
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0188_count []
+opentelemetry.source0.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0188_sum []
+opentelemetry.source0.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0210 []
+opentelemetry.source0.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 231855
     inst [2 or "le=4"] value 463710
@@ -2081,13 +2081,13 @@ opentelemetry.source0.sample_histogram0210 []
     inst [9 or "le=18"] value 2086695
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0210_count []
+opentelemetry.source0.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0210_sum []
+opentelemetry.source0.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0232 []
+opentelemetry.source0.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 255635
     inst [2 or "le=4"] value 511270
@@ -2100,13 +2100,13 @@ opentelemetry.source0.sample_histogram0232 []
     inst [9 or "le=18"] value 2300715
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0232_count []
+opentelemetry.source0.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0232_sum []
+opentelemetry.source0.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0254 []
+opentelemetry.source0.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 279415
     inst [2 or "le=4"] value 558830
@@ -2119,13 +2119,13 @@ opentelemetry.source0.sample_histogram0254 []
     inst [9 or "le=18"] value 2514735
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0254_count []
+opentelemetry.source0.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0254_sum []
+opentelemetry.source0.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0276 []
+opentelemetry.source0.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 303195
     inst [2 or "le=4"] value 606390
@@ -2138,13 +2138,13 @@ opentelemetry.source0.sample_histogram0276 []
     inst [9 or "le=18"] value 2728755
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0276_count []
+opentelemetry.source0.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0276_sum []
+opentelemetry.source0.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0298 []
+opentelemetry.source0.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 326975
     inst [2 or "le=4"] value 653950
@@ -2157,13 +2157,13 @@ opentelemetry.source0.sample_histogram0298 []
     inst [9 or "le=18"] value 2942775
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0298_count []
+opentelemetry.source0.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0298_sum []
+opentelemetry.source0.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0320 []
+opentelemetry.source0.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 350755
     inst [2 or "le=4"] value 701510
@@ -2176,13 +2176,13 @@ opentelemetry.source0.sample_histogram0320 []
     inst [9 or "le=18"] value 3156795
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0320_count []
+opentelemetry.source0.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0320_sum []
+opentelemetry.source0.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0342 []
+opentelemetry.source0.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 374535
     inst [2 or "le=4"] value 749070
@@ -2195,13 +2195,13 @@ opentelemetry.source0.sample_histogram0342 []
     inst [9 or "le=18"] value 3370815
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0342_count []
+opentelemetry.source0.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0342_sum []
+opentelemetry.source0.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0364 []
+opentelemetry.source0.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 398315
     inst [2 or "le=4"] value 796630
@@ -2214,13 +2214,13 @@ opentelemetry.source0.sample_histogram0364 []
     inst [9 or "le=18"] value 3584835
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0364_count []
+opentelemetry.source0.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0364_sum []
+opentelemetry.source0.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0386 []
+opentelemetry.source0.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 422095
     inst [2 or "le=4"] value 844190
@@ -2233,13 +2233,13 @@ opentelemetry.source0.sample_histogram0386 []
     inst [9 or "le=18"] value 3798855
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0386_count []
+opentelemetry.source0.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0386_sum []
+opentelemetry.source0.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_summary0002 []
+opentelemetry.source0.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.000319246
     inst [2 or "quantile: 0.5"] value 0.0006384920000000001
@@ -2251,13 +2251,13 @@ opentelemetry.source0.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.002553968
     inst [9 or "quantile: 2.25"] value 0.002873214
 
-opentelemetry.source0.sample_summary0002_count []
+opentelemetry.source0.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 3636
 
-opentelemetry.source0.sample_summary0002_sum []
+opentelemetry.source0.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 2.782414
 
-opentelemetry.source0.sample_summary0024 []
+opentelemetry.source0.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0009577380000000001
     inst [2 or "quantile: 0.5"] value 0.001915476
@@ -2269,13 +2269,13 @@ opentelemetry.source0.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.007661904000000001
     inst [9 or "quantile: 2.25"] value 0.008619642
 
-opentelemetry.source0.sample_summary0024_count []
+opentelemetry.source0.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 10908
 
-opentelemetry.source0.sample_summary0024_sum []
+opentelemetry.source0.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 8.347241
 
-opentelemetry.source0.sample_summary0046 []
+opentelemetry.source0.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00159623
     inst [2 or "quantile: 0.5"] value 0.00319246
@@ -2287,13 +2287,13 @@ opentelemetry.source0.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.01276984
     inst [9 or "quantile: 2.25"] value 0.01436607
 
-opentelemetry.source0.sample_summary0046_count []
+opentelemetry.source0.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 18180
 
-opentelemetry.source0.sample_summary0046_sum []
+opentelemetry.source0.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 13.912068
 
-opentelemetry.source0.sample_summary0068 []
+opentelemetry.source0.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -2305,13 +2305,13 @@ opentelemetry.source0.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source0.sample_summary0068_count []
+opentelemetry.source0.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source0.sample_summary0068_sum []
+opentelemetry.source0.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source0.sample_summary0090 []
+opentelemetry.source0.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -2323,13 +2323,13 @@ opentelemetry.source0.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source0.sample_summary0090_count []
+opentelemetry.source0.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source0.sample_summary0090_sum []
+opentelemetry.source0.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source0.sample_summary0112 []
+opentelemetry.source0.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -2341,13 +2341,13 @@ opentelemetry.source0.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source0.sample_summary0112_count []
+opentelemetry.source0.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source0.sample_summary0112_sum []
+opentelemetry.source0.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source0.sample_summary0134 []
+opentelemetry.source0.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -2359,13 +2359,13 @@ opentelemetry.source0.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source0.sample_summary0134_count []
+opentelemetry.source0.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source0.sample_summary0134_sum []
+opentelemetry.source0.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source0.sample_summary0156 []
+opentelemetry.source0.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -2377,13 +2377,13 @@ opentelemetry.source0.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source0.sample_summary0156_count []
+opentelemetry.source0.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source0.sample_summary0156_sum []
+opentelemetry.source0.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source0.sample_summary0178 []
+opentelemetry.source0.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -2395,13 +2395,13 @@ opentelemetry.source0.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source0.sample_summary0178_count []
+opentelemetry.source0.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source0.sample_summary0178_sum []
+opentelemetry.source0.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source0.sample_summary0200 []
+opentelemetry.source0.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -2413,13 +2413,13 @@ opentelemetry.source0.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source0.sample_summary0200_count []
+opentelemetry.source0.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source0.sample_summary0200_sum []
+opentelemetry.source0.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source0.sample_summary0222 []
+opentelemetry.source0.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -2431,13 +2431,13 @@ opentelemetry.source0.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source0.sample_summary0222_count []
+opentelemetry.source0.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source0.sample_summary0222_sum []
+opentelemetry.source0.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source0.sample_summary0244 []
+opentelemetry.source0.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -2449,13 +2449,13 @@ opentelemetry.source0.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source0.sample_summary0244_count []
+opentelemetry.source0.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source0.sample_summary0244_sum []
+opentelemetry.source0.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source0.sample_summary0266 []
+opentelemetry.source0.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -2467,13 +2467,13 @@ opentelemetry.source0.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source0.sample_summary0266_count []
+opentelemetry.source0.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source0.sample_summary0266_sum []
+opentelemetry.source0.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source0.sample_summary0288 []
+opentelemetry.source0.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -2485,13 +2485,13 @@ opentelemetry.source0.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source0.sample_summary0288_count []
+opentelemetry.source0.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source0.sample_summary0288_sum []
+opentelemetry.source0.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source0.sample_summary0310 []
+opentelemetry.source0.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -2503,13 +2503,13 @@ opentelemetry.source0.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source0.sample_summary0310_count []
+opentelemetry.source0.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source0.sample_summary0310_sum []
+opentelemetry.source0.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source0.sample_summary0332 []
+opentelemetry.source0.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -2521,13 +2521,13 @@ opentelemetry.source0.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source0.sample_summary0332_count []
+opentelemetry.source0.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source0.sample_summary0332_sum []
+opentelemetry.source0.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source0.sample_summary0354 []
+opentelemetry.source0.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -2539,13 +2539,13 @@ opentelemetry.source0.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source0.sample_summary0354_count []
+opentelemetry.source0.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source0.sample_summary0354_sum []
+opentelemetry.source0.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source0.sample_summary0376 []
+opentelemetry.source0.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -2557,13 +2557,13 @@ opentelemetry.source0.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source0.sample_summary0376_count []
+opentelemetry.source0.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source0.sample_summary0376_sum []
+opentelemetry.source0.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source0.sample_summary0398 []
+opentelemetry.source0.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -2575,13 +2575,13 @@ opentelemetry.source0.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source0.sample_summary0398_count []
+opentelemetry.source0.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source0.sample_summary0398_sum []
+opentelemetry.source0.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source0.sample_counter0001 []
+opentelemetry.source0.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 170205394
     inst [2 or "2 inst-2"] value 340410788
@@ -2593,7 +2593,7 @@ opentelemetry.source0.sample_counter0001 []
     inst [8 or "8 inst-8"] value 1361643150
     inst [9 or "9 inst-9"] value 1531848550
 
-opentelemetry.source0.sample_counter0023 []
+opentelemetry.source0.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 851026970
     inst [2 or "2 inst-2"] value 1702053940
@@ -2605,7 +2605,7 @@ opentelemetry.source0.sample_counter0023 []
     inst [8 or "8 inst-8"] value 6808215760
     inst [9 or "9 inst-9"] value 7659242730
 
-opentelemetry.source0.sample_counter0045 []
+opentelemetry.source0.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1531848550
     inst [2 or "2 inst-2"] value 3063697090
@@ -2617,7 +2617,7 @@ opentelemetry.source0.sample_counter0045 []
     inst [8 or "8 inst-8"] value 12254788400
     inst [9 or "9 inst-9"] value 13786636900
 
-opentelemetry.source0.sample_counter0067 []
+opentelemetry.source0.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -2629,7 +2629,7 @@ opentelemetry.source0.sample_counter0067 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source0.sample_counter0089 []
+opentelemetry.source0.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -2641,7 +2641,7 @@ opentelemetry.source0.sample_counter0089 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source0.sample_counter0111 []
+opentelemetry.source0.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -2653,7 +2653,7 @@ opentelemetry.source0.sample_counter0111 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source0.sample_counter0133 []
+opentelemetry.source0.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -2665,7 +2665,7 @@ opentelemetry.source0.sample_counter0133 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source0.sample_counter0155 []
+opentelemetry.source0.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -2677,7 +2677,7 @@ opentelemetry.source0.sample_counter0155 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source0.sample_counter0177 []
+opentelemetry.source0.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -2689,7 +2689,7 @@ opentelemetry.source0.sample_counter0177 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source0.sample_counter0199 []
+opentelemetry.source0.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -2701,7 +2701,7 @@ opentelemetry.source0.sample_counter0199 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source0.sample_counter0221 []
+opentelemetry.source0.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -2713,7 +2713,7 @@ opentelemetry.source0.sample_counter0221 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source0.sample_counter0243 []
+opentelemetry.source0.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -2725,7 +2725,7 @@ opentelemetry.source0.sample_counter0243 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source0.sample_counter0265 []
+opentelemetry.source0.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -2737,7 +2737,7 @@ opentelemetry.source0.sample_counter0265 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source0.sample_counter0287 []
+opentelemetry.source0.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -2749,7 +2749,7 @@ opentelemetry.source0.sample_counter0287 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source0.sample_counter0309 []
+opentelemetry.source0.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -2761,7 +2761,7 @@ opentelemetry.source0.sample_counter0309 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source0.sample_counter0331 []
+opentelemetry.source0.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -2773,7 +2773,7 @@ opentelemetry.source0.sample_counter0331 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source0.sample_counter0353 []
+opentelemetry.source0.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -2785,7 +2785,7 @@ opentelemetry.source0.sample_counter0353 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source0.sample_counter0375 []
+opentelemetry.source0.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -2797,7 +2797,7 @@ opentelemetry.source0.sample_counter0375 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source0.sample_counter0397 []
+opentelemetry.source0.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -2809,7 +2809,7 @@ opentelemetry.source0.sample_counter0397 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source0.sample_gauge0000 []
+opentelemetry.source0.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 0
     inst [2 or "2 inst-2"] value 0
@@ -2821,7 +2821,7 @@ opentelemetry.source0.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 0
     inst [9 or "9 inst-9"] value 0
 
-opentelemetry.source0.sample_gauge0022 []
+opentelemetry.source0.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 48.4
     inst [2 or "2 inst-2"] value 96.8
@@ -2833,7 +2833,7 @@ opentelemetry.source0.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 387.2
     inst [9 or "9 inst-9"] value 435.6
 
-opentelemetry.source0.sample_gauge0044 []
+opentelemetry.source0.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 96.8
     inst [2 or "2 inst-2"] value 193.6
@@ -2845,7 +2845,7 @@ opentelemetry.source0.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 774.4
     inst [9 or "9 inst-9"] value 871.2
 
-opentelemetry.source0.sample_gauge0066 []
+opentelemetry.source0.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -2857,7 +2857,7 @@ opentelemetry.source0.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source0.sample_gauge0088 []
+opentelemetry.source0.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -2869,7 +2869,7 @@ opentelemetry.source0.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source0.sample_gauge0110 []
+opentelemetry.source0.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -2881,7 +2881,7 @@ opentelemetry.source0.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source0.sample_gauge0132 []
+opentelemetry.source0.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -2893,7 +2893,7 @@ opentelemetry.source0.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source0.sample_gauge0154 []
+opentelemetry.source0.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -2905,7 +2905,7 @@ opentelemetry.source0.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source0.sample_gauge0176 []
+opentelemetry.source0.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -2917,7 +2917,7 @@ opentelemetry.source0.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source0.sample_gauge0198 []
+opentelemetry.source0.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -2929,7 +2929,7 @@ opentelemetry.source0.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source0.sample_gauge0220 []
+opentelemetry.source0.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -2941,7 +2941,7 @@ opentelemetry.source0.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source0.sample_gauge0242 []
+opentelemetry.source0.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -2953,7 +2953,7 @@ opentelemetry.source0.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source0.sample_gauge0264 []
+opentelemetry.source0.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -2965,7 +2965,7 @@ opentelemetry.source0.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source0.sample_gauge0286 []
+opentelemetry.source0.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -2977,7 +2977,7 @@ opentelemetry.source0.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source0.sample_gauge0308 []
+opentelemetry.source0.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -2989,7 +2989,7 @@ opentelemetry.source0.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source0.sample_gauge0330 []
+opentelemetry.source0.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -3001,7 +3001,7 @@ opentelemetry.source0.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source0.sample_gauge0352 []
+opentelemetry.source0.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -3013,7 +3013,7 @@ opentelemetry.source0.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source0.sample_gauge0374 []
+opentelemetry.source0.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -3025,7 +3025,7 @@ opentelemetry.source0.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source0.sample_gauge0396 []
+opentelemetry.source0.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -3037,7 +3037,7 @@ opentelemetry.source0.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source0.sample_histogram0012 []
+opentelemetry.source0.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 17835
     inst [2 or "le=4"] value 35670
@@ -3050,13 +3050,13 @@ opentelemetry.source0.sample_histogram0012 []
     inst [9 or "le=18"] value 160515
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0012_count []
+opentelemetry.source0.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0012_sum []
+opentelemetry.source0.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0034 []
+opentelemetry.source0.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 41615
     inst [2 or "le=4"] value 83230
@@ -3069,13 +3069,13 @@ opentelemetry.source0.sample_histogram0034 []
     inst [9 or "le=18"] value 374535
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0034_count []
+opentelemetry.source0.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0034_sum []
+opentelemetry.source0.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0056 []
+opentelemetry.source0.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 65395
     inst [2 or "le=4"] value 130790
@@ -3088,13 +3088,13 @@ opentelemetry.source0.sample_histogram0056 []
     inst [9 or "le=18"] value 588555
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0056_count []
+opentelemetry.source0.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0056_sum []
+opentelemetry.source0.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0078 []
+opentelemetry.source0.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 89175
     inst [2 or "le=4"] value 178350
@@ -3107,13 +3107,13 @@ opentelemetry.source0.sample_histogram0078 []
     inst [9 or "le=18"] value 802575
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0078_count []
+opentelemetry.source0.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0078_sum []
+opentelemetry.source0.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0100 []
+opentelemetry.source0.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 112955
     inst [2 or "le=4"] value 225910
@@ -3126,13 +3126,13 @@ opentelemetry.source0.sample_histogram0100 []
     inst [9 or "le=18"] value 1016595
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0100_count []
+opentelemetry.source0.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0100_sum []
+opentelemetry.source0.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0122 []
+opentelemetry.source0.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 136735
     inst [2 or "le=4"] value 273470
@@ -3145,13 +3145,13 @@ opentelemetry.source0.sample_histogram0122 []
     inst [9 or "le=18"] value 1230615
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0122_count []
+opentelemetry.source0.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0122_sum []
+opentelemetry.source0.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0144 []
+opentelemetry.source0.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 160515
     inst [2 or "le=4"] value 321030
@@ -3164,13 +3164,13 @@ opentelemetry.source0.sample_histogram0144 []
     inst [9 or "le=18"] value 1444635
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0144_count []
+opentelemetry.source0.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0144_sum []
+opentelemetry.source0.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0166 []
+opentelemetry.source0.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 184295
     inst [2 or "le=4"] value 368590
@@ -3183,13 +3183,13 @@ opentelemetry.source0.sample_histogram0166 []
     inst [9 or "le=18"] value 1658655
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0166_count []
+opentelemetry.source0.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0166_sum []
+opentelemetry.source0.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0188 []
+opentelemetry.source0.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 208075
     inst [2 or "le=4"] value 416150
@@ -3202,13 +3202,13 @@ opentelemetry.source0.sample_histogram0188 []
     inst [9 or "le=18"] value 1872675
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0188_count []
+opentelemetry.source0.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0188_sum []
+opentelemetry.source0.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0210 []
+opentelemetry.source0.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 231855
     inst [2 or "le=4"] value 463710
@@ -3221,13 +3221,13 @@ opentelemetry.source0.sample_histogram0210 []
     inst [9 or "le=18"] value 2086695
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0210_count []
+opentelemetry.source0.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0210_sum []
+opentelemetry.source0.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0232 []
+opentelemetry.source0.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 255635
     inst [2 or "le=4"] value 511270
@@ -3240,13 +3240,13 @@ opentelemetry.source0.sample_histogram0232 []
     inst [9 or "le=18"] value 2300715
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0232_count []
+opentelemetry.source0.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0232_sum []
+opentelemetry.source0.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0254 []
+opentelemetry.source0.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 279415
     inst [2 or "le=4"] value 558830
@@ -3259,13 +3259,13 @@ opentelemetry.source0.sample_histogram0254 []
     inst [9 or "le=18"] value 2514735
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0254_count []
+opentelemetry.source0.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0254_sum []
+opentelemetry.source0.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0276 []
+opentelemetry.source0.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 303195
     inst [2 or "le=4"] value 606390
@@ -3278,13 +3278,13 @@ opentelemetry.source0.sample_histogram0276 []
     inst [9 or "le=18"] value 2728755
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0276_count []
+opentelemetry.source0.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0276_sum []
+opentelemetry.source0.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0298 []
+opentelemetry.source0.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 326975
     inst [2 or "le=4"] value 653950
@@ -3297,13 +3297,13 @@ opentelemetry.source0.sample_histogram0298 []
     inst [9 or "le=18"] value 2942775
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0298_count []
+opentelemetry.source0.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0298_sum []
+opentelemetry.source0.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0320 []
+opentelemetry.source0.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 350755
     inst [2 or "le=4"] value 701510
@@ -3316,13 +3316,13 @@ opentelemetry.source0.sample_histogram0320 []
     inst [9 or "le=18"] value 3156795
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0320_count []
+opentelemetry.source0.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0320_sum []
+opentelemetry.source0.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0342 []
+opentelemetry.source0.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 374535
     inst [2 or "le=4"] value 749070
@@ -3335,13 +3335,13 @@ opentelemetry.source0.sample_histogram0342 []
     inst [9 or "le=18"] value 3370815
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0342_count []
+opentelemetry.source0.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0342_sum []
+opentelemetry.source0.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0364 []
+opentelemetry.source0.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 398315
     inst [2 or "le=4"] value 796630
@@ -3354,13 +3354,13 @@ opentelemetry.source0.sample_histogram0364 []
     inst [9 or "le=18"] value 3584835
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0364_count []
+opentelemetry.source0.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0364_sum []
+opentelemetry.source0.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0386 []
+opentelemetry.source0.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 422095
     inst [2 or "le=4"] value 844190
@@ -3373,13 +3373,13 @@ opentelemetry.source0.sample_histogram0386 []
     inst [9 or "le=18"] value 3798855
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0386_count []
+opentelemetry.source0.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0386_sum []
+opentelemetry.source0.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_summary0002 []
+opentelemetry.source0.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.000319246
     inst [2 or "quantile: 0.5"] value 0.0006384920000000001
@@ -3391,13 +3391,13 @@ opentelemetry.source0.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.002553968
     inst [9 or "quantile: 2.25"] value 0.002873214
 
-opentelemetry.source0.sample_summary0002_count []
+opentelemetry.source0.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 3636
 
-opentelemetry.source0.sample_summary0002_sum []
+opentelemetry.source0.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 2.782414
 
-opentelemetry.source0.sample_summary0024 []
+opentelemetry.source0.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0009577380000000001
     inst [2 or "quantile: 0.5"] value 0.001915476
@@ -3409,13 +3409,13 @@ opentelemetry.source0.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.007661904000000001
     inst [9 or "quantile: 2.25"] value 0.008619642
 
-opentelemetry.source0.sample_summary0024_count []
+opentelemetry.source0.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 10908
 
-opentelemetry.source0.sample_summary0024_sum []
+opentelemetry.source0.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 8.347241
 
-opentelemetry.source0.sample_summary0046 []
+opentelemetry.source0.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00159623
     inst [2 or "quantile: 0.5"] value 0.00319246
@@ -3427,13 +3427,13 @@ opentelemetry.source0.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.01276984
     inst [9 or "quantile: 2.25"] value 0.01436607
 
-opentelemetry.source0.sample_summary0046_count []
+opentelemetry.source0.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 18180
 
-opentelemetry.source0.sample_summary0046_sum []
+opentelemetry.source0.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 13.912068
 
-opentelemetry.source0.sample_summary0068 []
+opentelemetry.source0.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -3445,13 +3445,13 @@ opentelemetry.source0.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source0.sample_summary0068_count []
+opentelemetry.source0.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source0.sample_summary0068_sum []
+opentelemetry.source0.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source0.sample_summary0090 []
+opentelemetry.source0.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -3463,13 +3463,13 @@ opentelemetry.source0.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source0.sample_summary0090_count []
+opentelemetry.source0.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source0.sample_summary0090_sum []
+opentelemetry.source0.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source0.sample_summary0112 []
+opentelemetry.source0.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -3481,13 +3481,13 @@ opentelemetry.source0.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source0.sample_summary0112_count []
+opentelemetry.source0.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source0.sample_summary0112_sum []
+opentelemetry.source0.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source0.sample_summary0134 []
+opentelemetry.source0.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -3499,13 +3499,13 @@ opentelemetry.source0.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source0.sample_summary0134_count []
+opentelemetry.source0.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source0.sample_summary0134_sum []
+opentelemetry.source0.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source0.sample_summary0156 []
+opentelemetry.source0.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -3517,13 +3517,13 @@ opentelemetry.source0.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source0.sample_summary0156_count []
+opentelemetry.source0.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source0.sample_summary0156_sum []
+opentelemetry.source0.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source0.sample_summary0178 []
+opentelemetry.source0.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -3535,13 +3535,13 @@ opentelemetry.source0.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source0.sample_summary0178_count []
+opentelemetry.source0.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source0.sample_summary0178_sum []
+opentelemetry.source0.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source0.sample_summary0200 []
+opentelemetry.source0.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -3553,13 +3553,13 @@ opentelemetry.source0.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source0.sample_summary0200_count []
+opentelemetry.source0.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source0.sample_summary0200_sum []
+opentelemetry.source0.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source0.sample_summary0222 []
+opentelemetry.source0.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -3571,13 +3571,13 @@ opentelemetry.source0.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source0.sample_summary0222_count []
+opentelemetry.source0.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source0.sample_summary0222_sum []
+opentelemetry.source0.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source0.sample_summary0244 []
+opentelemetry.source0.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -3589,13 +3589,13 @@ opentelemetry.source0.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source0.sample_summary0244_count []
+opentelemetry.source0.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source0.sample_summary0244_sum []
+opentelemetry.source0.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source0.sample_summary0266 []
+opentelemetry.source0.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -3607,13 +3607,13 @@ opentelemetry.source0.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source0.sample_summary0266_count []
+opentelemetry.source0.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source0.sample_summary0266_sum []
+opentelemetry.source0.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source0.sample_summary0288 []
+opentelemetry.source0.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -3625,13 +3625,13 @@ opentelemetry.source0.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source0.sample_summary0288_count []
+opentelemetry.source0.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source0.sample_summary0288_sum []
+opentelemetry.source0.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source0.sample_summary0310 []
+opentelemetry.source0.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -3643,13 +3643,13 @@ opentelemetry.source0.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source0.sample_summary0310_count []
+opentelemetry.source0.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source0.sample_summary0310_sum []
+opentelemetry.source0.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source0.sample_summary0332 []
+opentelemetry.source0.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -3661,13 +3661,13 @@ opentelemetry.source0.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source0.sample_summary0332_count []
+opentelemetry.source0.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source0.sample_summary0332_sum []
+opentelemetry.source0.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source0.sample_summary0354 []
+opentelemetry.source0.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -3679,13 +3679,13 @@ opentelemetry.source0.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source0.sample_summary0354_count []
+opentelemetry.source0.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source0.sample_summary0354_sum []
+opentelemetry.source0.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source0.sample_summary0376 []
+opentelemetry.source0.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -3697,13 +3697,13 @@ opentelemetry.source0.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source0.sample_summary0376_count []
+opentelemetry.source0.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source0.sample_summary0376_sum []
+opentelemetry.source0.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source0.sample_summary0398 []
+opentelemetry.source0.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -3715,13 +3715,13 @@ opentelemetry.source0.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source0.sample_summary0398_count []
+opentelemetry.source0.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source0.sample_summary0398_sum []
+opentelemetry.source0.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source0.sample_counter0001 []
+opentelemetry.source0.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 170205394
     inst [2 or "2 inst-2"] value 340410788
@@ -3733,7 +3733,7 @@ opentelemetry.source0.sample_counter0001 []
     inst [8 or "8 inst-8"] value 1361643150
     inst [9 or "9 inst-9"] value 1531848550
 
-opentelemetry.source0.sample_counter0023 []
+opentelemetry.source0.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 851026970
     inst [2 or "2 inst-2"] value 1702053940
@@ -3745,7 +3745,7 @@ opentelemetry.source0.sample_counter0023 []
     inst [8 or "8 inst-8"] value 6808215760
     inst [9 or "9 inst-9"] value 7659242730
 
-opentelemetry.source0.sample_counter0045 []
+opentelemetry.source0.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1531848550
     inst [2 or "2 inst-2"] value 3063697090
@@ -3757,7 +3757,7 @@ opentelemetry.source0.sample_counter0045 []
     inst [8 or "8 inst-8"] value 12254788400
     inst [9 or "9 inst-9"] value 13786636900
 
-opentelemetry.source0.sample_counter0067 []
+opentelemetry.source0.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -3769,7 +3769,7 @@ opentelemetry.source0.sample_counter0067 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source0.sample_counter0089 []
+opentelemetry.source0.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -3781,7 +3781,7 @@ opentelemetry.source0.sample_counter0089 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source0.sample_counter0111 []
+opentelemetry.source0.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -3793,7 +3793,7 @@ opentelemetry.source0.sample_counter0111 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source0.sample_counter0133 []
+opentelemetry.source0.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -3805,7 +3805,7 @@ opentelemetry.source0.sample_counter0133 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source0.sample_counter0155 []
+opentelemetry.source0.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -3817,7 +3817,7 @@ opentelemetry.source0.sample_counter0155 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source0.sample_counter0177 []
+opentelemetry.source0.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -3829,7 +3829,7 @@ opentelemetry.source0.sample_counter0177 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source0.sample_counter0199 []
+opentelemetry.source0.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -3841,7 +3841,7 @@ opentelemetry.source0.sample_counter0199 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source0.sample_counter0221 []
+opentelemetry.source0.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -3853,7 +3853,7 @@ opentelemetry.source0.sample_counter0221 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source0.sample_counter0243 []
+opentelemetry.source0.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -3865,7 +3865,7 @@ opentelemetry.source0.sample_counter0243 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source0.sample_counter0265 []
+opentelemetry.source0.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -3877,7 +3877,7 @@ opentelemetry.source0.sample_counter0265 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source0.sample_counter0287 []
+opentelemetry.source0.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -3889,7 +3889,7 @@ opentelemetry.source0.sample_counter0287 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source0.sample_counter0309 []
+opentelemetry.source0.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -3901,7 +3901,7 @@ opentelemetry.source0.sample_counter0309 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source0.sample_counter0331 []
+opentelemetry.source0.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -3913,7 +3913,7 @@ opentelemetry.source0.sample_counter0331 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source0.sample_counter0353 []
+opentelemetry.source0.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -3925,7 +3925,7 @@ opentelemetry.source0.sample_counter0353 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source0.sample_counter0375 []
+opentelemetry.source0.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -3937,7 +3937,7 @@ opentelemetry.source0.sample_counter0375 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source0.sample_counter0397 []
+opentelemetry.source0.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -3949,7 +3949,7 @@ opentelemetry.source0.sample_counter0397 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source0.sample_gauge0000 []
+opentelemetry.source0.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 0
     inst [2 or "2 inst-2"] value 0
@@ -3961,7 +3961,7 @@ opentelemetry.source0.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 0
     inst [9 or "9 inst-9"] value 0
 
-opentelemetry.source0.sample_gauge0022 []
+opentelemetry.source0.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 48.4
     inst [2 or "2 inst-2"] value 96.8
@@ -3973,7 +3973,7 @@ opentelemetry.source0.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 387.2
     inst [9 or "9 inst-9"] value 435.6
 
-opentelemetry.source0.sample_gauge0044 []
+opentelemetry.source0.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 96.8
     inst [2 or "2 inst-2"] value 193.6
@@ -3985,7 +3985,7 @@ opentelemetry.source0.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 774.4
     inst [9 or "9 inst-9"] value 871.2
 
-opentelemetry.source0.sample_gauge0066 []
+opentelemetry.source0.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -3997,7 +3997,7 @@ opentelemetry.source0.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source0.sample_gauge0088 []
+opentelemetry.source0.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -4009,7 +4009,7 @@ opentelemetry.source0.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source0.sample_gauge0110 []
+opentelemetry.source0.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -4021,7 +4021,7 @@ opentelemetry.source0.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source0.sample_gauge0132 []
+opentelemetry.source0.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -4033,7 +4033,7 @@ opentelemetry.source0.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source0.sample_gauge0154 []
+opentelemetry.source0.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -4045,7 +4045,7 @@ opentelemetry.source0.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source0.sample_gauge0176 []
+opentelemetry.source0.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -4057,7 +4057,7 @@ opentelemetry.source0.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source0.sample_gauge0198 []
+opentelemetry.source0.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -4069,7 +4069,7 @@ opentelemetry.source0.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source0.sample_gauge0220 []
+opentelemetry.source0.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -4081,7 +4081,7 @@ opentelemetry.source0.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source0.sample_gauge0242 []
+opentelemetry.source0.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -4093,7 +4093,7 @@ opentelemetry.source0.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source0.sample_gauge0264 []
+opentelemetry.source0.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -4105,7 +4105,7 @@ opentelemetry.source0.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source0.sample_gauge0286 []
+opentelemetry.source0.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -4117,7 +4117,7 @@ opentelemetry.source0.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source0.sample_gauge0308 []
+opentelemetry.source0.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -4129,7 +4129,7 @@ opentelemetry.source0.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source0.sample_gauge0330 []
+opentelemetry.source0.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -4141,7 +4141,7 @@ opentelemetry.source0.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source0.sample_gauge0352 []
+opentelemetry.source0.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -4153,7 +4153,7 @@ opentelemetry.source0.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source0.sample_gauge0374 []
+opentelemetry.source0.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -4165,7 +4165,7 @@ opentelemetry.source0.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source0.sample_gauge0396 []
+opentelemetry.source0.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -4177,7 +4177,7 @@ opentelemetry.source0.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source0.sample_histogram0012 []
+opentelemetry.source0.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 17835
     inst [2 or "le=4"] value 35670
@@ -4190,13 +4190,13 @@ opentelemetry.source0.sample_histogram0012 []
     inst [9 or "le=18"] value 160515
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0012_count []
+opentelemetry.source0.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0012_sum []
+opentelemetry.source0.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0034 []
+opentelemetry.source0.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 41615
     inst [2 or "le=4"] value 83230
@@ -4209,13 +4209,13 @@ opentelemetry.source0.sample_histogram0034 []
     inst [9 or "le=18"] value 374535
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0034_count []
+opentelemetry.source0.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0034_sum []
+opentelemetry.source0.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0056 []
+opentelemetry.source0.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 65395
     inst [2 or "le=4"] value 130790
@@ -4228,13 +4228,13 @@ opentelemetry.source0.sample_histogram0056 []
     inst [9 or "le=18"] value 588555
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0056_count []
+opentelemetry.source0.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0056_sum []
+opentelemetry.source0.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0078 []
+opentelemetry.source0.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 89175
     inst [2 or "le=4"] value 178350
@@ -4247,13 +4247,13 @@ opentelemetry.source0.sample_histogram0078 []
     inst [9 or "le=18"] value 802575
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0078_count []
+opentelemetry.source0.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0078_sum []
+opentelemetry.source0.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0100 []
+opentelemetry.source0.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 112955
     inst [2 or "le=4"] value 225910
@@ -4266,13 +4266,13 @@ opentelemetry.source0.sample_histogram0100 []
     inst [9 or "le=18"] value 1016595
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0100_count []
+opentelemetry.source0.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0100_sum []
+opentelemetry.source0.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0122 []
+opentelemetry.source0.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 136735
     inst [2 or "le=4"] value 273470
@@ -4285,13 +4285,13 @@ opentelemetry.source0.sample_histogram0122 []
     inst [9 or "le=18"] value 1230615
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0122_count []
+opentelemetry.source0.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0122_sum []
+opentelemetry.source0.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0144 []
+opentelemetry.source0.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 160515
     inst [2 or "le=4"] value 321030
@@ -4304,13 +4304,13 @@ opentelemetry.source0.sample_histogram0144 []
     inst [9 or "le=18"] value 1444635
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0144_count []
+opentelemetry.source0.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0144_sum []
+opentelemetry.source0.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0166 []
+opentelemetry.source0.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 184295
     inst [2 or "le=4"] value 368590
@@ -4323,13 +4323,13 @@ opentelemetry.source0.sample_histogram0166 []
     inst [9 or "le=18"] value 1658655
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0166_count []
+opentelemetry.source0.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0166_sum []
+opentelemetry.source0.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0188 []
+opentelemetry.source0.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 208075
     inst [2 or "le=4"] value 416150
@@ -4342,13 +4342,13 @@ opentelemetry.source0.sample_histogram0188 []
     inst [9 or "le=18"] value 1872675
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0188_count []
+opentelemetry.source0.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0188_sum []
+opentelemetry.source0.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0210 []
+opentelemetry.source0.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 231855
     inst [2 or "le=4"] value 463710
@@ -4361,13 +4361,13 @@ opentelemetry.source0.sample_histogram0210 []
     inst [9 or "le=18"] value 2086695
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0210_count []
+opentelemetry.source0.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0210_sum []
+opentelemetry.source0.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0232 []
+opentelemetry.source0.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 255635
     inst [2 or "le=4"] value 511270
@@ -4380,13 +4380,13 @@ opentelemetry.source0.sample_histogram0232 []
     inst [9 or "le=18"] value 2300715
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0232_count []
+opentelemetry.source0.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0232_sum []
+opentelemetry.source0.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0254 []
+opentelemetry.source0.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 279415
     inst [2 or "le=4"] value 558830
@@ -4399,13 +4399,13 @@ opentelemetry.source0.sample_histogram0254 []
     inst [9 or "le=18"] value 2514735
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0254_count []
+opentelemetry.source0.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0254_sum []
+opentelemetry.source0.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0276 []
+opentelemetry.source0.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 303195
     inst [2 or "le=4"] value 606390
@@ -4418,13 +4418,13 @@ opentelemetry.source0.sample_histogram0276 []
     inst [9 or "le=18"] value 2728755
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0276_count []
+opentelemetry.source0.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0276_sum []
+opentelemetry.source0.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0298 []
+opentelemetry.source0.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 326975
     inst [2 or "le=4"] value 653950
@@ -4437,13 +4437,13 @@ opentelemetry.source0.sample_histogram0298 []
     inst [9 or "le=18"] value 2942775
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0298_count []
+opentelemetry.source0.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0298_sum []
+opentelemetry.source0.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0320 []
+opentelemetry.source0.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 350755
     inst [2 or "le=4"] value 701510
@@ -4456,13 +4456,13 @@ opentelemetry.source0.sample_histogram0320 []
     inst [9 or "le=18"] value 3156795
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0320_count []
+opentelemetry.source0.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0320_sum []
+opentelemetry.source0.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0342 []
+opentelemetry.source0.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 374535
     inst [2 or "le=4"] value 749070
@@ -4475,13 +4475,13 @@ opentelemetry.source0.sample_histogram0342 []
     inst [9 or "le=18"] value 3370815
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0342_count []
+opentelemetry.source0.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0342_sum []
+opentelemetry.source0.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0364 []
+opentelemetry.source0.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 398315
     inst [2 or "le=4"] value 796630
@@ -4494,13 +4494,13 @@ opentelemetry.source0.sample_histogram0364 []
     inst [9 or "le=18"] value 3584835
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0364_count []
+opentelemetry.source0.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0364_sum []
+opentelemetry.source0.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_histogram0386 []
+opentelemetry.source0.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 422095
     inst [2 or "le=4"] value 844190
@@ -4513,13 +4513,13 @@ opentelemetry.source0.sample_histogram0386 []
     inst [9 or "le=18"] value 3798855
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source0.sample_histogram0386_count []
+opentelemetry.source0.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source0.sample_histogram0386_sum []
+opentelemetry.source0.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source0.sample_summary0002 []
+opentelemetry.source0.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.000319246
     inst [2 or "quantile: 0.5"] value 0.0006384920000000001
@@ -4531,13 +4531,13 @@ opentelemetry.source0.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.002553968
     inst [9 or "quantile: 2.25"] value 0.002873214
 
-opentelemetry.source0.sample_summary0002_count []
+opentelemetry.source0.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 3636
 
-opentelemetry.source0.sample_summary0002_sum []
+opentelemetry.source0.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 2.782414
 
-opentelemetry.source0.sample_summary0024 []
+opentelemetry.source0.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0009577380000000001
     inst [2 or "quantile: 0.5"] value 0.001915476
@@ -4549,13 +4549,13 @@ opentelemetry.source0.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.007661904000000001
     inst [9 or "quantile: 2.25"] value 0.008619642
 
-opentelemetry.source0.sample_summary0024_count []
+opentelemetry.source0.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 10908
 
-opentelemetry.source0.sample_summary0024_sum []
+opentelemetry.source0.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 8.347241
 
-opentelemetry.source0.sample_summary0046 []
+opentelemetry.source0.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00159623
     inst [2 or "quantile: 0.5"] value 0.00319246
@@ -4567,13 +4567,13 @@ opentelemetry.source0.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.01276984
     inst [9 or "quantile: 2.25"] value 0.01436607
 
-opentelemetry.source0.sample_summary0046_count []
+opentelemetry.source0.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 18180
 
-opentelemetry.source0.sample_summary0046_sum []
+opentelemetry.source0.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 13.912068
 
-opentelemetry.source0.sample_summary0068 []
+opentelemetry.source0.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -4585,13 +4585,13 @@ opentelemetry.source0.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source0.sample_summary0068_count []
+opentelemetry.source0.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source0.sample_summary0068_sum []
+opentelemetry.source0.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source0.sample_summary0090 []
+opentelemetry.source0.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -4603,13 +4603,13 @@ opentelemetry.source0.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source0.sample_summary0090_count []
+opentelemetry.source0.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source0.sample_summary0090_sum []
+opentelemetry.source0.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source0.sample_summary0112 []
+opentelemetry.source0.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -4621,13 +4621,13 @@ opentelemetry.source0.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source0.sample_summary0112_count []
+opentelemetry.source0.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source0.sample_summary0112_sum []
+opentelemetry.source0.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source0.sample_summary0134 []
+opentelemetry.source0.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -4639,13 +4639,13 @@ opentelemetry.source0.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source0.sample_summary0134_count []
+opentelemetry.source0.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source0.sample_summary0134_sum []
+opentelemetry.source0.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source0.sample_summary0156 []
+opentelemetry.source0.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -4657,13 +4657,13 @@ opentelemetry.source0.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source0.sample_summary0156_count []
+opentelemetry.source0.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source0.sample_summary0156_sum []
+opentelemetry.source0.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source0.sample_summary0178 []
+opentelemetry.source0.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -4675,13 +4675,13 @@ opentelemetry.source0.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source0.sample_summary0178_count []
+opentelemetry.source0.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source0.sample_summary0178_sum []
+opentelemetry.source0.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source0.sample_summary0200 []
+opentelemetry.source0.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -4693,13 +4693,13 @@ opentelemetry.source0.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source0.sample_summary0200_count []
+opentelemetry.source0.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source0.sample_summary0200_sum []
+opentelemetry.source0.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source0.sample_summary0222 []
+opentelemetry.source0.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -4711,13 +4711,13 @@ opentelemetry.source0.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source0.sample_summary0222_count []
+opentelemetry.source0.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source0.sample_summary0222_sum []
+opentelemetry.source0.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source0.sample_summary0244 []
+opentelemetry.source0.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -4729,13 +4729,13 @@ opentelemetry.source0.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source0.sample_summary0244_count []
+opentelemetry.source0.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source0.sample_summary0244_sum []
+opentelemetry.source0.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source0.sample_summary0266 []
+opentelemetry.source0.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -4747,13 +4747,13 @@ opentelemetry.source0.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source0.sample_summary0266_count []
+opentelemetry.source0.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source0.sample_summary0266_sum []
+opentelemetry.source0.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source0.sample_summary0288 []
+opentelemetry.source0.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -4765,13 +4765,13 @@ opentelemetry.source0.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source0.sample_summary0288_count []
+opentelemetry.source0.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source0.sample_summary0288_sum []
+opentelemetry.source0.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source0.sample_summary0310 []
+opentelemetry.source0.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -4783,13 +4783,13 @@ opentelemetry.source0.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source0.sample_summary0310_count []
+opentelemetry.source0.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source0.sample_summary0310_sum []
+opentelemetry.source0.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source0.sample_summary0332 []
+opentelemetry.source0.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -4801,13 +4801,13 @@ opentelemetry.source0.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source0.sample_summary0332_count []
+opentelemetry.source0.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source0.sample_summary0332_sum []
+opentelemetry.source0.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source0.sample_summary0354 []
+opentelemetry.source0.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -4819,13 +4819,13 @@ opentelemetry.source0.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source0.sample_summary0354_count []
+opentelemetry.source0.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source0.sample_summary0354_sum []
+opentelemetry.source0.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source0.sample_summary0376 []
+opentelemetry.source0.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -4837,13 +4837,13 @@ opentelemetry.source0.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source0.sample_summary0376_count []
+opentelemetry.source0.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source0.sample_summary0376_sum []
+opentelemetry.source0.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source0.sample_summary0398 []
+opentelemetry.source0.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -4855,460 +4855,460 @@ opentelemetry.source0.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source0.sample_summary0398_count []
+opentelemetry.source0.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source0.sample_summary0398_sum []
+opentelemetry.source0.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source0.sample_counter0001 []
+opentelemetry.source0.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0023 []
+opentelemetry.source0.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0045 []
+opentelemetry.source0.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0067 []
+opentelemetry.source0.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0089 []
+opentelemetry.source0.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0111 []
+opentelemetry.source0.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0133 []
+opentelemetry.source0.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0155 []
+opentelemetry.source0.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0177 []
+opentelemetry.source0.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0199 []
+opentelemetry.source0.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0221 []
+opentelemetry.source0.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0243 []
+opentelemetry.source0.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0265 []
+opentelemetry.source0.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0287 []
+opentelemetry.source0.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0309 []
+opentelemetry.source0.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0331 []
+opentelemetry.source0.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0353 []
+opentelemetry.source0.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0375 []
+opentelemetry.source0.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_counter0397 []
+opentelemetry.source0.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0000 []
+opentelemetry.source0.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0022 []
+opentelemetry.source0.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0044 []
+opentelemetry.source0.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0066 []
+opentelemetry.source0.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0088 []
+opentelemetry.source0.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0110 []
+opentelemetry.source0.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0132 []
+opentelemetry.source0.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0154 []
+opentelemetry.source0.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0176 []
+opentelemetry.source0.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0198 []
+opentelemetry.source0.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0220 []
+opentelemetry.source0.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0242 []
+opentelemetry.source0.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0264 []
+opentelemetry.source0.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0286 []
+opentelemetry.source0.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0308 []
+opentelemetry.source0.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0330 []
+opentelemetry.source0.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0352 []
+opentelemetry.source0.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0374 []
+opentelemetry.source0.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0396 []
+opentelemetry.source0.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0012 []
+opentelemetry.source0.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0012_count []
+opentelemetry.source0.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0012_sum []
+opentelemetry.source0.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0034 []
+opentelemetry.source0.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0034_count []
+opentelemetry.source0.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0034_sum []
+opentelemetry.source0.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0056 []
+opentelemetry.source0.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0056_count []
+opentelemetry.source0.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0056_sum []
+opentelemetry.source0.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0078 []
+opentelemetry.source0.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0078_count []
+opentelemetry.source0.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0078_sum []
+opentelemetry.source0.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0100 []
+opentelemetry.source0.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0100_count []
+opentelemetry.source0.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0100_sum []
+opentelemetry.source0.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0122 []
+opentelemetry.source0.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0122_count []
+opentelemetry.source0.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0122_sum []
+opentelemetry.source0.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0144 []
+opentelemetry.source0.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0144_count []
+opentelemetry.source0.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0144_sum []
+opentelemetry.source0.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0166 []
+opentelemetry.source0.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0166_count []
+opentelemetry.source0.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0166_sum []
+opentelemetry.source0.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0188 []
+opentelemetry.source0.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0188_count []
+opentelemetry.source0.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0188_sum []
+opentelemetry.source0.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0210 []
+opentelemetry.source0.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0210_count []
+opentelemetry.source0.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0210_sum []
+opentelemetry.source0.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0232 []
+opentelemetry.source0.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0232_count []
+opentelemetry.source0.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0232_sum []
+opentelemetry.source0.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0254 []
+opentelemetry.source0.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0254_count []
+opentelemetry.source0.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0254_sum []
+opentelemetry.source0.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0276 []
+opentelemetry.source0.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0276_count []
+opentelemetry.source0.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0276_sum []
+opentelemetry.source0.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0298 []
+opentelemetry.source0.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0298_count []
+opentelemetry.source0.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0298_sum []
+opentelemetry.source0.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0320 []
+opentelemetry.source0.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0320_count []
+opentelemetry.source0.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0320_sum []
+opentelemetry.source0.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0342 []
+opentelemetry.source0.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0342_count []
+opentelemetry.source0.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0342_sum []
+opentelemetry.source0.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0364 []
+opentelemetry.source0.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0364_count []
+opentelemetry.source0.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0364_sum []
+opentelemetry.source0.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0386 []
+opentelemetry.source0.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0386_count []
+opentelemetry.source0.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_histogram0386_sum []
+opentelemetry.source0.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0002 []
+opentelemetry.source0.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0002_count []
+opentelemetry.source0.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0002_sum []
+opentelemetry.source0.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0024 []
+opentelemetry.source0.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0024_count []
+opentelemetry.source0.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0024_sum []
+opentelemetry.source0.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0046 []
+opentelemetry.source0.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0046_count []
+opentelemetry.source0.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0046_sum []
+opentelemetry.source0.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0068 []
+opentelemetry.source0.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0068_count []
+opentelemetry.source0.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0068_sum []
+opentelemetry.source0.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0090 []
+opentelemetry.source0.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0090_count []
+opentelemetry.source0.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0090_sum []
+opentelemetry.source0.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0112 []
+opentelemetry.source0.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0112_count []
+opentelemetry.source0.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0112_sum []
+opentelemetry.source0.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0134 []
+opentelemetry.source0.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0134_count []
+opentelemetry.source0.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0134_sum []
+opentelemetry.source0.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0156 []
+opentelemetry.source0.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0156_count []
+opentelemetry.source0.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0156_sum []
+opentelemetry.source0.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0178 []
+opentelemetry.source0.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0178_count []
+opentelemetry.source0.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0178_sum []
+opentelemetry.source0.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0200 []
+opentelemetry.source0.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0200_count []
+opentelemetry.source0.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0200_sum []
+opentelemetry.source0.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0222 []
+opentelemetry.source0.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0222_count []
+opentelemetry.source0.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0222_sum []
+opentelemetry.source0.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0244 []
+opentelemetry.source0.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0244_count []
+opentelemetry.source0.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0244_sum []
+opentelemetry.source0.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0266 []
+opentelemetry.source0.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0266_count []
+opentelemetry.source0.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0266_sum []
+opentelemetry.source0.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0288 []
+opentelemetry.source0.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0288_count []
+opentelemetry.source0.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0288_sum []
+opentelemetry.source0.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0310 []
+opentelemetry.source0.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0310_count []
+opentelemetry.source0.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0310_sum []
+opentelemetry.source0.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0332 []
+opentelemetry.source0.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0332_count []
+opentelemetry.source0.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0332_sum []
+opentelemetry.source0.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0354 []
+opentelemetry.source0.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0354_count []
+opentelemetry.source0.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0354_sum []
+opentelemetry.source0.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0376 []
+opentelemetry.source0.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0376_count []
+opentelemetry.source0.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0376_sum []
+opentelemetry.source0.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0398 []
+opentelemetry.source0.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0398_count []
+opentelemetry.source0.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0398_sum []
+opentelemetry.source0.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0001 []
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 510616182
     inst [2 or "2 inst-2"] value 1021232360
@@ -5320,7 +5320,7 @@ opentelemetry.source1.sample_counter0001 []
     inst [8 or "8 inst-8"] value 4084929460
     inst [9 or "9 inst-9"] value 4595545640
 
-opentelemetry.source1.sample_counter0023 []
+opentelemetry.source1.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1191437760
     inst [2 or "2 inst-2"] value 2382875520
@@ -5332,7 +5332,7 @@ opentelemetry.source1.sample_counter0023 []
     inst [8 or "8 inst-8"] value 9531502060
     inst [9 or "9 inst-9"] value 10722939800
 
-opentelemetry.source1.sample_counter0045 []
+opentelemetry.source1.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1872259330
     inst [2 or "2 inst-2"] value 3744518670
@@ -5344,7 +5344,7 @@ opentelemetry.source1.sample_counter0045 []
     inst [8 or "8 inst-8"] value 14978074700
     inst [9 or "9 inst-9"] value 16850334000
 
-opentelemetry.source1.sample_counter0067 []
+opentelemetry.source1.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2553080910
     inst [2 or "2 inst-2"] value 5106161820
@@ -5356,7 +5356,7 @@ opentelemetry.source1.sample_counter0067 []
     inst [8 or "8 inst-8"] value 20424647300
     inst [9 or "9 inst-9"] value 22977728200
 
-opentelemetry.source1.sample_counter0089 []
+opentelemetry.source1.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3233902490
     inst [2 or "2 inst-2"] value 6467804970
@@ -5368,7 +5368,7 @@ opentelemetry.source1.sample_counter0089 []
     inst [8 or "8 inst-8"] value 25871219900
     inst [9 or "9 inst-9"] value 29105122400
 
-opentelemetry.source1.sample_counter0111 []
+opentelemetry.source1.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3914724060
     inst [2 or "2 inst-2"] value 7829448120
@@ -5380,7 +5380,7 @@ opentelemetry.source1.sample_counter0111 []
     inst [8 or "8 inst-8"] value 31317792500
     inst [9 or "9 inst-9"] value 35232516600
 
-opentelemetry.source1.sample_counter0133 []
+opentelemetry.source1.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4595545640
     inst [2 or "2 inst-2"] value 9191091280
@@ -5392,7 +5392,7 @@ opentelemetry.source1.sample_counter0133 []
     inst [8 or "8 inst-8"] value 36764365100
     inst [9 or "9 inst-9"] value 41359910700
 
-opentelemetry.source1.sample_counter0155 []
+opentelemetry.source1.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5276367210
     inst [2 or "2 inst-2"] value 10552734400
@@ -5404,7 +5404,7 @@ opentelemetry.source1.sample_counter0155 []
     inst [8 or "8 inst-8"] value 42210937700
     inst [9 or "9 inst-9"] value 47487304900
 
-opentelemetry.source1.sample_counter0177 []
+opentelemetry.source1.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5957188790
     inst [2 or "2 inst-2"] value 11914377600
@@ -5416,7 +5416,7 @@ opentelemetry.source1.sample_counter0177 []
     inst [8 or "8 inst-8"] value 47657510300
     inst [9 or "9 inst-9"] value 53614699100
 
-opentelemetry.source1.sample_counter0199 []
+opentelemetry.source1.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6638010370
     inst [2 or "2 inst-2"] value 13276020700
@@ -5428,7 +5428,7 @@ opentelemetry.source1.sample_counter0199 []
     inst [8 or "8 inst-8"] value 53104082900
     inst [9 or "9 inst-9"] value 59742093300
 
-opentelemetry.source1.sample_counter0221 []
+opentelemetry.source1.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7318831940
     inst [2 or "2 inst-2"] value 14637663900
@@ -5440,7 +5440,7 @@ opentelemetry.source1.sample_counter0221 []
     inst [8 or "8 inst-8"] value 58550655500
     inst [9 or "9 inst-9"] value 65869487500
 
-opentelemetry.source1.sample_counter0243 []
+opentelemetry.source1.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7999653520
     inst [2 or "2 inst-2"] value 15999307000
@@ -5452,7 +5452,7 @@ opentelemetry.source1.sample_counter0243 []
     inst [8 or "8 inst-8"] value 63997228100
     inst [9 or "9 inst-9"] value 71996881700
 
-opentelemetry.source1.sample_counter0265 []
+opentelemetry.source1.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8680475090
     inst [2 or "2 inst-2"] value 17360950200
@@ -5464,7 +5464,7 @@ opentelemetry.source1.sample_counter0265 []
     inst [8 or "8 inst-8"] value 69443800800
     inst [9 or "9 inst-9"] value 78124275800
 
-opentelemetry.source1.sample_counter0287 []
+opentelemetry.source1.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9361296670
     inst [2 or "2 inst-2"] value 18722593300
@@ -5476,7 +5476,7 @@ opentelemetry.source1.sample_counter0287 []
     inst [8 or "8 inst-8"] value 74890373400
     inst [9 or "9 inst-9"] value 84251670000
 
-opentelemetry.source1.sample_counter0309 []
+opentelemetry.source1.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10042118200
     inst [2 or "2 inst-2"] value 20084236500
@@ -5488,7 +5488,7 @@ opentelemetry.source1.sample_counter0309 []
     inst [8 or "8 inst-8"] value 80336946000
     inst [9 or "9 inst-9"] value 90379064200
 
-opentelemetry.source1.sample_counter0331 []
+opentelemetry.source1.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10722939800
     inst [2 or "2 inst-2"] value 21445879600
@@ -5500,7 +5500,7 @@ opentelemetry.source1.sample_counter0331 []
     inst [8 or "8 inst-8"] value 85783518600
     inst [9 or "9 inst-9"] value 96506458400
 
-opentelemetry.source1.sample_counter0353 []
+opentelemetry.source1.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11403761400
     inst [2 or "2 inst-2"] value 22807522800
@@ -5512,7 +5512,7 @@ opentelemetry.source1.sample_counter0353 []
     inst [8 or "8 inst-8"] value 91230091200
     inst [9 or "9 inst-9"] value 102633853000
 
-opentelemetry.source1.sample_counter0375 []
+opentelemetry.source1.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12084583000
     inst [2 or "2 inst-2"] value 24169165900
@@ -5524,7 +5524,7 @@ opentelemetry.source1.sample_counter0375 []
     inst [8 or "8 inst-8"] value 96676663800
     inst [9 or "9 inst-9"] value 108761247000
 
-opentelemetry.source1.sample_counter0397 []
+opentelemetry.source1.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12765404600
     inst [2 or "2 inst-2"] value 25530809100
@@ -5536,7 +5536,7 @@ opentelemetry.source1.sample_counter0397 []
     inst [8 or "8 inst-8"] value 102123236000
     inst [9 or "9 inst-9"] value 114888641000
 
-opentelemetry.source1.sample_gauge0000 []
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 24.2
     inst [2 or "2 inst-2"] value 48.4
@@ -5548,7 +5548,7 @@ opentelemetry.source1.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 193.6
     inst [9 or "9 inst-9"] value 217.8
 
-opentelemetry.source1.sample_gauge0022 []
+opentelemetry.source1.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 72.59999999999999
     inst [2 or "2 inst-2"] value 145.2
@@ -5560,7 +5560,7 @@ opentelemetry.source1.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 580.8
     inst [9 or "9 inst-9"] value 653.4
 
-opentelemetry.source1.sample_gauge0044 []
+opentelemetry.source1.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 121
     inst [2 or "2 inst-2"] value 242
@@ -5572,7 +5572,7 @@ opentelemetry.source1.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 968
     inst [9 or "9 inst-9"] value 1089
 
-opentelemetry.source1.sample_gauge0066 []
+opentelemetry.source1.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 169.4
     inst [2 or "2 inst-2"] value 338.8
@@ -5584,7 +5584,7 @@ opentelemetry.source1.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1355.2
     inst [9 or "9 inst-9"] value 1524.6
 
-opentelemetry.source1.sample_gauge0088 []
+opentelemetry.source1.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 217.8
     inst [2 or "2 inst-2"] value 435.6
@@ -5596,7 +5596,7 @@ opentelemetry.source1.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 1742.4
     inst [9 or "9 inst-9"] value 1960.2
 
-opentelemetry.source1.sample_gauge0110 []
+opentelemetry.source1.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 266.2
     inst [2 or "2 inst-2"] value 532.4
@@ -5608,7 +5608,7 @@ opentelemetry.source1.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2129.6
     inst [9 or "9 inst-9"] value 2395.8
 
-opentelemetry.source1.sample_gauge0132 []
+opentelemetry.source1.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 314.6
     inst [2 or "2 inst-2"] value 629.2
@@ -5620,7 +5620,7 @@ opentelemetry.source1.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2516.8
     inst [9 or "9 inst-9"] value 2831.4
 
-opentelemetry.source1.sample_gauge0154 []
+opentelemetry.source1.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 363
     inst [2 or "2 inst-2"] value 726
@@ -5632,7 +5632,7 @@ opentelemetry.source1.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 2904
     inst [9 or "9 inst-9"] value 3267
 
-opentelemetry.source1.sample_gauge0176 []
+opentelemetry.source1.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 411.4
     inst [2 or "2 inst-2"] value 822.8
@@ -5644,7 +5644,7 @@ opentelemetry.source1.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3291.2
     inst [9 or "9 inst-9"] value 3702.6
 
-opentelemetry.source1.sample_gauge0198 []
+opentelemetry.source1.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 459.8
     inst [2 or "2 inst-2"] value 919.6
@@ -5656,7 +5656,7 @@ opentelemetry.source1.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 3678.4
     inst [9 or "9 inst-9"] value 4138.2
 
-opentelemetry.source1.sample_gauge0220 []
+opentelemetry.source1.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 508.2
     inst [2 or "2 inst-2"] value 1016.4
@@ -5668,7 +5668,7 @@ opentelemetry.source1.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 4065.6
     inst [9 or "9 inst-9"] value 4573.8
 
-opentelemetry.source1.sample_gauge0242 []
+opentelemetry.source1.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 556.6
     inst [2 or "2 inst-2"] value 1113.2
@@ -5680,7 +5680,7 @@ opentelemetry.source1.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4452.8
     inst [9 or "9 inst-9"] value 5009.4
 
-opentelemetry.source1.sample_gauge0264 []
+opentelemetry.source1.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 605
     inst [2 or "2 inst-2"] value 1210
@@ -5692,7 +5692,7 @@ opentelemetry.source1.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 4840
     inst [9 or "9 inst-9"] value 5445
 
-opentelemetry.source1.sample_gauge0286 []
+opentelemetry.source1.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 653.4
     inst [2 or "2 inst-2"] value 1306.8
@@ -5704,7 +5704,7 @@ opentelemetry.source1.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5227.2
     inst [9 or "9 inst-9"] value 5880.6
 
-opentelemetry.source1.sample_gauge0308 []
+opentelemetry.source1.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 701.8
     inst [2 or "2 inst-2"] value 1403.6
@@ -5716,7 +5716,7 @@ opentelemetry.source1.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 5614.4
     inst [9 or "9 inst-9"] value 6316.2
 
-opentelemetry.source1.sample_gauge0330 []
+opentelemetry.source1.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 750.2
     inst [2 or "2 inst-2"] value 1500.4
@@ -5728,7 +5728,7 @@ opentelemetry.source1.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6001.6
     inst [9 or "9 inst-9"] value 6751.8
 
-opentelemetry.source1.sample_gauge0352 []
+opentelemetry.source1.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 798.6
     inst [2 or "2 inst-2"] value 1597.2
@@ -5740,7 +5740,7 @@ opentelemetry.source1.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6388.8
     inst [9 or "9 inst-9"] value 7187.4
 
-opentelemetry.source1.sample_gauge0374 []
+opentelemetry.source1.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 847
     inst [2 or "2 inst-2"] value 1694
@@ -5752,7 +5752,7 @@ opentelemetry.source1.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 6776
     inst [9 or "9 inst-9"] value 7623
 
-opentelemetry.source1.sample_gauge0396 []
+opentelemetry.source1.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 895.4
     inst [2 or "2 inst-2"] value 1790.8
@@ -5764,7 +5764,7 @@ opentelemetry.source1.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7163.2
     inst [9 or "9 inst-9"] value 8058.6
 
-opentelemetry.source1.sample_histogram0012 []
+opentelemetry.source1.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 29725
     inst [2 or "le=4"] value 59450
@@ -5777,13 +5777,13 @@ opentelemetry.source1.sample_histogram0012 []
     inst [9 or "le=18"] value 267525
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0012_count []
+opentelemetry.source1.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0012_sum []
+opentelemetry.source1.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0034 []
+opentelemetry.source1.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 53505
     inst [2 or "le=4"] value 107010
@@ -5796,13 +5796,13 @@ opentelemetry.source1.sample_histogram0034 []
     inst [9 or "le=18"] value 481545
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0034_count []
+opentelemetry.source1.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0034_sum []
+opentelemetry.source1.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0056 []
+opentelemetry.source1.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 77285
     inst [2 or "le=4"] value 154570
@@ -5815,13 +5815,13 @@ opentelemetry.source1.sample_histogram0056 []
     inst [9 or "le=18"] value 695565
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0056_count []
+opentelemetry.source1.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0056_sum []
+opentelemetry.source1.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0078 []
+opentelemetry.source1.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 101065
     inst [2 or "le=4"] value 202130
@@ -5834,13 +5834,13 @@ opentelemetry.source1.sample_histogram0078 []
     inst [9 or "le=18"] value 909585
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0078_count []
+opentelemetry.source1.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0078_sum []
+opentelemetry.source1.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0100 []
+opentelemetry.source1.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 124845
     inst [2 or "le=4"] value 249690
@@ -5853,13 +5853,13 @@ opentelemetry.source1.sample_histogram0100 []
     inst [9 or "le=18"] value 1123605
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0100_count []
+opentelemetry.source1.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0100_sum []
+opentelemetry.source1.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0122 []
+opentelemetry.source1.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 148625
     inst [2 or "le=4"] value 297250
@@ -5872,13 +5872,13 @@ opentelemetry.source1.sample_histogram0122 []
     inst [9 or "le=18"] value 1337625
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0122_count []
+opentelemetry.source1.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0122_sum []
+opentelemetry.source1.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0144 []
+opentelemetry.source1.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 172405
     inst [2 or "le=4"] value 344810
@@ -5891,13 +5891,13 @@ opentelemetry.source1.sample_histogram0144 []
     inst [9 or "le=18"] value 1551645
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0144_count []
+opentelemetry.source1.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0144_sum []
+opentelemetry.source1.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0166 []
+opentelemetry.source1.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 196185
     inst [2 or "le=4"] value 392370
@@ -5910,13 +5910,13 @@ opentelemetry.source1.sample_histogram0166 []
     inst [9 or "le=18"] value 1765665
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0166_count []
+opentelemetry.source1.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0166_sum []
+opentelemetry.source1.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0188 []
+opentelemetry.source1.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 219965
     inst [2 or "le=4"] value 439930
@@ -5929,13 +5929,13 @@ opentelemetry.source1.sample_histogram0188 []
     inst [9 or "le=18"] value 1979685
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0188_count []
+opentelemetry.source1.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0188_sum []
+opentelemetry.source1.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0210 []
+opentelemetry.source1.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 243745
     inst [2 or "le=4"] value 487490
@@ -5948,13 +5948,13 @@ opentelemetry.source1.sample_histogram0210 []
     inst [9 or "le=18"] value 2193705
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0210_count []
+opentelemetry.source1.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0210_sum []
+opentelemetry.source1.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0232 []
+opentelemetry.source1.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 267525
     inst [2 or "le=4"] value 535050
@@ -5967,13 +5967,13 @@ opentelemetry.source1.sample_histogram0232 []
     inst [9 or "le=18"] value 2407725
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0232_count []
+opentelemetry.source1.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0232_sum []
+opentelemetry.source1.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0254 []
+opentelemetry.source1.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 291305
     inst [2 or "le=4"] value 582610
@@ -5986,13 +5986,13 @@ opentelemetry.source1.sample_histogram0254 []
     inst [9 or "le=18"] value 2621745
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0254_count []
+opentelemetry.source1.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0254_sum []
+opentelemetry.source1.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0276 []
+opentelemetry.source1.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 315085
     inst [2 or "le=4"] value 630170
@@ -6005,13 +6005,13 @@ opentelemetry.source1.sample_histogram0276 []
     inst [9 or "le=18"] value 2835765
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0276_count []
+opentelemetry.source1.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0276_sum []
+opentelemetry.source1.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0298 []
+opentelemetry.source1.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 338865
     inst [2 or "le=4"] value 677730
@@ -6024,13 +6024,13 @@ opentelemetry.source1.sample_histogram0298 []
     inst [9 or "le=18"] value 3049785
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0298_count []
+opentelemetry.source1.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0298_sum []
+opentelemetry.source1.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0320 []
+opentelemetry.source1.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 362645
     inst [2 or "le=4"] value 725290
@@ -6043,13 +6043,13 @@ opentelemetry.source1.sample_histogram0320 []
     inst [9 or "le=18"] value 3263805
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0320_count []
+opentelemetry.source1.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0320_sum []
+opentelemetry.source1.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0342 []
+opentelemetry.source1.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 386425
     inst [2 or "le=4"] value 772850
@@ -6062,13 +6062,13 @@ opentelemetry.source1.sample_histogram0342 []
     inst [9 or "le=18"] value 3477825
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0342_count []
+opentelemetry.source1.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0342_sum []
+opentelemetry.source1.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0364 []
+opentelemetry.source1.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 410205
     inst [2 or "le=4"] value 820410
@@ -6081,13 +6081,13 @@ opentelemetry.source1.sample_histogram0364 []
     inst [9 or "le=18"] value 3691845
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0364_count []
+opentelemetry.source1.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0364_sum []
+opentelemetry.source1.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0386 []
+opentelemetry.source1.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 433985
     inst [2 or "le=4"] value 867970
@@ -6100,13 +6100,13 @@ opentelemetry.source1.sample_histogram0386 []
     inst [9 or "le=18"] value 3905865
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0386_count []
+opentelemetry.source1.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0386_sum []
+opentelemetry.source1.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_summary0002 []
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0006384920000000001
     inst [2 or "quantile: 0.5"] value 0.001276984
@@ -6118,13 +6118,13 @@ opentelemetry.source1.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.005107936
     inst [9 or "quantile: 2.25"] value 0.005746428
 
-opentelemetry.source1.sample_summary0002_count []
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 7272
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 5.564827
 
-opentelemetry.source1.sample_summary0024 []
+opentelemetry.source1.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001276984
     inst [2 or "quantile: 0.5"] value 0.002553968
@@ -6136,13 +6136,13 @@ opentelemetry.source1.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.010215872
     inst [9 or "quantile: 2.25"] value 0.011492856
 
-opentelemetry.source1.sample_summary0024_count []
+opentelemetry.source1.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 14544
 
-opentelemetry.source1.sample_summary0024_sum []
+opentelemetry.source1.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 11.129654
 
-opentelemetry.source1.sample_summary0046 []
+opentelemetry.source1.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001915476
     inst [2 or "quantile: 0.5"] value 0.003830952
@@ -6154,13 +6154,13 @@ opentelemetry.source1.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.015323808
     inst [9 or "quantile: 2.25"] value 0.017239284
 
-opentelemetry.source1.sample_summary0046_count []
+opentelemetry.source1.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 21816
 
-opentelemetry.source1.sample_summary0046_sum []
+opentelemetry.source1.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 16.694481
 
-opentelemetry.source1.sample_summary0068 []
+opentelemetry.source1.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002553968
     inst [2 or "quantile: 0.5"] value 0.005107936
@@ -6172,13 +6172,13 @@ opentelemetry.source1.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.020431744
     inst [9 or "quantile: 2.25"] value 0.022985712
 
-opentelemetry.source1.sample_summary0068_count []
+opentelemetry.source1.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 29088
 
-opentelemetry.source1.sample_summary0068_sum []
+opentelemetry.source1.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 22.259308
 
-opentelemetry.source1.sample_summary0090 []
+opentelemetry.source1.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00319246
     inst [2 or "quantile: 0.5"] value 0.006384920000000001
@@ -6190,13 +6190,13 @@ opentelemetry.source1.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.02553968
     inst [9 or "quantile: 2.25"] value 0.02873214
 
-opentelemetry.source1.sample_summary0090_count []
+opentelemetry.source1.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 36360
 
-opentelemetry.source1.sample_summary0090_sum []
+opentelemetry.source1.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 27.824135
 
-opentelemetry.source1.sample_summary0112 []
+opentelemetry.source1.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003830952
     inst [2 or "quantile: 0.5"] value 0.007661904000000001
@@ -6208,13 +6208,13 @@ opentelemetry.source1.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.030647616
     inst [9 or "quantile: 2.25"] value 0.034478568
 
-opentelemetry.source1.sample_summary0112_count []
+opentelemetry.source1.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 43632
 
-opentelemetry.source1.sample_summary0112_sum []
+opentelemetry.source1.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 33.388962
 
-opentelemetry.source1.sample_summary0134 []
+opentelemetry.source1.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004469444
     inst [2 or "quantile: 0.5"] value 0.008938888000000001
@@ -6226,13 +6226,13 @@ opentelemetry.source1.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.035755552
     inst [9 or "quantile: 2.25"] value 0.04022499600000001
 
-opentelemetry.source1.sample_summary0134_count []
+opentelemetry.source1.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 50904
 
-opentelemetry.source1.sample_summary0134_sum []
+opentelemetry.source1.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 38.95379
 
-opentelemetry.source1.sample_summary0156 []
+opentelemetry.source1.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005107936
     inst [2 or "quantile: 0.5"] value 0.010215872
@@ -6244,13 +6244,13 @@ opentelemetry.source1.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.040863488
     inst [9 or "quantile: 2.25"] value 0.045971424
 
-opentelemetry.source1.sample_summary0156_count []
+opentelemetry.source1.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 58176
 
-opentelemetry.source1.sample_summary0156_sum []
+opentelemetry.source1.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 44.518617
 
-opentelemetry.source1.sample_summary0178 []
+opentelemetry.source1.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005746428
     inst [2 or "quantile: 0.5"] value 0.011492856
@@ -6262,13 +6262,13 @@ opentelemetry.source1.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.045971424
     inst [9 or "quantile: 2.25"] value 0.051717852
 
-opentelemetry.source1.sample_summary0178_count []
+opentelemetry.source1.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 65448
 
-opentelemetry.source1.sample_summary0178_sum []
+opentelemetry.source1.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 50.083444
 
-opentelemetry.source1.sample_summary0200 []
+opentelemetry.source1.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006384920000000001
     inst [2 or "quantile: 0.5"] value 0.01276984
@@ -6280,13 +6280,13 @@ opentelemetry.source1.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.05107936
     inst [9 or "quantile: 2.25"] value 0.05746428000000001
 
-opentelemetry.source1.sample_summary0200_count []
+opentelemetry.source1.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 72720
 
-opentelemetry.source1.sample_summary0200_sum []
+opentelemetry.source1.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 55.648271
 
-opentelemetry.source1.sample_summary0222 []
+opentelemetry.source1.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007023412000000001
     inst [2 or "quantile: 0.5"] value 0.014046824
@@ -6298,13 +6298,13 @@ opentelemetry.source1.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.056187296
     inst [9 or "quantile: 2.25"] value 0.063210708
 
-opentelemetry.source1.sample_summary0222_count []
+opentelemetry.source1.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 79992
 
-opentelemetry.source1.sample_summary0222_sum []
+opentelemetry.source1.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 61.213098
 
-opentelemetry.source1.sample_summary0244 []
+opentelemetry.source1.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007661904000000001
     inst [2 or "quantile: 0.5"] value 0.015323808
@@ -6316,13 +6316,13 @@ opentelemetry.source1.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.06129523200000001
     inst [9 or "quantile: 2.25"] value 0.068957136
 
-opentelemetry.source1.sample_summary0244_count []
+opentelemetry.source1.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 87264
 
-opentelemetry.source1.sample_summary0244_sum []
+opentelemetry.source1.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 66.777925
 
-opentelemetry.source1.sample_summary0266 []
+opentelemetry.source1.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008300396000000002
     inst [2 or "quantile: 0.5"] value 0.016600792
@@ -6334,13 +6334,13 @@ opentelemetry.source1.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.06640316800000001
     inst [9 or "quantile: 2.25"] value 0.074703564
 
-opentelemetry.source1.sample_summary0266_count []
+opentelemetry.source1.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 94536
 
-opentelemetry.source1.sample_summary0266_sum []
+opentelemetry.source1.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 72.342752
 
-opentelemetry.source1.sample_summary0288 []
+opentelemetry.source1.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008938888000000001
     inst [2 or "quantile: 0.5"] value 0.017877776
@@ -6352,13 +6352,13 @@ opentelemetry.source1.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.07151110400000001
     inst [9 or "quantile: 2.25"] value 0.08044999200000001
 
-opentelemetry.source1.sample_summary0288_count []
+opentelemetry.source1.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 101808
 
-opentelemetry.source1.sample_summary0288_sum []
+opentelemetry.source1.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 77.907579
 
-opentelemetry.source1.sample_summary0310 []
+opentelemetry.source1.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00957738
     inst [2 or "quantile: 0.5"] value 0.01915476
@@ -6370,13 +6370,13 @@ opentelemetry.source1.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.07661904
     inst [9 or "quantile: 2.25"] value 0.08619642000000001
 
-opentelemetry.source1.sample_summary0310_count []
+opentelemetry.source1.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 109080
 
-opentelemetry.source1.sample_summary0310_sum []
+opentelemetry.source1.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 83.47240600000001
 
-opentelemetry.source1.sample_summary0332 []
+opentelemetry.source1.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010215872
     inst [2 or "quantile: 0.5"] value 0.020431744
@@ -6388,13 +6388,13 @@ opentelemetry.source1.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.08172697600000001
     inst [9 or "quantile: 2.25"] value 0.09194284800000001
 
-opentelemetry.source1.sample_summary0332_count []
+opentelemetry.source1.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 116352
 
-opentelemetry.source1.sample_summary0332_sum []
+opentelemetry.source1.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 89.037233
 
-opentelemetry.source1.sample_summary0354 []
+opentelemetry.source1.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010854364
     inst [2 or "quantile: 0.5"] value 0.021708728
@@ -6406,13 +6406,13 @@ opentelemetry.source1.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.08683491200000001
     inst [9 or "quantile: 2.25"] value 0.09768927600000001
 
-opentelemetry.source1.sample_summary0354_count []
+opentelemetry.source1.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 123624
 
-opentelemetry.source1.sample_summary0354_sum []
+opentelemetry.source1.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 94.60205999999999
 
-opentelemetry.source1.sample_summary0376 []
+opentelemetry.source1.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011492856
     inst [2 or "quantile: 0.5"] value 0.022985712
@@ -6424,13 +6424,13 @@ opentelemetry.source1.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.09194284800000001
     inst [9 or "quantile: 2.25"] value 0.103435704
 
-opentelemetry.source1.sample_summary0376_count []
+opentelemetry.source1.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 130896
 
-opentelemetry.source1.sample_summary0376_sum []
+opentelemetry.source1.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 100.166887
 
-opentelemetry.source1.sample_summary0398 []
+opentelemetry.source1.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012131348
     inst [2 or "quantile: 0.5"] value 0.024262696
@@ -6442,13 +6442,13 @@ opentelemetry.source1.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.097050784
     inst [9 or "quantile: 2.25"] value 0.109182132
 
-opentelemetry.source1.sample_summary0398_count []
+opentelemetry.source1.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 138168
 
-opentelemetry.source1.sample_summary0398_sum []
+opentelemetry.source1.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 105.731715
 
-opentelemetry.source1.sample_counter0001 []
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 680821576
     inst [2 or "2 inst-2"] value 1361643150
@@ -6460,7 +6460,7 @@ opentelemetry.source1.sample_counter0001 []
     inst [8 or "8 inst-8"] value 5446572610
     inst [9 or "9 inst-9"] value 6127394180
 
-opentelemetry.source1.sample_counter0023 []
+opentelemetry.source1.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1361643150
     inst [2 or "2 inst-2"] value 2723286300
@@ -6472,7 +6472,7 @@ opentelemetry.source1.sample_counter0023 []
     inst [8 or "8 inst-8"] value 10893145200
     inst [9 or "9 inst-9"] value 12254788400
 
-opentelemetry.source1.sample_counter0045 []
+opentelemetry.source1.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2042464730
     inst [2 or "2 inst-2"] value 4084929460
@@ -6484,7 +6484,7 @@ opentelemetry.source1.sample_counter0045 []
     inst [8 or "8 inst-8"] value 16339717800
     inst [9 or "9 inst-9"] value 18382182600
 
-opentelemetry.source1.sample_counter0067 []
+opentelemetry.source1.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2723286300
     inst [2 or "2 inst-2"] value 5446572610
@@ -6496,7 +6496,7 @@ opentelemetry.source1.sample_counter0067 []
     inst [8 or "8 inst-8"] value 21786290400
     inst [9 or "9 inst-9"] value 24509576700
 
-opentelemetry.source1.sample_counter0089 []
+opentelemetry.source1.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3404107880
     inst [2 or "2 inst-2"] value 6808215760
@@ -6508,7 +6508,7 @@ opentelemetry.source1.sample_counter0089 []
     inst [8 or "8 inst-8"] value 27232863000
     inst [9 or "9 inst-9"] value 30636970900
 
-opentelemetry.source1.sample_counter0111 []
+opentelemetry.source1.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4084929460
     inst [2 or "2 inst-2"] value 8169858910
@@ -6520,7 +6520,7 @@ opentelemetry.source1.sample_counter0111 []
     inst [8 or "8 inst-8"] value 32679435600
     inst [9 or "9 inst-9"] value 36764365100
 
-opentelemetry.source1.sample_counter0133 []
+opentelemetry.source1.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4765751030
     inst [2 or "2 inst-2"] value 9531502060
@@ -6532,7 +6532,7 @@ opentelemetry.source1.sample_counter0133 []
     inst [8 or "8 inst-8"] value 38126008300
     inst [9 or "9 inst-9"] value 42891759300
 
-opentelemetry.source1.sample_counter0155 []
+opentelemetry.source1.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5446572610
     inst [2 or "2 inst-2"] value 10893145200
@@ -6544,7 +6544,7 @@ opentelemetry.source1.sample_counter0155 []
     inst [8 or "8 inst-8"] value 43572580900
     inst [9 or "9 inst-9"] value 49019153500
 
-opentelemetry.source1.sample_counter0177 []
+opentelemetry.source1.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6127394180
     inst [2 or "2 inst-2"] value 12254788400
@@ -6556,7 +6556,7 @@ opentelemetry.source1.sample_counter0177 []
     inst [8 or "8 inst-8"] value 49019153500
     inst [9 or "9 inst-9"] value 55146547700
 
-opentelemetry.source1.sample_counter0199 []
+opentelemetry.source1.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6808215760
     inst [2 or "2 inst-2"] value 13616431500
@@ -6568,7 +6568,7 @@ opentelemetry.source1.sample_counter0199 []
     inst [8 or "8 inst-8"] value 54465726100
     inst [9 or "9 inst-9"] value 61273941800
 
-opentelemetry.source1.sample_counter0221 []
+opentelemetry.source1.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7489037340
     inst [2 or "2 inst-2"] value 14978074700
@@ -6580,7 +6580,7 @@ opentelemetry.source1.sample_counter0221 []
     inst [8 or "8 inst-8"] value 59912298700
     inst [9 or "9 inst-9"] value 67401336000
 
-opentelemetry.source1.sample_counter0243 []
+opentelemetry.source1.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8169858910
     inst [2 or "2 inst-2"] value 16339717800
@@ -6592,7 +6592,7 @@ opentelemetry.source1.sample_counter0243 []
     inst [8 or "8 inst-8"] value 65358871300
     inst [9 or "9 inst-9"] value 73528730200
 
-opentelemetry.source1.sample_counter0265 []
+opentelemetry.source1.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8850680490
     inst [2 or "2 inst-2"] value 17701361000
@@ -6604,7 +6604,7 @@ opentelemetry.source1.sample_counter0265 []
     inst [8 or "8 inst-8"] value 70805443900
     inst [9 or "9 inst-9"] value 79656124400
 
-opentelemetry.source1.sample_counter0287 []
+opentelemetry.source1.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9531502060
     inst [2 or "2 inst-2"] value 19063004100
@@ -6616,7 +6616,7 @@ opentelemetry.source1.sample_counter0287 []
     inst [8 or "8 inst-8"] value 76252016500
     inst [9 or "9 inst-9"] value 85783518600
 
-opentelemetry.source1.sample_counter0309 []
+opentelemetry.source1.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10212323600
     inst [2 or "2 inst-2"] value 20424647300
@@ -6628,7 +6628,7 @@ opentelemetry.source1.sample_counter0309 []
     inst [8 or "8 inst-8"] value 81698589100
     inst [9 or "9 inst-9"] value 91910912800
 
-opentelemetry.source1.sample_counter0331 []
+opentelemetry.source1.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10893145200
     inst [2 or "2 inst-2"] value 21786290400
@@ -6640,7 +6640,7 @@ opentelemetry.source1.sample_counter0331 []
     inst [8 or "8 inst-8"] value 87145161700
     inst [9 or "9 inst-9"] value 98038306900
 
-opentelemetry.source1.sample_counter0353 []
+opentelemetry.source1.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11573966800
     inst [2 or "2 inst-2"] value 23147933600
@@ -6652,7 +6652,7 @@ opentelemetry.source1.sample_counter0353 []
     inst [8 or "8 inst-8"] value 92591734300
     inst [9 or "9 inst-9"] value 104165701000
 
-opentelemetry.source1.sample_counter0375 []
+opentelemetry.source1.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12254788400
     inst [2 or "2 inst-2"] value 24509576700
@@ -6664,7 +6664,7 @@ opentelemetry.source1.sample_counter0375 []
     inst [8 or "8 inst-8"] value 98038306900
     inst [9 or "9 inst-9"] value 110293095000
 
-opentelemetry.source1.sample_counter0397 []
+opentelemetry.source1.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12935609900
     inst [2 or "2 inst-2"] value 25871219900
@@ -6676,7 +6676,7 @@ opentelemetry.source1.sample_counter0397 []
     inst [8 or "8 inst-8"] value 103484880000
     inst [9 or "9 inst-9"] value 116420489000
 
-opentelemetry.source1.sample_gauge0000 []
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 36.3
     inst [2 or "2 inst-2"] value 72.59999999999999
@@ -6688,7 +6688,7 @@ opentelemetry.source1.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 290.4
     inst [9 or "9 inst-9"] value 326.7
 
-opentelemetry.source1.sample_gauge0022 []
+opentelemetry.source1.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 84.7
     inst [2 or "2 inst-2"] value 169.4
@@ -6700,7 +6700,7 @@ opentelemetry.source1.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 677.6
     inst [9 or "9 inst-9"] value 762.3
 
-opentelemetry.source1.sample_gauge0044 []
+opentelemetry.source1.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 133.1
     inst [2 or "2 inst-2"] value 266.2
@@ -6712,7 +6712,7 @@ opentelemetry.source1.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 1064.8
     inst [9 or "9 inst-9"] value 1197.9
 
-opentelemetry.source1.sample_gauge0066 []
+opentelemetry.source1.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 181.5
     inst [2 or "2 inst-2"] value 363
@@ -6724,7 +6724,7 @@ opentelemetry.source1.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1452
     inst [9 or "9 inst-9"] value 1633.5
 
-opentelemetry.source1.sample_gauge0088 []
+opentelemetry.source1.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 229.9
     inst [2 or "2 inst-2"] value 459.8
@@ -6736,7 +6736,7 @@ opentelemetry.source1.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 1839.2
     inst [9 or "9 inst-9"] value 2069.1
 
-opentelemetry.source1.sample_gauge0110 []
+opentelemetry.source1.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 278.3
     inst [2 or "2 inst-2"] value 556.6
@@ -6748,7 +6748,7 @@ opentelemetry.source1.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2226.4
     inst [9 or "9 inst-9"] value 2504.7
 
-opentelemetry.source1.sample_gauge0132 []
+opentelemetry.source1.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 326.7
     inst [2 or "2 inst-2"] value 653.4
@@ -6760,7 +6760,7 @@ opentelemetry.source1.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2613.6
     inst [9 or "9 inst-9"] value 2940.3
 
-opentelemetry.source1.sample_gauge0154 []
+opentelemetry.source1.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 375.1
     inst [2 or "2 inst-2"] value 750.2
@@ -6772,7 +6772,7 @@ opentelemetry.source1.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 3000.8
     inst [9 or "9 inst-9"] value 3375.9
 
-opentelemetry.source1.sample_gauge0176 []
+opentelemetry.source1.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 423.5
     inst [2 or "2 inst-2"] value 847
@@ -6784,7 +6784,7 @@ opentelemetry.source1.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3388
     inst [9 or "9 inst-9"] value 3811.5
 
-opentelemetry.source1.sample_gauge0198 []
+opentelemetry.source1.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 471.9
     inst [2 or "2 inst-2"] value 943.8
@@ -6796,7 +6796,7 @@ opentelemetry.source1.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 3775.2
     inst [9 or "9 inst-9"] value 4247.1
 
-opentelemetry.source1.sample_gauge0220 []
+opentelemetry.source1.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 520.3
     inst [2 or "2 inst-2"] value 1040.6
@@ -6808,7 +6808,7 @@ opentelemetry.source1.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 4162.4
     inst [9 or "9 inst-9"] value 4682.7
 
-opentelemetry.source1.sample_gauge0242 []
+opentelemetry.source1.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 568.7
     inst [2 or "2 inst-2"] value 1137.4
@@ -6820,7 +6820,7 @@ opentelemetry.source1.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4549.6
     inst [9 or "9 inst-9"] value 5118.3
 
-opentelemetry.source1.sample_gauge0264 []
+opentelemetry.source1.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 617.1
     inst [2 or "2 inst-2"] value 1234.2
@@ -6832,7 +6832,7 @@ opentelemetry.source1.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 4936.8
     inst [9 or "9 inst-9"] value 5553.9
 
-opentelemetry.source1.sample_gauge0286 []
+opentelemetry.source1.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 665.5
     inst [2 or "2 inst-2"] value 1331
@@ -6844,7 +6844,7 @@ opentelemetry.source1.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5324
     inst [9 or "9 inst-9"] value 5989.5
 
-opentelemetry.source1.sample_gauge0308 []
+opentelemetry.source1.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 713.9
     inst [2 or "2 inst-2"] value 1427.8
@@ -6856,7 +6856,7 @@ opentelemetry.source1.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 5711.2
     inst [9 or "9 inst-9"] value 6425.1
 
-opentelemetry.source1.sample_gauge0330 []
+opentelemetry.source1.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 762.3
     inst [2 or "2 inst-2"] value 1524.6
@@ -6868,7 +6868,7 @@ opentelemetry.source1.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6098.4
     inst [9 or "9 inst-9"] value 6860.7
 
-opentelemetry.source1.sample_gauge0352 []
+opentelemetry.source1.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 810.7
     inst [2 or "2 inst-2"] value 1621.4
@@ -6880,7 +6880,7 @@ opentelemetry.source1.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6485.6
     inst [9 or "9 inst-9"] value 7296.3
 
-opentelemetry.source1.sample_gauge0374 []
+opentelemetry.source1.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 859.1
     inst [2 or "2 inst-2"] value 1718.2
@@ -6892,7 +6892,7 @@ opentelemetry.source1.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 6872.8
     inst [9 or "9 inst-9"] value 7731.9
 
-opentelemetry.source1.sample_gauge0396 []
+opentelemetry.source1.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 907.5
     inst [2 or "2 inst-2"] value 1815
@@ -6904,7 +6904,7 @@ opentelemetry.source1.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7260
     inst [9 or "9 inst-9"] value 8167.5
 
-opentelemetry.source1.sample_histogram0012 []
+opentelemetry.source1.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 35670
     inst [2 or "le=4"] value 71340
@@ -6917,13 +6917,13 @@ opentelemetry.source1.sample_histogram0012 []
     inst [9 or "le=18"] value 321030
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0012_count []
+opentelemetry.source1.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0012_sum []
+opentelemetry.source1.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0034 []
+opentelemetry.source1.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 59450
     inst [2 or "le=4"] value 118900
@@ -6936,13 +6936,13 @@ opentelemetry.source1.sample_histogram0034 []
     inst [9 or "le=18"] value 535050
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0034_count []
+opentelemetry.source1.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0034_sum []
+opentelemetry.source1.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0056 []
+opentelemetry.source1.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 83230
     inst [2 or "le=4"] value 166460
@@ -6955,13 +6955,13 @@ opentelemetry.source1.sample_histogram0056 []
     inst [9 or "le=18"] value 749070
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0056_count []
+opentelemetry.source1.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0056_sum []
+opentelemetry.source1.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0078 []
+opentelemetry.source1.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 107010
     inst [2 or "le=4"] value 214020
@@ -6974,13 +6974,13 @@ opentelemetry.source1.sample_histogram0078 []
     inst [9 or "le=18"] value 963090
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0078_count []
+opentelemetry.source1.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0078_sum []
+opentelemetry.source1.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0100 []
+opentelemetry.source1.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 130790
     inst [2 or "le=4"] value 261580
@@ -6993,13 +6993,13 @@ opentelemetry.source1.sample_histogram0100 []
     inst [9 or "le=18"] value 1177110
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0100_count []
+opentelemetry.source1.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0100_sum []
+opentelemetry.source1.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0122 []
+opentelemetry.source1.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 154570
     inst [2 or "le=4"] value 309140
@@ -7012,13 +7012,13 @@ opentelemetry.source1.sample_histogram0122 []
     inst [9 or "le=18"] value 1391130
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0122_count []
+opentelemetry.source1.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0122_sum []
+opentelemetry.source1.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0144 []
+opentelemetry.source1.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 178350
     inst [2 or "le=4"] value 356700
@@ -7031,13 +7031,13 @@ opentelemetry.source1.sample_histogram0144 []
     inst [9 or "le=18"] value 1605150
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0144_count []
+opentelemetry.source1.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0144_sum []
+opentelemetry.source1.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0166 []
+opentelemetry.source1.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 202130
     inst [2 or "le=4"] value 404260
@@ -7050,13 +7050,13 @@ opentelemetry.source1.sample_histogram0166 []
     inst [9 or "le=18"] value 1819170
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0166_count []
+opentelemetry.source1.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0166_sum []
+opentelemetry.source1.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0188 []
+opentelemetry.source1.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 225910
     inst [2 or "le=4"] value 451820
@@ -7069,13 +7069,13 @@ opentelemetry.source1.sample_histogram0188 []
     inst [9 or "le=18"] value 2033190
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0188_count []
+opentelemetry.source1.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0188_sum []
+opentelemetry.source1.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0210 []
+opentelemetry.source1.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 249690
     inst [2 or "le=4"] value 499380
@@ -7088,13 +7088,13 @@ opentelemetry.source1.sample_histogram0210 []
     inst [9 or "le=18"] value 2247210
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0210_count []
+opentelemetry.source1.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0210_sum []
+opentelemetry.source1.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0232 []
+opentelemetry.source1.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 273470
     inst [2 or "le=4"] value 546940
@@ -7107,13 +7107,13 @@ opentelemetry.source1.sample_histogram0232 []
     inst [9 or "le=18"] value 2461230
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0232_count []
+opentelemetry.source1.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0232_sum []
+opentelemetry.source1.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0254 []
+opentelemetry.source1.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 297250
     inst [2 or "le=4"] value 594500
@@ -7126,13 +7126,13 @@ opentelemetry.source1.sample_histogram0254 []
     inst [9 or "le=18"] value 2675250
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0254_count []
+opentelemetry.source1.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0254_sum []
+opentelemetry.source1.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0276 []
+opentelemetry.source1.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 321030
     inst [2 or "le=4"] value 642060
@@ -7145,13 +7145,13 @@ opentelemetry.source1.sample_histogram0276 []
     inst [9 or "le=18"] value 2889270
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0276_count []
+opentelemetry.source1.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0276_sum []
+opentelemetry.source1.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0298 []
+opentelemetry.source1.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 344810
     inst [2 or "le=4"] value 689620
@@ -7164,13 +7164,13 @@ opentelemetry.source1.sample_histogram0298 []
     inst [9 or "le=18"] value 3103290
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0298_count []
+opentelemetry.source1.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0298_sum []
+opentelemetry.source1.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0320 []
+opentelemetry.source1.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 368590
     inst [2 or "le=4"] value 737180
@@ -7183,13 +7183,13 @@ opentelemetry.source1.sample_histogram0320 []
     inst [9 or "le=18"] value 3317310
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0320_count []
+opentelemetry.source1.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0320_sum []
+opentelemetry.source1.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0342 []
+opentelemetry.source1.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 392370
     inst [2 or "le=4"] value 784740
@@ -7202,13 +7202,13 @@ opentelemetry.source1.sample_histogram0342 []
     inst [9 or "le=18"] value 3531330
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0342_count []
+opentelemetry.source1.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0342_sum []
+opentelemetry.source1.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0364 []
+opentelemetry.source1.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 416150
     inst [2 or "le=4"] value 832300
@@ -7221,13 +7221,13 @@ opentelemetry.source1.sample_histogram0364 []
     inst [9 or "le=18"] value 3745350
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0364_count []
+opentelemetry.source1.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0364_sum []
+opentelemetry.source1.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0386 []
+opentelemetry.source1.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 439930
     inst [2 or "le=4"] value 879860
@@ -7240,13 +7240,13 @@ opentelemetry.source1.sample_histogram0386 []
     inst [9 or "le=18"] value 3959370
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0386_count []
+opentelemetry.source1.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0386_sum []
+opentelemetry.source1.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_summary0002 []
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0007981150000000001
     inst [2 or "quantile: 0.5"] value 0.00159623
@@ -7258,13 +7258,13 @@ opentelemetry.source1.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.006384920000000001
     inst [9 or "quantile: 2.25"] value 0.007183035000000001
 
-opentelemetry.source1.sample_summary0002_count []
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 9090
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 6.956034
 
-opentelemetry.source1.sample_summary0024 []
+opentelemetry.source1.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001436607
     inst [2 or "quantile: 0.5"] value 0.002873214
@@ -7276,13 +7276,13 @@ opentelemetry.source1.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.011492856
     inst [9 or "quantile: 2.25"] value 0.012929463
 
-opentelemetry.source1.sample_summary0024_count []
+opentelemetry.source1.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 16362
 
-opentelemetry.source1.sample_summary0024_sum []
+opentelemetry.source1.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 12.520861
 
-opentelemetry.source1.sample_summary0046 []
+opentelemetry.source1.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002075099
     inst [2 or "quantile: 0.5"] value 0.004150198000000001
@@ -7294,13 +7294,13 @@ opentelemetry.source1.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.016600792
     inst [9 or "quantile: 2.25"] value 0.018675891
 
-opentelemetry.source1.sample_summary0046_count []
+opentelemetry.source1.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 23634
 
-opentelemetry.source1.sample_summary0046_sum []
+opentelemetry.source1.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 18.085688
 
-opentelemetry.source1.sample_summary0068 []
+opentelemetry.source1.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002713591
     inst [2 or "quantile: 0.5"] value 0.005427182000000001
@@ -7312,13 +7312,13 @@ opentelemetry.source1.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.021708728
     inst [9 or "quantile: 2.25"] value 0.024422319
 
-opentelemetry.source1.sample_summary0068_count []
+opentelemetry.source1.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 30906
 
-opentelemetry.source1.sample_summary0068_sum []
+opentelemetry.source1.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 23.650515
 
-opentelemetry.source1.sample_summary0090 []
+opentelemetry.source1.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003352083
     inst [2 or "quantile: 0.5"] value 0.006704166000000001
@@ -7330,13 +7330,13 @@ opentelemetry.source1.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.026816664
     inst [9 or "quantile: 2.25"] value 0.030168747
 
-opentelemetry.source1.sample_summary0090_count []
+opentelemetry.source1.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 38178
 
-opentelemetry.source1.sample_summary0090_sum []
+opentelemetry.source1.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 29.215342
 
-opentelemetry.source1.sample_summary0112 []
+opentelemetry.source1.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003990575000000001
     inst [2 or "quantile: 0.5"] value 0.007981150000000001
@@ -7348,13 +7348,13 @@ opentelemetry.source1.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.0319246
     inst [9 or "quantile: 2.25"] value 0.035915175
 
-opentelemetry.source1.sample_summary0112_count []
+opentelemetry.source1.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 45450
 
-opentelemetry.source1.sample_summary0112_sum []
+opentelemetry.source1.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 34.780169
 
-opentelemetry.source1.sample_summary0134 []
+opentelemetry.source1.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004629067000000001
     inst [2 or "quantile: 0.5"] value 0.009258134000000001
@@ -7366,13 +7366,13 @@ opentelemetry.source1.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.037032536
     inst [9 or "quantile: 2.25"] value 0.04166160300000001
 
-opentelemetry.source1.sample_summary0134_count []
+opentelemetry.source1.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 52722
 
-opentelemetry.source1.sample_summary0134_sum []
+opentelemetry.source1.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 40.344996
 
-opentelemetry.source1.sample_summary0156 []
+opentelemetry.source1.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005267559000000001
     inst [2 or "quantile: 0.5"] value 0.010535118
@@ -7384,13 +7384,13 @@ opentelemetry.source1.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.04214047200000001
     inst [9 or "quantile: 2.25"] value 0.047408031
 
-opentelemetry.source1.sample_summary0156_count []
+opentelemetry.source1.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 59994
 
-opentelemetry.source1.sample_summary0156_sum []
+opentelemetry.source1.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 45.909823
 
-opentelemetry.source1.sample_summary0178 []
+opentelemetry.source1.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005906051000000001
     inst [2 or "quantile: 0.5"] value 0.011812102
@@ -7402,13 +7402,13 @@ opentelemetry.source1.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.04724840800000001
     inst [9 or "quantile: 2.25"] value 0.053154459
 
-opentelemetry.source1.sample_summary0178_count []
+opentelemetry.source1.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 67266
 
-opentelemetry.source1.sample_summary0178_sum []
+opentelemetry.source1.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 51.47465
 
-opentelemetry.source1.sample_summary0200 []
+opentelemetry.source1.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006544543000000001
     inst [2 or "quantile: 0.5"] value 0.013089086
@@ -7420,13 +7420,13 @@ opentelemetry.source1.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.05235634400000001
     inst [9 or "quantile: 2.25"] value 0.05890088700000001
 
-opentelemetry.source1.sample_summary0200_count []
+opentelemetry.source1.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 74538
 
-opentelemetry.source1.sample_summary0200_sum []
+opentelemetry.source1.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 57.039478
 
-opentelemetry.source1.sample_summary0222 []
+opentelemetry.source1.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007183035000000001
     inst [2 or "quantile: 0.5"] value 0.01436607
@@ -7438,13 +7438,13 @@ opentelemetry.source1.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.05746428000000001
     inst [9 or "quantile: 2.25"] value 0.06464731500000001
 
-opentelemetry.source1.sample_summary0222_count []
+opentelemetry.source1.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 81810
 
-opentelemetry.source1.sample_summary0222_sum []
+opentelemetry.source1.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 62.604305
 
-opentelemetry.source1.sample_summary0244 []
+opentelemetry.source1.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007821527
     inst [2 or "quantile: 0.5"] value 0.015643054
@@ -7456,13 +7456,13 @@ opentelemetry.source1.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.062572216
     inst [9 or "quantile: 2.25"] value 0.07039374300000001
 
-opentelemetry.source1.sample_summary0244_count []
+opentelemetry.source1.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 89082
 
-opentelemetry.source1.sample_summary0244_sum []
+opentelemetry.source1.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 68.169132
 
-opentelemetry.source1.sample_summary0266 []
+opentelemetry.source1.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008460019000000001
     inst [2 or "quantile: 0.5"] value 0.016920038
@@ -7474,13 +7474,13 @@ opentelemetry.source1.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.06768015200000001
     inst [9 or "quantile: 2.25"] value 0.07614017100000001
 
-opentelemetry.source1.sample_summary0266_count []
+opentelemetry.source1.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 96354
 
-opentelemetry.source1.sample_summary0266_sum []
+opentelemetry.source1.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 73.733959
 
-opentelemetry.source1.sample_summary0288 []
+opentelemetry.source1.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009098511
     inst [2 or "quantile: 0.5"] value 0.018197022
@@ -7492,13 +7492,13 @@ opentelemetry.source1.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.072788088
     inst [9 or "quantile: 2.25"] value 0.081886599
 
-opentelemetry.source1.sample_summary0288_count []
+opentelemetry.source1.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 103626
 
-opentelemetry.source1.sample_summary0288_sum []
+opentelemetry.source1.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 79.29878600000001
 
-opentelemetry.source1.sample_summary0310 []
+opentelemetry.source1.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009737003000000001
     inst [2 or "quantile: 0.5"] value 0.019474006
@@ -7510,13 +7510,13 @@ opentelemetry.source1.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.07789602400000001
     inst [9 or "quantile: 2.25"] value 0.087633027
 
-opentelemetry.source1.sample_summary0310_count []
+opentelemetry.source1.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 110898
 
-opentelemetry.source1.sample_summary0310_sum []
+opentelemetry.source1.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 84.863613
 
-opentelemetry.source1.sample_summary0332 []
+opentelemetry.source1.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010375495
     inst [2 or "quantile: 0.5"] value 0.02075099
@@ -7528,13 +7528,13 @@ opentelemetry.source1.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.08300396
     inst [9 or "quantile: 2.25"] value 0.09337945500000001
 
-opentelemetry.source1.sample_summary0332_count []
+opentelemetry.source1.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 118170
 
-opentelemetry.source1.sample_summary0332_sum []
+opentelemetry.source1.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 90.42843999999999
 
-opentelemetry.source1.sample_summary0354 []
+opentelemetry.source1.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011013987
     inst [2 or "quantile: 0.5"] value 0.022027974
@@ -7546,13 +7546,13 @@ opentelemetry.source1.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.08811189600000001
     inst [9 or "quantile: 2.25"] value 0.09912588300000001
 
-opentelemetry.source1.sample_summary0354_count []
+opentelemetry.source1.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 125442
 
-opentelemetry.source1.sample_summary0354_sum []
+opentelemetry.source1.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 95.993267
 
-opentelemetry.source1.sample_summary0376 []
+opentelemetry.source1.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011652479
     inst [2 or "quantile: 0.5"] value 0.023304958
@@ -7564,13 +7564,13 @@ opentelemetry.source1.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.093219832
     inst [9 or "quantile: 2.25"] value 0.104872311
 
-opentelemetry.source1.sample_summary0376_count []
+opentelemetry.source1.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 132714
 
-opentelemetry.source1.sample_summary0376_sum []
+opentelemetry.source1.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 101.558094
 
-opentelemetry.source1.sample_summary0398 []
+opentelemetry.source1.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012290971
     inst [2 or "quantile: 0.5"] value 0.024581942
@@ -7582,13 +7582,13 @@ opentelemetry.source1.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.09832776800000001
     inst [9 or "quantile: 2.25"] value 0.110618739
 
-opentelemetry.source1.sample_summary0398_count []
+opentelemetry.source1.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 139986
 
-opentelemetry.source1.sample_summary0398_sum []
+opentelemetry.source1.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 107.122921
 
-opentelemetry.source1.sample_counter0001 []
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 851026970
     inst [2 or "2 inst-2"] value 1702053940
@@ -7600,7 +7600,7 @@ opentelemetry.source1.sample_counter0001 []
     inst [8 or "8 inst-8"] value 6808215760
     inst [9 or "9 inst-9"] value 7659242730
 
-opentelemetry.source1.sample_counter0023 []
+opentelemetry.source1.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1531848550
     inst [2 or "2 inst-2"] value 3063697090
@@ -7612,7 +7612,7 @@ opentelemetry.source1.sample_counter0023 []
     inst [8 or "8 inst-8"] value 12254788400
     inst [9 or "9 inst-9"] value 13786636900
 
-opentelemetry.source1.sample_counter0045 []
+opentelemetry.source1.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -7624,7 +7624,7 @@ opentelemetry.source1.sample_counter0045 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source1.sample_counter0067 []
+opentelemetry.source1.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -7636,7 +7636,7 @@ opentelemetry.source1.sample_counter0067 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source1.sample_counter0089 []
+opentelemetry.source1.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -7648,7 +7648,7 @@ opentelemetry.source1.sample_counter0089 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source1.sample_counter0111 []
+opentelemetry.source1.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -7660,7 +7660,7 @@ opentelemetry.source1.sample_counter0111 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source1.sample_counter0133 []
+opentelemetry.source1.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -7672,7 +7672,7 @@ opentelemetry.source1.sample_counter0133 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source1.sample_counter0155 []
+opentelemetry.source1.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -7684,7 +7684,7 @@ opentelemetry.source1.sample_counter0155 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source1.sample_counter0177 []
+opentelemetry.source1.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -7696,7 +7696,7 @@ opentelemetry.source1.sample_counter0177 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source1.sample_counter0199 []
+opentelemetry.source1.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -7708,7 +7708,7 @@ opentelemetry.source1.sample_counter0199 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source1.sample_counter0221 []
+opentelemetry.source1.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -7720,7 +7720,7 @@ opentelemetry.source1.sample_counter0221 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source1.sample_counter0243 []
+opentelemetry.source1.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -7732,7 +7732,7 @@ opentelemetry.source1.sample_counter0243 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source1.sample_counter0265 []
+opentelemetry.source1.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -7744,7 +7744,7 @@ opentelemetry.source1.sample_counter0265 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source1.sample_counter0287 []
+opentelemetry.source1.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -7756,7 +7756,7 @@ opentelemetry.source1.sample_counter0287 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source1.sample_counter0309 []
+opentelemetry.source1.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -7768,7 +7768,7 @@ opentelemetry.source1.sample_counter0309 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source1.sample_counter0331 []
+opentelemetry.source1.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -7780,7 +7780,7 @@ opentelemetry.source1.sample_counter0331 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source1.sample_counter0353 []
+opentelemetry.source1.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -7792,7 +7792,7 @@ opentelemetry.source1.sample_counter0353 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source1.sample_counter0375 []
+opentelemetry.source1.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -7804,7 +7804,7 @@ opentelemetry.source1.sample_counter0375 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source1.sample_counter0397 []
+opentelemetry.source1.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13105815300
     inst [2 or "2 inst-2"] value 26211630700
@@ -7816,7 +7816,7 @@ opentelemetry.source1.sample_counter0397 []
     inst [8 or "8 inst-8"] value 104846523000
     inst [9 or "9 inst-9"] value 117952338000
 
-opentelemetry.source1.sample_gauge0000 []
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 48.4
     inst [2 or "2 inst-2"] value 96.8
@@ -7828,7 +7828,7 @@ opentelemetry.source1.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 387.2
     inst [9 or "9 inst-9"] value 435.6
 
-opentelemetry.source1.sample_gauge0022 []
+opentelemetry.source1.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 96.8
     inst [2 or "2 inst-2"] value 193.6
@@ -7840,7 +7840,7 @@ opentelemetry.source1.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 774.4
     inst [9 or "9 inst-9"] value 871.2
 
-opentelemetry.source1.sample_gauge0044 []
+opentelemetry.source1.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -7852,7 +7852,7 @@ opentelemetry.source1.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source1.sample_gauge0066 []
+opentelemetry.source1.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -7864,7 +7864,7 @@ opentelemetry.source1.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source1.sample_gauge0088 []
+opentelemetry.source1.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -7876,7 +7876,7 @@ opentelemetry.source1.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source1.sample_gauge0110 []
+opentelemetry.source1.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -7888,7 +7888,7 @@ opentelemetry.source1.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source1.sample_gauge0132 []
+opentelemetry.source1.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -7900,7 +7900,7 @@ opentelemetry.source1.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source1.sample_gauge0154 []
+opentelemetry.source1.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -7912,7 +7912,7 @@ opentelemetry.source1.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source1.sample_gauge0176 []
+opentelemetry.source1.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -7924,7 +7924,7 @@ opentelemetry.source1.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source1.sample_gauge0198 []
+opentelemetry.source1.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -7936,7 +7936,7 @@ opentelemetry.source1.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source1.sample_gauge0220 []
+opentelemetry.source1.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -7948,7 +7948,7 @@ opentelemetry.source1.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source1.sample_gauge0242 []
+opentelemetry.source1.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -7960,7 +7960,7 @@ opentelemetry.source1.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source1.sample_gauge0264 []
+opentelemetry.source1.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -7972,7 +7972,7 @@ opentelemetry.source1.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source1.sample_gauge0286 []
+opentelemetry.source1.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -7984,7 +7984,7 @@ opentelemetry.source1.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source1.sample_gauge0308 []
+opentelemetry.source1.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -7996,7 +7996,7 @@ opentelemetry.source1.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source1.sample_gauge0330 []
+opentelemetry.source1.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -8008,7 +8008,7 @@ opentelemetry.source1.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source1.sample_gauge0352 []
+opentelemetry.source1.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -8020,7 +8020,7 @@ opentelemetry.source1.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source1.sample_gauge0374 []
+opentelemetry.source1.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -8032,7 +8032,7 @@ opentelemetry.source1.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source1.sample_gauge0396 []
+opentelemetry.source1.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 919.6
     inst [2 or "2 inst-2"] value 1839.2
@@ -8044,7 +8044,7 @@ opentelemetry.source1.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7356.8
     inst [9 or "9 inst-9"] value 8276.4
 
-opentelemetry.source1.sample_histogram0012 []
+opentelemetry.source1.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 41615
     inst [2 or "le=4"] value 83230
@@ -8057,13 +8057,13 @@ opentelemetry.source1.sample_histogram0012 []
     inst [9 or "le=18"] value 374535
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0012_count []
+opentelemetry.source1.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0012_sum []
+opentelemetry.source1.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0034 []
+opentelemetry.source1.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 65395
     inst [2 or "le=4"] value 130790
@@ -8076,13 +8076,13 @@ opentelemetry.source1.sample_histogram0034 []
     inst [9 or "le=18"] value 588555
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0034_count []
+opentelemetry.source1.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0034_sum []
+opentelemetry.source1.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0056 []
+opentelemetry.source1.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 89175
     inst [2 or "le=4"] value 178350
@@ -8095,13 +8095,13 @@ opentelemetry.source1.sample_histogram0056 []
     inst [9 or "le=18"] value 802575
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0056_count []
+opentelemetry.source1.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0056_sum []
+opentelemetry.source1.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0078 []
+opentelemetry.source1.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 112955
     inst [2 or "le=4"] value 225910
@@ -8114,13 +8114,13 @@ opentelemetry.source1.sample_histogram0078 []
     inst [9 or "le=18"] value 1016595
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0078_count []
+opentelemetry.source1.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0078_sum []
+opentelemetry.source1.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0100 []
+opentelemetry.source1.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 136735
     inst [2 or "le=4"] value 273470
@@ -8133,13 +8133,13 @@ opentelemetry.source1.sample_histogram0100 []
     inst [9 or "le=18"] value 1230615
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0100_count []
+opentelemetry.source1.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0100_sum []
+opentelemetry.source1.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0122 []
+opentelemetry.source1.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 160515
     inst [2 or "le=4"] value 321030
@@ -8152,13 +8152,13 @@ opentelemetry.source1.sample_histogram0122 []
     inst [9 or "le=18"] value 1444635
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0122_count []
+opentelemetry.source1.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0122_sum []
+opentelemetry.source1.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0144 []
+opentelemetry.source1.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 184295
     inst [2 or "le=4"] value 368590
@@ -8171,13 +8171,13 @@ opentelemetry.source1.sample_histogram0144 []
     inst [9 or "le=18"] value 1658655
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0144_count []
+opentelemetry.source1.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0144_sum []
+opentelemetry.source1.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0166 []
+opentelemetry.source1.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 208075
     inst [2 or "le=4"] value 416150
@@ -8190,13 +8190,13 @@ opentelemetry.source1.sample_histogram0166 []
     inst [9 or "le=18"] value 1872675
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0166_count []
+opentelemetry.source1.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0166_sum []
+opentelemetry.source1.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0188 []
+opentelemetry.source1.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 231855
     inst [2 or "le=4"] value 463710
@@ -8209,13 +8209,13 @@ opentelemetry.source1.sample_histogram0188 []
     inst [9 or "le=18"] value 2086695
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0188_count []
+opentelemetry.source1.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0188_sum []
+opentelemetry.source1.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0210 []
+opentelemetry.source1.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 255635
     inst [2 or "le=4"] value 511270
@@ -8228,13 +8228,13 @@ opentelemetry.source1.sample_histogram0210 []
     inst [9 or "le=18"] value 2300715
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0210_count []
+opentelemetry.source1.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0210_sum []
+opentelemetry.source1.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0232 []
+opentelemetry.source1.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 279415
     inst [2 or "le=4"] value 558830
@@ -8247,13 +8247,13 @@ opentelemetry.source1.sample_histogram0232 []
     inst [9 or "le=18"] value 2514735
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0232_count []
+opentelemetry.source1.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0232_sum []
+opentelemetry.source1.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0254 []
+opentelemetry.source1.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 303195
     inst [2 or "le=4"] value 606390
@@ -8266,13 +8266,13 @@ opentelemetry.source1.sample_histogram0254 []
     inst [9 or "le=18"] value 2728755
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0254_count []
+opentelemetry.source1.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0254_sum []
+opentelemetry.source1.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0276 []
+opentelemetry.source1.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 326975
     inst [2 or "le=4"] value 653950
@@ -8285,13 +8285,13 @@ opentelemetry.source1.sample_histogram0276 []
     inst [9 or "le=18"] value 2942775
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0276_count []
+opentelemetry.source1.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0276_sum []
+opentelemetry.source1.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0298 []
+opentelemetry.source1.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 350755
     inst [2 or "le=4"] value 701510
@@ -8304,13 +8304,13 @@ opentelemetry.source1.sample_histogram0298 []
     inst [9 or "le=18"] value 3156795
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0298_count []
+opentelemetry.source1.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0298_sum []
+opentelemetry.source1.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0320 []
+opentelemetry.source1.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 374535
     inst [2 or "le=4"] value 749070
@@ -8323,13 +8323,13 @@ opentelemetry.source1.sample_histogram0320 []
     inst [9 or "le=18"] value 3370815
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0320_count []
+opentelemetry.source1.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0320_sum []
+opentelemetry.source1.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0342 []
+opentelemetry.source1.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 398315
     inst [2 or "le=4"] value 796630
@@ -8342,13 +8342,13 @@ opentelemetry.source1.sample_histogram0342 []
     inst [9 or "le=18"] value 3584835
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0342_count []
+opentelemetry.source1.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0342_sum []
+opentelemetry.source1.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0364 []
+opentelemetry.source1.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 422095
     inst [2 or "le=4"] value 844190
@@ -8361,13 +8361,13 @@ opentelemetry.source1.sample_histogram0364 []
     inst [9 or "le=18"] value 3798855
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0364_count []
+opentelemetry.source1.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0364_sum []
+opentelemetry.source1.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_histogram0386 []
+opentelemetry.source1.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 445875
     inst [2 or "le=4"] value 891750
@@ -8380,13 +8380,13 @@ opentelemetry.source1.sample_histogram0386 []
     inst [9 or "le=18"] value 4012875
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source1.sample_histogram0386_count []
+opentelemetry.source1.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source1.sample_histogram0386_sum []
+opentelemetry.source1.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source1.sample_summary0002 []
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0009577380000000001
     inst [2 or "quantile: 0.5"] value 0.001915476
@@ -8398,13 +8398,13 @@ opentelemetry.source1.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.007661904000000001
     inst [9 or "quantile: 2.25"] value 0.008619642
 
-opentelemetry.source1.sample_summary0002_count []
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 10908
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 8.347241
 
-opentelemetry.source1.sample_summary0024 []
+opentelemetry.source1.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00159623
     inst [2 or "quantile: 0.5"] value 0.00319246
@@ -8416,13 +8416,13 @@ opentelemetry.source1.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.01276984
     inst [9 or "quantile: 2.25"] value 0.01436607
 
-opentelemetry.source1.sample_summary0024_count []
+opentelemetry.source1.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 18180
 
-opentelemetry.source1.sample_summary0024_sum []
+opentelemetry.source1.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 13.912068
 
-opentelemetry.source1.sample_summary0046 []
+opentelemetry.source1.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -8434,13 +8434,13 @@ opentelemetry.source1.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source1.sample_summary0046_count []
+opentelemetry.source1.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source1.sample_summary0046_sum []
+opentelemetry.source1.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source1.sample_summary0068 []
+opentelemetry.source1.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -8452,13 +8452,13 @@ opentelemetry.source1.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source1.sample_summary0068_count []
+opentelemetry.source1.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source1.sample_summary0068_sum []
+opentelemetry.source1.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source1.sample_summary0090 []
+opentelemetry.source1.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -8470,13 +8470,13 @@ opentelemetry.source1.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source1.sample_summary0090_count []
+opentelemetry.source1.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source1.sample_summary0090_sum []
+opentelemetry.source1.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source1.sample_summary0112 []
+opentelemetry.source1.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -8488,13 +8488,13 @@ opentelemetry.source1.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source1.sample_summary0112_count []
+opentelemetry.source1.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source1.sample_summary0112_sum []
+opentelemetry.source1.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source1.sample_summary0134 []
+opentelemetry.source1.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -8506,13 +8506,13 @@ opentelemetry.source1.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source1.sample_summary0134_count []
+opentelemetry.source1.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source1.sample_summary0134_sum []
+opentelemetry.source1.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source1.sample_summary0156 []
+opentelemetry.source1.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -8524,13 +8524,13 @@ opentelemetry.source1.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source1.sample_summary0156_count []
+opentelemetry.source1.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source1.sample_summary0156_sum []
+opentelemetry.source1.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source1.sample_summary0178 []
+opentelemetry.source1.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -8542,13 +8542,13 @@ opentelemetry.source1.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source1.sample_summary0178_count []
+opentelemetry.source1.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source1.sample_summary0178_sum []
+opentelemetry.source1.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source1.sample_summary0200 []
+opentelemetry.source1.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -8560,13 +8560,13 @@ opentelemetry.source1.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source1.sample_summary0200_count []
+opentelemetry.source1.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source1.sample_summary0200_sum []
+opentelemetry.source1.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source1.sample_summary0222 []
+opentelemetry.source1.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -8578,13 +8578,13 @@ opentelemetry.source1.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source1.sample_summary0222_count []
+opentelemetry.source1.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source1.sample_summary0222_sum []
+opentelemetry.source1.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source1.sample_summary0244 []
+opentelemetry.source1.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -8596,13 +8596,13 @@ opentelemetry.source1.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source1.sample_summary0244_count []
+opentelemetry.source1.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source1.sample_summary0244_sum []
+opentelemetry.source1.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source1.sample_summary0266 []
+opentelemetry.source1.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -8614,13 +8614,13 @@ opentelemetry.source1.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source1.sample_summary0266_count []
+opentelemetry.source1.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source1.sample_summary0266_sum []
+opentelemetry.source1.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source1.sample_summary0288 []
+opentelemetry.source1.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -8632,13 +8632,13 @@ opentelemetry.source1.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source1.sample_summary0288_count []
+opentelemetry.source1.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source1.sample_summary0288_sum []
+opentelemetry.source1.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source1.sample_summary0310 []
+opentelemetry.source1.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -8650,13 +8650,13 @@ opentelemetry.source1.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source1.sample_summary0310_count []
+opentelemetry.source1.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source1.sample_summary0310_sum []
+opentelemetry.source1.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source1.sample_summary0332 []
+opentelemetry.source1.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -8668,13 +8668,13 @@ opentelemetry.source1.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source1.sample_summary0332_count []
+opentelemetry.source1.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source1.sample_summary0332_sum []
+opentelemetry.source1.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source1.sample_summary0354 []
+opentelemetry.source1.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -8686,13 +8686,13 @@ opentelemetry.source1.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source1.sample_summary0354_count []
+opentelemetry.source1.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source1.sample_summary0354_sum []
+opentelemetry.source1.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source1.sample_summary0376 []
+opentelemetry.source1.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -8704,13 +8704,13 @@ opentelemetry.source1.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source1.sample_summary0376_count []
+opentelemetry.source1.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source1.sample_summary0376_sum []
+opentelemetry.source1.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source1.sample_summary0398 []
+opentelemetry.source1.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012450594
     inst [2 or "quantile: 0.5"] value 0.024901188
@@ -8722,460 +8722,460 @@ opentelemetry.source1.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.099604752
     inst [9 or "quantile: 2.25"] value 0.112055346
 
-opentelemetry.source1.sample_summary0398_count []
+opentelemetry.source1.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 141804
 
-opentelemetry.source1.sample_summary0398_sum []
+opentelemetry.source1.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 108.514128
 
-opentelemetry.source1.sample_counter0001 []
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0023 []
+opentelemetry.source1.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0045 []
+opentelemetry.source1.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0067 []
+opentelemetry.source1.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0089 []
+opentelemetry.source1.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0111 []
+opentelemetry.source1.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0133 []
+opentelemetry.source1.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0155 []
+opentelemetry.source1.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0177 []
+opentelemetry.source1.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0199 []
+opentelemetry.source1.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0221 []
+opentelemetry.source1.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0243 []
+opentelemetry.source1.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0265 []
+opentelemetry.source1.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0287 []
+opentelemetry.source1.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0309 []
+opentelemetry.source1.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0331 []
+opentelemetry.source1.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0353 []
+opentelemetry.source1.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0375 []
+opentelemetry.source1.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0397 []
+opentelemetry.source1.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0000 []
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0022 []
+opentelemetry.source1.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0044 []
+opentelemetry.source1.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0066 []
+opentelemetry.source1.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0088 []
+opentelemetry.source1.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0110 []
+opentelemetry.source1.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0132 []
+opentelemetry.source1.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0154 []
+opentelemetry.source1.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0176 []
+opentelemetry.source1.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0198 []
+opentelemetry.source1.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0220 []
+opentelemetry.source1.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0242 []
+opentelemetry.source1.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0264 []
+opentelemetry.source1.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0286 []
+opentelemetry.source1.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0308 []
+opentelemetry.source1.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0330 []
+opentelemetry.source1.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0352 []
+opentelemetry.source1.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0374 []
+opentelemetry.source1.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0396 []
+opentelemetry.source1.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0012 []
+opentelemetry.source1.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0012_count []
+opentelemetry.source1.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0012_sum []
+opentelemetry.source1.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0034 []
+opentelemetry.source1.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0034_count []
+opentelemetry.source1.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0034_sum []
+opentelemetry.source1.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0056 []
+opentelemetry.source1.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0056_count []
+opentelemetry.source1.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0056_sum []
+opentelemetry.source1.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0078 []
+opentelemetry.source1.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0078_count []
+opentelemetry.source1.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0078_sum []
+opentelemetry.source1.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0100 []
+opentelemetry.source1.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0100_count []
+opentelemetry.source1.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0100_sum []
+opentelemetry.source1.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0122 []
+opentelemetry.source1.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0122_count []
+opentelemetry.source1.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0122_sum []
+opentelemetry.source1.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0144 []
+opentelemetry.source1.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0144_count []
+opentelemetry.source1.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0144_sum []
+opentelemetry.source1.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0166 []
+opentelemetry.source1.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0166_count []
+opentelemetry.source1.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0166_sum []
+opentelemetry.source1.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0188 []
+opentelemetry.source1.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0188_count []
+opentelemetry.source1.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0188_sum []
+opentelemetry.source1.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0210 []
+opentelemetry.source1.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0210_count []
+opentelemetry.source1.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0210_sum []
+opentelemetry.source1.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0232 []
+opentelemetry.source1.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0232_count []
+opentelemetry.source1.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0232_sum []
+opentelemetry.source1.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0254 []
+opentelemetry.source1.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0254_count []
+opentelemetry.source1.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0254_sum []
+opentelemetry.source1.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0276 []
+opentelemetry.source1.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0276_count []
+opentelemetry.source1.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0276_sum []
+opentelemetry.source1.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0298 []
+opentelemetry.source1.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0298_count []
+opentelemetry.source1.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0298_sum []
+opentelemetry.source1.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0320 []
+opentelemetry.source1.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0320_count []
+opentelemetry.source1.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0320_sum []
+opentelemetry.source1.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0342 []
+opentelemetry.source1.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0342_count []
+opentelemetry.source1.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0342_sum []
+opentelemetry.source1.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0364 []
+opentelemetry.source1.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0364_count []
+opentelemetry.source1.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0364_sum []
+opentelemetry.source1.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0386 []
+opentelemetry.source1.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0386_count []
+opentelemetry.source1.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_histogram0386_sum []
+opentelemetry.source1.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0002 []
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0002_count []
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0024 []
+opentelemetry.source1.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0024_count []
+opentelemetry.source1.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0024_sum []
+opentelemetry.source1.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0046 []
+opentelemetry.source1.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0046_count []
+opentelemetry.source1.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0046_sum []
+opentelemetry.source1.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0068 []
+opentelemetry.source1.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0068_count []
+opentelemetry.source1.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0068_sum []
+opentelemetry.source1.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0090 []
+opentelemetry.source1.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0090_count []
+opentelemetry.source1.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0090_sum []
+opentelemetry.source1.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0112 []
+opentelemetry.source1.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0112_count []
+opentelemetry.source1.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0112_sum []
+opentelemetry.source1.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0134 []
+opentelemetry.source1.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0134_count []
+opentelemetry.source1.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0134_sum []
+opentelemetry.source1.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0156 []
+opentelemetry.source1.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0156_count []
+opentelemetry.source1.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0156_sum []
+opentelemetry.source1.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0178 []
+opentelemetry.source1.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0178_count []
+opentelemetry.source1.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0178_sum []
+opentelemetry.source1.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0200 []
+opentelemetry.source1.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0200_count []
+opentelemetry.source1.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0200_sum []
+opentelemetry.source1.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0222 []
+opentelemetry.source1.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0222_count []
+opentelemetry.source1.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0222_sum []
+opentelemetry.source1.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0244 []
+opentelemetry.source1.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0244_count []
+opentelemetry.source1.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0244_sum []
+opentelemetry.source1.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0266 []
+opentelemetry.source1.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0266_count []
+opentelemetry.source1.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0266_sum []
+opentelemetry.source1.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0288 []
+opentelemetry.source1.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0288_count []
+opentelemetry.source1.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0288_sum []
+opentelemetry.source1.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0310 []
+opentelemetry.source1.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0310_count []
+opentelemetry.source1.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0310_sum []
+opentelemetry.source1.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0332 []
+opentelemetry.source1.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0332_count []
+opentelemetry.source1.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0332_sum []
+opentelemetry.source1.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0354 []
+opentelemetry.source1.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0354_count []
+opentelemetry.source1.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0354_sum []
+opentelemetry.source1.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0376 []
+opentelemetry.source1.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0376_count []
+opentelemetry.source1.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0376_sum []
+opentelemetry.source1.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0398 []
+opentelemetry.source1.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0398_count []
+opentelemetry.source1.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0398_sum []
+opentelemetry.source1.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source2.sample_counter0001 []
+opentelemetry.source2.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 510616182
     inst [2 or "2 inst-2"] value 1021232360
@@ -9187,7 +9187,7 @@ opentelemetry.source2.sample_counter0001 []
     inst [8 or "8 inst-8"] value 4084929460
     inst [9 or "9 inst-9"] value 4595545640
 
-opentelemetry.source2.sample_counter0023 []
+opentelemetry.source2.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1191437760
     inst [2 or "2 inst-2"] value 2382875520
@@ -9199,7 +9199,7 @@ opentelemetry.source2.sample_counter0023 []
     inst [8 or "8 inst-8"] value 9531502060
     inst [9 or "9 inst-9"] value 10722939800
 
-opentelemetry.source2.sample_counter0045 []
+opentelemetry.source2.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1872259330
     inst [2 or "2 inst-2"] value 3744518670
@@ -9211,7 +9211,7 @@ opentelemetry.source2.sample_counter0045 []
     inst [8 or "8 inst-8"] value 14978074700
     inst [9 or "9 inst-9"] value 16850334000
 
-opentelemetry.source2.sample_counter0067 []
+opentelemetry.source2.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2553080910
     inst [2 or "2 inst-2"] value 5106161820
@@ -9223,7 +9223,7 @@ opentelemetry.source2.sample_counter0067 []
     inst [8 or "8 inst-8"] value 20424647300
     inst [9 or "9 inst-9"] value 22977728200
 
-opentelemetry.source2.sample_counter0089 []
+opentelemetry.source2.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3233902490
     inst [2 or "2 inst-2"] value 6467804970
@@ -9235,7 +9235,7 @@ opentelemetry.source2.sample_counter0089 []
     inst [8 or "8 inst-8"] value 25871219900
     inst [9 or "9 inst-9"] value 29105122400
 
-opentelemetry.source2.sample_counter0111 []
+opentelemetry.source2.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3914724060
     inst [2 or "2 inst-2"] value 7829448120
@@ -9247,7 +9247,7 @@ opentelemetry.source2.sample_counter0111 []
     inst [8 or "8 inst-8"] value 31317792500
     inst [9 or "9 inst-9"] value 35232516600
 
-opentelemetry.source2.sample_counter0133 []
+opentelemetry.source2.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4595545640
     inst [2 or "2 inst-2"] value 9191091280
@@ -9259,7 +9259,7 @@ opentelemetry.source2.sample_counter0133 []
     inst [8 or "8 inst-8"] value 36764365100
     inst [9 or "9 inst-9"] value 41359910700
 
-opentelemetry.source2.sample_counter0155 []
+opentelemetry.source2.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5276367210
     inst [2 or "2 inst-2"] value 10552734400
@@ -9271,7 +9271,7 @@ opentelemetry.source2.sample_counter0155 []
     inst [8 or "8 inst-8"] value 42210937700
     inst [9 or "9 inst-9"] value 47487304900
 
-opentelemetry.source2.sample_counter0177 []
+opentelemetry.source2.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5957188790
     inst [2 or "2 inst-2"] value 11914377600
@@ -9283,7 +9283,7 @@ opentelemetry.source2.sample_counter0177 []
     inst [8 or "8 inst-8"] value 47657510300
     inst [9 or "9 inst-9"] value 53614699100
 
-opentelemetry.source2.sample_counter0199 []
+opentelemetry.source2.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6638010370
     inst [2 or "2 inst-2"] value 13276020700
@@ -9295,7 +9295,7 @@ opentelemetry.source2.sample_counter0199 []
     inst [8 or "8 inst-8"] value 53104082900
     inst [9 or "9 inst-9"] value 59742093300
 
-opentelemetry.source2.sample_counter0221 []
+opentelemetry.source2.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7318831940
     inst [2 or "2 inst-2"] value 14637663900
@@ -9307,7 +9307,7 @@ opentelemetry.source2.sample_counter0221 []
     inst [8 or "8 inst-8"] value 58550655500
     inst [9 or "9 inst-9"] value 65869487500
 
-opentelemetry.source2.sample_counter0243 []
+opentelemetry.source2.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7999653520
     inst [2 or "2 inst-2"] value 15999307000
@@ -9319,7 +9319,7 @@ opentelemetry.source2.sample_counter0243 []
     inst [8 or "8 inst-8"] value 63997228100
     inst [9 or "9 inst-9"] value 71996881700
 
-opentelemetry.source2.sample_counter0265 []
+opentelemetry.source2.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8680475090
     inst [2 or "2 inst-2"] value 17360950200
@@ -9331,7 +9331,7 @@ opentelemetry.source2.sample_counter0265 []
     inst [8 or "8 inst-8"] value 69443800800
     inst [9 or "9 inst-9"] value 78124275800
 
-opentelemetry.source2.sample_counter0287 []
+opentelemetry.source2.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9361296670
     inst [2 or "2 inst-2"] value 18722593300
@@ -9343,7 +9343,7 @@ opentelemetry.source2.sample_counter0287 []
     inst [8 or "8 inst-8"] value 74890373400
     inst [9 or "9 inst-9"] value 84251670000
 
-opentelemetry.source2.sample_counter0309 []
+opentelemetry.source2.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10042118200
     inst [2 or "2 inst-2"] value 20084236500
@@ -9355,7 +9355,7 @@ opentelemetry.source2.sample_counter0309 []
     inst [8 or "8 inst-8"] value 80336946000
     inst [9 or "9 inst-9"] value 90379064200
 
-opentelemetry.source2.sample_counter0331 []
+opentelemetry.source2.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10722939800
     inst [2 or "2 inst-2"] value 21445879600
@@ -9367,7 +9367,7 @@ opentelemetry.source2.sample_counter0331 []
     inst [8 or "8 inst-8"] value 85783518600
     inst [9 or "9 inst-9"] value 96506458400
 
-opentelemetry.source2.sample_counter0353 []
+opentelemetry.source2.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11403761400
     inst [2 or "2 inst-2"] value 22807522800
@@ -9379,7 +9379,7 @@ opentelemetry.source2.sample_counter0353 []
     inst [8 or "8 inst-8"] value 91230091200
     inst [9 or "9 inst-9"] value 102633853000
 
-opentelemetry.source2.sample_counter0375 []
+opentelemetry.source2.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12084583000
     inst [2 or "2 inst-2"] value 24169165900
@@ -9391,7 +9391,7 @@ opentelemetry.source2.sample_counter0375 []
     inst [8 or "8 inst-8"] value 96676663800
     inst [9 or "9 inst-9"] value 108761247000
 
-opentelemetry.source2.sample_counter0397 []
+opentelemetry.source2.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12765404600
     inst [2 or "2 inst-2"] value 25530809100
@@ -9403,7 +9403,7 @@ opentelemetry.source2.sample_counter0397 []
     inst [8 or "8 inst-8"] value 102123236000
     inst [9 or "9 inst-9"] value 114888641000
 
-opentelemetry.source2.sample_gauge0000 []
+opentelemetry.source2.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 24.2
     inst [2 or "2 inst-2"] value 48.4
@@ -9415,7 +9415,7 @@ opentelemetry.source2.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 193.6
     inst [9 or "9 inst-9"] value 217.8
 
-opentelemetry.source2.sample_gauge0022 []
+opentelemetry.source2.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 72.59999999999999
     inst [2 or "2 inst-2"] value 145.2
@@ -9427,7 +9427,7 @@ opentelemetry.source2.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 580.8
     inst [9 or "9 inst-9"] value 653.4
 
-opentelemetry.source2.sample_gauge0044 []
+opentelemetry.source2.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 121
     inst [2 or "2 inst-2"] value 242
@@ -9439,7 +9439,7 @@ opentelemetry.source2.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 968
     inst [9 or "9 inst-9"] value 1089
 
-opentelemetry.source2.sample_gauge0066 []
+opentelemetry.source2.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 169.4
     inst [2 or "2 inst-2"] value 338.8
@@ -9451,7 +9451,7 @@ opentelemetry.source2.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1355.2
     inst [9 or "9 inst-9"] value 1524.6
 
-opentelemetry.source2.sample_gauge0088 []
+opentelemetry.source2.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 217.8
     inst [2 or "2 inst-2"] value 435.6
@@ -9463,7 +9463,7 @@ opentelemetry.source2.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 1742.4
     inst [9 or "9 inst-9"] value 1960.2
 
-opentelemetry.source2.sample_gauge0110 []
+opentelemetry.source2.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 266.2
     inst [2 or "2 inst-2"] value 532.4
@@ -9475,7 +9475,7 @@ opentelemetry.source2.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2129.6
     inst [9 or "9 inst-9"] value 2395.8
 
-opentelemetry.source2.sample_gauge0132 []
+opentelemetry.source2.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 314.6
     inst [2 or "2 inst-2"] value 629.2
@@ -9487,7 +9487,7 @@ opentelemetry.source2.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2516.8
     inst [9 or "9 inst-9"] value 2831.4
 
-opentelemetry.source2.sample_gauge0154 []
+opentelemetry.source2.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 363
     inst [2 or "2 inst-2"] value 726
@@ -9499,7 +9499,7 @@ opentelemetry.source2.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 2904
     inst [9 or "9 inst-9"] value 3267
 
-opentelemetry.source2.sample_gauge0176 []
+opentelemetry.source2.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 411.4
     inst [2 or "2 inst-2"] value 822.8
@@ -9511,7 +9511,7 @@ opentelemetry.source2.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3291.2
     inst [9 or "9 inst-9"] value 3702.6
 
-opentelemetry.source2.sample_gauge0198 []
+opentelemetry.source2.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 459.8
     inst [2 or "2 inst-2"] value 919.6
@@ -9523,7 +9523,7 @@ opentelemetry.source2.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 3678.4
     inst [9 or "9 inst-9"] value 4138.2
 
-opentelemetry.source2.sample_gauge0220 []
+opentelemetry.source2.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 508.2
     inst [2 or "2 inst-2"] value 1016.4
@@ -9535,7 +9535,7 @@ opentelemetry.source2.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 4065.6
     inst [9 or "9 inst-9"] value 4573.8
 
-opentelemetry.source2.sample_gauge0242 []
+opentelemetry.source2.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 556.6
     inst [2 or "2 inst-2"] value 1113.2
@@ -9547,7 +9547,7 @@ opentelemetry.source2.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4452.8
     inst [9 or "9 inst-9"] value 5009.4
 
-opentelemetry.source2.sample_gauge0264 []
+opentelemetry.source2.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 605
     inst [2 or "2 inst-2"] value 1210
@@ -9559,7 +9559,7 @@ opentelemetry.source2.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 4840
     inst [9 or "9 inst-9"] value 5445
 
-opentelemetry.source2.sample_gauge0286 []
+opentelemetry.source2.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 653.4
     inst [2 or "2 inst-2"] value 1306.8
@@ -9571,7 +9571,7 @@ opentelemetry.source2.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5227.2
     inst [9 or "9 inst-9"] value 5880.6
 
-opentelemetry.source2.sample_gauge0308 []
+opentelemetry.source2.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 701.8
     inst [2 or "2 inst-2"] value 1403.6
@@ -9583,7 +9583,7 @@ opentelemetry.source2.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 5614.4
     inst [9 or "9 inst-9"] value 6316.2
 
-opentelemetry.source2.sample_gauge0330 []
+opentelemetry.source2.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 750.2
     inst [2 or "2 inst-2"] value 1500.4
@@ -9595,7 +9595,7 @@ opentelemetry.source2.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6001.6
     inst [9 or "9 inst-9"] value 6751.8
 
-opentelemetry.source2.sample_gauge0352 []
+opentelemetry.source2.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 798.6
     inst [2 or "2 inst-2"] value 1597.2
@@ -9607,7 +9607,7 @@ opentelemetry.source2.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6388.8
     inst [9 or "9 inst-9"] value 7187.4
 
-opentelemetry.source2.sample_gauge0374 []
+opentelemetry.source2.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 847
     inst [2 or "2 inst-2"] value 1694
@@ -9619,7 +9619,7 @@ opentelemetry.source2.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 6776
     inst [9 or "9 inst-9"] value 7623
 
-opentelemetry.source2.sample_gauge0396 []
+opentelemetry.source2.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 895.4
     inst [2 or "2 inst-2"] value 1790.8
@@ -9631,7 +9631,7 @@ opentelemetry.source2.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7163.2
     inst [9 or "9 inst-9"] value 8058.6
 
-opentelemetry.source2.sample_histogram0012 []
+opentelemetry.source2.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 29725
     inst [2 or "le=4"] value 59450
@@ -9644,13 +9644,13 @@ opentelemetry.source2.sample_histogram0012 []
     inst [9 or "le=18"] value 267525
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0012_count []
+opentelemetry.source2.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0012_sum []
+opentelemetry.source2.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0034 []
+opentelemetry.source2.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 53505
     inst [2 or "le=4"] value 107010
@@ -9663,13 +9663,13 @@ opentelemetry.source2.sample_histogram0034 []
     inst [9 or "le=18"] value 481545
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0034_count []
+opentelemetry.source2.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0034_sum []
+opentelemetry.source2.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0056 []
+opentelemetry.source2.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 77285
     inst [2 or "le=4"] value 154570
@@ -9682,13 +9682,13 @@ opentelemetry.source2.sample_histogram0056 []
     inst [9 or "le=18"] value 695565
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0056_count []
+opentelemetry.source2.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0056_sum []
+opentelemetry.source2.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0078 []
+opentelemetry.source2.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 101065
     inst [2 or "le=4"] value 202130
@@ -9701,13 +9701,13 @@ opentelemetry.source2.sample_histogram0078 []
     inst [9 or "le=18"] value 909585
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0078_count []
+opentelemetry.source2.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0078_sum []
+opentelemetry.source2.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0100 []
+opentelemetry.source2.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 124845
     inst [2 or "le=4"] value 249690
@@ -9720,13 +9720,13 @@ opentelemetry.source2.sample_histogram0100 []
     inst [9 or "le=18"] value 1123605
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0100_count []
+opentelemetry.source2.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0100_sum []
+opentelemetry.source2.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0122 []
+opentelemetry.source2.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 148625
     inst [2 or "le=4"] value 297250
@@ -9739,13 +9739,13 @@ opentelemetry.source2.sample_histogram0122 []
     inst [9 or "le=18"] value 1337625
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0122_count []
+opentelemetry.source2.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0122_sum []
+opentelemetry.source2.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0144 []
+opentelemetry.source2.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 172405
     inst [2 or "le=4"] value 344810
@@ -9758,13 +9758,13 @@ opentelemetry.source2.sample_histogram0144 []
     inst [9 or "le=18"] value 1551645
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0144_count []
+opentelemetry.source2.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0144_sum []
+opentelemetry.source2.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0166 []
+opentelemetry.source2.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 196185
     inst [2 or "le=4"] value 392370
@@ -9777,13 +9777,13 @@ opentelemetry.source2.sample_histogram0166 []
     inst [9 or "le=18"] value 1765665
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0166_count []
+opentelemetry.source2.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0166_sum []
+opentelemetry.source2.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0188 []
+opentelemetry.source2.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 219965
     inst [2 or "le=4"] value 439930
@@ -9796,13 +9796,13 @@ opentelemetry.source2.sample_histogram0188 []
     inst [9 or "le=18"] value 1979685
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0188_count []
+opentelemetry.source2.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0188_sum []
+opentelemetry.source2.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0210 []
+opentelemetry.source2.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 243745
     inst [2 or "le=4"] value 487490
@@ -9815,13 +9815,13 @@ opentelemetry.source2.sample_histogram0210 []
     inst [9 or "le=18"] value 2193705
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0210_count []
+opentelemetry.source2.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0210_sum []
+opentelemetry.source2.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0232 []
+opentelemetry.source2.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 267525
     inst [2 or "le=4"] value 535050
@@ -9834,13 +9834,13 @@ opentelemetry.source2.sample_histogram0232 []
     inst [9 or "le=18"] value 2407725
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0232_count []
+opentelemetry.source2.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0232_sum []
+opentelemetry.source2.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0254 []
+opentelemetry.source2.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 291305
     inst [2 or "le=4"] value 582610
@@ -9853,13 +9853,13 @@ opentelemetry.source2.sample_histogram0254 []
     inst [9 or "le=18"] value 2621745
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0254_count []
+opentelemetry.source2.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0254_sum []
+opentelemetry.source2.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0276 []
+opentelemetry.source2.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 315085
     inst [2 or "le=4"] value 630170
@@ -9872,13 +9872,13 @@ opentelemetry.source2.sample_histogram0276 []
     inst [9 or "le=18"] value 2835765
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0276_count []
+opentelemetry.source2.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0276_sum []
+opentelemetry.source2.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0298 []
+opentelemetry.source2.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 338865
     inst [2 or "le=4"] value 677730
@@ -9891,13 +9891,13 @@ opentelemetry.source2.sample_histogram0298 []
     inst [9 or "le=18"] value 3049785
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0298_count []
+opentelemetry.source2.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0298_sum []
+opentelemetry.source2.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0320 []
+opentelemetry.source2.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 362645
     inst [2 or "le=4"] value 725290
@@ -9910,13 +9910,13 @@ opentelemetry.source2.sample_histogram0320 []
     inst [9 or "le=18"] value 3263805
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0320_count []
+opentelemetry.source2.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0320_sum []
+opentelemetry.source2.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0342 []
+opentelemetry.source2.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 386425
     inst [2 or "le=4"] value 772850
@@ -9929,13 +9929,13 @@ opentelemetry.source2.sample_histogram0342 []
     inst [9 or "le=18"] value 3477825
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0342_count []
+opentelemetry.source2.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0342_sum []
+opentelemetry.source2.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0364 []
+opentelemetry.source2.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 410205
     inst [2 or "le=4"] value 820410
@@ -9948,13 +9948,13 @@ opentelemetry.source2.sample_histogram0364 []
     inst [9 or "le=18"] value 3691845
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0364_count []
+opentelemetry.source2.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0364_sum []
+opentelemetry.source2.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0386 []
+opentelemetry.source2.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 433985
     inst [2 or "le=4"] value 867970
@@ -9967,13 +9967,13 @@ opentelemetry.source2.sample_histogram0386 []
     inst [9 or "le=18"] value 3905865
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0386_count []
+opentelemetry.source2.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0386_sum []
+opentelemetry.source2.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_summary0002 []
+opentelemetry.source2.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0006384920000000001
     inst [2 or "quantile: 0.5"] value 0.001276984
@@ -9985,13 +9985,13 @@ opentelemetry.source2.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.005107936
     inst [9 or "quantile: 2.25"] value 0.005746428
 
-opentelemetry.source2.sample_summary0002_count []
+opentelemetry.source2.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 7272
 
-opentelemetry.source2.sample_summary0002_sum []
+opentelemetry.source2.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 5.564827
 
-opentelemetry.source2.sample_summary0024 []
+opentelemetry.source2.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001276984
     inst [2 or "quantile: 0.5"] value 0.002553968
@@ -10003,13 +10003,13 @@ opentelemetry.source2.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.010215872
     inst [9 or "quantile: 2.25"] value 0.011492856
 
-opentelemetry.source2.sample_summary0024_count []
+opentelemetry.source2.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 14544
 
-opentelemetry.source2.sample_summary0024_sum []
+opentelemetry.source2.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 11.129654
 
-opentelemetry.source2.sample_summary0046 []
+opentelemetry.source2.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001915476
     inst [2 or "quantile: 0.5"] value 0.003830952
@@ -10021,13 +10021,13 @@ opentelemetry.source2.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.015323808
     inst [9 or "quantile: 2.25"] value 0.017239284
 
-opentelemetry.source2.sample_summary0046_count []
+opentelemetry.source2.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 21816
 
-opentelemetry.source2.sample_summary0046_sum []
+opentelemetry.source2.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 16.694481
 
-opentelemetry.source2.sample_summary0068 []
+opentelemetry.source2.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002553968
     inst [2 or "quantile: 0.5"] value 0.005107936
@@ -10039,13 +10039,13 @@ opentelemetry.source2.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.020431744
     inst [9 or "quantile: 2.25"] value 0.022985712
 
-opentelemetry.source2.sample_summary0068_count []
+opentelemetry.source2.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 29088
 
-opentelemetry.source2.sample_summary0068_sum []
+opentelemetry.source2.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 22.259308
 
-opentelemetry.source2.sample_summary0090 []
+opentelemetry.source2.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00319246
     inst [2 or "quantile: 0.5"] value 0.006384920000000001
@@ -10057,13 +10057,13 @@ opentelemetry.source2.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.02553968
     inst [9 or "quantile: 2.25"] value 0.02873214
 
-opentelemetry.source2.sample_summary0090_count []
+opentelemetry.source2.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 36360
 
-opentelemetry.source2.sample_summary0090_sum []
+opentelemetry.source2.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 27.824135
 
-opentelemetry.source2.sample_summary0112 []
+opentelemetry.source2.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003830952
     inst [2 or "quantile: 0.5"] value 0.007661904000000001
@@ -10075,13 +10075,13 @@ opentelemetry.source2.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.030647616
     inst [9 or "quantile: 2.25"] value 0.034478568
 
-opentelemetry.source2.sample_summary0112_count []
+opentelemetry.source2.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 43632
 
-opentelemetry.source2.sample_summary0112_sum []
+opentelemetry.source2.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 33.388962
 
-opentelemetry.source2.sample_summary0134 []
+opentelemetry.source2.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004469444
     inst [2 or "quantile: 0.5"] value 0.008938888000000001
@@ -10093,13 +10093,13 @@ opentelemetry.source2.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.035755552
     inst [9 or "quantile: 2.25"] value 0.04022499600000001
 
-opentelemetry.source2.sample_summary0134_count []
+opentelemetry.source2.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 50904
 
-opentelemetry.source2.sample_summary0134_sum []
+opentelemetry.source2.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 38.95379
 
-opentelemetry.source2.sample_summary0156 []
+opentelemetry.source2.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005107936
     inst [2 or "quantile: 0.5"] value 0.010215872
@@ -10111,13 +10111,13 @@ opentelemetry.source2.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.040863488
     inst [9 or "quantile: 2.25"] value 0.045971424
 
-opentelemetry.source2.sample_summary0156_count []
+opentelemetry.source2.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 58176
 
-opentelemetry.source2.sample_summary0156_sum []
+opentelemetry.source2.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 44.518617
 
-opentelemetry.source2.sample_summary0178 []
+opentelemetry.source2.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005746428
     inst [2 or "quantile: 0.5"] value 0.011492856
@@ -10129,13 +10129,13 @@ opentelemetry.source2.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.045971424
     inst [9 or "quantile: 2.25"] value 0.051717852
 
-opentelemetry.source2.sample_summary0178_count []
+opentelemetry.source2.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 65448
 
-opentelemetry.source2.sample_summary0178_sum []
+opentelemetry.source2.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 50.083444
 
-opentelemetry.source2.sample_summary0200 []
+opentelemetry.source2.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006384920000000001
     inst [2 or "quantile: 0.5"] value 0.01276984
@@ -10147,13 +10147,13 @@ opentelemetry.source2.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.05107936
     inst [9 or "quantile: 2.25"] value 0.05746428000000001
 
-opentelemetry.source2.sample_summary0200_count []
+opentelemetry.source2.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 72720
 
-opentelemetry.source2.sample_summary0200_sum []
+opentelemetry.source2.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 55.648271
 
-opentelemetry.source2.sample_summary0222 []
+opentelemetry.source2.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007023412000000001
     inst [2 or "quantile: 0.5"] value 0.014046824
@@ -10165,13 +10165,13 @@ opentelemetry.source2.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.056187296
     inst [9 or "quantile: 2.25"] value 0.063210708
 
-opentelemetry.source2.sample_summary0222_count []
+opentelemetry.source2.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 79992
 
-opentelemetry.source2.sample_summary0222_sum []
+opentelemetry.source2.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 61.213098
 
-opentelemetry.source2.sample_summary0244 []
+opentelemetry.source2.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007661904000000001
     inst [2 or "quantile: 0.5"] value 0.015323808
@@ -10183,13 +10183,13 @@ opentelemetry.source2.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.06129523200000001
     inst [9 or "quantile: 2.25"] value 0.068957136
 
-opentelemetry.source2.sample_summary0244_count []
+opentelemetry.source2.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 87264
 
-opentelemetry.source2.sample_summary0244_sum []
+opentelemetry.source2.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 66.777925
 
-opentelemetry.source2.sample_summary0266 []
+opentelemetry.source2.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008300396000000002
     inst [2 or "quantile: 0.5"] value 0.016600792
@@ -10201,13 +10201,13 @@ opentelemetry.source2.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.06640316800000001
     inst [9 or "quantile: 2.25"] value 0.074703564
 
-opentelemetry.source2.sample_summary0266_count []
+opentelemetry.source2.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 94536
 
-opentelemetry.source2.sample_summary0266_sum []
+opentelemetry.source2.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 72.342752
 
-opentelemetry.source2.sample_summary0288 []
+opentelemetry.source2.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008938888000000001
     inst [2 or "quantile: 0.5"] value 0.017877776
@@ -10219,13 +10219,13 @@ opentelemetry.source2.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.07151110400000001
     inst [9 or "quantile: 2.25"] value 0.08044999200000001
 
-opentelemetry.source2.sample_summary0288_count []
+opentelemetry.source2.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 101808
 
-opentelemetry.source2.sample_summary0288_sum []
+opentelemetry.source2.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 77.907579
 
-opentelemetry.source2.sample_summary0310 []
+opentelemetry.source2.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00957738
     inst [2 or "quantile: 0.5"] value 0.01915476
@@ -10237,13 +10237,13 @@ opentelemetry.source2.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.07661904
     inst [9 or "quantile: 2.25"] value 0.08619642000000001
 
-opentelemetry.source2.sample_summary0310_count []
+opentelemetry.source2.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 109080
 
-opentelemetry.source2.sample_summary0310_sum []
+opentelemetry.source2.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 83.47240600000001
 
-opentelemetry.source2.sample_summary0332 []
+opentelemetry.source2.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010215872
     inst [2 or "quantile: 0.5"] value 0.020431744
@@ -10255,13 +10255,13 @@ opentelemetry.source2.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.08172697600000001
     inst [9 or "quantile: 2.25"] value 0.09194284800000001
 
-opentelemetry.source2.sample_summary0332_count []
+opentelemetry.source2.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 116352
 
-opentelemetry.source2.sample_summary0332_sum []
+opentelemetry.source2.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 89.037233
 
-opentelemetry.source2.sample_summary0354 []
+opentelemetry.source2.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010854364
     inst [2 or "quantile: 0.5"] value 0.021708728
@@ -10273,13 +10273,13 @@ opentelemetry.source2.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.08683491200000001
     inst [9 or "quantile: 2.25"] value 0.09768927600000001
 
-opentelemetry.source2.sample_summary0354_count []
+opentelemetry.source2.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 123624
 
-opentelemetry.source2.sample_summary0354_sum []
+opentelemetry.source2.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 94.60205999999999
 
-opentelemetry.source2.sample_summary0376 []
+opentelemetry.source2.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011492856
     inst [2 or "quantile: 0.5"] value 0.022985712
@@ -10291,13 +10291,13 @@ opentelemetry.source2.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.09194284800000001
     inst [9 or "quantile: 2.25"] value 0.103435704
 
-opentelemetry.source2.sample_summary0376_count []
+opentelemetry.source2.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 130896
 
-opentelemetry.source2.sample_summary0376_sum []
+opentelemetry.source2.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 100.166887
 
-opentelemetry.source2.sample_summary0398 []
+opentelemetry.source2.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012131348
     inst [2 or "quantile: 0.5"] value 0.024262696
@@ -10309,13 +10309,13 @@ opentelemetry.source2.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.097050784
     inst [9 or "quantile: 2.25"] value 0.109182132
 
-opentelemetry.source2.sample_summary0398_count []
+opentelemetry.source2.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 138168
 
-opentelemetry.source2.sample_summary0398_sum []
+opentelemetry.source2.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 105.731715
 
-opentelemetry.source2.sample_counter0001 []
+opentelemetry.source2.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 851026970
     inst [2 or "2 inst-2"] value 1702053940
@@ -10327,7 +10327,7 @@ opentelemetry.source2.sample_counter0001 []
     inst [8 or "8 inst-8"] value 6808215760
     inst [9 or "9 inst-9"] value 7659242730
 
-opentelemetry.source2.sample_counter0023 []
+opentelemetry.source2.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1531848550
     inst [2 or "2 inst-2"] value 3063697090
@@ -10339,7 +10339,7 @@ opentelemetry.source2.sample_counter0023 []
     inst [8 or "8 inst-8"] value 12254788400
     inst [9 or "9 inst-9"] value 13786636900
 
-opentelemetry.source2.sample_counter0045 []
+opentelemetry.source2.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -10351,7 +10351,7 @@ opentelemetry.source2.sample_counter0045 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source2.sample_counter0067 []
+opentelemetry.source2.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -10363,7 +10363,7 @@ opentelemetry.source2.sample_counter0067 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source2.sample_counter0089 []
+opentelemetry.source2.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -10375,7 +10375,7 @@ opentelemetry.source2.sample_counter0089 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source2.sample_counter0111 []
+opentelemetry.source2.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -10387,7 +10387,7 @@ opentelemetry.source2.sample_counter0111 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source2.sample_counter0133 []
+opentelemetry.source2.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -10399,7 +10399,7 @@ opentelemetry.source2.sample_counter0133 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source2.sample_counter0155 []
+opentelemetry.source2.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -10411,7 +10411,7 @@ opentelemetry.source2.sample_counter0155 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source2.sample_counter0177 []
+opentelemetry.source2.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -10423,7 +10423,7 @@ opentelemetry.source2.sample_counter0177 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source2.sample_counter0199 []
+opentelemetry.source2.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -10435,7 +10435,7 @@ opentelemetry.source2.sample_counter0199 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source2.sample_counter0221 []
+opentelemetry.source2.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -10447,7 +10447,7 @@ opentelemetry.source2.sample_counter0221 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source2.sample_counter0243 []
+opentelemetry.source2.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -10459,7 +10459,7 @@ opentelemetry.source2.sample_counter0243 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source2.sample_counter0265 []
+opentelemetry.source2.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -10471,7 +10471,7 @@ opentelemetry.source2.sample_counter0265 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source2.sample_counter0287 []
+opentelemetry.source2.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -10483,7 +10483,7 @@ opentelemetry.source2.sample_counter0287 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source2.sample_counter0309 []
+opentelemetry.source2.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -10495,7 +10495,7 @@ opentelemetry.source2.sample_counter0309 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source2.sample_counter0331 []
+opentelemetry.source2.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -10507,7 +10507,7 @@ opentelemetry.source2.sample_counter0331 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source2.sample_counter0353 []
+opentelemetry.source2.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -10519,7 +10519,7 @@ opentelemetry.source2.sample_counter0353 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source2.sample_counter0375 []
+opentelemetry.source2.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -10531,7 +10531,7 @@ opentelemetry.source2.sample_counter0375 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source2.sample_counter0397 []
+opentelemetry.source2.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13105815300
     inst [2 or "2 inst-2"] value 26211630700
@@ -10543,7 +10543,7 @@ opentelemetry.source2.sample_counter0397 []
     inst [8 or "8 inst-8"] value 104846523000
     inst [9 or "9 inst-9"] value 117952338000
 
-opentelemetry.source2.sample_gauge0000 []
+opentelemetry.source2.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 48.4
     inst [2 or "2 inst-2"] value 96.8
@@ -10555,7 +10555,7 @@ opentelemetry.source2.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 387.2
     inst [9 or "9 inst-9"] value 435.6
 
-opentelemetry.source2.sample_gauge0022 []
+opentelemetry.source2.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 96.8
     inst [2 or "2 inst-2"] value 193.6
@@ -10567,7 +10567,7 @@ opentelemetry.source2.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 774.4
     inst [9 or "9 inst-9"] value 871.2
 
-opentelemetry.source2.sample_gauge0044 []
+opentelemetry.source2.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -10579,7 +10579,7 @@ opentelemetry.source2.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source2.sample_gauge0066 []
+opentelemetry.source2.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -10591,7 +10591,7 @@ opentelemetry.source2.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source2.sample_gauge0088 []
+opentelemetry.source2.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -10603,7 +10603,7 @@ opentelemetry.source2.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source2.sample_gauge0110 []
+opentelemetry.source2.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -10615,7 +10615,7 @@ opentelemetry.source2.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source2.sample_gauge0132 []
+opentelemetry.source2.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -10627,7 +10627,7 @@ opentelemetry.source2.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source2.sample_gauge0154 []
+opentelemetry.source2.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -10639,7 +10639,7 @@ opentelemetry.source2.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source2.sample_gauge0176 []
+opentelemetry.source2.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -10651,7 +10651,7 @@ opentelemetry.source2.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source2.sample_gauge0198 []
+opentelemetry.source2.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -10663,7 +10663,7 @@ opentelemetry.source2.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source2.sample_gauge0220 []
+opentelemetry.source2.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -10675,7 +10675,7 @@ opentelemetry.source2.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source2.sample_gauge0242 []
+opentelemetry.source2.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -10687,7 +10687,7 @@ opentelemetry.source2.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source2.sample_gauge0264 []
+opentelemetry.source2.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -10699,7 +10699,7 @@ opentelemetry.source2.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source2.sample_gauge0286 []
+opentelemetry.source2.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -10711,7 +10711,7 @@ opentelemetry.source2.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source2.sample_gauge0308 []
+opentelemetry.source2.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -10723,7 +10723,7 @@ opentelemetry.source2.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source2.sample_gauge0330 []
+opentelemetry.source2.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -10735,7 +10735,7 @@ opentelemetry.source2.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source2.sample_gauge0352 []
+opentelemetry.source2.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -10747,7 +10747,7 @@ opentelemetry.source2.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source2.sample_gauge0374 []
+opentelemetry.source2.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -10759,7 +10759,7 @@ opentelemetry.source2.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source2.sample_gauge0396 []
+opentelemetry.source2.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 919.6
     inst [2 or "2 inst-2"] value 1839.2
@@ -10771,7 +10771,7 @@ opentelemetry.source2.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7356.8
     inst [9 or "9 inst-9"] value 8276.4
 
-opentelemetry.source2.sample_histogram0012 []
+opentelemetry.source2.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 41615
     inst [2 or "le=4"] value 83230
@@ -10784,13 +10784,13 @@ opentelemetry.source2.sample_histogram0012 []
     inst [9 or "le=18"] value 374535
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0012_count []
+opentelemetry.source2.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0012_sum []
+opentelemetry.source2.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0034 []
+opentelemetry.source2.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 65395
     inst [2 or "le=4"] value 130790
@@ -10803,13 +10803,13 @@ opentelemetry.source2.sample_histogram0034 []
     inst [9 or "le=18"] value 588555
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0034_count []
+opentelemetry.source2.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0034_sum []
+opentelemetry.source2.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0056 []
+opentelemetry.source2.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 89175
     inst [2 or "le=4"] value 178350
@@ -10822,13 +10822,13 @@ opentelemetry.source2.sample_histogram0056 []
     inst [9 or "le=18"] value 802575
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0056_count []
+opentelemetry.source2.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0056_sum []
+opentelemetry.source2.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0078 []
+opentelemetry.source2.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 112955
     inst [2 or "le=4"] value 225910
@@ -10841,13 +10841,13 @@ opentelemetry.source2.sample_histogram0078 []
     inst [9 or "le=18"] value 1016595
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0078_count []
+opentelemetry.source2.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0078_sum []
+opentelemetry.source2.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0100 []
+opentelemetry.source2.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 136735
     inst [2 or "le=4"] value 273470
@@ -10860,13 +10860,13 @@ opentelemetry.source2.sample_histogram0100 []
     inst [9 or "le=18"] value 1230615
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0100_count []
+opentelemetry.source2.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0100_sum []
+opentelemetry.source2.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0122 []
+opentelemetry.source2.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 160515
     inst [2 or "le=4"] value 321030
@@ -10879,13 +10879,13 @@ opentelemetry.source2.sample_histogram0122 []
     inst [9 or "le=18"] value 1444635
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0122_count []
+opentelemetry.source2.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0122_sum []
+opentelemetry.source2.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0144 []
+opentelemetry.source2.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 184295
     inst [2 or "le=4"] value 368590
@@ -10898,13 +10898,13 @@ opentelemetry.source2.sample_histogram0144 []
     inst [9 or "le=18"] value 1658655
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0144_count []
+opentelemetry.source2.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0144_sum []
+opentelemetry.source2.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0166 []
+opentelemetry.source2.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 208075
     inst [2 or "le=4"] value 416150
@@ -10917,13 +10917,13 @@ opentelemetry.source2.sample_histogram0166 []
     inst [9 or "le=18"] value 1872675
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0166_count []
+opentelemetry.source2.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0166_sum []
+opentelemetry.source2.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0188 []
+opentelemetry.source2.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 231855
     inst [2 or "le=4"] value 463710
@@ -10936,13 +10936,13 @@ opentelemetry.source2.sample_histogram0188 []
     inst [9 or "le=18"] value 2086695
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0188_count []
+opentelemetry.source2.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0188_sum []
+opentelemetry.source2.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0210 []
+opentelemetry.source2.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 255635
     inst [2 or "le=4"] value 511270
@@ -10955,13 +10955,13 @@ opentelemetry.source2.sample_histogram0210 []
     inst [9 or "le=18"] value 2300715
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0210_count []
+opentelemetry.source2.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0210_sum []
+opentelemetry.source2.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0232 []
+opentelemetry.source2.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 279415
     inst [2 or "le=4"] value 558830
@@ -10974,13 +10974,13 @@ opentelemetry.source2.sample_histogram0232 []
     inst [9 or "le=18"] value 2514735
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0232_count []
+opentelemetry.source2.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0232_sum []
+opentelemetry.source2.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0254 []
+opentelemetry.source2.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 303195
     inst [2 or "le=4"] value 606390
@@ -10993,13 +10993,13 @@ opentelemetry.source2.sample_histogram0254 []
     inst [9 or "le=18"] value 2728755
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0254_count []
+opentelemetry.source2.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0254_sum []
+opentelemetry.source2.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0276 []
+opentelemetry.source2.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 326975
     inst [2 or "le=4"] value 653950
@@ -11012,13 +11012,13 @@ opentelemetry.source2.sample_histogram0276 []
     inst [9 or "le=18"] value 2942775
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0276_count []
+opentelemetry.source2.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0276_sum []
+opentelemetry.source2.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0298 []
+opentelemetry.source2.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 350755
     inst [2 or "le=4"] value 701510
@@ -11031,13 +11031,13 @@ opentelemetry.source2.sample_histogram0298 []
     inst [9 or "le=18"] value 3156795
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0298_count []
+opentelemetry.source2.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0298_sum []
+opentelemetry.source2.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0320 []
+opentelemetry.source2.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 374535
     inst [2 or "le=4"] value 749070
@@ -11050,13 +11050,13 @@ opentelemetry.source2.sample_histogram0320 []
     inst [9 or "le=18"] value 3370815
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0320_count []
+opentelemetry.source2.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0320_sum []
+opentelemetry.source2.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0342 []
+opentelemetry.source2.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 398315
     inst [2 or "le=4"] value 796630
@@ -11069,13 +11069,13 @@ opentelemetry.source2.sample_histogram0342 []
     inst [9 or "le=18"] value 3584835
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0342_count []
+opentelemetry.source2.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0342_sum []
+opentelemetry.source2.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0364 []
+opentelemetry.source2.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 422095
     inst [2 or "le=4"] value 844190
@@ -11088,13 +11088,13 @@ opentelemetry.source2.sample_histogram0364 []
     inst [9 or "le=18"] value 3798855
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0364_count []
+opentelemetry.source2.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0364_sum []
+opentelemetry.source2.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0386 []
+opentelemetry.source2.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 445875
     inst [2 or "le=4"] value 891750
@@ -11107,13 +11107,13 @@ opentelemetry.source2.sample_histogram0386 []
     inst [9 or "le=18"] value 4012875
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0386_count []
+opentelemetry.source2.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0386_sum []
+opentelemetry.source2.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_summary0002 []
+opentelemetry.source2.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0009577380000000001
     inst [2 or "quantile: 0.5"] value 0.001915476
@@ -11125,13 +11125,13 @@ opentelemetry.source2.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.007661904000000001
     inst [9 or "quantile: 2.25"] value 0.008619642
 
-opentelemetry.source2.sample_summary0002_count []
+opentelemetry.source2.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 10908
 
-opentelemetry.source2.sample_summary0002_sum []
+opentelemetry.source2.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 8.347241
 
-opentelemetry.source2.sample_summary0024 []
+opentelemetry.source2.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00159623
     inst [2 or "quantile: 0.5"] value 0.00319246
@@ -11143,13 +11143,13 @@ opentelemetry.source2.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.01276984
     inst [9 or "quantile: 2.25"] value 0.01436607
 
-opentelemetry.source2.sample_summary0024_count []
+opentelemetry.source2.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 18180
 
-opentelemetry.source2.sample_summary0024_sum []
+opentelemetry.source2.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 13.912068
 
-opentelemetry.source2.sample_summary0046 []
+opentelemetry.source2.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -11161,13 +11161,13 @@ opentelemetry.source2.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source2.sample_summary0046_count []
+opentelemetry.source2.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source2.sample_summary0046_sum []
+opentelemetry.source2.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source2.sample_summary0068 []
+opentelemetry.source2.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -11179,13 +11179,13 @@ opentelemetry.source2.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source2.sample_summary0068_count []
+opentelemetry.source2.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source2.sample_summary0068_sum []
+opentelemetry.source2.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source2.sample_summary0090 []
+opentelemetry.source2.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -11197,13 +11197,13 @@ opentelemetry.source2.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source2.sample_summary0090_count []
+opentelemetry.source2.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source2.sample_summary0090_sum []
+opentelemetry.source2.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source2.sample_summary0112 []
+opentelemetry.source2.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -11215,13 +11215,13 @@ opentelemetry.source2.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source2.sample_summary0112_count []
+opentelemetry.source2.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source2.sample_summary0112_sum []
+opentelemetry.source2.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source2.sample_summary0134 []
+opentelemetry.source2.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -11233,13 +11233,13 @@ opentelemetry.source2.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source2.sample_summary0134_count []
+opentelemetry.source2.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source2.sample_summary0134_sum []
+opentelemetry.source2.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source2.sample_summary0156 []
+opentelemetry.source2.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -11251,13 +11251,13 @@ opentelemetry.source2.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source2.sample_summary0156_count []
+opentelemetry.source2.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source2.sample_summary0156_sum []
+opentelemetry.source2.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source2.sample_summary0178 []
+opentelemetry.source2.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -11269,13 +11269,13 @@ opentelemetry.source2.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source2.sample_summary0178_count []
+opentelemetry.source2.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source2.sample_summary0178_sum []
+opentelemetry.source2.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source2.sample_summary0200 []
+opentelemetry.source2.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -11287,13 +11287,13 @@ opentelemetry.source2.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source2.sample_summary0200_count []
+opentelemetry.source2.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source2.sample_summary0200_sum []
+opentelemetry.source2.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source2.sample_summary0222 []
+opentelemetry.source2.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -11305,13 +11305,13 @@ opentelemetry.source2.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source2.sample_summary0222_count []
+opentelemetry.source2.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source2.sample_summary0222_sum []
+opentelemetry.source2.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source2.sample_summary0244 []
+opentelemetry.source2.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -11323,13 +11323,13 @@ opentelemetry.source2.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source2.sample_summary0244_count []
+opentelemetry.source2.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source2.sample_summary0244_sum []
+opentelemetry.source2.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source2.sample_summary0266 []
+opentelemetry.source2.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -11341,13 +11341,13 @@ opentelemetry.source2.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source2.sample_summary0266_count []
+opentelemetry.source2.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source2.sample_summary0266_sum []
+opentelemetry.source2.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source2.sample_summary0288 []
+opentelemetry.source2.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -11359,13 +11359,13 @@ opentelemetry.source2.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source2.sample_summary0288_count []
+opentelemetry.source2.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source2.sample_summary0288_sum []
+opentelemetry.source2.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source2.sample_summary0310 []
+opentelemetry.source2.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -11377,13 +11377,13 @@ opentelemetry.source2.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source2.sample_summary0310_count []
+opentelemetry.source2.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source2.sample_summary0310_sum []
+opentelemetry.source2.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source2.sample_summary0332 []
+opentelemetry.source2.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -11395,13 +11395,13 @@ opentelemetry.source2.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source2.sample_summary0332_count []
+opentelemetry.source2.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source2.sample_summary0332_sum []
+opentelemetry.source2.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source2.sample_summary0354 []
+opentelemetry.source2.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -11413,13 +11413,13 @@ opentelemetry.source2.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source2.sample_summary0354_count []
+opentelemetry.source2.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source2.sample_summary0354_sum []
+opentelemetry.source2.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source2.sample_summary0376 []
+opentelemetry.source2.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -11431,13 +11431,13 @@ opentelemetry.source2.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source2.sample_summary0376_count []
+opentelemetry.source2.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source2.sample_summary0376_sum []
+opentelemetry.source2.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source2.sample_summary0398 []
+opentelemetry.source2.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012450594
     inst [2 or "quantile: 0.5"] value 0.024901188
@@ -11449,13 +11449,13 @@ opentelemetry.source2.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.099604752
     inst [9 or "quantile: 2.25"] value 0.112055346
 
-opentelemetry.source2.sample_summary0398_count []
+opentelemetry.source2.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 141804
 
-opentelemetry.source2.sample_summary0398_sum []
+opentelemetry.source2.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 108.514128
 
-opentelemetry.source2.sample_counter0001 []
+opentelemetry.source2.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1191437760
     inst [2 or "2 inst-2"] value 2382875520
@@ -11467,7 +11467,7 @@ opentelemetry.source2.sample_counter0001 []
     inst [8 or "8 inst-8"] value 9531502060
     inst [9 or "9 inst-9"] value 10722939800
 
-opentelemetry.source2.sample_counter0023 []
+opentelemetry.source2.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1872259330
     inst [2 or "2 inst-2"] value 3744518670
@@ -11479,7 +11479,7 @@ opentelemetry.source2.sample_counter0023 []
     inst [8 or "8 inst-8"] value 14978074700
     inst [9 or "9 inst-9"] value 16850334000
 
-opentelemetry.source2.sample_counter0045 []
+opentelemetry.source2.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2553080910
     inst [2 or "2 inst-2"] value 5106161820
@@ -11491,7 +11491,7 @@ opentelemetry.source2.sample_counter0045 []
     inst [8 or "8 inst-8"] value 20424647300
     inst [9 or "9 inst-9"] value 22977728200
 
-opentelemetry.source2.sample_counter0067 []
+opentelemetry.source2.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3233902490
     inst [2 or "2 inst-2"] value 6467804970
@@ -11503,7 +11503,7 @@ opentelemetry.source2.sample_counter0067 []
     inst [8 or "8 inst-8"] value 25871219900
     inst [9 or "9 inst-9"] value 29105122400
 
-opentelemetry.source2.sample_counter0089 []
+opentelemetry.source2.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3914724060
     inst [2 or "2 inst-2"] value 7829448120
@@ -11515,7 +11515,7 @@ opentelemetry.source2.sample_counter0089 []
     inst [8 or "8 inst-8"] value 31317792500
     inst [9 or "9 inst-9"] value 35232516600
 
-opentelemetry.source2.sample_counter0111 []
+opentelemetry.source2.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4595545640
     inst [2 or "2 inst-2"] value 9191091280
@@ -11527,7 +11527,7 @@ opentelemetry.source2.sample_counter0111 []
     inst [8 or "8 inst-8"] value 36764365100
     inst [9 or "9 inst-9"] value 41359910700
 
-opentelemetry.source2.sample_counter0133 []
+opentelemetry.source2.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5276367210
     inst [2 or "2 inst-2"] value 10552734400
@@ -11539,7 +11539,7 @@ opentelemetry.source2.sample_counter0133 []
     inst [8 or "8 inst-8"] value 42210937700
     inst [9 or "9 inst-9"] value 47487304900
 
-opentelemetry.source2.sample_counter0155 []
+opentelemetry.source2.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5957188790
     inst [2 or "2 inst-2"] value 11914377600
@@ -11551,7 +11551,7 @@ opentelemetry.source2.sample_counter0155 []
     inst [8 or "8 inst-8"] value 47657510300
     inst [9 or "9 inst-9"] value 53614699100
 
-opentelemetry.source2.sample_counter0177 []
+opentelemetry.source2.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6638010370
     inst [2 or "2 inst-2"] value 13276020700
@@ -11563,7 +11563,7 @@ opentelemetry.source2.sample_counter0177 []
     inst [8 or "8 inst-8"] value 53104082900
     inst [9 or "9 inst-9"] value 59742093300
 
-opentelemetry.source2.sample_counter0199 []
+opentelemetry.source2.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7318831940
     inst [2 or "2 inst-2"] value 14637663900
@@ -11575,7 +11575,7 @@ opentelemetry.source2.sample_counter0199 []
     inst [8 or "8 inst-8"] value 58550655500
     inst [9 or "9 inst-9"] value 65869487500
 
-opentelemetry.source2.sample_counter0221 []
+opentelemetry.source2.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7999653520
     inst [2 or "2 inst-2"] value 15999307000
@@ -11587,7 +11587,7 @@ opentelemetry.source2.sample_counter0221 []
     inst [8 or "8 inst-8"] value 63997228100
     inst [9 or "9 inst-9"] value 71996881700
 
-opentelemetry.source2.sample_counter0243 []
+opentelemetry.source2.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8680475090
     inst [2 or "2 inst-2"] value 17360950200
@@ -11599,7 +11599,7 @@ opentelemetry.source2.sample_counter0243 []
     inst [8 or "8 inst-8"] value 69443800800
     inst [9 or "9 inst-9"] value 78124275800
 
-opentelemetry.source2.sample_counter0265 []
+opentelemetry.source2.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9361296670
     inst [2 or "2 inst-2"] value 18722593300
@@ -11611,7 +11611,7 @@ opentelemetry.source2.sample_counter0265 []
     inst [8 or "8 inst-8"] value 74890373400
     inst [9 or "9 inst-9"] value 84251670000
 
-opentelemetry.source2.sample_counter0287 []
+opentelemetry.source2.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10042118200
     inst [2 or "2 inst-2"] value 20084236500
@@ -11623,7 +11623,7 @@ opentelemetry.source2.sample_counter0287 []
     inst [8 or "8 inst-8"] value 80336946000
     inst [9 or "9 inst-9"] value 90379064200
 
-opentelemetry.source2.sample_counter0309 []
+opentelemetry.source2.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10722939800
     inst [2 or "2 inst-2"] value 21445879600
@@ -11635,7 +11635,7 @@ opentelemetry.source2.sample_counter0309 []
     inst [8 or "8 inst-8"] value 85783518600
     inst [9 or "9 inst-9"] value 96506458400
 
-opentelemetry.source2.sample_counter0331 []
+opentelemetry.source2.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11403761400
     inst [2 or "2 inst-2"] value 22807522800
@@ -11647,7 +11647,7 @@ opentelemetry.source2.sample_counter0331 []
     inst [8 or "8 inst-8"] value 91230091200
     inst [9 or "9 inst-9"] value 102633853000
 
-opentelemetry.source2.sample_counter0353 []
+opentelemetry.source2.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12084583000
     inst [2 or "2 inst-2"] value 24169165900
@@ -11659,7 +11659,7 @@ opentelemetry.source2.sample_counter0353 []
     inst [8 or "8 inst-8"] value 96676663800
     inst [9 or "9 inst-9"] value 108761247000
 
-opentelemetry.source2.sample_counter0375 []
+opentelemetry.source2.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12765404600
     inst [2 or "2 inst-2"] value 25530809100
@@ -11671,7 +11671,7 @@ opentelemetry.source2.sample_counter0375 []
     inst [8 or "8 inst-8"] value 102123236000
     inst [9 or "9 inst-9"] value 114888641000
 
-opentelemetry.source2.sample_counter0397 []
+opentelemetry.source2.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13446226100
     inst [2 or "2 inst-2"] value 26892452300
@@ -11683,7 +11683,7 @@ opentelemetry.source2.sample_counter0397 []
     inst [8 or "8 inst-8"] value 107569809000
     inst [9 or "9 inst-9"] value 121016035000
 
-opentelemetry.source2.sample_gauge0000 []
+opentelemetry.source2.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 72.59999999999999
     inst [2 or "2 inst-2"] value 145.2
@@ -11695,7 +11695,7 @@ opentelemetry.source2.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 580.8
     inst [9 or "9 inst-9"] value 653.4
 
-opentelemetry.source2.sample_gauge0022 []
+opentelemetry.source2.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 121
     inst [2 or "2 inst-2"] value 242
@@ -11707,7 +11707,7 @@ opentelemetry.source2.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 968
     inst [9 or "9 inst-9"] value 1089
 
-opentelemetry.source2.sample_gauge0044 []
+opentelemetry.source2.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 169.4
     inst [2 or "2 inst-2"] value 338.8
@@ -11719,7 +11719,7 @@ opentelemetry.source2.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 1355.2
     inst [9 or "9 inst-9"] value 1524.6
 
-opentelemetry.source2.sample_gauge0066 []
+opentelemetry.source2.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 217.8
     inst [2 or "2 inst-2"] value 435.6
@@ -11731,7 +11731,7 @@ opentelemetry.source2.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1742.4
     inst [9 or "9 inst-9"] value 1960.2
 
-opentelemetry.source2.sample_gauge0088 []
+opentelemetry.source2.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 266.2
     inst [2 or "2 inst-2"] value 532.4
@@ -11743,7 +11743,7 @@ opentelemetry.source2.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 2129.6
     inst [9 or "9 inst-9"] value 2395.8
 
-opentelemetry.source2.sample_gauge0110 []
+opentelemetry.source2.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 314.6
     inst [2 or "2 inst-2"] value 629.2
@@ -11755,7 +11755,7 @@ opentelemetry.source2.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2516.8
     inst [9 or "9 inst-9"] value 2831.4
 
-opentelemetry.source2.sample_gauge0132 []
+opentelemetry.source2.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 363
     inst [2 or "2 inst-2"] value 726
@@ -11767,7 +11767,7 @@ opentelemetry.source2.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2904
     inst [9 or "9 inst-9"] value 3267
 
-opentelemetry.source2.sample_gauge0154 []
+opentelemetry.source2.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 411.4
     inst [2 or "2 inst-2"] value 822.8
@@ -11779,7 +11779,7 @@ opentelemetry.source2.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 3291.2
     inst [9 or "9 inst-9"] value 3702.6
 
-opentelemetry.source2.sample_gauge0176 []
+opentelemetry.source2.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 459.8
     inst [2 or "2 inst-2"] value 919.6
@@ -11791,7 +11791,7 @@ opentelemetry.source2.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3678.4
     inst [9 or "9 inst-9"] value 4138.2
 
-opentelemetry.source2.sample_gauge0198 []
+opentelemetry.source2.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 508.2
     inst [2 or "2 inst-2"] value 1016.4
@@ -11803,7 +11803,7 @@ opentelemetry.source2.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 4065.6
     inst [9 or "9 inst-9"] value 4573.8
 
-opentelemetry.source2.sample_gauge0220 []
+opentelemetry.source2.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 556.6
     inst [2 or "2 inst-2"] value 1113.2
@@ -11815,7 +11815,7 @@ opentelemetry.source2.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 4452.8
     inst [9 or "9 inst-9"] value 5009.4
 
-opentelemetry.source2.sample_gauge0242 []
+opentelemetry.source2.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 605
     inst [2 or "2 inst-2"] value 1210
@@ -11827,7 +11827,7 @@ opentelemetry.source2.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4840
     inst [9 or "9 inst-9"] value 5445
 
-opentelemetry.source2.sample_gauge0264 []
+opentelemetry.source2.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 653.4
     inst [2 or "2 inst-2"] value 1306.8
@@ -11839,7 +11839,7 @@ opentelemetry.source2.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 5227.2
     inst [9 or "9 inst-9"] value 5880.6
 
-opentelemetry.source2.sample_gauge0286 []
+opentelemetry.source2.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 701.8
     inst [2 or "2 inst-2"] value 1403.6
@@ -11851,7 +11851,7 @@ opentelemetry.source2.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5614.4
     inst [9 or "9 inst-9"] value 6316.2
 
-opentelemetry.source2.sample_gauge0308 []
+opentelemetry.source2.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 750.2
     inst [2 or "2 inst-2"] value 1500.4
@@ -11863,7 +11863,7 @@ opentelemetry.source2.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 6001.6
     inst [9 or "9 inst-9"] value 6751.8
 
-opentelemetry.source2.sample_gauge0330 []
+opentelemetry.source2.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 798.6
     inst [2 or "2 inst-2"] value 1597.2
@@ -11875,7 +11875,7 @@ opentelemetry.source2.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6388.8
     inst [9 or "9 inst-9"] value 7187.4
 
-opentelemetry.source2.sample_gauge0352 []
+opentelemetry.source2.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 847
     inst [2 or "2 inst-2"] value 1694
@@ -11887,7 +11887,7 @@ opentelemetry.source2.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6776
     inst [9 or "9 inst-9"] value 7623
 
-opentelemetry.source2.sample_gauge0374 []
+opentelemetry.source2.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 895.4
     inst [2 or "2 inst-2"] value 1790.8
@@ -11899,7 +11899,7 @@ opentelemetry.source2.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 7163.2
     inst [9 or "9 inst-9"] value 8058.6
 
-opentelemetry.source2.sample_gauge0396 []
+opentelemetry.source2.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 943.8
     inst [2 or "2 inst-2"] value 1887.6
@@ -11911,7 +11911,7 @@ opentelemetry.source2.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7550.4
     inst [9 or "9 inst-9"] value 8494.200000000001
 
-opentelemetry.source2.sample_histogram0012 []
+opentelemetry.source2.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 53505
     inst [2 or "le=4"] value 107010
@@ -11924,13 +11924,13 @@ opentelemetry.source2.sample_histogram0012 []
     inst [9 or "le=18"] value 481545
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0012_count []
+opentelemetry.source2.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0012_sum []
+opentelemetry.source2.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0034 []
+opentelemetry.source2.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 77285
     inst [2 or "le=4"] value 154570
@@ -11943,13 +11943,13 @@ opentelemetry.source2.sample_histogram0034 []
     inst [9 or "le=18"] value 695565
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0034_count []
+opentelemetry.source2.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0034_sum []
+opentelemetry.source2.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0056 []
+opentelemetry.source2.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 101065
     inst [2 or "le=4"] value 202130
@@ -11962,13 +11962,13 @@ opentelemetry.source2.sample_histogram0056 []
     inst [9 or "le=18"] value 909585
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0056_count []
+opentelemetry.source2.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0056_sum []
+opentelemetry.source2.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0078 []
+opentelemetry.source2.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 124845
     inst [2 or "le=4"] value 249690
@@ -11981,13 +11981,13 @@ opentelemetry.source2.sample_histogram0078 []
     inst [9 or "le=18"] value 1123605
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0078_count []
+opentelemetry.source2.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0078_sum []
+opentelemetry.source2.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0100 []
+opentelemetry.source2.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 148625
     inst [2 or "le=4"] value 297250
@@ -12000,13 +12000,13 @@ opentelemetry.source2.sample_histogram0100 []
     inst [9 or "le=18"] value 1337625
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0100_count []
+opentelemetry.source2.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0100_sum []
+opentelemetry.source2.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0122 []
+opentelemetry.source2.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 172405
     inst [2 or "le=4"] value 344810
@@ -12019,13 +12019,13 @@ opentelemetry.source2.sample_histogram0122 []
     inst [9 or "le=18"] value 1551645
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0122_count []
+opentelemetry.source2.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0122_sum []
+opentelemetry.source2.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0144 []
+opentelemetry.source2.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 196185
     inst [2 or "le=4"] value 392370
@@ -12038,13 +12038,13 @@ opentelemetry.source2.sample_histogram0144 []
     inst [9 or "le=18"] value 1765665
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0144_count []
+opentelemetry.source2.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0144_sum []
+opentelemetry.source2.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0166 []
+opentelemetry.source2.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 219965
     inst [2 or "le=4"] value 439930
@@ -12057,13 +12057,13 @@ opentelemetry.source2.sample_histogram0166 []
     inst [9 or "le=18"] value 1979685
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0166_count []
+opentelemetry.source2.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0166_sum []
+opentelemetry.source2.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0188 []
+opentelemetry.source2.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 243745
     inst [2 or "le=4"] value 487490
@@ -12076,13 +12076,13 @@ opentelemetry.source2.sample_histogram0188 []
     inst [9 or "le=18"] value 2193705
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0188_count []
+opentelemetry.source2.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0188_sum []
+opentelemetry.source2.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0210 []
+opentelemetry.source2.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 267525
     inst [2 or "le=4"] value 535050
@@ -12095,13 +12095,13 @@ opentelemetry.source2.sample_histogram0210 []
     inst [9 or "le=18"] value 2407725
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0210_count []
+opentelemetry.source2.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0210_sum []
+opentelemetry.source2.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0232 []
+opentelemetry.source2.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 291305
     inst [2 or "le=4"] value 582610
@@ -12114,13 +12114,13 @@ opentelemetry.source2.sample_histogram0232 []
     inst [9 or "le=18"] value 2621745
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0232_count []
+opentelemetry.source2.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0232_sum []
+opentelemetry.source2.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0254 []
+opentelemetry.source2.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 315085
     inst [2 or "le=4"] value 630170
@@ -12133,13 +12133,13 @@ opentelemetry.source2.sample_histogram0254 []
     inst [9 or "le=18"] value 2835765
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0254_count []
+opentelemetry.source2.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0254_sum []
+opentelemetry.source2.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0276 []
+opentelemetry.source2.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 338865
     inst [2 or "le=4"] value 677730
@@ -12152,13 +12152,13 @@ opentelemetry.source2.sample_histogram0276 []
     inst [9 or "le=18"] value 3049785
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0276_count []
+opentelemetry.source2.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0276_sum []
+opentelemetry.source2.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0298 []
+opentelemetry.source2.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 362645
     inst [2 or "le=4"] value 725290
@@ -12171,13 +12171,13 @@ opentelemetry.source2.sample_histogram0298 []
     inst [9 or "le=18"] value 3263805
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0298_count []
+opentelemetry.source2.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0298_sum []
+opentelemetry.source2.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0320 []
+opentelemetry.source2.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 386425
     inst [2 or "le=4"] value 772850
@@ -12190,13 +12190,13 @@ opentelemetry.source2.sample_histogram0320 []
     inst [9 or "le=18"] value 3477825
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0320_count []
+opentelemetry.source2.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0320_sum []
+opentelemetry.source2.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0342 []
+opentelemetry.source2.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 410205
     inst [2 or "le=4"] value 820410
@@ -12209,13 +12209,13 @@ opentelemetry.source2.sample_histogram0342 []
     inst [9 or "le=18"] value 3691845
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0342_count []
+opentelemetry.source2.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0342_sum []
+opentelemetry.source2.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0364 []
+opentelemetry.source2.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 433985
     inst [2 or "le=4"] value 867970
@@ -12228,13 +12228,13 @@ opentelemetry.source2.sample_histogram0364 []
     inst [9 or "le=18"] value 3905865
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0364_count []
+opentelemetry.source2.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0364_sum []
+opentelemetry.source2.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0386 []
+opentelemetry.source2.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 457765
     inst [2 or "le=4"] value 915530
@@ -12247,13 +12247,13 @@ opentelemetry.source2.sample_histogram0386 []
     inst [9 or "le=18"] value 4119885
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0386_count []
+opentelemetry.source2.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0386_sum []
+opentelemetry.source2.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_summary0002 []
+opentelemetry.source2.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001276984
     inst [2 or "quantile: 0.5"] value 0.002553968
@@ -12265,13 +12265,13 @@ opentelemetry.source2.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.010215872
     inst [9 or "quantile: 2.25"] value 0.011492856
 
-opentelemetry.source2.sample_summary0002_count []
+opentelemetry.source2.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 14544
 
-opentelemetry.source2.sample_summary0002_sum []
+opentelemetry.source2.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 11.129654
 
-opentelemetry.source2.sample_summary0024 []
+opentelemetry.source2.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001915476
     inst [2 or "quantile: 0.5"] value 0.003830952
@@ -12283,13 +12283,13 @@ opentelemetry.source2.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.015323808
     inst [9 or "quantile: 2.25"] value 0.017239284
 
-opentelemetry.source2.sample_summary0024_count []
+opentelemetry.source2.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 21816
 
-opentelemetry.source2.sample_summary0024_sum []
+opentelemetry.source2.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 16.694481
 
-opentelemetry.source2.sample_summary0046 []
+opentelemetry.source2.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002553968
     inst [2 or "quantile: 0.5"] value 0.005107936
@@ -12301,13 +12301,13 @@ opentelemetry.source2.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.020431744
     inst [9 or "quantile: 2.25"] value 0.022985712
 
-opentelemetry.source2.sample_summary0046_count []
+opentelemetry.source2.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 29088
 
-opentelemetry.source2.sample_summary0046_sum []
+opentelemetry.source2.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 22.259308
 
-opentelemetry.source2.sample_summary0068 []
+opentelemetry.source2.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00319246
     inst [2 or "quantile: 0.5"] value 0.006384920000000001
@@ -12319,13 +12319,13 @@ opentelemetry.source2.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.02553968
     inst [9 or "quantile: 2.25"] value 0.02873214
 
-opentelemetry.source2.sample_summary0068_count []
+opentelemetry.source2.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 36360
 
-opentelemetry.source2.sample_summary0068_sum []
+opentelemetry.source2.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 27.824135
 
-opentelemetry.source2.sample_summary0090 []
+opentelemetry.source2.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003830952
     inst [2 or "quantile: 0.5"] value 0.007661904000000001
@@ -12337,13 +12337,13 @@ opentelemetry.source2.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.030647616
     inst [9 or "quantile: 2.25"] value 0.034478568
 
-opentelemetry.source2.sample_summary0090_count []
+opentelemetry.source2.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 43632
 
-opentelemetry.source2.sample_summary0090_sum []
+opentelemetry.source2.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 33.388962
 
-opentelemetry.source2.sample_summary0112 []
+opentelemetry.source2.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004469444
     inst [2 or "quantile: 0.5"] value 0.008938888000000001
@@ -12355,13 +12355,13 @@ opentelemetry.source2.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.035755552
     inst [9 or "quantile: 2.25"] value 0.04022499600000001
 
-opentelemetry.source2.sample_summary0112_count []
+opentelemetry.source2.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 50904
 
-opentelemetry.source2.sample_summary0112_sum []
+opentelemetry.source2.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 38.95379
 
-opentelemetry.source2.sample_summary0134 []
+opentelemetry.source2.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005107936
     inst [2 or "quantile: 0.5"] value 0.010215872
@@ -12373,13 +12373,13 @@ opentelemetry.source2.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.040863488
     inst [9 or "quantile: 2.25"] value 0.045971424
 
-opentelemetry.source2.sample_summary0134_count []
+opentelemetry.source2.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 58176
 
-opentelemetry.source2.sample_summary0134_sum []
+opentelemetry.source2.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 44.518617
 
-opentelemetry.source2.sample_summary0156 []
+opentelemetry.source2.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005746428
     inst [2 or "quantile: 0.5"] value 0.011492856
@@ -12391,13 +12391,13 @@ opentelemetry.source2.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.045971424
     inst [9 or "quantile: 2.25"] value 0.051717852
 
-opentelemetry.source2.sample_summary0156_count []
+opentelemetry.source2.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 65448
 
-opentelemetry.source2.sample_summary0156_sum []
+opentelemetry.source2.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 50.083444
 
-opentelemetry.source2.sample_summary0178 []
+opentelemetry.source2.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006384920000000001
     inst [2 or "quantile: 0.5"] value 0.01276984
@@ -12409,13 +12409,13 @@ opentelemetry.source2.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.05107936
     inst [9 or "quantile: 2.25"] value 0.05746428000000001
 
-opentelemetry.source2.sample_summary0178_count []
+opentelemetry.source2.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 72720
 
-opentelemetry.source2.sample_summary0178_sum []
+opentelemetry.source2.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 55.648271
 
-opentelemetry.source2.sample_summary0200 []
+opentelemetry.source2.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007023412000000001
     inst [2 or "quantile: 0.5"] value 0.014046824
@@ -12427,13 +12427,13 @@ opentelemetry.source2.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.056187296
     inst [9 or "quantile: 2.25"] value 0.063210708
 
-opentelemetry.source2.sample_summary0200_count []
+opentelemetry.source2.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 79992
 
-opentelemetry.source2.sample_summary0200_sum []
+opentelemetry.source2.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 61.213098
 
-opentelemetry.source2.sample_summary0222 []
+opentelemetry.source2.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007661904000000001
     inst [2 or "quantile: 0.5"] value 0.015323808
@@ -12445,13 +12445,13 @@ opentelemetry.source2.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.06129523200000001
     inst [9 or "quantile: 2.25"] value 0.068957136
 
-opentelemetry.source2.sample_summary0222_count []
+opentelemetry.source2.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 87264
 
-opentelemetry.source2.sample_summary0222_sum []
+opentelemetry.source2.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 66.777925
 
-opentelemetry.source2.sample_summary0244 []
+opentelemetry.source2.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008300396000000002
     inst [2 or "quantile: 0.5"] value 0.016600792
@@ -12463,13 +12463,13 @@ opentelemetry.source2.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.06640316800000001
     inst [9 or "quantile: 2.25"] value 0.074703564
 
-opentelemetry.source2.sample_summary0244_count []
+opentelemetry.source2.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 94536
 
-opentelemetry.source2.sample_summary0244_sum []
+opentelemetry.source2.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 72.342752
 
-opentelemetry.source2.sample_summary0266 []
+opentelemetry.source2.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008938888000000001
     inst [2 or "quantile: 0.5"] value 0.017877776
@@ -12481,13 +12481,13 @@ opentelemetry.source2.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.07151110400000001
     inst [9 or "quantile: 2.25"] value 0.08044999200000001
 
-opentelemetry.source2.sample_summary0266_count []
+opentelemetry.source2.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 101808
 
-opentelemetry.source2.sample_summary0266_sum []
+opentelemetry.source2.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 77.907579
 
-opentelemetry.source2.sample_summary0288 []
+opentelemetry.source2.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00957738
     inst [2 or "quantile: 0.5"] value 0.01915476
@@ -12499,13 +12499,13 @@ opentelemetry.source2.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.07661904
     inst [9 or "quantile: 2.25"] value 0.08619642000000001
 
-opentelemetry.source2.sample_summary0288_count []
+opentelemetry.source2.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 109080
 
-opentelemetry.source2.sample_summary0288_sum []
+opentelemetry.source2.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 83.47240600000001
 
-opentelemetry.source2.sample_summary0310 []
+opentelemetry.source2.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010215872
     inst [2 or "quantile: 0.5"] value 0.020431744
@@ -12517,13 +12517,13 @@ opentelemetry.source2.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.08172697600000001
     inst [9 or "quantile: 2.25"] value 0.09194284800000001
 
-opentelemetry.source2.sample_summary0310_count []
+opentelemetry.source2.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 116352
 
-opentelemetry.source2.sample_summary0310_sum []
+opentelemetry.source2.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 89.037233
 
-opentelemetry.source2.sample_summary0332 []
+opentelemetry.source2.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010854364
     inst [2 or "quantile: 0.5"] value 0.021708728
@@ -12535,13 +12535,13 @@ opentelemetry.source2.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.08683491200000001
     inst [9 or "quantile: 2.25"] value 0.09768927600000001
 
-opentelemetry.source2.sample_summary0332_count []
+opentelemetry.source2.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 123624
 
-opentelemetry.source2.sample_summary0332_sum []
+opentelemetry.source2.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 94.60205999999999
 
-opentelemetry.source2.sample_summary0354 []
+opentelemetry.source2.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011492856
     inst [2 or "quantile: 0.5"] value 0.022985712
@@ -12553,13 +12553,13 @@ opentelemetry.source2.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.09194284800000001
     inst [9 or "quantile: 2.25"] value 0.103435704
 
-opentelemetry.source2.sample_summary0354_count []
+opentelemetry.source2.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 130896
 
-opentelemetry.source2.sample_summary0354_sum []
+opentelemetry.source2.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 100.166887
 
-opentelemetry.source2.sample_summary0376 []
+opentelemetry.source2.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012131348
     inst [2 or "quantile: 0.5"] value 0.024262696
@@ -12571,13 +12571,13 @@ opentelemetry.source2.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.097050784
     inst [9 or "quantile: 2.25"] value 0.109182132
 
-opentelemetry.source2.sample_summary0376_count []
+opentelemetry.source2.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 138168
 
-opentelemetry.source2.sample_summary0376_sum []
+opentelemetry.source2.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 105.731715
 
-opentelemetry.source2.sample_summary0398 []
+opentelemetry.source2.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01276984
     inst [2 or "quantile: 0.5"] value 0.02553968
@@ -12589,13 +12589,13 @@ opentelemetry.source2.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.10215872
     inst [9 or "quantile: 2.25"] value 0.11492856
 
-opentelemetry.source2.sample_summary0398_count []
+opentelemetry.source2.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 145440
 
-opentelemetry.source2.sample_summary0398_sum []
+opentelemetry.source2.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 111.296542
 
-opentelemetry.source2.sample_counter0001 []
+opentelemetry.source2.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1531848550
     inst [2 or "2 inst-2"] value 3063697090
@@ -12607,7 +12607,7 @@ opentelemetry.source2.sample_counter0001 []
     inst [8 or "8 inst-8"] value 12254788400
     inst [9 or "9 inst-9"] value 13786636900
 
-opentelemetry.source2.sample_counter0023 []
+opentelemetry.source2.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -12619,7 +12619,7 @@ opentelemetry.source2.sample_counter0023 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source2.sample_counter0045 []
+opentelemetry.source2.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -12631,7 +12631,7 @@ opentelemetry.source2.sample_counter0045 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source2.sample_counter0067 []
+opentelemetry.source2.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -12643,7 +12643,7 @@ opentelemetry.source2.sample_counter0067 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source2.sample_counter0089 []
+opentelemetry.source2.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -12655,7 +12655,7 @@ opentelemetry.source2.sample_counter0089 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source2.sample_counter0111 []
+opentelemetry.source2.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -12667,7 +12667,7 @@ opentelemetry.source2.sample_counter0111 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source2.sample_counter0133 []
+opentelemetry.source2.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -12679,7 +12679,7 @@ opentelemetry.source2.sample_counter0133 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source2.sample_counter0155 []
+opentelemetry.source2.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -12691,7 +12691,7 @@ opentelemetry.source2.sample_counter0155 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source2.sample_counter0177 []
+opentelemetry.source2.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -12703,7 +12703,7 @@ opentelemetry.source2.sample_counter0177 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source2.sample_counter0199 []
+opentelemetry.source2.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -12715,7 +12715,7 @@ opentelemetry.source2.sample_counter0199 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source2.sample_counter0221 []
+opentelemetry.source2.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -12727,7 +12727,7 @@ opentelemetry.source2.sample_counter0221 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source2.sample_counter0243 []
+opentelemetry.source2.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -12739,7 +12739,7 @@ opentelemetry.source2.sample_counter0243 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source2.sample_counter0265 []
+opentelemetry.source2.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -12751,7 +12751,7 @@ opentelemetry.source2.sample_counter0265 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source2.sample_counter0287 []
+opentelemetry.source2.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -12763,7 +12763,7 @@ opentelemetry.source2.sample_counter0287 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source2.sample_counter0309 []
+opentelemetry.source2.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -12775,7 +12775,7 @@ opentelemetry.source2.sample_counter0309 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source2.sample_counter0331 []
+opentelemetry.source2.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -12787,7 +12787,7 @@ opentelemetry.source2.sample_counter0331 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source2.sample_counter0353 []
+opentelemetry.source2.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -12799,7 +12799,7 @@ opentelemetry.source2.sample_counter0353 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source2.sample_counter0375 []
+opentelemetry.source2.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13105815300
     inst [2 or "2 inst-2"] value 26211630700
@@ -12811,7 +12811,7 @@ opentelemetry.source2.sample_counter0375 []
     inst [8 or "8 inst-8"] value 104846523000
     inst [9 or "9 inst-9"] value 117952338000
 
-opentelemetry.source2.sample_counter0397 []
+opentelemetry.source2.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13786636900
     inst [2 or "2 inst-2"] value 27573273800
@@ -12823,7 +12823,7 @@ opentelemetry.source2.sample_counter0397 []
     inst [8 or "8 inst-8"] value 110293095000
     inst [9 or "9 inst-9"] value 124079732000
 
-opentelemetry.source2.sample_gauge0000 []
+opentelemetry.source2.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 96.8
     inst [2 or "2 inst-2"] value 193.6
@@ -12835,7 +12835,7 @@ opentelemetry.source2.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 774.4
     inst [9 or "9 inst-9"] value 871.2
 
-opentelemetry.source2.sample_gauge0022 []
+opentelemetry.source2.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -12847,7 +12847,7 @@ opentelemetry.source2.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source2.sample_gauge0044 []
+opentelemetry.source2.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -12859,7 +12859,7 @@ opentelemetry.source2.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source2.sample_gauge0066 []
+opentelemetry.source2.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -12871,7 +12871,7 @@ opentelemetry.source2.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source2.sample_gauge0088 []
+opentelemetry.source2.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -12883,7 +12883,7 @@ opentelemetry.source2.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source2.sample_gauge0110 []
+opentelemetry.source2.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -12895,7 +12895,7 @@ opentelemetry.source2.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source2.sample_gauge0132 []
+opentelemetry.source2.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -12907,7 +12907,7 @@ opentelemetry.source2.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source2.sample_gauge0154 []
+opentelemetry.source2.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -12919,7 +12919,7 @@ opentelemetry.source2.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source2.sample_gauge0176 []
+opentelemetry.source2.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -12931,7 +12931,7 @@ opentelemetry.source2.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source2.sample_gauge0198 []
+opentelemetry.source2.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -12943,7 +12943,7 @@ opentelemetry.source2.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source2.sample_gauge0220 []
+opentelemetry.source2.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -12955,7 +12955,7 @@ opentelemetry.source2.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source2.sample_gauge0242 []
+opentelemetry.source2.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -12967,7 +12967,7 @@ opentelemetry.source2.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source2.sample_gauge0264 []
+opentelemetry.source2.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -12979,7 +12979,7 @@ opentelemetry.source2.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source2.sample_gauge0286 []
+opentelemetry.source2.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -12991,7 +12991,7 @@ opentelemetry.source2.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source2.sample_gauge0308 []
+opentelemetry.source2.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -13003,7 +13003,7 @@ opentelemetry.source2.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source2.sample_gauge0330 []
+opentelemetry.source2.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -13015,7 +13015,7 @@ opentelemetry.source2.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source2.sample_gauge0352 []
+opentelemetry.source2.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -13027,7 +13027,7 @@ opentelemetry.source2.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source2.sample_gauge0374 []
+opentelemetry.source2.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 919.6
     inst [2 or "2 inst-2"] value 1839.2
@@ -13039,7 +13039,7 @@ opentelemetry.source2.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 7356.8
     inst [9 or "9 inst-9"] value 8276.4
 
-opentelemetry.source2.sample_gauge0396 []
+opentelemetry.source2.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 968
     inst [2 or "2 inst-2"] value 1936
@@ -13051,7 +13051,7 @@ opentelemetry.source2.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7744
     inst [9 or "9 inst-9"] value 8712
 
-opentelemetry.source2.sample_histogram0012 []
+opentelemetry.source2.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 65395
     inst [2 or "le=4"] value 130790
@@ -13064,13 +13064,13 @@ opentelemetry.source2.sample_histogram0012 []
     inst [9 or "le=18"] value 588555
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0012_count []
+opentelemetry.source2.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0012_sum []
+opentelemetry.source2.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0034 []
+opentelemetry.source2.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 89175
     inst [2 or "le=4"] value 178350
@@ -13083,13 +13083,13 @@ opentelemetry.source2.sample_histogram0034 []
     inst [9 or "le=18"] value 802575
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0034_count []
+opentelemetry.source2.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0034_sum []
+opentelemetry.source2.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0056 []
+opentelemetry.source2.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 112955
     inst [2 or "le=4"] value 225910
@@ -13102,13 +13102,13 @@ opentelemetry.source2.sample_histogram0056 []
     inst [9 or "le=18"] value 1016595
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0056_count []
+opentelemetry.source2.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0056_sum []
+opentelemetry.source2.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0078 []
+opentelemetry.source2.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 136735
     inst [2 or "le=4"] value 273470
@@ -13121,13 +13121,13 @@ opentelemetry.source2.sample_histogram0078 []
     inst [9 or "le=18"] value 1230615
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0078_count []
+opentelemetry.source2.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0078_sum []
+opentelemetry.source2.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0100 []
+opentelemetry.source2.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 160515
     inst [2 or "le=4"] value 321030
@@ -13140,13 +13140,13 @@ opentelemetry.source2.sample_histogram0100 []
     inst [9 or "le=18"] value 1444635
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0100_count []
+opentelemetry.source2.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0100_sum []
+opentelemetry.source2.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0122 []
+opentelemetry.source2.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 184295
     inst [2 or "le=4"] value 368590
@@ -13159,13 +13159,13 @@ opentelemetry.source2.sample_histogram0122 []
     inst [9 or "le=18"] value 1658655
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0122_count []
+opentelemetry.source2.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0122_sum []
+opentelemetry.source2.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0144 []
+opentelemetry.source2.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 208075
     inst [2 or "le=4"] value 416150
@@ -13178,13 +13178,13 @@ opentelemetry.source2.sample_histogram0144 []
     inst [9 or "le=18"] value 1872675
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0144_count []
+opentelemetry.source2.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0144_sum []
+opentelemetry.source2.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0166 []
+opentelemetry.source2.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 231855
     inst [2 or "le=4"] value 463710
@@ -13197,13 +13197,13 @@ opentelemetry.source2.sample_histogram0166 []
     inst [9 or "le=18"] value 2086695
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0166_count []
+opentelemetry.source2.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0166_sum []
+opentelemetry.source2.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0188 []
+opentelemetry.source2.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 255635
     inst [2 or "le=4"] value 511270
@@ -13216,13 +13216,13 @@ opentelemetry.source2.sample_histogram0188 []
     inst [9 or "le=18"] value 2300715
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0188_count []
+opentelemetry.source2.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0188_sum []
+opentelemetry.source2.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0210 []
+opentelemetry.source2.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 279415
     inst [2 or "le=4"] value 558830
@@ -13235,13 +13235,13 @@ opentelemetry.source2.sample_histogram0210 []
     inst [9 or "le=18"] value 2514735
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0210_count []
+opentelemetry.source2.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0210_sum []
+opentelemetry.source2.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0232 []
+opentelemetry.source2.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 303195
     inst [2 or "le=4"] value 606390
@@ -13254,13 +13254,13 @@ opentelemetry.source2.sample_histogram0232 []
     inst [9 or "le=18"] value 2728755
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0232_count []
+opentelemetry.source2.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0232_sum []
+opentelemetry.source2.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0254 []
+opentelemetry.source2.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 326975
     inst [2 or "le=4"] value 653950
@@ -13273,13 +13273,13 @@ opentelemetry.source2.sample_histogram0254 []
     inst [9 or "le=18"] value 2942775
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0254_count []
+opentelemetry.source2.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0254_sum []
+opentelemetry.source2.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0276 []
+opentelemetry.source2.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 350755
     inst [2 or "le=4"] value 701510
@@ -13292,13 +13292,13 @@ opentelemetry.source2.sample_histogram0276 []
     inst [9 or "le=18"] value 3156795
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0276_count []
+opentelemetry.source2.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0276_sum []
+opentelemetry.source2.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0298 []
+opentelemetry.source2.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 374535
     inst [2 or "le=4"] value 749070
@@ -13311,13 +13311,13 @@ opentelemetry.source2.sample_histogram0298 []
     inst [9 or "le=18"] value 3370815
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0298_count []
+opentelemetry.source2.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0298_sum []
+opentelemetry.source2.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0320 []
+opentelemetry.source2.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 398315
     inst [2 or "le=4"] value 796630
@@ -13330,13 +13330,13 @@ opentelemetry.source2.sample_histogram0320 []
     inst [9 or "le=18"] value 3584835
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0320_count []
+opentelemetry.source2.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0320_sum []
+opentelemetry.source2.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0342 []
+opentelemetry.source2.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 422095
     inst [2 or "le=4"] value 844190
@@ -13349,13 +13349,13 @@ opentelemetry.source2.sample_histogram0342 []
     inst [9 or "le=18"] value 3798855
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0342_count []
+opentelemetry.source2.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0342_sum []
+opentelemetry.source2.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0364 []
+opentelemetry.source2.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 445875
     inst [2 or "le=4"] value 891750
@@ -13368,13 +13368,13 @@ opentelemetry.source2.sample_histogram0364 []
     inst [9 or "le=18"] value 4012875
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0364_count []
+opentelemetry.source2.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0364_sum []
+opentelemetry.source2.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_histogram0386 []
+opentelemetry.source2.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 469655
     inst [2 or "le=4"] value 939310
@@ -13387,13 +13387,13 @@ opentelemetry.source2.sample_histogram0386 []
     inst [9 or "le=18"] value 4226895
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source2.sample_histogram0386_count []
+opentelemetry.source2.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source2.sample_histogram0386_sum []
+opentelemetry.source2.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source2.sample_summary0002 []
+opentelemetry.source2.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00159623
     inst [2 or "quantile: 0.5"] value 0.00319246
@@ -13405,13 +13405,13 @@ opentelemetry.source2.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.01276984
     inst [9 or "quantile: 2.25"] value 0.01436607
 
-opentelemetry.source2.sample_summary0002_count []
+opentelemetry.source2.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 18180
 
-opentelemetry.source2.sample_summary0002_sum []
+opentelemetry.source2.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 13.912068
 
-opentelemetry.source2.sample_summary0024 []
+opentelemetry.source2.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -13423,13 +13423,13 @@ opentelemetry.source2.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source2.sample_summary0024_count []
+opentelemetry.source2.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source2.sample_summary0024_sum []
+opentelemetry.source2.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source2.sample_summary0046 []
+opentelemetry.source2.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -13441,13 +13441,13 @@ opentelemetry.source2.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source2.sample_summary0046_count []
+opentelemetry.source2.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source2.sample_summary0046_sum []
+opentelemetry.source2.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source2.sample_summary0068 []
+opentelemetry.source2.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -13459,13 +13459,13 @@ opentelemetry.source2.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source2.sample_summary0068_count []
+opentelemetry.source2.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source2.sample_summary0068_sum []
+opentelemetry.source2.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source2.sample_summary0090 []
+opentelemetry.source2.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -13477,13 +13477,13 @@ opentelemetry.source2.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source2.sample_summary0090_count []
+opentelemetry.source2.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source2.sample_summary0090_sum []
+opentelemetry.source2.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source2.sample_summary0112 []
+opentelemetry.source2.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -13495,13 +13495,13 @@ opentelemetry.source2.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source2.sample_summary0112_count []
+opentelemetry.source2.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source2.sample_summary0112_sum []
+opentelemetry.source2.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source2.sample_summary0134 []
+opentelemetry.source2.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -13513,13 +13513,13 @@ opentelemetry.source2.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source2.sample_summary0134_count []
+opentelemetry.source2.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source2.sample_summary0134_sum []
+opentelemetry.source2.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source2.sample_summary0156 []
+opentelemetry.source2.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -13531,13 +13531,13 @@ opentelemetry.source2.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source2.sample_summary0156_count []
+opentelemetry.source2.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source2.sample_summary0156_sum []
+opentelemetry.source2.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source2.sample_summary0178 []
+opentelemetry.source2.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -13549,13 +13549,13 @@ opentelemetry.source2.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source2.sample_summary0178_count []
+opentelemetry.source2.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source2.sample_summary0178_sum []
+opentelemetry.source2.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source2.sample_summary0200 []
+opentelemetry.source2.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -13567,13 +13567,13 @@ opentelemetry.source2.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source2.sample_summary0200_count []
+opentelemetry.source2.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source2.sample_summary0200_sum []
+opentelemetry.source2.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source2.sample_summary0222 []
+opentelemetry.source2.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -13585,13 +13585,13 @@ opentelemetry.source2.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source2.sample_summary0222_count []
+opentelemetry.source2.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source2.sample_summary0222_sum []
+opentelemetry.source2.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source2.sample_summary0244 []
+opentelemetry.source2.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -13603,13 +13603,13 @@ opentelemetry.source2.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source2.sample_summary0244_count []
+opentelemetry.source2.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source2.sample_summary0244_sum []
+opentelemetry.source2.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source2.sample_summary0266 []
+opentelemetry.source2.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -13621,13 +13621,13 @@ opentelemetry.source2.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source2.sample_summary0266_count []
+opentelemetry.source2.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source2.sample_summary0266_sum []
+opentelemetry.source2.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source2.sample_summary0288 []
+opentelemetry.source2.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -13639,13 +13639,13 @@ opentelemetry.source2.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source2.sample_summary0288_count []
+opentelemetry.source2.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source2.sample_summary0288_sum []
+opentelemetry.source2.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source2.sample_summary0310 []
+opentelemetry.source2.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -13657,13 +13657,13 @@ opentelemetry.source2.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source2.sample_summary0310_count []
+opentelemetry.source2.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source2.sample_summary0310_sum []
+opentelemetry.source2.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source2.sample_summary0332 []
+opentelemetry.source2.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -13675,13 +13675,13 @@ opentelemetry.source2.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source2.sample_summary0332_count []
+opentelemetry.source2.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source2.sample_summary0332_sum []
+opentelemetry.source2.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source2.sample_summary0354 []
+opentelemetry.source2.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -13693,13 +13693,13 @@ opentelemetry.source2.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source2.sample_summary0354_count []
+opentelemetry.source2.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source2.sample_summary0354_sum []
+opentelemetry.source2.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source2.sample_summary0376 []
+opentelemetry.source2.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012450594
     inst [2 or "quantile: 0.5"] value 0.024901188
@@ -13711,13 +13711,13 @@ opentelemetry.source2.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.099604752
     inst [9 or "quantile: 2.25"] value 0.112055346
 
-opentelemetry.source2.sample_summary0376_count []
+opentelemetry.source2.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 141804
 
-opentelemetry.source2.sample_summary0376_sum []
+opentelemetry.source2.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 108.514128
 
-opentelemetry.source2.sample_summary0398 []
+opentelemetry.source2.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013089086
     inst [2 or "quantile: 0.5"] value 0.026178172
@@ -13729,13 +13729,13 @@ opentelemetry.source2.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.104712688
     inst [9 or "quantile: 2.25"] value 0.117801774
 
-opentelemetry.source2.sample_summary0398_count []
+opentelemetry.source2.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 149076
 
-opentelemetry.source2.sample_summary0398_sum []
+opentelemetry.source2.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 114.078955
 
-opentelemetry.source3.sample_counter0001 []
+opentelemetry.source3.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 680821576
     inst [2 or "2 inst-2"] value 1361643150
@@ -13747,7 +13747,7 @@ opentelemetry.source3.sample_counter0001 []
     inst [8 or "8 inst-8"] value 5446572610
     inst [9 or "9 inst-9"] value 6127394180
 
-opentelemetry.source3.sample_counter0023 []
+opentelemetry.source3.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1361643150
     inst [2 or "2 inst-2"] value 2723286300
@@ -13759,7 +13759,7 @@ opentelemetry.source3.sample_counter0023 []
     inst [8 or "8 inst-8"] value 10893145200
     inst [9 or "9 inst-9"] value 12254788400
 
-opentelemetry.source3.sample_counter0045 []
+opentelemetry.source3.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2042464730
     inst [2 or "2 inst-2"] value 4084929460
@@ -13771,7 +13771,7 @@ opentelemetry.source3.sample_counter0045 []
     inst [8 or "8 inst-8"] value 16339717800
     inst [9 or "9 inst-9"] value 18382182600
 
-opentelemetry.source3.sample_counter0067 []
+opentelemetry.source3.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2723286300
     inst [2 or "2 inst-2"] value 5446572610
@@ -13783,7 +13783,7 @@ opentelemetry.source3.sample_counter0067 []
     inst [8 or "8 inst-8"] value 21786290400
     inst [9 or "9 inst-9"] value 24509576700
 
-opentelemetry.source3.sample_counter0089 []
+opentelemetry.source3.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3404107880
     inst [2 or "2 inst-2"] value 6808215760
@@ -13795,7 +13795,7 @@ opentelemetry.source3.sample_counter0089 []
     inst [8 or "8 inst-8"] value 27232863000
     inst [9 or "9 inst-9"] value 30636970900
 
-opentelemetry.source3.sample_counter0111 []
+opentelemetry.source3.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4084929460
     inst [2 or "2 inst-2"] value 8169858910
@@ -13807,7 +13807,7 @@ opentelemetry.source3.sample_counter0111 []
     inst [8 or "8 inst-8"] value 32679435600
     inst [9 or "9 inst-9"] value 36764365100
 
-opentelemetry.source3.sample_counter0133 []
+opentelemetry.source3.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4765751030
     inst [2 or "2 inst-2"] value 9531502060
@@ -13819,7 +13819,7 @@ opentelemetry.source3.sample_counter0133 []
     inst [8 or "8 inst-8"] value 38126008300
     inst [9 or "9 inst-9"] value 42891759300
 
-opentelemetry.source3.sample_counter0155 []
+opentelemetry.source3.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5446572610
     inst [2 or "2 inst-2"] value 10893145200
@@ -13831,7 +13831,7 @@ opentelemetry.source3.sample_counter0155 []
     inst [8 or "8 inst-8"] value 43572580900
     inst [9 or "9 inst-9"] value 49019153500
 
-opentelemetry.source3.sample_counter0177 []
+opentelemetry.source3.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6127394180
     inst [2 or "2 inst-2"] value 12254788400
@@ -13843,7 +13843,7 @@ opentelemetry.source3.sample_counter0177 []
     inst [8 or "8 inst-8"] value 49019153500
     inst [9 or "9 inst-9"] value 55146547700
 
-opentelemetry.source3.sample_counter0199 []
+opentelemetry.source3.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6808215760
     inst [2 or "2 inst-2"] value 13616431500
@@ -13855,7 +13855,7 @@ opentelemetry.source3.sample_counter0199 []
     inst [8 or "8 inst-8"] value 54465726100
     inst [9 or "9 inst-9"] value 61273941800
 
-opentelemetry.source3.sample_counter0221 []
+opentelemetry.source3.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7489037340
     inst [2 or "2 inst-2"] value 14978074700
@@ -13867,7 +13867,7 @@ opentelemetry.source3.sample_counter0221 []
     inst [8 or "8 inst-8"] value 59912298700
     inst [9 or "9 inst-9"] value 67401336000
 
-opentelemetry.source3.sample_counter0243 []
+opentelemetry.source3.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8169858910
     inst [2 or "2 inst-2"] value 16339717800
@@ -13879,7 +13879,7 @@ opentelemetry.source3.sample_counter0243 []
     inst [8 or "8 inst-8"] value 65358871300
     inst [9 or "9 inst-9"] value 73528730200
 
-opentelemetry.source3.sample_counter0265 []
+opentelemetry.source3.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8850680490
     inst [2 or "2 inst-2"] value 17701361000
@@ -13891,7 +13891,7 @@ opentelemetry.source3.sample_counter0265 []
     inst [8 or "8 inst-8"] value 70805443900
     inst [9 or "9 inst-9"] value 79656124400
 
-opentelemetry.source3.sample_counter0287 []
+opentelemetry.source3.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9531502060
     inst [2 or "2 inst-2"] value 19063004100
@@ -13903,7 +13903,7 @@ opentelemetry.source3.sample_counter0287 []
     inst [8 or "8 inst-8"] value 76252016500
     inst [9 or "9 inst-9"] value 85783518600
 
-opentelemetry.source3.sample_counter0309 []
+opentelemetry.source3.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10212323600
     inst [2 or "2 inst-2"] value 20424647300
@@ -13915,7 +13915,7 @@ opentelemetry.source3.sample_counter0309 []
     inst [8 or "8 inst-8"] value 81698589100
     inst [9 or "9 inst-9"] value 91910912800
 
-opentelemetry.source3.sample_counter0331 []
+opentelemetry.source3.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10893145200
     inst [2 or "2 inst-2"] value 21786290400
@@ -13927,7 +13927,7 @@ opentelemetry.source3.sample_counter0331 []
     inst [8 or "8 inst-8"] value 87145161700
     inst [9 or "9 inst-9"] value 98038306900
 
-opentelemetry.source3.sample_counter0353 []
+opentelemetry.source3.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11573966800
     inst [2 or "2 inst-2"] value 23147933600
@@ -13939,7 +13939,7 @@ opentelemetry.source3.sample_counter0353 []
     inst [8 or "8 inst-8"] value 92591734300
     inst [9 or "9 inst-9"] value 104165701000
 
-opentelemetry.source3.sample_counter0375 []
+opentelemetry.source3.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12254788400
     inst [2 or "2 inst-2"] value 24509576700
@@ -13951,7 +13951,7 @@ opentelemetry.source3.sample_counter0375 []
     inst [8 or "8 inst-8"] value 98038306900
     inst [9 or "9 inst-9"] value 110293095000
 
-opentelemetry.source3.sample_counter0397 []
+opentelemetry.source3.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12935609900
     inst [2 or "2 inst-2"] value 25871219900
@@ -13963,7 +13963,7 @@ opentelemetry.source3.sample_counter0397 []
     inst [8 or "8 inst-8"] value 103484880000
     inst [9 or "9 inst-9"] value 116420489000
 
-opentelemetry.source3.sample_gauge0000 []
+opentelemetry.source3.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 36.3
     inst [2 or "2 inst-2"] value 72.59999999999999
@@ -13975,7 +13975,7 @@ opentelemetry.source3.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 290.4
     inst [9 or "9 inst-9"] value 326.7
 
-opentelemetry.source3.sample_gauge0022 []
+opentelemetry.source3.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 84.7
     inst [2 or "2 inst-2"] value 169.4
@@ -13987,7 +13987,7 @@ opentelemetry.source3.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 677.6
     inst [9 or "9 inst-9"] value 762.3
 
-opentelemetry.source3.sample_gauge0044 []
+opentelemetry.source3.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 133.1
     inst [2 or "2 inst-2"] value 266.2
@@ -13999,7 +13999,7 @@ opentelemetry.source3.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 1064.8
     inst [9 or "9 inst-9"] value 1197.9
 
-opentelemetry.source3.sample_gauge0066 []
+opentelemetry.source3.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 181.5
     inst [2 or "2 inst-2"] value 363
@@ -14011,7 +14011,7 @@ opentelemetry.source3.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1452
     inst [9 or "9 inst-9"] value 1633.5
 
-opentelemetry.source3.sample_gauge0088 []
+opentelemetry.source3.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 229.9
     inst [2 or "2 inst-2"] value 459.8
@@ -14023,7 +14023,7 @@ opentelemetry.source3.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 1839.2
     inst [9 or "9 inst-9"] value 2069.1
 
-opentelemetry.source3.sample_gauge0110 []
+opentelemetry.source3.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 278.3
     inst [2 or "2 inst-2"] value 556.6
@@ -14035,7 +14035,7 @@ opentelemetry.source3.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2226.4
     inst [9 or "9 inst-9"] value 2504.7
 
-opentelemetry.source3.sample_gauge0132 []
+opentelemetry.source3.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 326.7
     inst [2 or "2 inst-2"] value 653.4
@@ -14047,7 +14047,7 @@ opentelemetry.source3.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2613.6
     inst [9 or "9 inst-9"] value 2940.3
 
-opentelemetry.source3.sample_gauge0154 []
+opentelemetry.source3.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 375.1
     inst [2 or "2 inst-2"] value 750.2
@@ -14059,7 +14059,7 @@ opentelemetry.source3.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 3000.8
     inst [9 or "9 inst-9"] value 3375.9
 
-opentelemetry.source3.sample_gauge0176 []
+opentelemetry.source3.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 423.5
     inst [2 or "2 inst-2"] value 847
@@ -14071,7 +14071,7 @@ opentelemetry.source3.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3388
     inst [9 or "9 inst-9"] value 3811.5
 
-opentelemetry.source3.sample_gauge0198 []
+opentelemetry.source3.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 471.9
     inst [2 or "2 inst-2"] value 943.8
@@ -14083,7 +14083,7 @@ opentelemetry.source3.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 3775.2
     inst [9 or "9 inst-9"] value 4247.1
 
-opentelemetry.source3.sample_gauge0220 []
+opentelemetry.source3.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 520.3
     inst [2 or "2 inst-2"] value 1040.6
@@ -14095,7 +14095,7 @@ opentelemetry.source3.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 4162.4
     inst [9 or "9 inst-9"] value 4682.7
 
-opentelemetry.source3.sample_gauge0242 []
+opentelemetry.source3.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 568.7
     inst [2 or "2 inst-2"] value 1137.4
@@ -14107,7 +14107,7 @@ opentelemetry.source3.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4549.6
     inst [9 or "9 inst-9"] value 5118.3
 
-opentelemetry.source3.sample_gauge0264 []
+opentelemetry.source3.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 617.1
     inst [2 or "2 inst-2"] value 1234.2
@@ -14119,7 +14119,7 @@ opentelemetry.source3.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 4936.8
     inst [9 or "9 inst-9"] value 5553.9
 
-opentelemetry.source3.sample_gauge0286 []
+opentelemetry.source3.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 665.5
     inst [2 or "2 inst-2"] value 1331
@@ -14131,7 +14131,7 @@ opentelemetry.source3.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5324
     inst [9 or "9 inst-9"] value 5989.5
 
-opentelemetry.source3.sample_gauge0308 []
+opentelemetry.source3.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 713.9
     inst [2 or "2 inst-2"] value 1427.8
@@ -14143,7 +14143,7 @@ opentelemetry.source3.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 5711.2
     inst [9 or "9 inst-9"] value 6425.1
 
-opentelemetry.source3.sample_gauge0330 []
+opentelemetry.source3.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 762.3
     inst [2 or "2 inst-2"] value 1524.6
@@ -14155,7 +14155,7 @@ opentelemetry.source3.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6098.4
     inst [9 or "9 inst-9"] value 6860.7
 
-opentelemetry.source3.sample_gauge0352 []
+opentelemetry.source3.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 810.7
     inst [2 or "2 inst-2"] value 1621.4
@@ -14167,7 +14167,7 @@ opentelemetry.source3.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6485.6
     inst [9 or "9 inst-9"] value 7296.3
 
-opentelemetry.source3.sample_gauge0374 []
+opentelemetry.source3.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 859.1
     inst [2 or "2 inst-2"] value 1718.2
@@ -14179,7 +14179,7 @@ opentelemetry.source3.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 6872.8
     inst [9 or "9 inst-9"] value 7731.9
 
-opentelemetry.source3.sample_gauge0396 []
+opentelemetry.source3.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 907.5
     inst [2 or "2 inst-2"] value 1815
@@ -14191,7 +14191,7 @@ opentelemetry.source3.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7260
     inst [9 or "9 inst-9"] value 8167.5
 
-opentelemetry.source3.sample_histogram0012 []
+opentelemetry.source3.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 35670
     inst [2 or "le=4"] value 71340
@@ -14204,13 +14204,13 @@ opentelemetry.source3.sample_histogram0012 []
     inst [9 or "le=18"] value 321030
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0012_count []
+opentelemetry.source3.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0012_sum []
+opentelemetry.source3.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0034 []
+opentelemetry.source3.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 59450
     inst [2 or "le=4"] value 118900
@@ -14223,13 +14223,13 @@ opentelemetry.source3.sample_histogram0034 []
     inst [9 or "le=18"] value 535050
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0034_count []
+opentelemetry.source3.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0034_sum []
+opentelemetry.source3.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0056 []
+opentelemetry.source3.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 83230
     inst [2 or "le=4"] value 166460
@@ -14242,13 +14242,13 @@ opentelemetry.source3.sample_histogram0056 []
     inst [9 or "le=18"] value 749070
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0056_count []
+opentelemetry.source3.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0056_sum []
+opentelemetry.source3.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0078 []
+opentelemetry.source3.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 107010
     inst [2 or "le=4"] value 214020
@@ -14261,13 +14261,13 @@ opentelemetry.source3.sample_histogram0078 []
     inst [9 or "le=18"] value 963090
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0078_count []
+opentelemetry.source3.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0078_sum []
+opentelemetry.source3.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0100 []
+opentelemetry.source3.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 130790
     inst [2 or "le=4"] value 261580
@@ -14280,13 +14280,13 @@ opentelemetry.source3.sample_histogram0100 []
     inst [9 or "le=18"] value 1177110
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0100_count []
+opentelemetry.source3.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0100_sum []
+opentelemetry.source3.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0122 []
+opentelemetry.source3.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 154570
     inst [2 or "le=4"] value 309140
@@ -14299,13 +14299,13 @@ opentelemetry.source3.sample_histogram0122 []
     inst [9 or "le=18"] value 1391130
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0122_count []
+opentelemetry.source3.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0122_sum []
+opentelemetry.source3.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0144 []
+opentelemetry.source3.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 178350
     inst [2 or "le=4"] value 356700
@@ -14318,13 +14318,13 @@ opentelemetry.source3.sample_histogram0144 []
     inst [9 or "le=18"] value 1605150
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0144_count []
+opentelemetry.source3.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0144_sum []
+opentelemetry.source3.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0166 []
+opentelemetry.source3.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 202130
     inst [2 or "le=4"] value 404260
@@ -14337,13 +14337,13 @@ opentelemetry.source3.sample_histogram0166 []
     inst [9 or "le=18"] value 1819170
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0166_count []
+opentelemetry.source3.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0166_sum []
+opentelemetry.source3.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0188 []
+opentelemetry.source3.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 225910
     inst [2 or "le=4"] value 451820
@@ -14356,13 +14356,13 @@ opentelemetry.source3.sample_histogram0188 []
     inst [9 or "le=18"] value 2033190
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0188_count []
+opentelemetry.source3.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0188_sum []
+opentelemetry.source3.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0210 []
+opentelemetry.source3.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 249690
     inst [2 or "le=4"] value 499380
@@ -14375,13 +14375,13 @@ opentelemetry.source3.sample_histogram0210 []
     inst [9 or "le=18"] value 2247210
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0210_count []
+opentelemetry.source3.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0210_sum []
+opentelemetry.source3.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0232 []
+opentelemetry.source3.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 273470
     inst [2 or "le=4"] value 546940
@@ -14394,13 +14394,13 @@ opentelemetry.source3.sample_histogram0232 []
     inst [9 or "le=18"] value 2461230
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0232_count []
+opentelemetry.source3.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0232_sum []
+opentelemetry.source3.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0254 []
+opentelemetry.source3.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 297250
     inst [2 or "le=4"] value 594500
@@ -14413,13 +14413,13 @@ opentelemetry.source3.sample_histogram0254 []
     inst [9 or "le=18"] value 2675250
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0254_count []
+opentelemetry.source3.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0254_sum []
+opentelemetry.source3.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0276 []
+opentelemetry.source3.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 321030
     inst [2 or "le=4"] value 642060
@@ -14432,13 +14432,13 @@ opentelemetry.source3.sample_histogram0276 []
     inst [9 or "le=18"] value 2889270
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0276_count []
+opentelemetry.source3.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0276_sum []
+opentelemetry.source3.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0298 []
+opentelemetry.source3.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 344810
     inst [2 or "le=4"] value 689620
@@ -14451,13 +14451,13 @@ opentelemetry.source3.sample_histogram0298 []
     inst [9 or "le=18"] value 3103290
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0298_count []
+opentelemetry.source3.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0298_sum []
+opentelemetry.source3.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0320 []
+opentelemetry.source3.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 368590
     inst [2 or "le=4"] value 737180
@@ -14470,13 +14470,13 @@ opentelemetry.source3.sample_histogram0320 []
     inst [9 or "le=18"] value 3317310
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0320_count []
+opentelemetry.source3.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0320_sum []
+opentelemetry.source3.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0342 []
+opentelemetry.source3.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 392370
     inst [2 or "le=4"] value 784740
@@ -14489,13 +14489,13 @@ opentelemetry.source3.sample_histogram0342 []
     inst [9 or "le=18"] value 3531330
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0342_count []
+opentelemetry.source3.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0342_sum []
+opentelemetry.source3.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0364 []
+opentelemetry.source3.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 416150
     inst [2 or "le=4"] value 832300
@@ -14508,13 +14508,13 @@ opentelemetry.source3.sample_histogram0364 []
     inst [9 or "le=18"] value 3745350
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0364_count []
+opentelemetry.source3.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0364_sum []
+opentelemetry.source3.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0386 []
+opentelemetry.source3.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 439930
     inst [2 or "le=4"] value 879860
@@ -14527,13 +14527,13 @@ opentelemetry.source3.sample_histogram0386 []
     inst [9 or "le=18"] value 3959370
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0386_count []
+opentelemetry.source3.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0386_sum []
+opentelemetry.source3.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_summary0002 []
+opentelemetry.source3.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0007981150000000001
     inst [2 or "quantile: 0.5"] value 0.00159623
@@ -14545,13 +14545,13 @@ opentelemetry.source3.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.006384920000000001
     inst [9 or "quantile: 2.25"] value 0.007183035000000001
 
-opentelemetry.source3.sample_summary0002_count []
+opentelemetry.source3.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 9090
 
-opentelemetry.source3.sample_summary0002_sum []
+opentelemetry.source3.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 6.956034
 
-opentelemetry.source3.sample_summary0024 []
+opentelemetry.source3.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001436607
     inst [2 or "quantile: 0.5"] value 0.002873214
@@ -14563,13 +14563,13 @@ opentelemetry.source3.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.011492856
     inst [9 or "quantile: 2.25"] value 0.012929463
 
-opentelemetry.source3.sample_summary0024_count []
+opentelemetry.source3.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 16362
 
-opentelemetry.source3.sample_summary0024_sum []
+opentelemetry.source3.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 12.520861
 
-opentelemetry.source3.sample_summary0046 []
+opentelemetry.source3.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002075099
     inst [2 or "quantile: 0.5"] value 0.004150198000000001
@@ -14581,13 +14581,13 @@ opentelemetry.source3.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.016600792
     inst [9 or "quantile: 2.25"] value 0.018675891
 
-opentelemetry.source3.sample_summary0046_count []
+opentelemetry.source3.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 23634
 
-opentelemetry.source3.sample_summary0046_sum []
+opentelemetry.source3.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 18.085688
 
-opentelemetry.source3.sample_summary0068 []
+opentelemetry.source3.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002713591
     inst [2 or "quantile: 0.5"] value 0.005427182000000001
@@ -14599,13 +14599,13 @@ opentelemetry.source3.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.021708728
     inst [9 or "quantile: 2.25"] value 0.024422319
 
-opentelemetry.source3.sample_summary0068_count []
+opentelemetry.source3.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 30906
 
-opentelemetry.source3.sample_summary0068_sum []
+opentelemetry.source3.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 23.650515
 
-opentelemetry.source3.sample_summary0090 []
+opentelemetry.source3.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003352083
     inst [2 or "quantile: 0.5"] value 0.006704166000000001
@@ -14617,13 +14617,13 @@ opentelemetry.source3.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.026816664
     inst [9 or "quantile: 2.25"] value 0.030168747
 
-opentelemetry.source3.sample_summary0090_count []
+opentelemetry.source3.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 38178
 
-opentelemetry.source3.sample_summary0090_sum []
+opentelemetry.source3.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 29.215342
 
-opentelemetry.source3.sample_summary0112 []
+opentelemetry.source3.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003990575000000001
     inst [2 or "quantile: 0.5"] value 0.007981150000000001
@@ -14635,13 +14635,13 @@ opentelemetry.source3.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.0319246
     inst [9 or "quantile: 2.25"] value 0.035915175
 
-opentelemetry.source3.sample_summary0112_count []
+opentelemetry.source3.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 45450
 
-opentelemetry.source3.sample_summary0112_sum []
+opentelemetry.source3.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 34.780169
 
-opentelemetry.source3.sample_summary0134 []
+opentelemetry.source3.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004629067000000001
     inst [2 or "quantile: 0.5"] value 0.009258134000000001
@@ -14653,13 +14653,13 @@ opentelemetry.source3.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.037032536
     inst [9 or "quantile: 2.25"] value 0.04166160300000001
 
-opentelemetry.source3.sample_summary0134_count []
+opentelemetry.source3.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 52722
 
-opentelemetry.source3.sample_summary0134_sum []
+opentelemetry.source3.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 40.344996
 
-opentelemetry.source3.sample_summary0156 []
+opentelemetry.source3.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005267559000000001
     inst [2 or "quantile: 0.5"] value 0.010535118
@@ -14671,13 +14671,13 @@ opentelemetry.source3.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.04214047200000001
     inst [9 or "quantile: 2.25"] value 0.047408031
 
-opentelemetry.source3.sample_summary0156_count []
+opentelemetry.source3.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 59994
 
-opentelemetry.source3.sample_summary0156_sum []
+opentelemetry.source3.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 45.909823
 
-opentelemetry.source3.sample_summary0178 []
+opentelemetry.source3.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005906051000000001
     inst [2 or "quantile: 0.5"] value 0.011812102
@@ -14689,13 +14689,13 @@ opentelemetry.source3.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.04724840800000001
     inst [9 or "quantile: 2.25"] value 0.053154459
 
-opentelemetry.source3.sample_summary0178_count []
+opentelemetry.source3.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 67266
 
-opentelemetry.source3.sample_summary0178_sum []
+opentelemetry.source3.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 51.47465
 
-opentelemetry.source3.sample_summary0200 []
+opentelemetry.source3.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006544543000000001
     inst [2 or "quantile: 0.5"] value 0.013089086
@@ -14707,13 +14707,13 @@ opentelemetry.source3.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.05235634400000001
     inst [9 or "quantile: 2.25"] value 0.05890088700000001
 
-opentelemetry.source3.sample_summary0200_count []
+opentelemetry.source3.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 74538
 
-opentelemetry.source3.sample_summary0200_sum []
+opentelemetry.source3.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 57.039478
 
-opentelemetry.source3.sample_summary0222 []
+opentelemetry.source3.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007183035000000001
     inst [2 or "quantile: 0.5"] value 0.01436607
@@ -14725,13 +14725,13 @@ opentelemetry.source3.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.05746428000000001
     inst [9 or "quantile: 2.25"] value 0.06464731500000001
 
-opentelemetry.source3.sample_summary0222_count []
+opentelemetry.source3.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 81810
 
-opentelemetry.source3.sample_summary0222_sum []
+opentelemetry.source3.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 62.604305
 
-opentelemetry.source3.sample_summary0244 []
+opentelemetry.source3.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007821527
     inst [2 or "quantile: 0.5"] value 0.015643054
@@ -14743,13 +14743,13 @@ opentelemetry.source3.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.062572216
     inst [9 or "quantile: 2.25"] value 0.07039374300000001
 
-opentelemetry.source3.sample_summary0244_count []
+opentelemetry.source3.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 89082
 
-opentelemetry.source3.sample_summary0244_sum []
+opentelemetry.source3.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 68.169132
 
-opentelemetry.source3.sample_summary0266 []
+opentelemetry.source3.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008460019000000001
     inst [2 or "quantile: 0.5"] value 0.016920038
@@ -14761,13 +14761,13 @@ opentelemetry.source3.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.06768015200000001
     inst [9 or "quantile: 2.25"] value 0.07614017100000001
 
-opentelemetry.source3.sample_summary0266_count []
+opentelemetry.source3.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 96354
 
-opentelemetry.source3.sample_summary0266_sum []
+opentelemetry.source3.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 73.733959
 
-opentelemetry.source3.sample_summary0288 []
+opentelemetry.source3.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009098511
     inst [2 or "quantile: 0.5"] value 0.018197022
@@ -14779,13 +14779,13 @@ opentelemetry.source3.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.072788088
     inst [9 or "quantile: 2.25"] value 0.081886599
 
-opentelemetry.source3.sample_summary0288_count []
+opentelemetry.source3.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 103626
 
-opentelemetry.source3.sample_summary0288_sum []
+opentelemetry.source3.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 79.29878600000001
 
-opentelemetry.source3.sample_summary0310 []
+opentelemetry.source3.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009737003000000001
     inst [2 or "quantile: 0.5"] value 0.019474006
@@ -14797,13 +14797,13 @@ opentelemetry.source3.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.07789602400000001
     inst [9 or "quantile: 2.25"] value 0.087633027
 
-opentelemetry.source3.sample_summary0310_count []
+opentelemetry.source3.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 110898
 
-opentelemetry.source3.sample_summary0310_sum []
+opentelemetry.source3.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 84.863613
 
-opentelemetry.source3.sample_summary0332 []
+opentelemetry.source3.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010375495
     inst [2 or "quantile: 0.5"] value 0.02075099
@@ -14815,13 +14815,13 @@ opentelemetry.source3.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.08300396
     inst [9 or "quantile: 2.25"] value 0.09337945500000001
 
-opentelemetry.source3.sample_summary0332_count []
+opentelemetry.source3.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 118170
 
-opentelemetry.source3.sample_summary0332_sum []
+opentelemetry.source3.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 90.42843999999999
 
-opentelemetry.source3.sample_summary0354 []
+opentelemetry.source3.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011013987
     inst [2 or "quantile: 0.5"] value 0.022027974
@@ -14833,13 +14833,13 @@ opentelemetry.source3.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.08811189600000001
     inst [9 or "quantile: 2.25"] value 0.09912588300000001
 
-opentelemetry.source3.sample_summary0354_count []
+opentelemetry.source3.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 125442
 
-opentelemetry.source3.sample_summary0354_sum []
+opentelemetry.source3.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 95.993267
 
-opentelemetry.source3.sample_summary0376 []
+opentelemetry.source3.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011652479
     inst [2 or "quantile: 0.5"] value 0.023304958
@@ -14851,13 +14851,13 @@ opentelemetry.source3.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.093219832
     inst [9 or "quantile: 2.25"] value 0.104872311
 
-opentelemetry.source3.sample_summary0376_count []
+opentelemetry.source3.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 132714
 
-opentelemetry.source3.sample_summary0376_sum []
+opentelemetry.source3.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 101.558094
 
-opentelemetry.source3.sample_summary0398 []
+opentelemetry.source3.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012290971
     inst [2 or "quantile: 0.5"] value 0.024581942
@@ -14869,13 +14869,13 @@ opentelemetry.source3.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.09832776800000001
     inst [9 or "quantile: 2.25"] value 0.110618739
 
-opentelemetry.source3.sample_summary0398_count []
+opentelemetry.source3.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 139986
 
-opentelemetry.source3.sample_summary0398_sum []
+opentelemetry.source3.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 107.122921
 
-opentelemetry.source3.sample_counter0001 []
+opentelemetry.source3.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1191437760
     inst [2 or "2 inst-2"] value 2382875520
@@ -14887,7 +14887,7 @@ opentelemetry.source3.sample_counter0001 []
     inst [8 or "8 inst-8"] value 9531502060
     inst [9 or "9 inst-9"] value 10722939800
 
-opentelemetry.source3.sample_counter0023 []
+opentelemetry.source3.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1872259330
     inst [2 or "2 inst-2"] value 3744518670
@@ -14899,7 +14899,7 @@ opentelemetry.source3.sample_counter0023 []
     inst [8 or "8 inst-8"] value 14978074700
     inst [9 or "9 inst-9"] value 16850334000
 
-opentelemetry.source3.sample_counter0045 []
+opentelemetry.source3.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2553080910
     inst [2 or "2 inst-2"] value 5106161820
@@ -14911,7 +14911,7 @@ opentelemetry.source3.sample_counter0045 []
     inst [8 or "8 inst-8"] value 20424647300
     inst [9 or "9 inst-9"] value 22977728200
 
-opentelemetry.source3.sample_counter0067 []
+opentelemetry.source3.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3233902490
     inst [2 or "2 inst-2"] value 6467804970
@@ -14923,7 +14923,7 @@ opentelemetry.source3.sample_counter0067 []
     inst [8 or "8 inst-8"] value 25871219900
     inst [9 or "9 inst-9"] value 29105122400
 
-opentelemetry.source3.sample_counter0089 []
+opentelemetry.source3.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3914724060
     inst [2 or "2 inst-2"] value 7829448120
@@ -14935,7 +14935,7 @@ opentelemetry.source3.sample_counter0089 []
     inst [8 or "8 inst-8"] value 31317792500
     inst [9 or "9 inst-9"] value 35232516600
 
-opentelemetry.source3.sample_counter0111 []
+opentelemetry.source3.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4595545640
     inst [2 or "2 inst-2"] value 9191091280
@@ -14947,7 +14947,7 @@ opentelemetry.source3.sample_counter0111 []
     inst [8 or "8 inst-8"] value 36764365100
     inst [9 or "9 inst-9"] value 41359910700
 
-opentelemetry.source3.sample_counter0133 []
+opentelemetry.source3.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5276367210
     inst [2 or "2 inst-2"] value 10552734400
@@ -14959,7 +14959,7 @@ opentelemetry.source3.sample_counter0133 []
     inst [8 or "8 inst-8"] value 42210937700
     inst [9 or "9 inst-9"] value 47487304900
 
-opentelemetry.source3.sample_counter0155 []
+opentelemetry.source3.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5957188790
     inst [2 or "2 inst-2"] value 11914377600
@@ -14971,7 +14971,7 @@ opentelemetry.source3.sample_counter0155 []
     inst [8 or "8 inst-8"] value 47657510300
     inst [9 or "9 inst-9"] value 53614699100
 
-opentelemetry.source3.sample_counter0177 []
+opentelemetry.source3.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6638010370
     inst [2 or "2 inst-2"] value 13276020700
@@ -14983,7 +14983,7 @@ opentelemetry.source3.sample_counter0177 []
     inst [8 or "8 inst-8"] value 53104082900
     inst [9 or "9 inst-9"] value 59742093300
 
-opentelemetry.source3.sample_counter0199 []
+opentelemetry.source3.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7318831940
     inst [2 or "2 inst-2"] value 14637663900
@@ -14995,7 +14995,7 @@ opentelemetry.source3.sample_counter0199 []
     inst [8 or "8 inst-8"] value 58550655500
     inst [9 or "9 inst-9"] value 65869487500
 
-opentelemetry.source3.sample_counter0221 []
+opentelemetry.source3.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7999653520
     inst [2 or "2 inst-2"] value 15999307000
@@ -15007,7 +15007,7 @@ opentelemetry.source3.sample_counter0221 []
     inst [8 or "8 inst-8"] value 63997228100
     inst [9 or "9 inst-9"] value 71996881700
 
-opentelemetry.source3.sample_counter0243 []
+opentelemetry.source3.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8680475090
     inst [2 or "2 inst-2"] value 17360950200
@@ -15019,7 +15019,7 @@ opentelemetry.source3.sample_counter0243 []
     inst [8 or "8 inst-8"] value 69443800800
     inst [9 or "9 inst-9"] value 78124275800
 
-opentelemetry.source3.sample_counter0265 []
+opentelemetry.source3.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9361296670
     inst [2 or "2 inst-2"] value 18722593300
@@ -15031,7 +15031,7 @@ opentelemetry.source3.sample_counter0265 []
     inst [8 or "8 inst-8"] value 74890373400
     inst [9 or "9 inst-9"] value 84251670000
 
-opentelemetry.source3.sample_counter0287 []
+opentelemetry.source3.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10042118200
     inst [2 or "2 inst-2"] value 20084236500
@@ -15043,7 +15043,7 @@ opentelemetry.source3.sample_counter0287 []
     inst [8 or "8 inst-8"] value 80336946000
     inst [9 or "9 inst-9"] value 90379064200
 
-opentelemetry.source3.sample_counter0309 []
+opentelemetry.source3.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10722939800
     inst [2 or "2 inst-2"] value 21445879600
@@ -15055,7 +15055,7 @@ opentelemetry.source3.sample_counter0309 []
     inst [8 or "8 inst-8"] value 85783518600
     inst [9 or "9 inst-9"] value 96506458400
 
-opentelemetry.source3.sample_counter0331 []
+opentelemetry.source3.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11403761400
     inst [2 or "2 inst-2"] value 22807522800
@@ -15067,7 +15067,7 @@ opentelemetry.source3.sample_counter0331 []
     inst [8 or "8 inst-8"] value 91230091200
     inst [9 or "9 inst-9"] value 102633853000
 
-opentelemetry.source3.sample_counter0353 []
+opentelemetry.source3.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12084583000
     inst [2 or "2 inst-2"] value 24169165900
@@ -15079,7 +15079,7 @@ opentelemetry.source3.sample_counter0353 []
     inst [8 or "8 inst-8"] value 96676663800
     inst [9 or "9 inst-9"] value 108761247000
 
-opentelemetry.source3.sample_counter0375 []
+opentelemetry.source3.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12765404600
     inst [2 or "2 inst-2"] value 25530809100
@@ -15091,7 +15091,7 @@ opentelemetry.source3.sample_counter0375 []
     inst [8 or "8 inst-8"] value 102123236000
     inst [9 or "9 inst-9"] value 114888641000
 
-opentelemetry.source3.sample_counter0397 []
+opentelemetry.source3.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13446226100
     inst [2 or "2 inst-2"] value 26892452300
@@ -15103,7 +15103,7 @@ opentelemetry.source3.sample_counter0397 []
     inst [8 or "8 inst-8"] value 107569809000
     inst [9 or "9 inst-9"] value 121016035000
 
-opentelemetry.source3.sample_gauge0000 []
+opentelemetry.source3.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 72.59999999999999
     inst [2 or "2 inst-2"] value 145.2
@@ -15115,7 +15115,7 @@ opentelemetry.source3.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 580.8
     inst [9 or "9 inst-9"] value 653.4
 
-opentelemetry.source3.sample_gauge0022 []
+opentelemetry.source3.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 121
     inst [2 or "2 inst-2"] value 242
@@ -15127,7 +15127,7 @@ opentelemetry.source3.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 968
     inst [9 or "9 inst-9"] value 1089
 
-opentelemetry.source3.sample_gauge0044 []
+opentelemetry.source3.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 169.4
     inst [2 or "2 inst-2"] value 338.8
@@ -15139,7 +15139,7 @@ opentelemetry.source3.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 1355.2
     inst [9 or "9 inst-9"] value 1524.6
 
-opentelemetry.source3.sample_gauge0066 []
+opentelemetry.source3.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 217.8
     inst [2 or "2 inst-2"] value 435.6
@@ -15151,7 +15151,7 @@ opentelemetry.source3.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1742.4
     inst [9 or "9 inst-9"] value 1960.2
 
-opentelemetry.source3.sample_gauge0088 []
+opentelemetry.source3.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 266.2
     inst [2 or "2 inst-2"] value 532.4
@@ -15163,7 +15163,7 @@ opentelemetry.source3.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 2129.6
     inst [9 or "9 inst-9"] value 2395.8
 
-opentelemetry.source3.sample_gauge0110 []
+opentelemetry.source3.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 314.6
     inst [2 or "2 inst-2"] value 629.2
@@ -15175,7 +15175,7 @@ opentelemetry.source3.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2516.8
     inst [9 or "9 inst-9"] value 2831.4
 
-opentelemetry.source3.sample_gauge0132 []
+opentelemetry.source3.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 363
     inst [2 or "2 inst-2"] value 726
@@ -15187,7 +15187,7 @@ opentelemetry.source3.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2904
     inst [9 or "9 inst-9"] value 3267
 
-opentelemetry.source3.sample_gauge0154 []
+opentelemetry.source3.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 411.4
     inst [2 or "2 inst-2"] value 822.8
@@ -15199,7 +15199,7 @@ opentelemetry.source3.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 3291.2
     inst [9 or "9 inst-9"] value 3702.6
 
-opentelemetry.source3.sample_gauge0176 []
+opentelemetry.source3.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 459.8
     inst [2 or "2 inst-2"] value 919.6
@@ -15211,7 +15211,7 @@ opentelemetry.source3.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3678.4
     inst [9 or "9 inst-9"] value 4138.2
 
-opentelemetry.source3.sample_gauge0198 []
+opentelemetry.source3.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 508.2
     inst [2 or "2 inst-2"] value 1016.4
@@ -15223,7 +15223,7 @@ opentelemetry.source3.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 4065.6
     inst [9 or "9 inst-9"] value 4573.8
 
-opentelemetry.source3.sample_gauge0220 []
+opentelemetry.source3.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 556.6
     inst [2 or "2 inst-2"] value 1113.2
@@ -15235,7 +15235,7 @@ opentelemetry.source3.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 4452.8
     inst [9 or "9 inst-9"] value 5009.4
 
-opentelemetry.source3.sample_gauge0242 []
+opentelemetry.source3.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 605
     inst [2 or "2 inst-2"] value 1210
@@ -15247,7 +15247,7 @@ opentelemetry.source3.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4840
     inst [9 or "9 inst-9"] value 5445
 
-opentelemetry.source3.sample_gauge0264 []
+opentelemetry.source3.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 653.4
     inst [2 or "2 inst-2"] value 1306.8
@@ -15259,7 +15259,7 @@ opentelemetry.source3.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 5227.2
     inst [9 or "9 inst-9"] value 5880.6
 
-opentelemetry.source3.sample_gauge0286 []
+opentelemetry.source3.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 701.8
     inst [2 or "2 inst-2"] value 1403.6
@@ -15271,7 +15271,7 @@ opentelemetry.source3.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5614.4
     inst [9 or "9 inst-9"] value 6316.2
 
-opentelemetry.source3.sample_gauge0308 []
+opentelemetry.source3.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 750.2
     inst [2 or "2 inst-2"] value 1500.4
@@ -15283,7 +15283,7 @@ opentelemetry.source3.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 6001.6
     inst [9 or "9 inst-9"] value 6751.8
 
-opentelemetry.source3.sample_gauge0330 []
+opentelemetry.source3.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 798.6
     inst [2 or "2 inst-2"] value 1597.2
@@ -15295,7 +15295,7 @@ opentelemetry.source3.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6388.8
     inst [9 or "9 inst-9"] value 7187.4
 
-opentelemetry.source3.sample_gauge0352 []
+opentelemetry.source3.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 847
     inst [2 or "2 inst-2"] value 1694
@@ -15307,7 +15307,7 @@ opentelemetry.source3.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6776
     inst [9 or "9 inst-9"] value 7623
 
-opentelemetry.source3.sample_gauge0374 []
+opentelemetry.source3.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 895.4
     inst [2 or "2 inst-2"] value 1790.8
@@ -15319,7 +15319,7 @@ opentelemetry.source3.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 7163.2
     inst [9 or "9 inst-9"] value 8058.6
 
-opentelemetry.source3.sample_gauge0396 []
+opentelemetry.source3.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 943.8
     inst [2 or "2 inst-2"] value 1887.6
@@ -15331,7 +15331,7 @@ opentelemetry.source3.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7550.4
     inst [9 or "9 inst-9"] value 8494.200000000001
 
-opentelemetry.source3.sample_histogram0012 []
+opentelemetry.source3.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 53505
     inst [2 or "le=4"] value 107010
@@ -15344,13 +15344,13 @@ opentelemetry.source3.sample_histogram0012 []
     inst [9 or "le=18"] value 481545
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0012_count []
+opentelemetry.source3.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0012_sum []
+opentelemetry.source3.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0034 []
+opentelemetry.source3.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 77285
     inst [2 or "le=4"] value 154570
@@ -15363,13 +15363,13 @@ opentelemetry.source3.sample_histogram0034 []
     inst [9 or "le=18"] value 695565
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0034_count []
+opentelemetry.source3.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0034_sum []
+opentelemetry.source3.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0056 []
+opentelemetry.source3.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 101065
     inst [2 or "le=4"] value 202130
@@ -15382,13 +15382,13 @@ opentelemetry.source3.sample_histogram0056 []
     inst [9 or "le=18"] value 909585
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0056_count []
+opentelemetry.source3.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0056_sum []
+opentelemetry.source3.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0078 []
+opentelemetry.source3.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 124845
     inst [2 or "le=4"] value 249690
@@ -15401,13 +15401,13 @@ opentelemetry.source3.sample_histogram0078 []
     inst [9 or "le=18"] value 1123605
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0078_count []
+opentelemetry.source3.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0078_sum []
+opentelemetry.source3.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0100 []
+opentelemetry.source3.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 148625
     inst [2 or "le=4"] value 297250
@@ -15420,13 +15420,13 @@ opentelemetry.source3.sample_histogram0100 []
     inst [9 or "le=18"] value 1337625
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0100_count []
+opentelemetry.source3.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0100_sum []
+opentelemetry.source3.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0122 []
+opentelemetry.source3.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 172405
     inst [2 or "le=4"] value 344810
@@ -15439,13 +15439,13 @@ opentelemetry.source3.sample_histogram0122 []
     inst [9 or "le=18"] value 1551645
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0122_count []
+opentelemetry.source3.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0122_sum []
+opentelemetry.source3.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0144 []
+opentelemetry.source3.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 196185
     inst [2 or "le=4"] value 392370
@@ -15458,13 +15458,13 @@ opentelemetry.source3.sample_histogram0144 []
     inst [9 or "le=18"] value 1765665
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0144_count []
+opentelemetry.source3.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0144_sum []
+opentelemetry.source3.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0166 []
+opentelemetry.source3.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 219965
     inst [2 or "le=4"] value 439930
@@ -15477,13 +15477,13 @@ opentelemetry.source3.sample_histogram0166 []
     inst [9 or "le=18"] value 1979685
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0166_count []
+opentelemetry.source3.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0166_sum []
+opentelemetry.source3.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0188 []
+opentelemetry.source3.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 243745
     inst [2 or "le=4"] value 487490
@@ -15496,13 +15496,13 @@ opentelemetry.source3.sample_histogram0188 []
     inst [9 or "le=18"] value 2193705
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0188_count []
+opentelemetry.source3.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0188_sum []
+opentelemetry.source3.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0210 []
+opentelemetry.source3.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 267525
     inst [2 or "le=4"] value 535050
@@ -15515,13 +15515,13 @@ opentelemetry.source3.sample_histogram0210 []
     inst [9 or "le=18"] value 2407725
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0210_count []
+opentelemetry.source3.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0210_sum []
+opentelemetry.source3.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0232 []
+opentelemetry.source3.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 291305
     inst [2 or "le=4"] value 582610
@@ -15534,13 +15534,13 @@ opentelemetry.source3.sample_histogram0232 []
     inst [9 or "le=18"] value 2621745
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0232_count []
+opentelemetry.source3.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0232_sum []
+opentelemetry.source3.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0254 []
+opentelemetry.source3.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 315085
     inst [2 or "le=4"] value 630170
@@ -15553,13 +15553,13 @@ opentelemetry.source3.sample_histogram0254 []
     inst [9 or "le=18"] value 2835765
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0254_count []
+opentelemetry.source3.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0254_sum []
+opentelemetry.source3.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0276 []
+opentelemetry.source3.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 338865
     inst [2 or "le=4"] value 677730
@@ -15572,13 +15572,13 @@ opentelemetry.source3.sample_histogram0276 []
     inst [9 or "le=18"] value 3049785
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0276_count []
+opentelemetry.source3.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0276_sum []
+opentelemetry.source3.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0298 []
+opentelemetry.source3.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 362645
     inst [2 or "le=4"] value 725290
@@ -15591,13 +15591,13 @@ opentelemetry.source3.sample_histogram0298 []
     inst [9 or "le=18"] value 3263805
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0298_count []
+opentelemetry.source3.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0298_sum []
+opentelemetry.source3.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0320 []
+opentelemetry.source3.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 386425
     inst [2 or "le=4"] value 772850
@@ -15610,13 +15610,13 @@ opentelemetry.source3.sample_histogram0320 []
     inst [9 or "le=18"] value 3477825
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0320_count []
+opentelemetry.source3.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0320_sum []
+opentelemetry.source3.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0342 []
+opentelemetry.source3.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 410205
     inst [2 or "le=4"] value 820410
@@ -15629,13 +15629,13 @@ opentelemetry.source3.sample_histogram0342 []
     inst [9 or "le=18"] value 3691845
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0342_count []
+opentelemetry.source3.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0342_sum []
+opentelemetry.source3.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0364 []
+opentelemetry.source3.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 433985
     inst [2 or "le=4"] value 867970
@@ -15648,13 +15648,13 @@ opentelemetry.source3.sample_histogram0364 []
     inst [9 or "le=18"] value 3905865
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0364_count []
+opentelemetry.source3.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0364_sum []
+opentelemetry.source3.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0386 []
+opentelemetry.source3.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 457765
     inst [2 or "le=4"] value 915530
@@ -15667,13 +15667,13 @@ opentelemetry.source3.sample_histogram0386 []
     inst [9 or "le=18"] value 4119885
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0386_count []
+opentelemetry.source3.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0386_sum []
+opentelemetry.source3.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_summary0002 []
+opentelemetry.source3.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001276984
     inst [2 or "quantile: 0.5"] value 0.002553968
@@ -15685,13 +15685,13 @@ opentelemetry.source3.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.010215872
     inst [9 or "quantile: 2.25"] value 0.011492856
 
-opentelemetry.source3.sample_summary0002_count []
+opentelemetry.source3.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 14544
 
-opentelemetry.source3.sample_summary0002_sum []
+opentelemetry.source3.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 11.129654
 
-opentelemetry.source3.sample_summary0024 []
+opentelemetry.source3.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001915476
     inst [2 or "quantile: 0.5"] value 0.003830952
@@ -15703,13 +15703,13 @@ opentelemetry.source3.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.015323808
     inst [9 or "quantile: 2.25"] value 0.017239284
 
-opentelemetry.source3.sample_summary0024_count []
+opentelemetry.source3.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 21816
 
-opentelemetry.source3.sample_summary0024_sum []
+opentelemetry.source3.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 16.694481
 
-opentelemetry.source3.sample_summary0046 []
+opentelemetry.source3.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002553968
     inst [2 or "quantile: 0.5"] value 0.005107936
@@ -15721,13 +15721,13 @@ opentelemetry.source3.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.020431744
     inst [9 or "quantile: 2.25"] value 0.022985712
 
-opentelemetry.source3.sample_summary0046_count []
+opentelemetry.source3.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 29088
 
-opentelemetry.source3.sample_summary0046_sum []
+opentelemetry.source3.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 22.259308
 
-opentelemetry.source3.sample_summary0068 []
+opentelemetry.source3.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00319246
     inst [2 or "quantile: 0.5"] value 0.006384920000000001
@@ -15739,13 +15739,13 @@ opentelemetry.source3.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.02553968
     inst [9 or "quantile: 2.25"] value 0.02873214
 
-opentelemetry.source3.sample_summary0068_count []
+opentelemetry.source3.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 36360
 
-opentelemetry.source3.sample_summary0068_sum []
+opentelemetry.source3.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 27.824135
 
-opentelemetry.source3.sample_summary0090 []
+opentelemetry.source3.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003830952
     inst [2 or "quantile: 0.5"] value 0.007661904000000001
@@ -15757,13 +15757,13 @@ opentelemetry.source3.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.030647616
     inst [9 or "quantile: 2.25"] value 0.034478568
 
-opentelemetry.source3.sample_summary0090_count []
+opentelemetry.source3.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 43632
 
-opentelemetry.source3.sample_summary0090_sum []
+opentelemetry.source3.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 33.388962
 
-opentelemetry.source3.sample_summary0112 []
+opentelemetry.source3.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004469444
     inst [2 or "quantile: 0.5"] value 0.008938888000000001
@@ -15775,13 +15775,13 @@ opentelemetry.source3.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.035755552
     inst [9 or "quantile: 2.25"] value 0.04022499600000001
 
-opentelemetry.source3.sample_summary0112_count []
+opentelemetry.source3.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 50904
 
-opentelemetry.source3.sample_summary0112_sum []
+opentelemetry.source3.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 38.95379
 
-opentelemetry.source3.sample_summary0134 []
+opentelemetry.source3.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005107936
     inst [2 or "quantile: 0.5"] value 0.010215872
@@ -15793,13 +15793,13 @@ opentelemetry.source3.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.040863488
     inst [9 or "quantile: 2.25"] value 0.045971424
 
-opentelemetry.source3.sample_summary0134_count []
+opentelemetry.source3.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 58176
 
-opentelemetry.source3.sample_summary0134_sum []
+opentelemetry.source3.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 44.518617
 
-opentelemetry.source3.sample_summary0156 []
+opentelemetry.source3.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005746428
     inst [2 or "quantile: 0.5"] value 0.011492856
@@ -15811,13 +15811,13 @@ opentelemetry.source3.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.045971424
     inst [9 or "quantile: 2.25"] value 0.051717852
 
-opentelemetry.source3.sample_summary0156_count []
+opentelemetry.source3.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 65448
 
-opentelemetry.source3.sample_summary0156_sum []
+opentelemetry.source3.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 50.083444
 
-opentelemetry.source3.sample_summary0178 []
+opentelemetry.source3.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006384920000000001
     inst [2 or "quantile: 0.5"] value 0.01276984
@@ -15829,13 +15829,13 @@ opentelemetry.source3.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.05107936
     inst [9 or "quantile: 2.25"] value 0.05746428000000001
 
-opentelemetry.source3.sample_summary0178_count []
+opentelemetry.source3.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 72720
 
-opentelemetry.source3.sample_summary0178_sum []
+opentelemetry.source3.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 55.648271
 
-opentelemetry.source3.sample_summary0200 []
+opentelemetry.source3.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007023412000000001
     inst [2 or "quantile: 0.5"] value 0.014046824
@@ -15847,13 +15847,13 @@ opentelemetry.source3.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.056187296
     inst [9 or "quantile: 2.25"] value 0.063210708
 
-opentelemetry.source3.sample_summary0200_count []
+opentelemetry.source3.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 79992
 
-opentelemetry.source3.sample_summary0200_sum []
+opentelemetry.source3.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 61.213098
 
-opentelemetry.source3.sample_summary0222 []
+opentelemetry.source3.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007661904000000001
     inst [2 or "quantile: 0.5"] value 0.015323808
@@ -15865,13 +15865,13 @@ opentelemetry.source3.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.06129523200000001
     inst [9 or "quantile: 2.25"] value 0.068957136
 
-opentelemetry.source3.sample_summary0222_count []
+opentelemetry.source3.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 87264
 
-opentelemetry.source3.sample_summary0222_sum []
+opentelemetry.source3.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 66.777925
 
-opentelemetry.source3.sample_summary0244 []
+opentelemetry.source3.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008300396000000002
     inst [2 or "quantile: 0.5"] value 0.016600792
@@ -15883,13 +15883,13 @@ opentelemetry.source3.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.06640316800000001
     inst [9 or "quantile: 2.25"] value 0.074703564
 
-opentelemetry.source3.sample_summary0244_count []
+opentelemetry.source3.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 94536
 
-opentelemetry.source3.sample_summary0244_sum []
+opentelemetry.source3.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 72.342752
 
-opentelemetry.source3.sample_summary0266 []
+opentelemetry.source3.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008938888000000001
     inst [2 or "quantile: 0.5"] value 0.017877776
@@ -15901,13 +15901,13 @@ opentelemetry.source3.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.07151110400000001
     inst [9 or "quantile: 2.25"] value 0.08044999200000001
 
-opentelemetry.source3.sample_summary0266_count []
+opentelemetry.source3.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 101808
 
-opentelemetry.source3.sample_summary0266_sum []
+opentelemetry.source3.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 77.907579
 
-opentelemetry.source3.sample_summary0288 []
+opentelemetry.source3.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00957738
     inst [2 or "quantile: 0.5"] value 0.01915476
@@ -15919,13 +15919,13 @@ opentelemetry.source3.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.07661904
     inst [9 or "quantile: 2.25"] value 0.08619642000000001
 
-opentelemetry.source3.sample_summary0288_count []
+opentelemetry.source3.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 109080
 
-opentelemetry.source3.sample_summary0288_sum []
+opentelemetry.source3.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 83.47240600000001
 
-opentelemetry.source3.sample_summary0310 []
+opentelemetry.source3.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010215872
     inst [2 or "quantile: 0.5"] value 0.020431744
@@ -15937,13 +15937,13 @@ opentelemetry.source3.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.08172697600000001
     inst [9 or "quantile: 2.25"] value 0.09194284800000001
 
-opentelemetry.source3.sample_summary0310_count []
+opentelemetry.source3.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 116352
 
-opentelemetry.source3.sample_summary0310_sum []
+opentelemetry.source3.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 89.037233
 
-opentelemetry.source3.sample_summary0332 []
+opentelemetry.source3.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010854364
     inst [2 or "quantile: 0.5"] value 0.021708728
@@ -15955,13 +15955,13 @@ opentelemetry.source3.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.08683491200000001
     inst [9 or "quantile: 2.25"] value 0.09768927600000001
 
-opentelemetry.source3.sample_summary0332_count []
+opentelemetry.source3.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 123624
 
-opentelemetry.source3.sample_summary0332_sum []
+opentelemetry.source3.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 94.60205999999999
 
-opentelemetry.source3.sample_summary0354 []
+opentelemetry.source3.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011492856
     inst [2 or "quantile: 0.5"] value 0.022985712
@@ -15973,13 +15973,13 @@ opentelemetry.source3.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.09194284800000001
     inst [9 or "quantile: 2.25"] value 0.103435704
 
-opentelemetry.source3.sample_summary0354_count []
+opentelemetry.source3.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 130896
 
-opentelemetry.source3.sample_summary0354_sum []
+opentelemetry.source3.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 100.166887
 
-opentelemetry.source3.sample_summary0376 []
+opentelemetry.source3.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012131348
     inst [2 or "quantile: 0.5"] value 0.024262696
@@ -15991,13 +15991,13 @@ opentelemetry.source3.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.097050784
     inst [9 or "quantile: 2.25"] value 0.109182132
 
-opentelemetry.source3.sample_summary0376_count []
+opentelemetry.source3.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 138168
 
-opentelemetry.source3.sample_summary0376_sum []
+opentelemetry.source3.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 105.731715
 
-opentelemetry.source3.sample_summary0398 []
+opentelemetry.source3.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01276984
     inst [2 or "quantile: 0.5"] value 0.02553968
@@ -16009,13 +16009,13 @@ opentelemetry.source3.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.10215872
     inst [9 or "quantile: 2.25"] value 0.11492856
 
-opentelemetry.source3.sample_summary0398_count []
+opentelemetry.source3.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 145440
 
-opentelemetry.source3.sample_summary0398_sum []
+opentelemetry.source3.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 111.296542
 
-opentelemetry.source3.sample_counter0001 []
+opentelemetry.source3.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1702053940
     inst [2 or "2 inst-2"] value 3404107880
@@ -16027,7 +16027,7 @@ opentelemetry.source3.sample_counter0001 []
     inst [8 or "8 inst-8"] value 13616431500
     inst [9 or "9 inst-9"] value 15318485500
 
-opentelemetry.source3.sample_counter0023 []
+opentelemetry.source3.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2382875520
     inst [2 or "2 inst-2"] value 4765751030
@@ -16039,7 +16039,7 @@ opentelemetry.source3.sample_counter0023 []
     inst [8 or "8 inst-8"] value 19063004100
     inst [9 or "9 inst-9"] value 21445879600
 
-opentelemetry.source3.sample_counter0045 []
+opentelemetry.source3.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3063697090
     inst [2 or "2 inst-2"] value 6127394180
@@ -16051,7 +16051,7 @@ opentelemetry.source3.sample_counter0045 []
     inst [8 or "8 inst-8"] value 24509576700
     inst [9 or "9 inst-9"] value 27573273800
 
-opentelemetry.source3.sample_counter0067 []
+opentelemetry.source3.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3744518670
     inst [2 or "2 inst-2"] value 7489037340
@@ -16063,7 +16063,7 @@ opentelemetry.source3.sample_counter0067 []
     inst [8 or "8 inst-8"] value 29956149300
     inst [9 or "9 inst-9"] value 33700668000
 
-opentelemetry.source3.sample_counter0089 []
+opentelemetry.source3.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4425340240
     inst [2 or "2 inst-2"] value 8850680490
@@ -16075,7 +16075,7 @@ opentelemetry.source3.sample_counter0089 []
     inst [8 or "8 inst-8"] value 35402722000
     inst [9 or "9 inst-9"] value 39828062200
 
-opentelemetry.source3.sample_counter0111 []
+opentelemetry.source3.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5106161820
     inst [2 or "2 inst-2"] value 10212323600
@@ -16087,7 +16087,7 @@ opentelemetry.source3.sample_counter0111 []
     inst [8 or "8 inst-8"] value 40849294600
     inst [9 or "9 inst-9"] value 45955456400
 
-opentelemetry.source3.sample_counter0133 []
+opentelemetry.source3.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5786983400
     inst [2 or "2 inst-2"] value 11573966800
@@ -16099,7 +16099,7 @@ opentelemetry.source3.sample_counter0133 []
     inst [8 or "8 inst-8"] value 46295867200
     inst [9 or "9 inst-9"] value 52082850600
 
-opentelemetry.source3.sample_counter0155 []
+opentelemetry.source3.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6467804970
     inst [2 or "2 inst-2"] value 12935609900
@@ -16111,7 +16111,7 @@ opentelemetry.source3.sample_counter0155 []
     inst [8 or "8 inst-8"] value 51742439800
     inst [9 or "9 inst-9"] value 58210244700
 
-opentelemetry.source3.sample_counter0177 []
+opentelemetry.source3.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7148626550
     inst [2 or "2 inst-2"] value 14297253100
@@ -16123,7 +16123,7 @@ opentelemetry.source3.sample_counter0177 []
     inst [8 or "8 inst-8"] value 57189012400
     inst [9 or "9 inst-9"] value 64337638900
 
-opentelemetry.source3.sample_counter0199 []
+opentelemetry.source3.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7829448120
     inst [2 or "2 inst-2"] value 15658896200
@@ -16135,7 +16135,7 @@ opentelemetry.source3.sample_counter0199 []
     inst [8 or "8 inst-8"] value 62635585000
     inst [9 or "9 inst-9"] value 70465033100
 
-opentelemetry.source3.sample_counter0221 []
+opentelemetry.source3.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8510269700
     inst [2 or "2 inst-2"] value 17020539400
@@ -16147,7 +16147,7 @@ opentelemetry.source3.sample_counter0221 []
     inst [8 or "8 inst-8"] value 68082157600
     inst [9 or "9 inst-9"] value 76592427300
 
-opentelemetry.source3.sample_counter0243 []
+opentelemetry.source3.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9191091280
     inst [2 or "2 inst-2"] value 18382182600
@@ -16159,7 +16159,7 @@ opentelemetry.source3.sample_counter0243 []
     inst [8 or "8 inst-8"] value 73528730200
     inst [9 or "9 inst-9"] value 82719821500
 
-opentelemetry.source3.sample_counter0265 []
+opentelemetry.source3.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9871912850
     inst [2 or "2 inst-2"] value 19743825700
@@ -16171,7 +16171,7 @@ opentelemetry.source3.sample_counter0265 []
     inst [8 or "8 inst-8"] value 78975302800
     inst [9 or "9 inst-9"] value 88847215700
 
-opentelemetry.source3.sample_counter0287 []
+opentelemetry.source3.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10552734400
     inst [2 or "2 inst-2"] value 21105468900
@@ -16183,7 +16183,7 @@ opentelemetry.source3.sample_counter0287 []
     inst [8 or "8 inst-8"] value 84421875400
     inst [9 or "9 inst-9"] value 94974609900
 
-opentelemetry.source3.sample_counter0309 []
+opentelemetry.source3.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11233556000
     inst [2 or "2 inst-2"] value 22467112000
@@ -16195,7 +16195,7 @@ opentelemetry.source3.sample_counter0309 []
     inst [8 or "8 inst-8"] value 89868448000
     inst [9 or "9 inst-9"] value 101102004000
 
-opentelemetry.source3.sample_counter0331 []
+opentelemetry.source3.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11914377600
     inst [2 or "2 inst-2"] value 23828755200
@@ -16207,7 +16207,7 @@ opentelemetry.source3.sample_counter0331 []
     inst [8 or "8 inst-8"] value 95315020600
     inst [9 or "9 inst-9"] value 107229398000
 
-opentelemetry.source3.sample_counter0353 []
+opentelemetry.source3.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12595199200
     inst [2 or "2 inst-2"] value 25190398300
@@ -16219,7 +16219,7 @@ opentelemetry.source3.sample_counter0353 []
     inst [8 or "8 inst-8"] value 100761593000
     inst [9 or "9 inst-9"] value 113356792000
 
-opentelemetry.source3.sample_counter0375 []
+opentelemetry.source3.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13276020700
     inst [2 or "2 inst-2"] value 26552041500
@@ -16231,7 +16231,7 @@ opentelemetry.source3.sample_counter0375 []
     inst [8 or "8 inst-8"] value 106208166000
     inst [9 or "9 inst-9"] value 119484187000
 
-opentelemetry.source3.sample_counter0397 []
+opentelemetry.source3.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13956842300
     inst [2 or "2 inst-2"] value 27913684600
@@ -16243,7 +16243,7 @@ opentelemetry.source3.sample_counter0397 []
     inst [8 or "8 inst-8"] value 111654738000
     inst [9 or "9 inst-9"] value 125611581000
 
-opentelemetry.source3.sample_gauge0000 []
+opentelemetry.source3.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 108.9
     inst [2 or "2 inst-2"] value 217.8
@@ -16255,7 +16255,7 @@ opentelemetry.source3.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 871.2
     inst [9 or "9 inst-9"] value 980.1
 
-opentelemetry.source3.sample_gauge0022 []
+opentelemetry.source3.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 157.3
     inst [2 or "2 inst-2"] value 314.6
@@ -16267,7 +16267,7 @@ opentelemetry.source3.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 1258.4
     inst [9 or "9 inst-9"] value 1415.7
 
-opentelemetry.source3.sample_gauge0044 []
+opentelemetry.source3.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 205.7
     inst [2 or "2 inst-2"] value 411.4
@@ -16279,7 +16279,7 @@ opentelemetry.source3.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 1645.6
     inst [9 or "9 inst-9"] value 1851.3
 
-opentelemetry.source3.sample_gauge0066 []
+opentelemetry.source3.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 254.1
     inst [2 or "2 inst-2"] value 508.2
@@ -16291,7 +16291,7 @@ opentelemetry.source3.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 2032.8
     inst [9 or "9 inst-9"] value 2286.9
 
-opentelemetry.source3.sample_gauge0088 []
+opentelemetry.source3.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 302.5
     inst [2 or "2 inst-2"] value 605
@@ -16303,7 +16303,7 @@ opentelemetry.source3.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 2420
     inst [9 or "9 inst-9"] value 2722.5
 
-opentelemetry.source3.sample_gauge0110 []
+opentelemetry.source3.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 350.9
     inst [2 or "2 inst-2"] value 701.8
@@ -16315,7 +16315,7 @@ opentelemetry.source3.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2807.2
     inst [9 or "9 inst-9"] value 3158.1
 
-opentelemetry.source3.sample_gauge0132 []
+opentelemetry.source3.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 399.3
     inst [2 or "2 inst-2"] value 798.6
@@ -16327,7 +16327,7 @@ opentelemetry.source3.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 3194.4
     inst [9 or "9 inst-9"] value 3593.7
 
-opentelemetry.source3.sample_gauge0154 []
+opentelemetry.source3.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 447.7
     inst [2 or "2 inst-2"] value 895.4
@@ -16339,7 +16339,7 @@ opentelemetry.source3.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 3581.6
     inst [9 or "9 inst-9"] value 4029.3
 
-opentelemetry.source3.sample_gauge0176 []
+opentelemetry.source3.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 496.1
     inst [2 or "2 inst-2"] value 992.2
@@ -16351,7 +16351,7 @@ opentelemetry.source3.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3968.8
     inst [9 or "9 inst-9"] value 4464.9
 
-opentelemetry.source3.sample_gauge0198 []
+opentelemetry.source3.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 544.5
     inst [2 or "2 inst-2"] value 1089
@@ -16363,7 +16363,7 @@ opentelemetry.source3.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 4356
     inst [9 or "9 inst-9"] value 4900.5
 
-opentelemetry.source3.sample_gauge0220 []
+opentelemetry.source3.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 592.9
     inst [2 or "2 inst-2"] value 1185.8
@@ -16375,7 +16375,7 @@ opentelemetry.source3.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 4743.2
     inst [9 or "9 inst-9"] value 5336.1
 
-opentelemetry.source3.sample_gauge0242 []
+opentelemetry.source3.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 641.3
     inst [2 or "2 inst-2"] value 1282.6
@@ -16387,7 +16387,7 @@ opentelemetry.source3.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 5130.4
     inst [9 or "9 inst-9"] value 5771.7
 
-opentelemetry.source3.sample_gauge0264 []
+opentelemetry.source3.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 689.7
     inst [2 or "2 inst-2"] value 1379.4
@@ -16399,7 +16399,7 @@ opentelemetry.source3.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 5517.6
     inst [9 or "9 inst-9"] value 6207.3
 
-opentelemetry.source3.sample_gauge0286 []
+opentelemetry.source3.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 738.1
     inst [2 or "2 inst-2"] value 1476.2
@@ -16411,7 +16411,7 @@ opentelemetry.source3.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5904.8
     inst [9 or "9 inst-9"] value 6642.9
 
-opentelemetry.source3.sample_gauge0308 []
+opentelemetry.source3.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 786.5
     inst [2 or "2 inst-2"] value 1573
@@ -16423,7 +16423,7 @@ opentelemetry.source3.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 6292
     inst [9 or "9 inst-9"] value 7078.5
 
-opentelemetry.source3.sample_gauge0330 []
+opentelemetry.source3.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 834.9
     inst [2 or "2 inst-2"] value 1669.8
@@ -16435,7 +16435,7 @@ opentelemetry.source3.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6679.2
     inst [9 or "9 inst-9"] value 7514.1
 
-opentelemetry.source3.sample_gauge0352 []
+opentelemetry.source3.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 883.3
     inst [2 or "2 inst-2"] value 1766.6
@@ -16447,7 +16447,7 @@ opentelemetry.source3.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 7066.4
     inst [9 or "9 inst-9"] value 7949.7
 
-opentelemetry.source3.sample_gauge0374 []
+opentelemetry.source3.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 931.7
     inst [2 or "2 inst-2"] value 1863.4
@@ -16459,7 +16459,7 @@ opentelemetry.source3.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 7453.6
     inst [9 or "9 inst-9"] value 8385.299999999999
 
-opentelemetry.source3.sample_gauge0396 []
+opentelemetry.source3.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 980.1
     inst [2 or "2 inst-2"] value 1960.2
@@ -16471,7 +16471,7 @@ opentelemetry.source3.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7840.8
     inst [9 or "9 inst-9"] value 8820.9
 
-opentelemetry.source3.sample_histogram0012 []
+opentelemetry.source3.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 71340
     inst [2 or "le=4"] value 142680
@@ -16484,13 +16484,13 @@ opentelemetry.source3.sample_histogram0012 []
     inst [9 or "le=18"] value 642060
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0012_count []
+opentelemetry.source3.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0012_sum []
+opentelemetry.source3.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0034 []
+opentelemetry.source3.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 95120
     inst [2 or "le=4"] value 190240
@@ -16503,13 +16503,13 @@ opentelemetry.source3.sample_histogram0034 []
     inst [9 or "le=18"] value 856080
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0034_count []
+opentelemetry.source3.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0034_sum []
+opentelemetry.source3.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0056 []
+opentelemetry.source3.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 118900
     inst [2 or "le=4"] value 237800
@@ -16522,13 +16522,13 @@ opentelemetry.source3.sample_histogram0056 []
     inst [9 or "le=18"] value 1070100
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0056_count []
+opentelemetry.source3.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0056_sum []
+opentelemetry.source3.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0078 []
+opentelemetry.source3.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 142680
     inst [2 or "le=4"] value 285360
@@ -16541,13 +16541,13 @@ opentelemetry.source3.sample_histogram0078 []
     inst [9 or "le=18"] value 1284120
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0078_count []
+opentelemetry.source3.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0078_sum []
+opentelemetry.source3.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0100 []
+opentelemetry.source3.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 166460
     inst [2 or "le=4"] value 332920
@@ -16560,13 +16560,13 @@ opentelemetry.source3.sample_histogram0100 []
     inst [9 or "le=18"] value 1498140
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0100_count []
+opentelemetry.source3.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0100_sum []
+opentelemetry.source3.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0122 []
+opentelemetry.source3.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 190240
     inst [2 or "le=4"] value 380480
@@ -16579,13 +16579,13 @@ opentelemetry.source3.sample_histogram0122 []
     inst [9 or "le=18"] value 1712160
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0122_count []
+opentelemetry.source3.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0122_sum []
+opentelemetry.source3.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0144 []
+opentelemetry.source3.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 214020
     inst [2 or "le=4"] value 428040
@@ -16598,13 +16598,13 @@ opentelemetry.source3.sample_histogram0144 []
     inst [9 or "le=18"] value 1926180
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0144_count []
+opentelemetry.source3.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0144_sum []
+opentelemetry.source3.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0166 []
+opentelemetry.source3.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 237800
     inst [2 or "le=4"] value 475600
@@ -16617,13 +16617,13 @@ opentelemetry.source3.sample_histogram0166 []
     inst [9 or "le=18"] value 2140200
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0166_count []
+opentelemetry.source3.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0166_sum []
+opentelemetry.source3.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0188 []
+opentelemetry.source3.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 261580
     inst [2 or "le=4"] value 523160
@@ -16636,13 +16636,13 @@ opentelemetry.source3.sample_histogram0188 []
     inst [9 or "le=18"] value 2354220
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0188_count []
+opentelemetry.source3.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0188_sum []
+opentelemetry.source3.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0210 []
+opentelemetry.source3.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 285360
     inst [2 or "le=4"] value 570720
@@ -16655,13 +16655,13 @@ opentelemetry.source3.sample_histogram0210 []
     inst [9 or "le=18"] value 2568240
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0210_count []
+opentelemetry.source3.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0210_sum []
+opentelemetry.source3.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0232 []
+opentelemetry.source3.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 309140
     inst [2 or "le=4"] value 618280
@@ -16674,13 +16674,13 @@ opentelemetry.source3.sample_histogram0232 []
     inst [9 or "le=18"] value 2782260
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0232_count []
+opentelemetry.source3.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0232_sum []
+opentelemetry.source3.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0254 []
+opentelemetry.source3.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 332920
     inst [2 or "le=4"] value 665840
@@ -16693,13 +16693,13 @@ opentelemetry.source3.sample_histogram0254 []
     inst [9 or "le=18"] value 2996280
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0254_count []
+opentelemetry.source3.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0254_sum []
+opentelemetry.source3.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0276 []
+opentelemetry.source3.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 356700
     inst [2 or "le=4"] value 713400
@@ -16712,13 +16712,13 @@ opentelemetry.source3.sample_histogram0276 []
     inst [9 or "le=18"] value 3210300
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0276_count []
+opentelemetry.source3.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0276_sum []
+opentelemetry.source3.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0298 []
+opentelemetry.source3.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 380480
     inst [2 or "le=4"] value 760960
@@ -16731,13 +16731,13 @@ opentelemetry.source3.sample_histogram0298 []
     inst [9 or "le=18"] value 3424320
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0298_count []
+opentelemetry.source3.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0298_sum []
+opentelemetry.source3.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0320 []
+opentelemetry.source3.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 404260
     inst [2 or "le=4"] value 808520
@@ -16750,13 +16750,13 @@ opentelemetry.source3.sample_histogram0320 []
     inst [9 or "le=18"] value 3638340
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0320_count []
+opentelemetry.source3.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0320_sum []
+opentelemetry.source3.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0342 []
+opentelemetry.source3.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 428040
     inst [2 or "le=4"] value 856080
@@ -16769,13 +16769,13 @@ opentelemetry.source3.sample_histogram0342 []
     inst [9 or "le=18"] value 3852360
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0342_count []
+opentelemetry.source3.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0342_sum []
+opentelemetry.source3.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0364 []
+opentelemetry.source3.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 451820
     inst [2 or "le=4"] value 903640
@@ -16788,13 +16788,13 @@ opentelemetry.source3.sample_histogram0364 []
     inst [9 or "le=18"] value 4066380
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0364_count []
+opentelemetry.source3.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0364_sum []
+opentelemetry.source3.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0386 []
+opentelemetry.source3.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 475600
     inst [2 or "le=4"] value 951200
@@ -16807,13 +16807,13 @@ opentelemetry.source3.sample_histogram0386 []
     inst [9 or "le=18"] value 4280400
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0386_count []
+opentelemetry.source3.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0386_sum []
+opentelemetry.source3.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_summary0002 []
+opentelemetry.source3.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001755853
     inst [2 or "quantile: 0.5"] value 0.003511706
@@ -16825,13 +16825,13 @@ opentelemetry.source3.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.014046824
     inst [9 or "quantile: 2.25"] value 0.015802677
 
-opentelemetry.source3.sample_summary0002_count []
+opentelemetry.source3.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 19998
 
-opentelemetry.source3.sample_summary0002_sum []
+opentelemetry.source3.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 15.303274
 
-opentelemetry.source3.sample_summary0024 []
+opentelemetry.source3.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002394345
     inst [2 or "quantile: 0.5"] value 0.00478869
@@ -16843,13 +16843,13 @@ opentelemetry.source3.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.01915476
     inst [9 or "quantile: 2.25"] value 0.021549105
 
-opentelemetry.source3.sample_summary0024_count []
+opentelemetry.source3.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 27270
 
-opentelemetry.source3.sample_summary0024_sum []
+opentelemetry.source3.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 20.868102
 
-opentelemetry.source3.sample_summary0046 []
+opentelemetry.source3.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003032837
     inst [2 or "quantile: 0.5"] value 0.006065674
@@ -16861,13 +16861,13 @@ opentelemetry.source3.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.024262696
     inst [9 or "quantile: 2.25"] value 0.027295533
 
-opentelemetry.source3.sample_summary0046_count []
+opentelemetry.source3.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 34542
 
-opentelemetry.source3.sample_summary0046_sum []
+opentelemetry.source3.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 26.432929
 
-opentelemetry.source3.sample_summary0068 []
+opentelemetry.source3.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003671329
     inst [2 or "quantile: 0.5"] value 0.007342658
@@ -16879,13 +16879,13 @@ opentelemetry.source3.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.029370632
     inst [9 or "quantile: 2.25"] value 0.033041961
 
-opentelemetry.source3.sample_summary0068_count []
+opentelemetry.source3.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 41814
 
-opentelemetry.source3.sample_summary0068_sum []
+opentelemetry.source3.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 31.997756
 
-opentelemetry.source3.sample_summary0090 []
+opentelemetry.source3.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004309821
     inst [2 or "quantile: 0.5"] value 0.008619642
@@ -16897,13 +16897,13 @@ opentelemetry.source3.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.034478568
     inst [9 or "quantile: 2.25"] value 0.03878838900000001
 
-opentelemetry.source3.sample_summary0090_count []
+opentelemetry.source3.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 49086
 
-opentelemetry.source3.sample_summary0090_sum []
+opentelemetry.source3.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 37.562583
 
-opentelemetry.source3.sample_summary0112 []
+opentelemetry.source3.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004948313
     inst [2 or "quantile: 0.5"] value 0.009896626
@@ -16915,13 +16915,13 @@ opentelemetry.source3.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.039586504
     inst [9 or "quantile: 2.25"] value 0.044534817
 
-opentelemetry.source3.sample_summary0112_count []
+opentelemetry.source3.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 56358
 
-opentelemetry.source3.sample_summary0112_sum []
+opentelemetry.source3.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 43.12741
 
-opentelemetry.source3.sample_summary0134 []
+opentelemetry.source3.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005586805
     inst [2 or "quantile: 0.5"] value 0.01117361
@@ -16933,13 +16933,13 @@ opentelemetry.source3.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.04469444
     inst [9 or "quantile: 2.25"] value 0.050281245
 
-opentelemetry.source3.sample_summary0134_count []
+opentelemetry.source3.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 63630
 
-opentelemetry.source3.sample_summary0134_sum []
+opentelemetry.source3.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 48.692237
 
-opentelemetry.source3.sample_summary0156 []
+opentelemetry.source3.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006225297
     inst [2 or "quantile: 0.5"] value 0.012450594
@@ -16951,13 +16951,13 @@ opentelemetry.source3.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.049802376
     inst [9 or "quantile: 2.25"] value 0.05602767300000001
 
-opentelemetry.source3.sample_summary0156_count []
+opentelemetry.source3.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 70902
 
-opentelemetry.source3.sample_summary0156_sum []
+opentelemetry.source3.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 54.257064
 
-opentelemetry.source3.sample_summary0178 []
+opentelemetry.source3.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006863789
     inst [2 or "quantile: 0.5"] value 0.013727578
@@ -16969,13 +16969,13 @@ opentelemetry.source3.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.054910312
     inst [9 or "quantile: 2.25"] value 0.061774101
 
-opentelemetry.source3.sample_summary0178_count []
+opentelemetry.source3.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 78174
 
-opentelemetry.source3.sample_summary0178_sum []
+opentelemetry.source3.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 59.821891
 
-opentelemetry.source3.sample_summary0200 []
+opentelemetry.source3.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007502281
     inst [2 or "quantile: 0.5"] value 0.015004562
@@ -16987,13 +16987,13 @@ opentelemetry.source3.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.060018248
     inst [9 or "quantile: 2.25"] value 0.06752052900000001
 
-opentelemetry.source3.sample_summary0200_count []
+opentelemetry.source3.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 85446
 
-opentelemetry.source3.sample_summary0200_sum []
+opentelemetry.source3.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 65.386718
 
-opentelemetry.source3.sample_summary0222 []
+opentelemetry.source3.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008140773
     inst [2 or "quantile: 0.5"] value 0.016281546
@@ -17005,13 +17005,13 @@ opentelemetry.source3.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.065126184
     inst [9 or "quantile: 2.25"] value 0.07326695700000001
 
-opentelemetry.source3.sample_summary0222_count []
+opentelemetry.source3.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 92718
 
-opentelemetry.source3.sample_summary0222_sum []
+opentelemetry.source3.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 70.951545
 
-opentelemetry.source3.sample_summary0244 []
+opentelemetry.source3.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008779265000000001
     inst [2 or "quantile: 0.5"] value 0.01755853
@@ -17023,13 +17023,13 @@ opentelemetry.source3.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.07023412000000001
     inst [9 or "quantile: 2.25"] value 0.07901338500000001
 
-opentelemetry.source3.sample_summary0244_count []
+opentelemetry.source3.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 99990
 
-opentelemetry.source3.sample_summary0244_sum []
+opentelemetry.source3.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 76.516372
 
-opentelemetry.source3.sample_summary0266 []
+opentelemetry.source3.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009417757000000001
     inst [2 or "quantile: 0.5"] value 0.018835514
@@ -17041,13 +17041,13 @@ opentelemetry.source3.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.075342056
     inst [9 or "quantile: 2.25"] value 0.084759813
 
-opentelemetry.source3.sample_summary0266_count []
+opentelemetry.source3.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 107262
 
-opentelemetry.source3.sample_summary0266_sum []
+opentelemetry.source3.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 82.081199
 
-opentelemetry.source3.sample_summary0288 []
+opentelemetry.source3.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010056249
     inst [2 or "quantile: 0.5"] value 0.020112498
@@ -17059,13 +17059,13 @@ opentelemetry.source3.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.08044999200000001
     inst [9 or "quantile: 2.25"] value 0.090506241
 
-opentelemetry.source3.sample_summary0288_count []
+opentelemetry.source3.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 114534
 
-opentelemetry.source3.sample_summary0288_sum []
+opentelemetry.source3.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 87.646027
 
-opentelemetry.source3.sample_summary0310 []
+opentelemetry.source3.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010694741
     inst [2 or "quantile: 0.5"] value 0.021389482
@@ -17077,13 +17077,13 @@ opentelemetry.source3.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.08555792800000001
     inst [9 or "quantile: 2.25"] value 0.09625266900000001
 
-opentelemetry.source3.sample_summary0310_count []
+opentelemetry.source3.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 121806
 
-opentelemetry.source3.sample_summary0310_sum []
+opentelemetry.source3.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 93.210854
 
-opentelemetry.source3.sample_summary0332 []
+opentelemetry.source3.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011333233
     inst [2 or "quantile: 0.5"] value 0.022666466
@@ -17095,13 +17095,13 @@ opentelemetry.source3.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.09066586400000001
     inst [9 or "quantile: 2.25"] value 0.101999097
 
-opentelemetry.source3.sample_summary0332_count []
+opentelemetry.source3.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 129078
 
-opentelemetry.source3.sample_summary0332_sum []
+opentelemetry.source3.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 98.77568100000001
 
-opentelemetry.source3.sample_summary0354 []
+opentelemetry.source3.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011971725
     inst [2 or "quantile: 0.5"] value 0.02394345
@@ -17113,13 +17113,13 @@ opentelemetry.source3.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.09577380000000001
     inst [9 or "quantile: 2.25"] value 0.107745525
 
-opentelemetry.source3.sample_summary0354_count []
+opentelemetry.source3.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 136350
 
-opentelemetry.source3.sample_summary0354_sum []
+opentelemetry.source3.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 104.340508
 
-opentelemetry.source3.sample_summary0376 []
+opentelemetry.source3.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012610217
     inst [2 or "quantile: 0.5"] value 0.025220434
@@ -17131,13 +17131,13 @@ opentelemetry.source3.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.100881736
     inst [9 or "quantile: 2.25"] value 0.113491953
 
-opentelemetry.source3.sample_summary0376_count []
+opentelemetry.source3.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 143622
 
-opentelemetry.source3.sample_summary0376_sum []
+opentelemetry.source3.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 109.905335
 
-opentelemetry.source3.sample_summary0398 []
+opentelemetry.source3.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013248709
     inst [2 or "quantile: 0.5"] value 0.026497418
@@ -17149,13 +17149,13 @@ opentelemetry.source3.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.105989672
     inst [9 or "quantile: 2.25"] value 0.119238381
 
-opentelemetry.source3.sample_summary0398_count []
+opentelemetry.source3.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 150894
 
-opentelemetry.source3.sample_summary0398_sum []
+opentelemetry.source3.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 115.470162
 
-opentelemetry.source3.sample_counter0001 []
+opentelemetry.source3.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -17167,7 +17167,7 @@ opentelemetry.source3.sample_counter0001 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source3.sample_counter0023 []
+opentelemetry.source3.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -17179,7 +17179,7 @@ opentelemetry.source3.sample_counter0023 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source3.sample_counter0045 []
+opentelemetry.source3.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -17191,7 +17191,7 @@ opentelemetry.source3.sample_counter0045 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source3.sample_counter0067 []
+opentelemetry.source3.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -17203,7 +17203,7 @@ opentelemetry.source3.sample_counter0067 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source3.sample_counter0089 []
+opentelemetry.source3.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -17215,7 +17215,7 @@ opentelemetry.source3.sample_counter0089 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source3.sample_counter0111 []
+opentelemetry.source3.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -17227,7 +17227,7 @@ opentelemetry.source3.sample_counter0111 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source3.sample_counter0133 []
+opentelemetry.source3.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -17239,7 +17239,7 @@ opentelemetry.source3.sample_counter0133 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source3.sample_counter0155 []
+opentelemetry.source3.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -17251,7 +17251,7 @@ opentelemetry.source3.sample_counter0155 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source3.sample_counter0177 []
+opentelemetry.source3.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -17263,7 +17263,7 @@ opentelemetry.source3.sample_counter0177 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source3.sample_counter0199 []
+opentelemetry.source3.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -17275,7 +17275,7 @@ opentelemetry.source3.sample_counter0199 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source3.sample_counter0221 []
+opentelemetry.source3.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -17287,7 +17287,7 @@ opentelemetry.source3.sample_counter0221 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source3.sample_counter0243 []
+opentelemetry.source3.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -17299,7 +17299,7 @@ opentelemetry.source3.sample_counter0243 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source3.sample_counter0265 []
+opentelemetry.source3.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -17311,7 +17311,7 @@ opentelemetry.source3.sample_counter0265 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source3.sample_counter0287 []
+opentelemetry.source3.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -17323,7 +17323,7 @@ opentelemetry.source3.sample_counter0287 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source3.sample_counter0309 []
+opentelemetry.source3.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -17335,7 +17335,7 @@ opentelemetry.source3.sample_counter0309 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source3.sample_counter0331 []
+opentelemetry.source3.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -17347,7 +17347,7 @@ opentelemetry.source3.sample_counter0331 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source3.sample_counter0353 []
+opentelemetry.source3.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13105815300
     inst [2 or "2 inst-2"] value 26211630700
@@ -17359,7 +17359,7 @@ opentelemetry.source3.sample_counter0353 []
     inst [8 or "8 inst-8"] value 104846523000
     inst [9 or "9 inst-9"] value 117952338000
 
-opentelemetry.source3.sample_counter0375 []
+opentelemetry.source3.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13786636900
     inst [2 or "2 inst-2"] value 27573273800
@@ -17371,7 +17371,7 @@ opentelemetry.source3.sample_counter0375 []
     inst [8 or "8 inst-8"] value 110293095000
     inst [9 or "9 inst-9"] value 124079732000
 
-opentelemetry.source3.sample_counter0397 []
+opentelemetry.source3.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14467458500
     inst [2 or "2 inst-2"] value 28934917000
@@ -17383,7 +17383,7 @@ opentelemetry.source3.sample_counter0397 []
     inst [8 or "8 inst-8"] value 115739668000
     inst [9 or "9 inst-9"] value 130207126000
 
-opentelemetry.source3.sample_gauge0000 []
+opentelemetry.source3.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -17395,7 +17395,7 @@ opentelemetry.source3.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source3.sample_gauge0022 []
+opentelemetry.source3.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -17407,7 +17407,7 @@ opentelemetry.source3.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source3.sample_gauge0044 []
+opentelemetry.source3.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -17419,7 +17419,7 @@ opentelemetry.source3.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source3.sample_gauge0066 []
+opentelemetry.source3.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -17431,7 +17431,7 @@ opentelemetry.source3.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source3.sample_gauge0088 []
+opentelemetry.source3.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -17443,7 +17443,7 @@ opentelemetry.source3.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source3.sample_gauge0110 []
+opentelemetry.source3.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -17455,7 +17455,7 @@ opentelemetry.source3.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source3.sample_gauge0132 []
+opentelemetry.source3.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -17467,7 +17467,7 @@ opentelemetry.source3.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source3.sample_gauge0154 []
+opentelemetry.source3.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -17479,7 +17479,7 @@ opentelemetry.source3.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source3.sample_gauge0176 []
+opentelemetry.source3.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -17491,7 +17491,7 @@ opentelemetry.source3.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source3.sample_gauge0198 []
+opentelemetry.source3.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -17503,7 +17503,7 @@ opentelemetry.source3.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source3.sample_gauge0220 []
+opentelemetry.source3.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -17515,7 +17515,7 @@ opentelemetry.source3.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source3.sample_gauge0242 []
+opentelemetry.source3.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -17527,7 +17527,7 @@ opentelemetry.source3.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source3.sample_gauge0264 []
+opentelemetry.source3.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -17539,7 +17539,7 @@ opentelemetry.source3.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source3.sample_gauge0286 []
+opentelemetry.source3.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -17551,7 +17551,7 @@ opentelemetry.source3.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source3.sample_gauge0308 []
+opentelemetry.source3.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -17563,7 +17563,7 @@ opentelemetry.source3.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source3.sample_gauge0330 []
+opentelemetry.source3.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -17575,7 +17575,7 @@ opentelemetry.source3.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source3.sample_gauge0352 []
+opentelemetry.source3.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 919.6
     inst [2 or "2 inst-2"] value 1839.2
@@ -17587,7 +17587,7 @@ opentelemetry.source3.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 7356.8
     inst [9 or "9 inst-9"] value 8276.4
 
-opentelemetry.source3.sample_gauge0374 []
+opentelemetry.source3.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 968
     inst [2 or "2 inst-2"] value 1936
@@ -17599,7 +17599,7 @@ opentelemetry.source3.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 7744
     inst [9 or "9 inst-9"] value 8712
 
-opentelemetry.source3.sample_gauge0396 []
+opentelemetry.source3.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1016.4
     inst [2 or "2 inst-2"] value 2032.8
@@ -17611,7 +17611,7 @@ opentelemetry.source3.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 8131.2
     inst [9 or "9 inst-9"] value 9147.6
 
-opentelemetry.source3.sample_histogram0012 []
+opentelemetry.source3.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 89175
     inst [2 or "le=4"] value 178350
@@ -17624,13 +17624,13 @@ opentelemetry.source3.sample_histogram0012 []
     inst [9 or "le=18"] value 802575
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0012_count []
+opentelemetry.source3.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0012_sum []
+opentelemetry.source3.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0034 []
+opentelemetry.source3.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 112955
     inst [2 or "le=4"] value 225910
@@ -17643,13 +17643,13 @@ opentelemetry.source3.sample_histogram0034 []
     inst [9 or "le=18"] value 1016595
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0034_count []
+opentelemetry.source3.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0034_sum []
+opentelemetry.source3.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0056 []
+opentelemetry.source3.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 136735
     inst [2 or "le=4"] value 273470
@@ -17662,13 +17662,13 @@ opentelemetry.source3.sample_histogram0056 []
     inst [9 or "le=18"] value 1230615
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0056_count []
+opentelemetry.source3.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0056_sum []
+opentelemetry.source3.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0078 []
+opentelemetry.source3.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 160515
     inst [2 or "le=4"] value 321030
@@ -17681,13 +17681,13 @@ opentelemetry.source3.sample_histogram0078 []
     inst [9 or "le=18"] value 1444635
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0078_count []
+opentelemetry.source3.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0078_sum []
+opentelemetry.source3.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0100 []
+opentelemetry.source3.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 184295
     inst [2 or "le=4"] value 368590
@@ -17700,13 +17700,13 @@ opentelemetry.source3.sample_histogram0100 []
     inst [9 or "le=18"] value 1658655
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0100_count []
+opentelemetry.source3.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0100_sum []
+opentelemetry.source3.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0122 []
+opentelemetry.source3.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 208075
     inst [2 or "le=4"] value 416150
@@ -17719,13 +17719,13 @@ opentelemetry.source3.sample_histogram0122 []
     inst [9 or "le=18"] value 1872675
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0122_count []
+opentelemetry.source3.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0122_sum []
+opentelemetry.source3.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0144 []
+opentelemetry.source3.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 231855
     inst [2 or "le=4"] value 463710
@@ -17738,13 +17738,13 @@ opentelemetry.source3.sample_histogram0144 []
     inst [9 or "le=18"] value 2086695
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0144_count []
+opentelemetry.source3.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0144_sum []
+opentelemetry.source3.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0166 []
+opentelemetry.source3.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 255635
     inst [2 or "le=4"] value 511270
@@ -17757,13 +17757,13 @@ opentelemetry.source3.sample_histogram0166 []
     inst [9 or "le=18"] value 2300715
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0166_count []
+opentelemetry.source3.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0166_sum []
+opentelemetry.source3.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0188 []
+opentelemetry.source3.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 279415
     inst [2 or "le=4"] value 558830
@@ -17776,13 +17776,13 @@ opentelemetry.source3.sample_histogram0188 []
     inst [9 or "le=18"] value 2514735
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0188_count []
+opentelemetry.source3.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0188_sum []
+opentelemetry.source3.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0210 []
+opentelemetry.source3.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 303195
     inst [2 or "le=4"] value 606390
@@ -17795,13 +17795,13 @@ opentelemetry.source3.sample_histogram0210 []
     inst [9 or "le=18"] value 2728755
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0210_count []
+opentelemetry.source3.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0210_sum []
+opentelemetry.source3.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0232 []
+opentelemetry.source3.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 326975
     inst [2 or "le=4"] value 653950
@@ -17814,13 +17814,13 @@ opentelemetry.source3.sample_histogram0232 []
     inst [9 or "le=18"] value 2942775
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0232_count []
+opentelemetry.source3.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0232_sum []
+opentelemetry.source3.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0254 []
+opentelemetry.source3.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 350755
     inst [2 or "le=4"] value 701510
@@ -17833,13 +17833,13 @@ opentelemetry.source3.sample_histogram0254 []
     inst [9 or "le=18"] value 3156795
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0254_count []
+opentelemetry.source3.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0254_sum []
+opentelemetry.source3.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0276 []
+opentelemetry.source3.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 374535
     inst [2 or "le=4"] value 749070
@@ -17852,13 +17852,13 @@ opentelemetry.source3.sample_histogram0276 []
     inst [9 or "le=18"] value 3370815
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0276_count []
+opentelemetry.source3.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0276_sum []
+opentelemetry.source3.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0298 []
+opentelemetry.source3.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 398315
     inst [2 or "le=4"] value 796630
@@ -17871,13 +17871,13 @@ opentelemetry.source3.sample_histogram0298 []
     inst [9 or "le=18"] value 3584835
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0298_count []
+opentelemetry.source3.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0298_sum []
+opentelemetry.source3.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0320 []
+opentelemetry.source3.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 422095
     inst [2 or "le=4"] value 844190
@@ -17890,13 +17890,13 @@ opentelemetry.source3.sample_histogram0320 []
     inst [9 or "le=18"] value 3798855
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0320_count []
+opentelemetry.source3.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0320_sum []
+opentelemetry.source3.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0342 []
+opentelemetry.source3.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 445875
     inst [2 or "le=4"] value 891750
@@ -17909,13 +17909,13 @@ opentelemetry.source3.sample_histogram0342 []
     inst [9 or "le=18"] value 4012875
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0342_count []
+opentelemetry.source3.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0342_sum []
+opentelemetry.source3.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0364 []
+opentelemetry.source3.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 469655
     inst [2 or "le=4"] value 939310
@@ -17928,13 +17928,13 @@ opentelemetry.source3.sample_histogram0364 []
     inst [9 or "le=18"] value 4226895
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0364_count []
+opentelemetry.source3.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0364_sum []
+opentelemetry.source3.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_histogram0386 []
+opentelemetry.source3.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 493435
     inst [2 or "le=4"] value 986870
@@ -17947,13 +17947,13 @@ opentelemetry.source3.sample_histogram0386 []
     inst [9 or "le=18"] value 4440915
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source3.sample_histogram0386_count []
+opentelemetry.source3.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source3.sample_histogram0386_sum []
+opentelemetry.source3.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source3.sample_summary0002 []
+opentelemetry.source3.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -17965,13 +17965,13 @@ opentelemetry.source3.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source3.sample_summary0002_count []
+opentelemetry.source3.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source3.sample_summary0002_sum []
+opentelemetry.source3.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source3.sample_summary0024 []
+opentelemetry.source3.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -17983,13 +17983,13 @@ opentelemetry.source3.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source3.sample_summary0024_count []
+opentelemetry.source3.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source3.sample_summary0024_sum []
+opentelemetry.source3.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source3.sample_summary0046 []
+opentelemetry.source3.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -18001,13 +18001,13 @@ opentelemetry.source3.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source3.sample_summary0046_count []
+opentelemetry.source3.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source3.sample_summary0046_sum []
+opentelemetry.source3.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source3.sample_summary0068 []
+opentelemetry.source3.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -18019,13 +18019,13 @@ opentelemetry.source3.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source3.sample_summary0068_count []
+opentelemetry.source3.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source3.sample_summary0068_sum []
+opentelemetry.source3.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source3.sample_summary0090 []
+opentelemetry.source3.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -18037,13 +18037,13 @@ opentelemetry.source3.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source3.sample_summary0090_count []
+opentelemetry.source3.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source3.sample_summary0090_sum []
+opentelemetry.source3.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source3.sample_summary0112 []
+opentelemetry.source3.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -18055,13 +18055,13 @@ opentelemetry.source3.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source3.sample_summary0112_count []
+opentelemetry.source3.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source3.sample_summary0112_sum []
+opentelemetry.source3.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source3.sample_summary0134 []
+opentelemetry.source3.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -18073,13 +18073,13 @@ opentelemetry.source3.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source3.sample_summary0134_count []
+opentelemetry.source3.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source3.sample_summary0134_sum []
+opentelemetry.source3.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source3.sample_summary0156 []
+opentelemetry.source3.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -18091,13 +18091,13 @@ opentelemetry.source3.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source3.sample_summary0156_count []
+opentelemetry.source3.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source3.sample_summary0156_sum []
+opentelemetry.source3.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source3.sample_summary0178 []
+opentelemetry.source3.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -18109,13 +18109,13 @@ opentelemetry.source3.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source3.sample_summary0178_count []
+opentelemetry.source3.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source3.sample_summary0178_sum []
+opentelemetry.source3.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source3.sample_summary0200 []
+opentelemetry.source3.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -18127,13 +18127,13 @@ opentelemetry.source3.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source3.sample_summary0200_count []
+opentelemetry.source3.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source3.sample_summary0200_sum []
+opentelemetry.source3.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source3.sample_summary0222 []
+opentelemetry.source3.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -18145,13 +18145,13 @@ opentelemetry.source3.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source3.sample_summary0222_count []
+opentelemetry.source3.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source3.sample_summary0222_sum []
+opentelemetry.source3.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source3.sample_summary0244 []
+opentelemetry.source3.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -18163,13 +18163,13 @@ opentelemetry.source3.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source3.sample_summary0244_count []
+opentelemetry.source3.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source3.sample_summary0244_sum []
+opentelemetry.source3.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source3.sample_summary0266 []
+opentelemetry.source3.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -18181,13 +18181,13 @@ opentelemetry.source3.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source3.sample_summary0266_count []
+opentelemetry.source3.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source3.sample_summary0266_sum []
+opentelemetry.source3.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source3.sample_summary0288 []
+opentelemetry.source3.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -18199,13 +18199,13 @@ opentelemetry.source3.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source3.sample_summary0288_count []
+opentelemetry.source3.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source3.sample_summary0288_sum []
+opentelemetry.source3.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source3.sample_summary0310 []
+opentelemetry.source3.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -18217,13 +18217,13 @@ opentelemetry.source3.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source3.sample_summary0310_count []
+opentelemetry.source3.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source3.sample_summary0310_sum []
+opentelemetry.source3.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source3.sample_summary0332 []
+opentelemetry.source3.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -18235,13 +18235,13 @@ opentelemetry.source3.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source3.sample_summary0332_count []
+opentelemetry.source3.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source3.sample_summary0332_sum []
+opentelemetry.source3.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source3.sample_summary0354 []
+opentelemetry.source3.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012450594
     inst [2 or "quantile: 0.5"] value 0.024901188
@@ -18253,13 +18253,13 @@ opentelemetry.source3.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.099604752
     inst [9 or "quantile: 2.25"] value 0.112055346
 
-opentelemetry.source3.sample_summary0354_count []
+opentelemetry.source3.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 141804
 
-opentelemetry.source3.sample_summary0354_sum []
+opentelemetry.source3.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 108.514128
 
-opentelemetry.source3.sample_summary0376 []
+opentelemetry.source3.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013089086
     inst [2 or "quantile: 0.5"] value 0.026178172
@@ -18271,13 +18271,13 @@ opentelemetry.source3.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.104712688
     inst [9 or "quantile: 2.25"] value 0.117801774
 
-opentelemetry.source3.sample_summary0376_count []
+opentelemetry.source3.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 149076
 
-opentelemetry.source3.sample_summary0376_sum []
+opentelemetry.source3.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 114.078955
 
-opentelemetry.source3.sample_summary0398 []
+opentelemetry.source3.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013727578
     inst [2 or "quantile: 0.5"] value 0.027455156
@@ -18289,13 +18289,13 @@ opentelemetry.source3.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.109820624
     inst [9 or "quantile: 2.25"] value 0.123548202
 
-opentelemetry.source3.sample_summary0398_count []
+opentelemetry.source3.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 156348
 
-opentelemetry.source3.sample_summary0398_sum []
+opentelemetry.source3.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 119.643782
 
-opentelemetry.source4.sample_counter0001 []
+opentelemetry.source4.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 851026970
     inst [2 or "2 inst-2"] value 1702053940
@@ -18307,7 +18307,7 @@ opentelemetry.source4.sample_counter0001 []
     inst [8 or "8 inst-8"] value 6808215760
     inst [9 or "9 inst-9"] value 7659242730
 
-opentelemetry.source4.sample_counter0023 []
+opentelemetry.source4.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1531848550
     inst [2 or "2 inst-2"] value 3063697090
@@ -18319,7 +18319,7 @@ opentelemetry.source4.sample_counter0023 []
     inst [8 or "8 inst-8"] value 12254788400
     inst [9 or "9 inst-9"] value 13786636900
 
-opentelemetry.source4.sample_counter0045 []
+opentelemetry.source4.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -18331,7 +18331,7 @@ opentelemetry.source4.sample_counter0045 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source4.sample_counter0067 []
+opentelemetry.source4.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -18343,7 +18343,7 @@ opentelemetry.source4.sample_counter0067 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source4.sample_counter0089 []
+opentelemetry.source4.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -18355,7 +18355,7 @@ opentelemetry.source4.sample_counter0089 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source4.sample_counter0111 []
+opentelemetry.source4.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -18367,7 +18367,7 @@ opentelemetry.source4.sample_counter0111 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source4.sample_counter0133 []
+opentelemetry.source4.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -18379,7 +18379,7 @@ opentelemetry.source4.sample_counter0133 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source4.sample_counter0155 []
+opentelemetry.source4.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -18391,7 +18391,7 @@ opentelemetry.source4.sample_counter0155 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source4.sample_counter0177 []
+opentelemetry.source4.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -18403,7 +18403,7 @@ opentelemetry.source4.sample_counter0177 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source4.sample_counter0199 []
+opentelemetry.source4.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -18415,7 +18415,7 @@ opentelemetry.source4.sample_counter0199 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source4.sample_counter0221 []
+opentelemetry.source4.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -18427,7 +18427,7 @@ opentelemetry.source4.sample_counter0221 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source4.sample_counter0243 []
+opentelemetry.source4.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -18439,7 +18439,7 @@ opentelemetry.source4.sample_counter0243 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source4.sample_counter0265 []
+opentelemetry.source4.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -18451,7 +18451,7 @@ opentelemetry.source4.sample_counter0265 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source4.sample_counter0287 []
+opentelemetry.source4.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -18463,7 +18463,7 @@ opentelemetry.source4.sample_counter0287 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source4.sample_counter0309 []
+opentelemetry.source4.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -18475,7 +18475,7 @@ opentelemetry.source4.sample_counter0309 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source4.sample_counter0331 []
+opentelemetry.source4.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -18487,7 +18487,7 @@ opentelemetry.source4.sample_counter0331 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source4.sample_counter0353 []
+opentelemetry.source4.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -18499,7 +18499,7 @@ opentelemetry.source4.sample_counter0353 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source4.sample_counter0375 []
+opentelemetry.source4.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -18511,7 +18511,7 @@ opentelemetry.source4.sample_counter0375 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source4.sample_counter0397 []
+opentelemetry.source4.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13105815300
     inst [2 or "2 inst-2"] value 26211630700
@@ -18523,7 +18523,7 @@ opentelemetry.source4.sample_counter0397 []
     inst [8 or "8 inst-8"] value 104846523000
     inst [9 or "9 inst-9"] value 117952338000
 
-opentelemetry.source4.sample_gauge0000 []
+opentelemetry.source4.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 48.4
     inst [2 or "2 inst-2"] value 96.8
@@ -18535,7 +18535,7 @@ opentelemetry.source4.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 387.2
     inst [9 or "9 inst-9"] value 435.6
 
-opentelemetry.source4.sample_gauge0022 []
+opentelemetry.source4.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 96.8
     inst [2 or "2 inst-2"] value 193.6
@@ -18547,7 +18547,7 @@ opentelemetry.source4.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 774.4
     inst [9 or "9 inst-9"] value 871.2
 
-opentelemetry.source4.sample_gauge0044 []
+opentelemetry.source4.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -18559,7 +18559,7 @@ opentelemetry.source4.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source4.sample_gauge0066 []
+opentelemetry.source4.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -18571,7 +18571,7 @@ opentelemetry.source4.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source4.sample_gauge0088 []
+opentelemetry.source4.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -18583,7 +18583,7 @@ opentelemetry.source4.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source4.sample_gauge0110 []
+opentelemetry.source4.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -18595,7 +18595,7 @@ opentelemetry.source4.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source4.sample_gauge0132 []
+opentelemetry.source4.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -18607,7 +18607,7 @@ opentelemetry.source4.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source4.sample_gauge0154 []
+opentelemetry.source4.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -18619,7 +18619,7 @@ opentelemetry.source4.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source4.sample_gauge0176 []
+opentelemetry.source4.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -18631,7 +18631,7 @@ opentelemetry.source4.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source4.sample_gauge0198 []
+opentelemetry.source4.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -18643,7 +18643,7 @@ opentelemetry.source4.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source4.sample_gauge0220 []
+opentelemetry.source4.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -18655,7 +18655,7 @@ opentelemetry.source4.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source4.sample_gauge0242 []
+opentelemetry.source4.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -18667,7 +18667,7 @@ opentelemetry.source4.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source4.sample_gauge0264 []
+opentelemetry.source4.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -18679,7 +18679,7 @@ opentelemetry.source4.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source4.sample_gauge0286 []
+opentelemetry.source4.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -18691,7 +18691,7 @@ opentelemetry.source4.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source4.sample_gauge0308 []
+opentelemetry.source4.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -18703,7 +18703,7 @@ opentelemetry.source4.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source4.sample_gauge0330 []
+opentelemetry.source4.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -18715,7 +18715,7 @@ opentelemetry.source4.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source4.sample_gauge0352 []
+opentelemetry.source4.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -18727,7 +18727,7 @@ opentelemetry.source4.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source4.sample_gauge0374 []
+opentelemetry.source4.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -18739,7 +18739,7 @@ opentelemetry.source4.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source4.sample_gauge0396 []
+opentelemetry.source4.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 919.6
     inst [2 or "2 inst-2"] value 1839.2
@@ -18751,7 +18751,7 @@ opentelemetry.source4.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7356.8
     inst [9 or "9 inst-9"] value 8276.4
 
-opentelemetry.source4.sample_histogram0012 []
+opentelemetry.source4.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 41615
     inst [2 or "le=4"] value 83230
@@ -18764,13 +18764,13 @@ opentelemetry.source4.sample_histogram0012 []
     inst [9 or "le=18"] value 374535
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0012_count []
+opentelemetry.source4.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0012_sum []
+opentelemetry.source4.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0034 []
+opentelemetry.source4.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 65395
     inst [2 or "le=4"] value 130790
@@ -18783,13 +18783,13 @@ opentelemetry.source4.sample_histogram0034 []
     inst [9 or "le=18"] value 588555
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0034_count []
+opentelemetry.source4.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0034_sum []
+opentelemetry.source4.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0056 []
+opentelemetry.source4.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 89175
     inst [2 or "le=4"] value 178350
@@ -18802,13 +18802,13 @@ opentelemetry.source4.sample_histogram0056 []
     inst [9 or "le=18"] value 802575
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0056_count []
+opentelemetry.source4.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0056_sum []
+opentelemetry.source4.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0078 []
+opentelemetry.source4.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 112955
     inst [2 or "le=4"] value 225910
@@ -18821,13 +18821,13 @@ opentelemetry.source4.sample_histogram0078 []
     inst [9 or "le=18"] value 1016595
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0078_count []
+opentelemetry.source4.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0078_sum []
+opentelemetry.source4.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0100 []
+opentelemetry.source4.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 136735
     inst [2 or "le=4"] value 273470
@@ -18840,13 +18840,13 @@ opentelemetry.source4.sample_histogram0100 []
     inst [9 or "le=18"] value 1230615
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0100_count []
+opentelemetry.source4.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0100_sum []
+opentelemetry.source4.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0122 []
+opentelemetry.source4.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 160515
     inst [2 or "le=4"] value 321030
@@ -18859,13 +18859,13 @@ opentelemetry.source4.sample_histogram0122 []
     inst [9 or "le=18"] value 1444635
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0122_count []
+opentelemetry.source4.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0122_sum []
+opentelemetry.source4.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0144 []
+opentelemetry.source4.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 184295
     inst [2 or "le=4"] value 368590
@@ -18878,13 +18878,13 @@ opentelemetry.source4.sample_histogram0144 []
     inst [9 or "le=18"] value 1658655
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0144_count []
+opentelemetry.source4.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0144_sum []
+opentelemetry.source4.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0166 []
+opentelemetry.source4.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 208075
     inst [2 or "le=4"] value 416150
@@ -18897,13 +18897,13 @@ opentelemetry.source4.sample_histogram0166 []
     inst [9 or "le=18"] value 1872675
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0166_count []
+opentelemetry.source4.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0166_sum []
+opentelemetry.source4.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0188 []
+opentelemetry.source4.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 231855
     inst [2 or "le=4"] value 463710
@@ -18916,13 +18916,13 @@ opentelemetry.source4.sample_histogram0188 []
     inst [9 or "le=18"] value 2086695
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0188_count []
+opentelemetry.source4.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0188_sum []
+opentelemetry.source4.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0210 []
+opentelemetry.source4.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 255635
     inst [2 or "le=4"] value 511270
@@ -18935,13 +18935,13 @@ opentelemetry.source4.sample_histogram0210 []
     inst [9 or "le=18"] value 2300715
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0210_count []
+opentelemetry.source4.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0210_sum []
+opentelemetry.source4.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0232 []
+opentelemetry.source4.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 279415
     inst [2 or "le=4"] value 558830
@@ -18954,13 +18954,13 @@ opentelemetry.source4.sample_histogram0232 []
     inst [9 or "le=18"] value 2514735
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0232_count []
+opentelemetry.source4.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0232_sum []
+opentelemetry.source4.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0254 []
+opentelemetry.source4.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 303195
     inst [2 or "le=4"] value 606390
@@ -18973,13 +18973,13 @@ opentelemetry.source4.sample_histogram0254 []
     inst [9 or "le=18"] value 2728755
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0254_count []
+opentelemetry.source4.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0254_sum []
+opentelemetry.source4.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0276 []
+opentelemetry.source4.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 326975
     inst [2 or "le=4"] value 653950
@@ -18992,13 +18992,13 @@ opentelemetry.source4.sample_histogram0276 []
     inst [9 or "le=18"] value 2942775
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0276_count []
+opentelemetry.source4.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0276_sum []
+opentelemetry.source4.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0298 []
+opentelemetry.source4.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 350755
     inst [2 or "le=4"] value 701510
@@ -19011,13 +19011,13 @@ opentelemetry.source4.sample_histogram0298 []
     inst [9 or "le=18"] value 3156795
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0298_count []
+opentelemetry.source4.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0298_sum []
+opentelemetry.source4.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0320 []
+opentelemetry.source4.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 374535
     inst [2 or "le=4"] value 749070
@@ -19030,13 +19030,13 @@ opentelemetry.source4.sample_histogram0320 []
     inst [9 or "le=18"] value 3370815
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0320_count []
+opentelemetry.source4.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0320_sum []
+opentelemetry.source4.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0342 []
+opentelemetry.source4.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 398315
     inst [2 or "le=4"] value 796630
@@ -19049,13 +19049,13 @@ opentelemetry.source4.sample_histogram0342 []
     inst [9 or "le=18"] value 3584835
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0342_count []
+opentelemetry.source4.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0342_sum []
+opentelemetry.source4.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0364 []
+opentelemetry.source4.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 422095
     inst [2 or "le=4"] value 844190
@@ -19068,13 +19068,13 @@ opentelemetry.source4.sample_histogram0364 []
     inst [9 or "le=18"] value 3798855
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0364_count []
+opentelemetry.source4.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0364_sum []
+opentelemetry.source4.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0386 []
+opentelemetry.source4.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 445875
     inst [2 or "le=4"] value 891750
@@ -19087,13 +19087,13 @@ opentelemetry.source4.sample_histogram0386 []
     inst [9 or "le=18"] value 4012875
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0386_count []
+opentelemetry.source4.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0386_sum []
+opentelemetry.source4.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_summary0002 []
+opentelemetry.source4.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0009577380000000001
     inst [2 or "quantile: 0.5"] value 0.001915476
@@ -19105,13 +19105,13 @@ opentelemetry.source4.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.007661904000000001
     inst [9 or "quantile: 2.25"] value 0.008619642
 
-opentelemetry.source4.sample_summary0002_count []
+opentelemetry.source4.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 10908
 
-opentelemetry.source4.sample_summary0002_sum []
+opentelemetry.source4.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 8.347241
 
-opentelemetry.source4.sample_summary0024 []
+opentelemetry.source4.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00159623
     inst [2 or "quantile: 0.5"] value 0.00319246
@@ -19123,13 +19123,13 @@ opentelemetry.source4.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.01276984
     inst [9 or "quantile: 2.25"] value 0.01436607
 
-opentelemetry.source4.sample_summary0024_count []
+opentelemetry.source4.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 18180
 
-opentelemetry.source4.sample_summary0024_sum []
+opentelemetry.source4.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 13.912068
 
-opentelemetry.source4.sample_summary0046 []
+opentelemetry.source4.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -19141,13 +19141,13 @@ opentelemetry.source4.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source4.sample_summary0046_count []
+opentelemetry.source4.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source4.sample_summary0046_sum []
+opentelemetry.source4.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source4.sample_summary0068 []
+opentelemetry.source4.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -19159,13 +19159,13 @@ opentelemetry.source4.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source4.sample_summary0068_count []
+opentelemetry.source4.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source4.sample_summary0068_sum []
+opentelemetry.source4.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source4.sample_summary0090 []
+opentelemetry.source4.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -19177,13 +19177,13 @@ opentelemetry.source4.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source4.sample_summary0090_count []
+opentelemetry.source4.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source4.sample_summary0090_sum []
+opentelemetry.source4.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source4.sample_summary0112 []
+opentelemetry.source4.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -19195,13 +19195,13 @@ opentelemetry.source4.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source4.sample_summary0112_count []
+opentelemetry.source4.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source4.sample_summary0112_sum []
+opentelemetry.source4.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source4.sample_summary0134 []
+opentelemetry.source4.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -19213,13 +19213,13 @@ opentelemetry.source4.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source4.sample_summary0134_count []
+opentelemetry.source4.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source4.sample_summary0134_sum []
+opentelemetry.source4.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source4.sample_summary0156 []
+opentelemetry.source4.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -19231,13 +19231,13 @@ opentelemetry.source4.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source4.sample_summary0156_count []
+opentelemetry.source4.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source4.sample_summary0156_sum []
+opentelemetry.source4.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source4.sample_summary0178 []
+opentelemetry.source4.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -19249,13 +19249,13 @@ opentelemetry.source4.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source4.sample_summary0178_count []
+opentelemetry.source4.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source4.sample_summary0178_sum []
+opentelemetry.source4.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source4.sample_summary0200 []
+opentelemetry.source4.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -19267,13 +19267,13 @@ opentelemetry.source4.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source4.sample_summary0200_count []
+opentelemetry.source4.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source4.sample_summary0200_sum []
+opentelemetry.source4.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source4.sample_summary0222 []
+opentelemetry.source4.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -19285,13 +19285,13 @@ opentelemetry.source4.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source4.sample_summary0222_count []
+opentelemetry.source4.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source4.sample_summary0222_sum []
+opentelemetry.source4.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source4.sample_summary0244 []
+opentelemetry.source4.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -19303,13 +19303,13 @@ opentelemetry.source4.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source4.sample_summary0244_count []
+opentelemetry.source4.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source4.sample_summary0244_sum []
+opentelemetry.source4.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source4.sample_summary0266 []
+opentelemetry.source4.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -19321,13 +19321,13 @@ opentelemetry.source4.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source4.sample_summary0266_count []
+opentelemetry.source4.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source4.sample_summary0266_sum []
+opentelemetry.source4.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source4.sample_summary0288 []
+opentelemetry.source4.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -19339,13 +19339,13 @@ opentelemetry.source4.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source4.sample_summary0288_count []
+opentelemetry.source4.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source4.sample_summary0288_sum []
+opentelemetry.source4.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source4.sample_summary0310 []
+opentelemetry.source4.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -19357,13 +19357,13 @@ opentelemetry.source4.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source4.sample_summary0310_count []
+opentelemetry.source4.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source4.sample_summary0310_sum []
+opentelemetry.source4.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source4.sample_summary0332 []
+opentelemetry.source4.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -19375,13 +19375,13 @@ opentelemetry.source4.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source4.sample_summary0332_count []
+opentelemetry.source4.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source4.sample_summary0332_sum []
+opentelemetry.source4.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source4.sample_summary0354 []
+opentelemetry.source4.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -19393,13 +19393,13 @@ opentelemetry.source4.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source4.sample_summary0354_count []
+opentelemetry.source4.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source4.sample_summary0354_sum []
+opentelemetry.source4.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source4.sample_summary0376 []
+opentelemetry.source4.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -19411,13 +19411,13 @@ opentelemetry.source4.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source4.sample_summary0376_count []
+opentelemetry.source4.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source4.sample_summary0376_sum []
+opentelemetry.source4.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source4.sample_summary0398 []
+opentelemetry.source4.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012450594
     inst [2 or "quantile: 0.5"] value 0.024901188
@@ -19429,13 +19429,13 @@ opentelemetry.source4.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.099604752
     inst [9 or "quantile: 2.25"] value 0.112055346
 
-opentelemetry.source4.sample_summary0398_count []
+opentelemetry.source4.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 141804
 
-opentelemetry.source4.sample_summary0398_sum []
+opentelemetry.source4.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 108.514128
 
-opentelemetry.source4.sample_counter0001 []
+opentelemetry.source4.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1531848550
     inst [2 or "2 inst-2"] value 3063697090
@@ -19447,7 +19447,7 @@ opentelemetry.source4.sample_counter0001 []
     inst [8 or "8 inst-8"] value 12254788400
     inst [9 or "9 inst-9"] value 13786636900
 
-opentelemetry.source4.sample_counter0023 []
+opentelemetry.source4.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -19459,7 +19459,7 @@ opentelemetry.source4.sample_counter0023 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source4.sample_counter0045 []
+opentelemetry.source4.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -19471,7 +19471,7 @@ opentelemetry.source4.sample_counter0045 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source4.sample_counter0067 []
+opentelemetry.source4.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -19483,7 +19483,7 @@ opentelemetry.source4.sample_counter0067 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source4.sample_counter0089 []
+opentelemetry.source4.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -19495,7 +19495,7 @@ opentelemetry.source4.sample_counter0089 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source4.sample_counter0111 []
+opentelemetry.source4.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -19507,7 +19507,7 @@ opentelemetry.source4.sample_counter0111 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source4.sample_counter0133 []
+opentelemetry.source4.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -19519,7 +19519,7 @@ opentelemetry.source4.sample_counter0133 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source4.sample_counter0155 []
+opentelemetry.source4.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -19531,7 +19531,7 @@ opentelemetry.source4.sample_counter0155 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source4.sample_counter0177 []
+opentelemetry.source4.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -19543,7 +19543,7 @@ opentelemetry.source4.sample_counter0177 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source4.sample_counter0199 []
+opentelemetry.source4.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -19555,7 +19555,7 @@ opentelemetry.source4.sample_counter0199 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source4.sample_counter0221 []
+opentelemetry.source4.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -19567,7 +19567,7 @@ opentelemetry.source4.sample_counter0221 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source4.sample_counter0243 []
+opentelemetry.source4.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -19579,7 +19579,7 @@ opentelemetry.source4.sample_counter0243 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source4.sample_counter0265 []
+opentelemetry.source4.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -19591,7 +19591,7 @@ opentelemetry.source4.sample_counter0265 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source4.sample_counter0287 []
+opentelemetry.source4.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -19603,7 +19603,7 @@ opentelemetry.source4.sample_counter0287 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source4.sample_counter0309 []
+opentelemetry.source4.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -19615,7 +19615,7 @@ opentelemetry.source4.sample_counter0309 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source4.sample_counter0331 []
+opentelemetry.source4.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -19627,7 +19627,7 @@ opentelemetry.source4.sample_counter0331 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source4.sample_counter0353 []
+opentelemetry.source4.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -19639,7 +19639,7 @@ opentelemetry.source4.sample_counter0353 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source4.sample_counter0375 []
+opentelemetry.source4.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13105815300
     inst [2 or "2 inst-2"] value 26211630700
@@ -19651,7 +19651,7 @@ opentelemetry.source4.sample_counter0375 []
     inst [8 or "8 inst-8"] value 104846523000
     inst [9 or "9 inst-9"] value 117952338000
 
-opentelemetry.source4.sample_counter0397 []
+opentelemetry.source4.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13786636900
     inst [2 or "2 inst-2"] value 27573273800
@@ -19663,7 +19663,7 @@ opentelemetry.source4.sample_counter0397 []
     inst [8 or "8 inst-8"] value 110293095000
     inst [9 or "9 inst-9"] value 124079732000
 
-opentelemetry.source4.sample_gauge0000 []
+opentelemetry.source4.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 96.8
     inst [2 or "2 inst-2"] value 193.6
@@ -19675,7 +19675,7 @@ opentelemetry.source4.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 774.4
     inst [9 or "9 inst-9"] value 871.2
 
-opentelemetry.source4.sample_gauge0022 []
+opentelemetry.source4.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -19687,7 +19687,7 @@ opentelemetry.source4.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source4.sample_gauge0044 []
+opentelemetry.source4.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -19699,7 +19699,7 @@ opentelemetry.source4.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source4.sample_gauge0066 []
+opentelemetry.source4.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -19711,7 +19711,7 @@ opentelemetry.source4.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source4.sample_gauge0088 []
+opentelemetry.source4.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -19723,7 +19723,7 @@ opentelemetry.source4.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source4.sample_gauge0110 []
+opentelemetry.source4.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -19735,7 +19735,7 @@ opentelemetry.source4.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source4.sample_gauge0132 []
+opentelemetry.source4.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -19747,7 +19747,7 @@ opentelemetry.source4.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source4.sample_gauge0154 []
+opentelemetry.source4.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -19759,7 +19759,7 @@ opentelemetry.source4.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source4.sample_gauge0176 []
+opentelemetry.source4.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -19771,7 +19771,7 @@ opentelemetry.source4.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source4.sample_gauge0198 []
+opentelemetry.source4.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -19783,7 +19783,7 @@ opentelemetry.source4.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source4.sample_gauge0220 []
+opentelemetry.source4.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -19795,7 +19795,7 @@ opentelemetry.source4.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source4.sample_gauge0242 []
+opentelemetry.source4.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -19807,7 +19807,7 @@ opentelemetry.source4.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source4.sample_gauge0264 []
+opentelemetry.source4.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -19819,7 +19819,7 @@ opentelemetry.source4.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source4.sample_gauge0286 []
+opentelemetry.source4.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -19831,7 +19831,7 @@ opentelemetry.source4.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source4.sample_gauge0308 []
+opentelemetry.source4.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -19843,7 +19843,7 @@ opentelemetry.source4.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source4.sample_gauge0330 []
+opentelemetry.source4.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -19855,7 +19855,7 @@ opentelemetry.source4.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source4.sample_gauge0352 []
+opentelemetry.source4.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -19867,7 +19867,7 @@ opentelemetry.source4.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source4.sample_gauge0374 []
+opentelemetry.source4.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 919.6
     inst [2 or "2 inst-2"] value 1839.2
@@ -19879,7 +19879,7 @@ opentelemetry.source4.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 7356.8
     inst [9 or "9 inst-9"] value 8276.4
 
-opentelemetry.source4.sample_gauge0396 []
+opentelemetry.source4.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 968
     inst [2 or "2 inst-2"] value 1936
@@ -19891,7 +19891,7 @@ opentelemetry.source4.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 7744
     inst [9 or "9 inst-9"] value 8712
 
-opentelemetry.source4.sample_histogram0012 []
+opentelemetry.source4.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 65395
     inst [2 or "le=4"] value 130790
@@ -19904,13 +19904,13 @@ opentelemetry.source4.sample_histogram0012 []
     inst [9 or "le=18"] value 588555
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0012_count []
+opentelemetry.source4.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0012_sum []
+opentelemetry.source4.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0034 []
+opentelemetry.source4.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 89175
     inst [2 or "le=4"] value 178350
@@ -19923,13 +19923,13 @@ opentelemetry.source4.sample_histogram0034 []
     inst [9 or "le=18"] value 802575
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0034_count []
+opentelemetry.source4.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0034_sum []
+opentelemetry.source4.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0056 []
+opentelemetry.source4.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 112955
     inst [2 or "le=4"] value 225910
@@ -19942,13 +19942,13 @@ opentelemetry.source4.sample_histogram0056 []
     inst [9 or "le=18"] value 1016595
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0056_count []
+opentelemetry.source4.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0056_sum []
+opentelemetry.source4.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0078 []
+opentelemetry.source4.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 136735
     inst [2 or "le=4"] value 273470
@@ -19961,13 +19961,13 @@ opentelemetry.source4.sample_histogram0078 []
     inst [9 or "le=18"] value 1230615
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0078_count []
+opentelemetry.source4.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0078_sum []
+opentelemetry.source4.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0100 []
+opentelemetry.source4.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 160515
     inst [2 or "le=4"] value 321030
@@ -19980,13 +19980,13 @@ opentelemetry.source4.sample_histogram0100 []
     inst [9 or "le=18"] value 1444635
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0100_count []
+opentelemetry.source4.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0100_sum []
+opentelemetry.source4.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0122 []
+opentelemetry.source4.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 184295
     inst [2 or "le=4"] value 368590
@@ -19999,13 +19999,13 @@ opentelemetry.source4.sample_histogram0122 []
     inst [9 or "le=18"] value 1658655
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0122_count []
+opentelemetry.source4.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0122_sum []
+opentelemetry.source4.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0144 []
+opentelemetry.source4.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 208075
     inst [2 or "le=4"] value 416150
@@ -20018,13 +20018,13 @@ opentelemetry.source4.sample_histogram0144 []
     inst [9 or "le=18"] value 1872675
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0144_count []
+opentelemetry.source4.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0144_sum []
+opentelemetry.source4.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0166 []
+opentelemetry.source4.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 231855
     inst [2 or "le=4"] value 463710
@@ -20037,13 +20037,13 @@ opentelemetry.source4.sample_histogram0166 []
     inst [9 or "le=18"] value 2086695
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0166_count []
+opentelemetry.source4.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0166_sum []
+opentelemetry.source4.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0188 []
+opentelemetry.source4.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 255635
     inst [2 or "le=4"] value 511270
@@ -20056,13 +20056,13 @@ opentelemetry.source4.sample_histogram0188 []
     inst [9 or "le=18"] value 2300715
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0188_count []
+opentelemetry.source4.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0188_sum []
+opentelemetry.source4.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0210 []
+opentelemetry.source4.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 279415
     inst [2 or "le=4"] value 558830
@@ -20075,13 +20075,13 @@ opentelemetry.source4.sample_histogram0210 []
     inst [9 or "le=18"] value 2514735
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0210_count []
+opentelemetry.source4.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0210_sum []
+opentelemetry.source4.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0232 []
+opentelemetry.source4.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 303195
     inst [2 or "le=4"] value 606390
@@ -20094,13 +20094,13 @@ opentelemetry.source4.sample_histogram0232 []
     inst [9 or "le=18"] value 2728755
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0232_count []
+opentelemetry.source4.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0232_sum []
+opentelemetry.source4.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0254 []
+opentelemetry.source4.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 326975
     inst [2 or "le=4"] value 653950
@@ -20113,13 +20113,13 @@ opentelemetry.source4.sample_histogram0254 []
     inst [9 or "le=18"] value 2942775
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0254_count []
+opentelemetry.source4.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0254_sum []
+opentelemetry.source4.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0276 []
+opentelemetry.source4.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 350755
     inst [2 or "le=4"] value 701510
@@ -20132,13 +20132,13 @@ opentelemetry.source4.sample_histogram0276 []
     inst [9 or "le=18"] value 3156795
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0276_count []
+opentelemetry.source4.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0276_sum []
+opentelemetry.source4.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0298 []
+opentelemetry.source4.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 374535
     inst [2 or "le=4"] value 749070
@@ -20151,13 +20151,13 @@ opentelemetry.source4.sample_histogram0298 []
     inst [9 or "le=18"] value 3370815
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0298_count []
+opentelemetry.source4.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0298_sum []
+opentelemetry.source4.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0320 []
+opentelemetry.source4.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 398315
     inst [2 or "le=4"] value 796630
@@ -20170,13 +20170,13 @@ opentelemetry.source4.sample_histogram0320 []
     inst [9 or "le=18"] value 3584835
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0320_count []
+opentelemetry.source4.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0320_sum []
+opentelemetry.source4.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0342 []
+opentelemetry.source4.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 422095
     inst [2 or "le=4"] value 844190
@@ -20189,13 +20189,13 @@ opentelemetry.source4.sample_histogram0342 []
     inst [9 or "le=18"] value 3798855
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0342_count []
+opentelemetry.source4.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0342_sum []
+opentelemetry.source4.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0364 []
+opentelemetry.source4.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 445875
     inst [2 or "le=4"] value 891750
@@ -20208,13 +20208,13 @@ opentelemetry.source4.sample_histogram0364 []
     inst [9 or "le=18"] value 4012875
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0364_count []
+opentelemetry.source4.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0364_sum []
+opentelemetry.source4.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0386 []
+opentelemetry.source4.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 469655
     inst [2 or "le=4"] value 939310
@@ -20227,13 +20227,13 @@ opentelemetry.source4.sample_histogram0386 []
     inst [9 or "le=18"] value 4226895
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0386_count []
+opentelemetry.source4.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0386_sum []
+opentelemetry.source4.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_summary0002 []
+opentelemetry.source4.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00159623
     inst [2 or "quantile: 0.5"] value 0.00319246
@@ -20245,13 +20245,13 @@ opentelemetry.source4.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.01276984
     inst [9 or "quantile: 2.25"] value 0.01436607
 
-opentelemetry.source4.sample_summary0002_count []
+opentelemetry.source4.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 18180
 
-opentelemetry.source4.sample_summary0002_sum []
+opentelemetry.source4.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 13.912068
 
-opentelemetry.source4.sample_summary0024 []
+opentelemetry.source4.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -20263,13 +20263,13 @@ opentelemetry.source4.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source4.sample_summary0024_count []
+opentelemetry.source4.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source4.sample_summary0024_sum []
+opentelemetry.source4.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source4.sample_summary0046 []
+opentelemetry.source4.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -20281,13 +20281,13 @@ opentelemetry.source4.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source4.sample_summary0046_count []
+opentelemetry.source4.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source4.sample_summary0046_sum []
+opentelemetry.source4.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source4.sample_summary0068 []
+opentelemetry.source4.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -20299,13 +20299,13 @@ opentelemetry.source4.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source4.sample_summary0068_count []
+opentelemetry.source4.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source4.sample_summary0068_sum []
+opentelemetry.source4.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source4.sample_summary0090 []
+opentelemetry.source4.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -20317,13 +20317,13 @@ opentelemetry.source4.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source4.sample_summary0090_count []
+opentelemetry.source4.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source4.sample_summary0090_sum []
+opentelemetry.source4.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source4.sample_summary0112 []
+opentelemetry.source4.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -20335,13 +20335,13 @@ opentelemetry.source4.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source4.sample_summary0112_count []
+opentelemetry.source4.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source4.sample_summary0112_sum []
+opentelemetry.source4.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source4.sample_summary0134 []
+opentelemetry.source4.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -20353,13 +20353,13 @@ opentelemetry.source4.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source4.sample_summary0134_count []
+opentelemetry.source4.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source4.sample_summary0134_sum []
+opentelemetry.source4.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source4.sample_summary0156 []
+opentelemetry.source4.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -20371,13 +20371,13 @@ opentelemetry.source4.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source4.sample_summary0156_count []
+opentelemetry.source4.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source4.sample_summary0156_sum []
+opentelemetry.source4.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source4.sample_summary0178 []
+opentelemetry.source4.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -20389,13 +20389,13 @@ opentelemetry.source4.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source4.sample_summary0178_count []
+opentelemetry.source4.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source4.sample_summary0178_sum []
+opentelemetry.source4.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source4.sample_summary0200 []
+opentelemetry.source4.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -20407,13 +20407,13 @@ opentelemetry.source4.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source4.sample_summary0200_count []
+opentelemetry.source4.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source4.sample_summary0200_sum []
+opentelemetry.source4.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source4.sample_summary0222 []
+opentelemetry.source4.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -20425,13 +20425,13 @@ opentelemetry.source4.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source4.sample_summary0222_count []
+opentelemetry.source4.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source4.sample_summary0222_sum []
+opentelemetry.source4.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source4.sample_summary0244 []
+opentelemetry.source4.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -20443,13 +20443,13 @@ opentelemetry.source4.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source4.sample_summary0244_count []
+opentelemetry.source4.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source4.sample_summary0244_sum []
+opentelemetry.source4.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source4.sample_summary0266 []
+opentelemetry.source4.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -20461,13 +20461,13 @@ opentelemetry.source4.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source4.sample_summary0266_count []
+opentelemetry.source4.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source4.sample_summary0266_sum []
+opentelemetry.source4.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source4.sample_summary0288 []
+opentelemetry.source4.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -20479,13 +20479,13 @@ opentelemetry.source4.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source4.sample_summary0288_count []
+opentelemetry.source4.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source4.sample_summary0288_sum []
+opentelemetry.source4.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source4.sample_summary0310 []
+opentelemetry.source4.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -20497,13 +20497,13 @@ opentelemetry.source4.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source4.sample_summary0310_count []
+opentelemetry.source4.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source4.sample_summary0310_sum []
+opentelemetry.source4.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source4.sample_summary0332 []
+opentelemetry.source4.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -20515,13 +20515,13 @@ opentelemetry.source4.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source4.sample_summary0332_count []
+opentelemetry.source4.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source4.sample_summary0332_sum []
+opentelemetry.source4.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source4.sample_summary0354 []
+opentelemetry.source4.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -20533,13 +20533,13 @@ opentelemetry.source4.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source4.sample_summary0354_count []
+opentelemetry.source4.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source4.sample_summary0354_sum []
+opentelemetry.source4.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source4.sample_summary0376 []
+opentelemetry.source4.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012450594
     inst [2 or "quantile: 0.5"] value 0.024901188
@@ -20551,13 +20551,13 @@ opentelemetry.source4.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.099604752
     inst [9 or "quantile: 2.25"] value 0.112055346
 
-opentelemetry.source4.sample_summary0376_count []
+opentelemetry.source4.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 141804
 
-opentelemetry.source4.sample_summary0376_sum []
+opentelemetry.source4.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 108.514128
 
-opentelemetry.source4.sample_summary0398 []
+opentelemetry.source4.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013089086
     inst [2 or "quantile: 0.5"] value 0.026178172
@@ -20569,13 +20569,13 @@ opentelemetry.source4.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.104712688
     inst [9 or "quantile: 2.25"] value 0.117801774
 
-opentelemetry.source4.sample_summary0398_count []
+opentelemetry.source4.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 149076
 
-opentelemetry.source4.sample_summary0398_sum []
+opentelemetry.source4.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 114.078955
 
-opentelemetry.source4.sample_counter0001 []
+opentelemetry.source4.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -20587,7 +20587,7 @@ opentelemetry.source4.sample_counter0001 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source4.sample_counter0023 []
+opentelemetry.source4.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -20599,7 +20599,7 @@ opentelemetry.source4.sample_counter0023 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source4.sample_counter0045 []
+opentelemetry.source4.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -20611,7 +20611,7 @@ opentelemetry.source4.sample_counter0045 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source4.sample_counter0067 []
+opentelemetry.source4.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -20623,7 +20623,7 @@ opentelemetry.source4.sample_counter0067 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source4.sample_counter0089 []
+opentelemetry.source4.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -20635,7 +20635,7 @@ opentelemetry.source4.sample_counter0089 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source4.sample_counter0111 []
+opentelemetry.source4.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -20647,7 +20647,7 @@ opentelemetry.source4.sample_counter0111 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source4.sample_counter0133 []
+opentelemetry.source4.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -20659,7 +20659,7 @@ opentelemetry.source4.sample_counter0133 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source4.sample_counter0155 []
+opentelemetry.source4.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -20671,7 +20671,7 @@ opentelemetry.source4.sample_counter0155 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source4.sample_counter0177 []
+opentelemetry.source4.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -20683,7 +20683,7 @@ opentelemetry.source4.sample_counter0177 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source4.sample_counter0199 []
+opentelemetry.source4.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -20695,7 +20695,7 @@ opentelemetry.source4.sample_counter0199 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source4.sample_counter0221 []
+opentelemetry.source4.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -20707,7 +20707,7 @@ opentelemetry.source4.sample_counter0221 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source4.sample_counter0243 []
+opentelemetry.source4.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -20719,7 +20719,7 @@ opentelemetry.source4.sample_counter0243 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source4.sample_counter0265 []
+opentelemetry.source4.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -20731,7 +20731,7 @@ opentelemetry.source4.sample_counter0265 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source4.sample_counter0287 []
+opentelemetry.source4.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -20743,7 +20743,7 @@ opentelemetry.source4.sample_counter0287 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source4.sample_counter0309 []
+opentelemetry.source4.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -20755,7 +20755,7 @@ opentelemetry.source4.sample_counter0309 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source4.sample_counter0331 []
+opentelemetry.source4.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -20767,7 +20767,7 @@ opentelemetry.source4.sample_counter0331 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source4.sample_counter0353 []
+opentelemetry.source4.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13105815300
     inst [2 or "2 inst-2"] value 26211630700
@@ -20779,7 +20779,7 @@ opentelemetry.source4.sample_counter0353 []
     inst [8 or "8 inst-8"] value 104846523000
     inst [9 or "9 inst-9"] value 117952338000
 
-opentelemetry.source4.sample_counter0375 []
+opentelemetry.source4.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13786636900
     inst [2 or "2 inst-2"] value 27573273800
@@ -20791,7 +20791,7 @@ opentelemetry.source4.sample_counter0375 []
     inst [8 or "8 inst-8"] value 110293095000
     inst [9 or "9 inst-9"] value 124079732000
 
-opentelemetry.source4.sample_counter0397 []
+opentelemetry.source4.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14467458500
     inst [2 or "2 inst-2"] value 28934917000
@@ -20803,7 +20803,7 @@ opentelemetry.source4.sample_counter0397 []
     inst [8 or "8 inst-8"] value 115739668000
     inst [9 or "9 inst-9"] value 130207126000
 
-opentelemetry.source4.sample_gauge0000 []
+opentelemetry.source4.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -20815,7 +20815,7 @@ opentelemetry.source4.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source4.sample_gauge0022 []
+opentelemetry.source4.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -20827,7 +20827,7 @@ opentelemetry.source4.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source4.sample_gauge0044 []
+opentelemetry.source4.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -20839,7 +20839,7 @@ opentelemetry.source4.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source4.sample_gauge0066 []
+opentelemetry.source4.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -20851,7 +20851,7 @@ opentelemetry.source4.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source4.sample_gauge0088 []
+opentelemetry.source4.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -20863,7 +20863,7 @@ opentelemetry.source4.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source4.sample_gauge0110 []
+opentelemetry.source4.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -20875,7 +20875,7 @@ opentelemetry.source4.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source4.sample_gauge0132 []
+opentelemetry.source4.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -20887,7 +20887,7 @@ opentelemetry.source4.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source4.sample_gauge0154 []
+opentelemetry.source4.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -20899,7 +20899,7 @@ opentelemetry.source4.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source4.sample_gauge0176 []
+opentelemetry.source4.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -20911,7 +20911,7 @@ opentelemetry.source4.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source4.sample_gauge0198 []
+opentelemetry.source4.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -20923,7 +20923,7 @@ opentelemetry.source4.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source4.sample_gauge0220 []
+opentelemetry.source4.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -20935,7 +20935,7 @@ opentelemetry.source4.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source4.sample_gauge0242 []
+opentelemetry.source4.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -20947,7 +20947,7 @@ opentelemetry.source4.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source4.sample_gauge0264 []
+opentelemetry.source4.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -20959,7 +20959,7 @@ opentelemetry.source4.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source4.sample_gauge0286 []
+opentelemetry.source4.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -20971,7 +20971,7 @@ opentelemetry.source4.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source4.sample_gauge0308 []
+opentelemetry.source4.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -20983,7 +20983,7 @@ opentelemetry.source4.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source4.sample_gauge0330 []
+opentelemetry.source4.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -20995,7 +20995,7 @@ opentelemetry.source4.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source4.sample_gauge0352 []
+opentelemetry.source4.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 919.6
     inst [2 or "2 inst-2"] value 1839.2
@@ -21007,7 +21007,7 @@ opentelemetry.source4.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 7356.8
     inst [9 or "9 inst-9"] value 8276.4
 
-opentelemetry.source4.sample_gauge0374 []
+opentelemetry.source4.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 968
     inst [2 or "2 inst-2"] value 1936
@@ -21019,7 +21019,7 @@ opentelemetry.source4.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 7744
     inst [9 or "9 inst-9"] value 8712
 
-opentelemetry.source4.sample_gauge0396 []
+opentelemetry.source4.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1016.4
     inst [2 or "2 inst-2"] value 2032.8
@@ -21031,7 +21031,7 @@ opentelemetry.source4.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 8131.2
     inst [9 or "9 inst-9"] value 9147.6
 
-opentelemetry.source4.sample_histogram0012 []
+opentelemetry.source4.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 89175
     inst [2 or "le=4"] value 178350
@@ -21044,13 +21044,13 @@ opentelemetry.source4.sample_histogram0012 []
     inst [9 or "le=18"] value 802575
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0012_count []
+opentelemetry.source4.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0012_sum []
+opentelemetry.source4.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0034 []
+opentelemetry.source4.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 112955
     inst [2 or "le=4"] value 225910
@@ -21063,13 +21063,13 @@ opentelemetry.source4.sample_histogram0034 []
     inst [9 or "le=18"] value 1016595
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0034_count []
+opentelemetry.source4.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0034_sum []
+opentelemetry.source4.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0056 []
+opentelemetry.source4.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 136735
     inst [2 or "le=4"] value 273470
@@ -21082,13 +21082,13 @@ opentelemetry.source4.sample_histogram0056 []
     inst [9 or "le=18"] value 1230615
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0056_count []
+opentelemetry.source4.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0056_sum []
+opentelemetry.source4.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0078 []
+opentelemetry.source4.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 160515
     inst [2 or "le=4"] value 321030
@@ -21101,13 +21101,13 @@ opentelemetry.source4.sample_histogram0078 []
     inst [9 or "le=18"] value 1444635
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0078_count []
+opentelemetry.source4.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0078_sum []
+opentelemetry.source4.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0100 []
+opentelemetry.source4.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 184295
     inst [2 or "le=4"] value 368590
@@ -21120,13 +21120,13 @@ opentelemetry.source4.sample_histogram0100 []
     inst [9 or "le=18"] value 1658655
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0100_count []
+opentelemetry.source4.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0100_sum []
+opentelemetry.source4.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0122 []
+opentelemetry.source4.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 208075
     inst [2 or "le=4"] value 416150
@@ -21139,13 +21139,13 @@ opentelemetry.source4.sample_histogram0122 []
     inst [9 or "le=18"] value 1872675
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0122_count []
+opentelemetry.source4.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0122_sum []
+opentelemetry.source4.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0144 []
+opentelemetry.source4.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 231855
     inst [2 or "le=4"] value 463710
@@ -21158,13 +21158,13 @@ opentelemetry.source4.sample_histogram0144 []
     inst [9 or "le=18"] value 2086695
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0144_count []
+opentelemetry.source4.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0144_sum []
+opentelemetry.source4.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0166 []
+opentelemetry.source4.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 255635
     inst [2 or "le=4"] value 511270
@@ -21177,13 +21177,13 @@ opentelemetry.source4.sample_histogram0166 []
     inst [9 or "le=18"] value 2300715
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0166_count []
+opentelemetry.source4.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0166_sum []
+opentelemetry.source4.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0188 []
+opentelemetry.source4.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 279415
     inst [2 or "le=4"] value 558830
@@ -21196,13 +21196,13 @@ opentelemetry.source4.sample_histogram0188 []
     inst [9 or "le=18"] value 2514735
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0188_count []
+opentelemetry.source4.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0188_sum []
+opentelemetry.source4.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0210 []
+opentelemetry.source4.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 303195
     inst [2 or "le=4"] value 606390
@@ -21215,13 +21215,13 @@ opentelemetry.source4.sample_histogram0210 []
     inst [9 or "le=18"] value 2728755
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0210_count []
+opentelemetry.source4.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0210_sum []
+opentelemetry.source4.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0232 []
+opentelemetry.source4.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 326975
     inst [2 or "le=4"] value 653950
@@ -21234,13 +21234,13 @@ opentelemetry.source4.sample_histogram0232 []
     inst [9 or "le=18"] value 2942775
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0232_count []
+opentelemetry.source4.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0232_sum []
+opentelemetry.source4.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0254 []
+opentelemetry.source4.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 350755
     inst [2 or "le=4"] value 701510
@@ -21253,13 +21253,13 @@ opentelemetry.source4.sample_histogram0254 []
     inst [9 or "le=18"] value 3156795
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0254_count []
+opentelemetry.source4.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0254_sum []
+opentelemetry.source4.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0276 []
+opentelemetry.source4.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 374535
     inst [2 or "le=4"] value 749070
@@ -21272,13 +21272,13 @@ opentelemetry.source4.sample_histogram0276 []
     inst [9 or "le=18"] value 3370815
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0276_count []
+opentelemetry.source4.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0276_sum []
+opentelemetry.source4.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0298 []
+opentelemetry.source4.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 398315
     inst [2 or "le=4"] value 796630
@@ -21291,13 +21291,13 @@ opentelemetry.source4.sample_histogram0298 []
     inst [9 or "le=18"] value 3584835
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0298_count []
+opentelemetry.source4.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0298_sum []
+opentelemetry.source4.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0320 []
+opentelemetry.source4.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 422095
     inst [2 or "le=4"] value 844190
@@ -21310,13 +21310,13 @@ opentelemetry.source4.sample_histogram0320 []
     inst [9 or "le=18"] value 3798855
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0320_count []
+opentelemetry.source4.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0320_sum []
+opentelemetry.source4.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0342 []
+opentelemetry.source4.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 445875
     inst [2 or "le=4"] value 891750
@@ -21329,13 +21329,13 @@ opentelemetry.source4.sample_histogram0342 []
     inst [9 or "le=18"] value 4012875
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0342_count []
+opentelemetry.source4.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0342_sum []
+opentelemetry.source4.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0364 []
+opentelemetry.source4.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 469655
     inst [2 or "le=4"] value 939310
@@ -21348,13 +21348,13 @@ opentelemetry.source4.sample_histogram0364 []
     inst [9 or "le=18"] value 4226895
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0364_count []
+opentelemetry.source4.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0364_sum []
+opentelemetry.source4.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0386 []
+opentelemetry.source4.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 493435
     inst [2 or "le=4"] value 986870
@@ -21367,13 +21367,13 @@ opentelemetry.source4.sample_histogram0386 []
     inst [9 or "le=18"] value 4440915
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0386_count []
+opentelemetry.source4.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0386_sum []
+opentelemetry.source4.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_summary0002 []
+opentelemetry.source4.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -21385,13 +21385,13 @@ opentelemetry.source4.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source4.sample_summary0002_count []
+opentelemetry.source4.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source4.sample_summary0002_sum []
+opentelemetry.source4.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source4.sample_summary0024 []
+opentelemetry.source4.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -21403,13 +21403,13 @@ opentelemetry.source4.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source4.sample_summary0024_count []
+opentelemetry.source4.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source4.sample_summary0024_sum []
+opentelemetry.source4.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source4.sample_summary0046 []
+opentelemetry.source4.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -21421,13 +21421,13 @@ opentelemetry.source4.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source4.sample_summary0046_count []
+opentelemetry.source4.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source4.sample_summary0046_sum []
+opentelemetry.source4.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source4.sample_summary0068 []
+opentelemetry.source4.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -21439,13 +21439,13 @@ opentelemetry.source4.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source4.sample_summary0068_count []
+opentelemetry.source4.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source4.sample_summary0068_sum []
+opentelemetry.source4.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source4.sample_summary0090 []
+opentelemetry.source4.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -21457,13 +21457,13 @@ opentelemetry.source4.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source4.sample_summary0090_count []
+opentelemetry.source4.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source4.sample_summary0090_sum []
+opentelemetry.source4.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source4.sample_summary0112 []
+opentelemetry.source4.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -21475,13 +21475,13 @@ opentelemetry.source4.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source4.sample_summary0112_count []
+opentelemetry.source4.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source4.sample_summary0112_sum []
+opentelemetry.source4.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source4.sample_summary0134 []
+opentelemetry.source4.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -21493,13 +21493,13 @@ opentelemetry.source4.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source4.sample_summary0134_count []
+opentelemetry.source4.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source4.sample_summary0134_sum []
+opentelemetry.source4.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source4.sample_summary0156 []
+opentelemetry.source4.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -21511,13 +21511,13 @@ opentelemetry.source4.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source4.sample_summary0156_count []
+opentelemetry.source4.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source4.sample_summary0156_sum []
+opentelemetry.source4.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source4.sample_summary0178 []
+opentelemetry.source4.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -21529,13 +21529,13 @@ opentelemetry.source4.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source4.sample_summary0178_count []
+opentelemetry.source4.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source4.sample_summary0178_sum []
+opentelemetry.source4.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source4.sample_summary0200 []
+opentelemetry.source4.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -21547,13 +21547,13 @@ opentelemetry.source4.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source4.sample_summary0200_count []
+opentelemetry.source4.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source4.sample_summary0200_sum []
+opentelemetry.source4.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source4.sample_summary0222 []
+opentelemetry.source4.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -21565,13 +21565,13 @@ opentelemetry.source4.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source4.sample_summary0222_count []
+opentelemetry.source4.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source4.sample_summary0222_sum []
+opentelemetry.source4.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source4.sample_summary0244 []
+opentelemetry.source4.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -21583,13 +21583,13 @@ opentelemetry.source4.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source4.sample_summary0244_count []
+opentelemetry.source4.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source4.sample_summary0244_sum []
+opentelemetry.source4.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source4.sample_summary0266 []
+opentelemetry.source4.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -21601,13 +21601,13 @@ opentelemetry.source4.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source4.sample_summary0266_count []
+opentelemetry.source4.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source4.sample_summary0266_sum []
+opentelemetry.source4.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source4.sample_summary0288 []
+opentelemetry.source4.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -21619,13 +21619,13 @@ opentelemetry.source4.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source4.sample_summary0288_count []
+opentelemetry.source4.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source4.sample_summary0288_sum []
+opentelemetry.source4.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source4.sample_summary0310 []
+opentelemetry.source4.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -21637,13 +21637,13 @@ opentelemetry.source4.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source4.sample_summary0310_count []
+opentelemetry.source4.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source4.sample_summary0310_sum []
+opentelemetry.source4.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source4.sample_summary0332 []
+opentelemetry.source4.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -21655,13 +21655,13 @@ opentelemetry.source4.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source4.sample_summary0332_count []
+opentelemetry.source4.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source4.sample_summary0332_sum []
+opentelemetry.source4.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source4.sample_summary0354 []
+opentelemetry.source4.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012450594
     inst [2 or "quantile: 0.5"] value 0.024901188
@@ -21673,13 +21673,13 @@ opentelemetry.source4.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.099604752
     inst [9 or "quantile: 2.25"] value 0.112055346
 
-opentelemetry.source4.sample_summary0354_count []
+opentelemetry.source4.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 141804
 
-opentelemetry.source4.sample_summary0354_sum []
+opentelemetry.source4.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 108.514128
 
-opentelemetry.source4.sample_summary0376 []
+opentelemetry.source4.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013089086
     inst [2 or "quantile: 0.5"] value 0.026178172
@@ -21691,13 +21691,13 @@ opentelemetry.source4.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.104712688
     inst [9 or "quantile: 2.25"] value 0.117801774
 
-opentelemetry.source4.sample_summary0376_count []
+opentelemetry.source4.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 149076
 
-opentelemetry.source4.sample_summary0376_sum []
+opentelemetry.source4.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 114.078955
 
-opentelemetry.source4.sample_summary0398 []
+opentelemetry.source4.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013727578
     inst [2 or "quantile: 0.5"] value 0.027455156
@@ -21709,13 +21709,13 @@ opentelemetry.source4.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.109820624
     inst [9 or "quantile: 2.25"] value 0.123548202
 
-opentelemetry.source4.sample_summary0398_count []
+opentelemetry.source4.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 156348
 
-opentelemetry.source4.sample_summary0398_sum []
+opentelemetry.source4.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 119.643782
 
-opentelemetry.source4.sample_counter0001 []
+opentelemetry.source4.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -21727,7 +21727,7 @@ opentelemetry.source4.sample_counter0001 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source4.sample_counter0023 []
+opentelemetry.source4.sample_counter0023 [sample_counter0023 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -21739,7 +21739,7 @@ opentelemetry.source4.sample_counter0023 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source4.sample_counter0045 []
+opentelemetry.source4.sample_counter0045 [sample_counter0045 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -21751,7 +21751,7 @@ opentelemetry.source4.sample_counter0045 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source4.sample_counter0067 []
+opentelemetry.source4.sample_counter0067 [sample_counter0067 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -21763,7 +21763,7 @@ opentelemetry.source4.sample_counter0067 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source4.sample_counter0089 []
+opentelemetry.source4.sample_counter0089 [sample_counter0089 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -21775,7 +21775,7 @@ opentelemetry.source4.sample_counter0089 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source4.sample_counter0111 []
+opentelemetry.source4.sample_counter0111 [sample_counter0111 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -21787,7 +21787,7 @@ opentelemetry.source4.sample_counter0111 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source4.sample_counter0133 []
+opentelemetry.source4.sample_counter0133 [sample_counter0133 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -21799,7 +21799,7 @@ opentelemetry.source4.sample_counter0133 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source4.sample_counter0155 []
+opentelemetry.source4.sample_counter0155 [sample_counter0155 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -21811,7 +21811,7 @@ opentelemetry.source4.sample_counter0155 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source4.sample_counter0177 []
+opentelemetry.source4.sample_counter0177 [sample_counter0177 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -21823,7 +21823,7 @@ opentelemetry.source4.sample_counter0177 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source4.sample_counter0199 []
+opentelemetry.source4.sample_counter0199 [sample_counter0199 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -21835,7 +21835,7 @@ opentelemetry.source4.sample_counter0199 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source4.sample_counter0221 []
+opentelemetry.source4.sample_counter0221 [sample_counter0221 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -21847,7 +21847,7 @@ opentelemetry.source4.sample_counter0221 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source4.sample_counter0243 []
+opentelemetry.source4.sample_counter0243 [sample_counter0243 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -21859,7 +21859,7 @@ opentelemetry.source4.sample_counter0243 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source4.sample_counter0265 []
+opentelemetry.source4.sample_counter0265 [sample_counter0265 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -21871,7 +21871,7 @@ opentelemetry.source4.sample_counter0265 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source4.sample_counter0287 []
+opentelemetry.source4.sample_counter0287 [sample_counter0287 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -21883,7 +21883,7 @@ opentelemetry.source4.sample_counter0287 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source4.sample_counter0309 []
+opentelemetry.source4.sample_counter0309 [sample_counter0309 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -21895,7 +21895,7 @@ opentelemetry.source4.sample_counter0309 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source4.sample_counter0331 []
+opentelemetry.source4.sample_counter0331 [sample_counter0331 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13105815300
     inst [2 or "2 inst-2"] value 26211630700
@@ -21907,7 +21907,7 @@ opentelemetry.source4.sample_counter0331 []
     inst [8 or "8 inst-8"] value 104846523000
     inst [9 or "9 inst-9"] value 117952338000
 
-opentelemetry.source4.sample_counter0353 []
+opentelemetry.source4.sample_counter0353 [sample_counter0353 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13786636900
     inst [2 or "2 inst-2"] value 27573273800
@@ -21919,7 +21919,7 @@ opentelemetry.source4.sample_counter0353 []
     inst [8 or "8 inst-8"] value 110293095000
     inst [9 or "9 inst-9"] value 124079732000
 
-opentelemetry.source4.sample_counter0375 []
+opentelemetry.source4.sample_counter0375 [sample_counter0375 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14467458500
     inst [2 or "2 inst-2"] value 28934917000
@@ -21931,7 +21931,7 @@ opentelemetry.source4.sample_counter0375 []
     inst [8 or "8 inst-8"] value 115739668000
     inst [9 or "9 inst-9"] value 130207126000
 
-opentelemetry.source4.sample_counter0397 []
+opentelemetry.source4.sample_counter0397 [sample_counter0397 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 15148280100
     inst [2 or "2 inst-2"] value 30296560100
@@ -21943,7 +21943,7 @@ opentelemetry.source4.sample_counter0397 []
     inst [8 or "8 inst-8"] value 121186241000
     inst [9 or "9 inst-9"] value 136334521000
 
-opentelemetry.source4.sample_gauge0000 []
+opentelemetry.source4.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -21955,7 +21955,7 @@ opentelemetry.source4.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source4.sample_gauge0022 []
+opentelemetry.source4.sample_gauge0022 [sample_gauge0022 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -21967,7 +21967,7 @@ opentelemetry.source4.sample_gauge0022 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source4.sample_gauge0044 []
+opentelemetry.source4.sample_gauge0044 [sample_gauge0044 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -21979,7 +21979,7 @@ opentelemetry.source4.sample_gauge0044 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source4.sample_gauge0066 []
+opentelemetry.source4.sample_gauge0066 [sample_gauge0066 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -21991,7 +21991,7 @@ opentelemetry.source4.sample_gauge0066 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source4.sample_gauge0088 []
+opentelemetry.source4.sample_gauge0088 [sample_gauge0088 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -22003,7 +22003,7 @@ opentelemetry.source4.sample_gauge0088 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source4.sample_gauge0110 []
+opentelemetry.source4.sample_gauge0110 [sample_gauge0110 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -22015,7 +22015,7 @@ opentelemetry.source4.sample_gauge0110 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source4.sample_gauge0132 []
+opentelemetry.source4.sample_gauge0132 [sample_gauge0132 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -22027,7 +22027,7 @@ opentelemetry.source4.sample_gauge0132 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source4.sample_gauge0154 []
+opentelemetry.source4.sample_gauge0154 [sample_gauge0154 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -22039,7 +22039,7 @@ opentelemetry.source4.sample_gauge0154 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source4.sample_gauge0176 []
+opentelemetry.source4.sample_gauge0176 [sample_gauge0176 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -22051,7 +22051,7 @@ opentelemetry.source4.sample_gauge0176 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source4.sample_gauge0198 []
+opentelemetry.source4.sample_gauge0198 [sample_gauge0198 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -22063,7 +22063,7 @@ opentelemetry.source4.sample_gauge0198 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source4.sample_gauge0220 []
+opentelemetry.source4.sample_gauge0220 [sample_gauge0220 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -22075,7 +22075,7 @@ opentelemetry.source4.sample_gauge0220 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source4.sample_gauge0242 []
+opentelemetry.source4.sample_gauge0242 [sample_gauge0242 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -22087,7 +22087,7 @@ opentelemetry.source4.sample_gauge0242 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source4.sample_gauge0264 []
+opentelemetry.source4.sample_gauge0264 [sample_gauge0264 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -22099,7 +22099,7 @@ opentelemetry.source4.sample_gauge0264 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source4.sample_gauge0286 []
+opentelemetry.source4.sample_gauge0286 [sample_gauge0286 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -22111,7 +22111,7 @@ opentelemetry.source4.sample_gauge0286 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source4.sample_gauge0308 []
+opentelemetry.source4.sample_gauge0308 [sample_gauge0308 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -22123,7 +22123,7 @@ opentelemetry.source4.sample_gauge0308 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source4.sample_gauge0330 []
+opentelemetry.source4.sample_gauge0330 [sample_gauge0330 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 919.6
     inst [2 or "2 inst-2"] value 1839.2
@@ -22135,7 +22135,7 @@ opentelemetry.source4.sample_gauge0330 []
     inst [8 or "8 inst-8"] value 7356.8
     inst [9 or "9 inst-9"] value 8276.4
 
-opentelemetry.source4.sample_gauge0352 []
+opentelemetry.source4.sample_gauge0352 [sample_gauge0352 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 968
     inst [2 or "2 inst-2"] value 1936
@@ -22147,7 +22147,7 @@ opentelemetry.source4.sample_gauge0352 []
     inst [8 or "8 inst-8"] value 7744
     inst [9 or "9 inst-9"] value 8712
 
-opentelemetry.source4.sample_gauge0374 []
+opentelemetry.source4.sample_gauge0374 [sample_gauge0374 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1016.4
     inst [2 or "2 inst-2"] value 2032.8
@@ -22159,7 +22159,7 @@ opentelemetry.source4.sample_gauge0374 []
     inst [8 or "8 inst-8"] value 8131.2
     inst [9 or "9 inst-9"] value 9147.6
 
-opentelemetry.source4.sample_gauge0396 []
+opentelemetry.source4.sample_gauge0396 [sample_gauge0396 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1064.8
     inst [2 or "2 inst-2"] value 2129.6
@@ -22171,7 +22171,7 @@ opentelemetry.source4.sample_gauge0396 []
     inst [8 or "8 inst-8"] value 8518.4
     inst [9 or "9 inst-9"] value 9583.200000000001
 
-opentelemetry.source4.sample_histogram0012 []
+opentelemetry.source4.sample_histogram0012 [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 112955
     inst [2 or "le=4"] value 225910
@@ -22184,13 +22184,13 @@ opentelemetry.source4.sample_histogram0012 []
     inst [9 or "le=18"] value 1016595
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0012_count []
+opentelemetry.source4.sample_histogram0012_count [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0012_sum []
+opentelemetry.source4.sample_histogram0012_sum [sample_histogram0012 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0034 []
+opentelemetry.source4.sample_histogram0034 [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 136735
     inst [2 or "le=4"] value 273470
@@ -22203,13 +22203,13 @@ opentelemetry.source4.sample_histogram0034 []
     inst [9 or "le=18"] value 1230615
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0034_count []
+opentelemetry.source4.sample_histogram0034_count [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0034_sum []
+opentelemetry.source4.sample_histogram0034_sum [sample_histogram0034 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0056 []
+opentelemetry.source4.sample_histogram0056 [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 160515
     inst [2 or "le=4"] value 321030
@@ -22222,13 +22222,13 @@ opentelemetry.source4.sample_histogram0056 []
     inst [9 or "le=18"] value 1444635
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0056_count []
+opentelemetry.source4.sample_histogram0056_count [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0056_sum []
+opentelemetry.source4.sample_histogram0056_sum [sample_histogram0056 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0078 []
+opentelemetry.source4.sample_histogram0078 [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 184295
     inst [2 or "le=4"] value 368590
@@ -22241,13 +22241,13 @@ opentelemetry.source4.sample_histogram0078 []
     inst [9 or "le=18"] value 1658655
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0078_count []
+opentelemetry.source4.sample_histogram0078_count [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0078_sum []
+opentelemetry.source4.sample_histogram0078_sum [sample_histogram0078 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0100 []
+opentelemetry.source4.sample_histogram0100 [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 208075
     inst [2 or "le=4"] value 416150
@@ -22260,13 +22260,13 @@ opentelemetry.source4.sample_histogram0100 []
     inst [9 or "le=18"] value 1872675
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0100_count []
+opentelemetry.source4.sample_histogram0100_count [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0100_sum []
+opentelemetry.source4.sample_histogram0100_sum [sample_histogram0100 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0122 []
+opentelemetry.source4.sample_histogram0122 [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 231855
     inst [2 or "le=4"] value 463710
@@ -22279,13 +22279,13 @@ opentelemetry.source4.sample_histogram0122 []
     inst [9 or "le=18"] value 2086695
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0122_count []
+opentelemetry.source4.sample_histogram0122_count [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0122_sum []
+opentelemetry.source4.sample_histogram0122_sum [sample_histogram0122 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0144 []
+opentelemetry.source4.sample_histogram0144 [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 255635
     inst [2 or "le=4"] value 511270
@@ -22298,13 +22298,13 @@ opentelemetry.source4.sample_histogram0144 []
     inst [9 or "le=18"] value 2300715
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0144_count []
+opentelemetry.source4.sample_histogram0144_count [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0144_sum []
+opentelemetry.source4.sample_histogram0144_sum [sample_histogram0144 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0166 []
+opentelemetry.source4.sample_histogram0166 [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 279415
     inst [2 or "le=4"] value 558830
@@ -22317,13 +22317,13 @@ opentelemetry.source4.sample_histogram0166 []
     inst [9 or "le=18"] value 2514735
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0166_count []
+opentelemetry.source4.sample_histogram0166_count [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0166_sum []
+opentelemetry.source4.sample_histogram0166_sum [sample_histogram0166 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0188 []
+opentelemetry.source4.sample_histogram0188 [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 303195
     inst [2 or "le=4"] value 606390
@@ -22336,13 +22336,13 @@ opentelemetry.source4.sample_histogram0188 []
     inst [9 or "le=18"] value 2728755
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0188_count []
+opentelemetry.source4.sample_histogram0188_count [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0188_sum []
+opentelemetry.source4.sample_histogram0188_sum [sample_histogram0188 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0210 []
+opentelemetry.source4.sample_histogram0210 [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 326975
     inst [2 or "le=4"] value 653950
@@ -22355,13 +22355,13 @@ opentelemetry.source4.sample_histogram0210 []
     inst [9 or "le=18"] value 2942775
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0210_count []
+opentelemetry.source4.sample_histogram0210_count [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0210_sum []
+opentelemetry.source4.sample_histogram0210_sum [sample_histogram0210 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0232 []
+opentelemetry.source4.sample_histogram0232 [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 350755
     inst [2 or "le=4"] value 701510
@@ -22374,13 +22374,13 @@ opentelemetry.source4.sample_histogram0232 []
     inst [9 or "le=18"] value 3156795
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0232_count []
+opentelemetry.source4.sample_histogram0232_count [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0232_sum []
+opentelemetry.source4.sample_histogram0232_sum [sample_histogram0232 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0254 []
+opentelemetry.source4.sample_histogram0254 [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 374535
     inst [2 or "le=4"] value 749070
@@ -22393,13 +22393,13 @@ opentelemetry.source4.sample_histogram0254 []
     inst [9 or "le=18"] value 3370815
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0254_count []
+opentelemetry.source4.sample_histogram0254_count [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0254_sum []
+opentelemetry.source4.sample_histogram0254_sum [sample_histogram0254 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0276 []
+opentelemetry.source4.sample_histogram0276 [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 398315
     inst [2 or "le=4"] value 796630
@@ -22412,13 +22412,13 @@ opentelemetry.source4.sample_histogram0276 []
     inst [9 or "le=18"] value 3584835
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0276_count []
+opentelemetry.source4.sample_histogram0276_count [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0276_sum []
+opentelemetry.source4.sample_histogram0276_sum [sample_histogram0276 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0298 []
+opentelemetry.source4.sample_histogram0298 [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 422095
     inst [2 or "le=4"] value 844190
@@ -22431,13 +22431,13 @@ opentelemetry.source4.sample_histogram0298 []
     inst [9 or "le=18"] value 3798855
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0298_count []
+opentelemetry.source4.sample_histogram0298_count [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0298_sum []
+opentelemetry.source4.sample_histogram0298_sum [sample_histogram0298 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0320 []
+opentelemetry.source4.sample_histogram0320 [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 445875
     inst [2 or "le=4"] value 891750
@@ -22450,13 +22450,13 @@ opentelemetry.source4.sample_histogram0320 []
     inst [9 or "le=18"] value 4012875
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0320_count []
+opentelemetry.source4.sample_histogram0320_count [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0320_sum []
+opentelemetry.source4.sample_histogram0320_sum [sample_histogram0320 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0342 []
+opentelemetry.source4.sample_histogram0342 [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 469655
     inst [2 or "le=4"] value 939310
@@ -22469,13 +22469,13 @@ opentelemetry.source4.sample_histogram0342 []
     inst [9 or "le=18"] value 4226895
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0342_count []
+opentelemetry.source4.sample_histogram0342_count [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0342_sum []
+opentelemetry.source4.sample_histogram0342_sum [sample_histogram0342 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0364 []
+opentelemetry.source4.sample_histogram0364 [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 493435
     inst [2 or "le=4"] value 986870
@@ -22488,13 +22488,13 @@ opentelemetry.source4.sample_histogram0364 []
     inst [9 or "le=18"] value 4440915
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0364_count []
+opentelemetry.source4.sample_histogram0364_count [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0364_sum []
+opentelemetry.source4.sample_histogram0364_sum [sample_histogram0364 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_histogram0386 []
+opentelemetry.source4.sample_histogram0386 [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     inst [0 or "le=0"] value 0
     inst [1 or "le=2"] value 517215
     inst [2 or "le=4"] value 1034430
@@ -22507,13 +22507,13 @@ opentelemetry.source4.sample_histogram0386 []
     inst [9 or "le=18"] value 4654935
     inst [10 or "le=inf"] value 0
 
-opentelemetry.source4.sample_histogram0386_count []
+opentelemetry.source4.sample_histogram0386_count [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 181350
 
-opentelemetry.source4.sample_histogram0386_sum []
+opentelemetry.source4.sample_histogram0386_sum [sample_histogram0386 instance scale 2 value scale 5945 (sample histogram has instances)]
     value 451570
 
-opentelemetry.source4.sample_summary0002 []
+opentelemetry.source4.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -22525,13 +22525,13 @@ opentelemetry.source4.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source4.sample_summary0002_count []
+opentelemetry.source4.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source4.sample_summary0002_sum []
+opentelemetry.source4.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source4.sample_summary0024 []
+opentelemetry.source4.sample_summary0024 [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -22543,13 +22543,13 @@ opentelemetry.source4.sample_summary0024 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source4.sample_summary0024_count []
+opentelemetry.source4.sample_summary0024_count [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source4.sample_summary0024_sum []
+opentelemetry.source4.sample_summary0024_sum [sample_summary0024 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source4.sample_summary0046 []
+opentelemetry.source4.sample_summary0046 [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -22561,13 +22561,13 @@ opentelemetry.source4.sample_summary0046 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source4.sample_summary0046_count []
+opentelemetry.source4.sample_summary0046_count [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source4.sample_summary0046_sum []
+opentelemetry.source4.sample_summary0046_sum [sample_summary0046 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source4.sample_summary0068 []
+opentelemetry.source4.sample_summary0068 [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -22579,13 +22579,13 @@ opentelemetry.source4.sample_summary0068 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source4.sample_summary0068_count []
+opentelemetry.source4.sample_summary0068_count [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source4.sample_summary0068_sum []
+opentelemetry.source4.sample_summary0068_sum [sample_summary0068 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source4.sample_summary0090 []
+opentelemetry.source4.sample_summary0090 [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -22597,13 +22597,13 @@ opentelemetry.source4.sample_summary0090 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source4.sample_summary0090_count []
+opentelemetry.source4.sample_summary0090_count [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source4.sample_summary0090_sum []
+opentelemetry.source4.sample_summary0090_sum [sample_summary0090 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source4.sample_summary0112 []
+opentelemetry.source4.sample_summary0112 [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -22615,13 +22615,13 @@ opentelemetry.source4.sample_summary0112 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source4.sample_summary0112_count []
+opentelemetry.source4.sample_summary0112_count [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source4.sample_summary0112_sum []
+opentelemetry.source4.sample_summary0112_sum [sample_summary0112 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source4.sample_summary0134 []
+opentelemetry.source4.sample_summary0134 [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -22633,13 +22633,13 @@ opentelemetry.source4.sample_summary0134 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source4.sample_summary0134_count []
+opentelemetry.source4.sample_summary0134_count [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source4.sample_summary0134_sum []
+opentelemetry.source4.sample_summary0134_sum [sample_summary0134 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source4.sample_summary0156 []
+opentelemetry.source4.sample_summary0156 [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -22651,13 +22651,13 @@ opentelemetry.source4.sample_summary0156 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source4.sample_summary0156_count []
+opentelemetry.source4.sample_summary0156_count [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source4.sample_summary0156_sum []
+opentelemetry.source4.sample_summary0156_sum [sample_summary0156 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source4.sample_summary0178 []
+opentelemetry.source4.sample_summary0178 [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -22669,13 +22669,13 @@ opentelemetry.source4.sample_summary0178 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source4.sample_summary0178_count []
+opentelemetry.source4.sample_summary0178_count [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source4.sample_summary0178_sum []
+opentelemetry.source4.sample_summary0178_sum [sample_summary0178 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source4.sample_summary0200 []
+opentelemetry.source4.sample_summary0200 [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -22687,13 +22687,13 @@ opentelemetry.source4.sample_summary0200 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source4.sample_summary0200_count []
+opentelemetry.source4.sample_summary0200_count [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source4.sample_summary0200_sum []
+opentelemetry.source4.sample_summary0200_sum [sample_summary0200 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source4.sample_summary0222 []
+opentelemetry.source4.sample_summary0222 [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -22705,13 +22705,13 @@ opentelemetry.source4.sample_summary0222 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source4.sample_summary0222_count []
+opentelemetry.source4.sample_summary0222_count [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source4.sample_summary0222_sum []
+opentelemetry.source4.sample_summary0222_sum [sample_summary0222 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source4.sample_summary0244 []
+opentelemetry.source4.sample_summary0244 [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -22723,13 +22723,13 @@ opentelemetry.source4.sample_summary0244 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source4.sample_summary0244_count []
+opentelemetry.source4.sample_summary0244_count [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source4.sample_summary0244_sum []
+opentelemetry.source4.sample_summary0244_sum [sample_summary0244 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source4.sample_summary0266 []
+opentelemetry.source4.sample_summary0266 [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -22741,13 +22741,13 @@ opentelemetry.source4.sample_summary0266 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source4.sample_summary0266_count []
+opentelemetry.source4.sample_summary0266_count [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source4.sample_summary0266_sum []
+opentelemetry.source4.sample_summary0266_sum [sample_summary0266 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source4.sample_summary0288 []
+opentelemetry.source4.sample_summary0288 [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -22759,13 +22759,13 @@ opentelemetry.source4.sample_summary0288 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source4.sample_summary0288_count []
+opentelemetry.source4.sample_summary0288_count [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source4.sample_summary0288_sum []
+opentelemetry.source4.sample_summary0288_sum [sample_summary0288 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source4.sample_summary0310 []
+opentelemetry.source4.sample_summary0310 [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -22777,13 +22777,13 @@ opentelemetry.source4.sample_summary0310 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source4.sample_summary0310_count []
+opentelemetry.source4.sample_summary0310_count [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source4.sample_summary0310_sum []
+opentelemetry.source4.sample_summary0310_sum [sample_summary0310 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source4.sample_summary0332 []
+opentelemetry.source4.sample_summary0332 [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012450594
     inst [2 or "quantile: 0.5"] value 0.024901188
@@ -22795,13 +22795,13 @@ opentelemetry.source4.sample_summary0332 []
     inst [8 or "quantile: 2.0"] value 0.099604752
     inst [9 or "quantile: 2.25"] value 0.112055346
 
-opentelemetry.source4.sample_summary0332_count []
+opentelemetry.source4.sample_summary0332_count [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 141804
 
-opentelemetry.source4.sample_summary0332_sum []
+opentelemetry.source4.sample_summary0332_sum [sample_summary0332 instance scale 0.25 value scale 0.000159623]
     value 108.514128
 
-opentelemetry.source4.sample_summary0354 []
+opentelemetry.source4.sample_summary0354 [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013089086
     inst [2 or "quantile: 0.5"] value 0.026178172
@@ -22813,13 +22813,13 @@ opentelemetry.source4.sample_summary0354 []
     inst [8 or "quantile: 2.0"] value 0.104712688
     inst [9 or "quantile: 2.25"] value 0.117801774
 
-opentelemetry.source4.sample_summary0354_count []
+opentelemetry.source4.sample_summary0354_count [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 149076
 
-opentelemetry.source4.sample_summary0354_sum []
+opentelemetry.source4.sample_summary0354_sum [sample_summary0354 instance scale 0.25 value scale 0.000159623]
     value 114.078955
 
-opentelemetry.source4.sample_summary0376 []
+opentelemetry.source4.sample_summary0376 [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013727578
     inst [2 or "quantile: 0.5"] value 0.027455156
@@ -22831,13 +22831,13 @@ opentelemetry.source4.sample_summary0376 []
     inst [8 or "quantile: 2.0"] value 0.109820624
     inst [9 or "quantile: 2.25"] value 0.123548202
 
-opentelemetry.source4.sample_summary0376_count []
+opentelemetry.source4.sample_summary0376_count [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 156348
 
-opentelemetry.source4.sample_summary0376_sum []
+opentelemetry.source4.sample_summary0376_sum [sample_summary0376 instance scale 0.25 value scale 0.000159623]
     value 119.643782
 
-opentelemetry.source4.sample_summary0398 []
+opentelemetry.source4.sample_summary0398 [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01436607
     inst [2 or "quantile: 0.5"] value 0.02873214
@@ -22849,10 +22849,10 @@ opentelemetry.source4.sample_summary0398 []
     inst [8 or "quantile: 2.0"] value 0.11492856
     inst [9 or "quantile: 2.25"] value 0.12929463
 
-opentelemetry.source4.sample_summary0398_count []
+opentelemetry.source4.sample_summary0398_count [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 163620
 
-opentelemetry.source4.sample_summary0398_sum []
+opentelemetry.source4.sample_summary0398_sum [sample_summary0398 instance scale 0.25 value scale 0.000159623]
     value 125.208609
 
 === remove opentelemetry agent ===

--- a/qa/1647.out
+++ b/qa/1647.out
@@ -33,8 +33,8 @@ SOMETEXT: unrecognised
 
 === pminfo listing. Note opentelemetry.simplemetric.metric2 should be filtered out
 
-opentelemetry.simplemetric.metric1 PMID: 164.1.0 []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.simplemetric.metric1 PMID: 164.1.0 [I am a Counter]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Counter

--- a/qa/1678
+++ b/qa/1678
@@ -17,8 +17,6 @@ echo "QA output created by $seq"
 
 _pmdaopentelemetry_check || _notrun "opentelemetry pmda and/or load generator not installed"
 
-_notrun "currently failing, needs analysis and updates"
-
 status=1        # failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 totalendpoints=100 #total queue to work through
@@ -55,7 +53,6 @@ _stop_auto_restart pmcd
 
 _pmdaopentelemetry_save_config
 _pmdaopentelemetry_install
-
 port=`_find_free_port 10000`
 echo "port=$port" >>$here/$seq.full
 

--- a/qa/1678.out
+++ b/qa/1678.out
@@ -4,7 +4,7 @@ QA output created by 1678
 Fetch and desc opentelemetry metrics: success
 
 opentelemetry.source0.sample_counter0001
-    Data Type: double  InDom: 88.5121 0x16001401
+    Data Type: double  InDom: 164.5121 0x29001401
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 170205394
@@ -18,7 +18,7 @@ opentelemetry.source0.sample_counter0001
     inst [9 or "9 inst-9"] value 1531848550
 
 opentelemetry.source0.sample_gauge0000
-    Data Type: double  InDom: 88.5120 0x16001400
+    Data Type: double  InDom: 164.5120 0x29001400
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 0
@@ -32,8 +32,8 @@ opentelemetry.source0.sample_gauge0000
     inst [9 or "9 inst-9"] value 0
 
 opentelemetry.source0.sample_summary0002
-    Data Type: double  InDom: 88.5122 0x16001402
-    Semantics: instant  Units: none
+    Data Type: double  InDom: 164.5122 0x29001402
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.000319246
     inst [2 or "quantile: 0.5"] value 0.0006384920000000001
@@ -46,16 +46,16 @@ opentelemetry.source0.sample_summary0002
     inst [9 or "quantile: 2.25"] value 0.002873214
 
 opentelemetry.source0.sample_summary0002_count
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 3636
 
 opentelemetry.source0.sample_summary0002_sum
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 2.782414
 
-opentelemetry.source0.sample_counter0001 []
+opentelemetry.source0.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 170205394
     inst [2 or "2 inst-2"] value 340410788
@@ -67,7 +67,7 @@ opentelemetry.source0.sample_counter0001 []
     inst [8 or "8 inst-8"] value 1361643150
     inst [9 or "9 inst-9"] value 1531848550
 
-opentelemetry.source0.sample_gauge0000 []
+opentelemetry.source0.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 0
     inst [2 or "2 inst-2"] value 0
@@ -79,7 +79,7 @@ opentelemetry.source0.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 0
     inst [9 or "9 inst-9"] value 0
 
-opentelemetry.source0.sample_summary0002 []
+opentelemetry.source0.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.000319246
     inst [2 or "quantile: 0.5"] value 0.0006384920000000001
@@ -91,13 +91,13 @@ opentelemetry.source0.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.002553968
     inst [9 or "quantile: 2.25"] value 0.002873214
 
-opentelemetry.source0.sample_summary0002_count []
+opentelemetry.source0.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 3636
 
-opentelemetry.source0.sample_summary0002_sum []
+opentelemetry.source0.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 2.782414
 
-opentelemetry.source1.sample_counter0001 []
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 340410788
     inst [2 or "2 inst-2"] value 680821576
@@ -109,7 +109,7 @@ opentelemetry.source1.sample_counter0001 []
     inst [8 or "8 inst-8"] value 2723286300
     inst [9 or "9 inst-9"] value 3063697090
 
-opentelemetry.source1.sample_gauge0000 []
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12.1
     inst [2 or "2 inst-2"] value 24.2
@@ -121,7 +121,7 @@ opentelemetry.source1.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 96.8
     inst [9 or "9 inst-9"] value 108.9
 
-opentelemetry.source1.sample_summary0002 []
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.000478869
     inst [2 or "quantile: 0.5"] value 0.0009577380000000001
@@ -133,13 +133,13 @@ opentelemetry.source1.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.003830952
     inst [9 or "quantile: 2.25"] value 0.004309821
 
-opentelemetry.source1.sample_summary0002_count []
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 5454
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 4.17362
 
-opentelemetry.source1.sample_counter0001 []
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 510616182
     inst [2 or "2 inst-2"] value 1021232360
@@ -151,7 +151,7 @@ opentelemetry.source1.sample_counter0001 []
     inst [8 or "8 inst-8"] value 4084929460
     inst [9 or "9 inst-9"] value 4595545640
 
-opentelemetry.source1.sample_gauge0000 []
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 24.2
     inst [2 or "2 inst-2"] value 48.4
@@ -163,7 +163,7 @@ opentelemetry.source1.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 193.6
     inst [9 or "9 inst-9"] value 217.8
 
-opentelemetry.source1.sample_summary0002 []
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0006384920000000001
     inst [2 or "quantile: 0.5"] value 0.001276984
@@ -175,13 +175,13 @@ opentelemetry.source1.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.005107936
     inst [9 or "quantile: 2.25"] value 0.005746428
 
-opentelemetry.source1.sample_summary0002_count []
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 7272
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 5.564827
 
-opentelemetry.source1.sample_counter0001 []
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 680821576
     inst [2 or "2 inst-2"] value 1361643150
@@ -193,7 +193,7 @@ opentelemetry.source1.sample_counter0001 []
     inst [8 or "8 inst-8"] value 5446572610
     inst [9 or "9 inst-9"] value 6127394180
 
-opentelemetry.source1.sample_gauge0000 []
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 36.3
     inst [2 or "2 inst-2"] value 72.59999999999999
@@ -205,7 +205,7 @@ opentelemetry.source1.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 290.4
     inst [9 or "9 inst-9"] value 326.7
 
-opentelemetry.source1.sample_summary0002 []
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0007981150000000001
     inst [2 or "quantile: 0.5"] value 0.00159623
@@ -217,13 +217,13 @@ opentelemetry.source1.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.006384920000000001
     inst [9 or "quantile: 2.25"] value 0.007183035000000001
 
-opentelemetry.source1.sample_summary0002_count []
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 9090
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 6.956034
 
-opentelemetry.source2.sample_counter0001 []
+opentelemetry.source2.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 510616182
     inst [2 or "2 inst-2"] value 1021232360
@@ -235,7 +235,7 @@ opentelemetry.source2.sample_counter0001 []
     inst [8 or "8 inst-8"] value 4084929460
     inst [9 or "9 inst-9"] value 4595545640
 
-opentelemetry.source2.sample_gauge0000 []
+opentelemetry.source2.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 24.2
     inst [2 or "2 inst-2"] value 48.4
@@ -247,7 +247,7 @@ opentelemetry.source2.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 193.6
     inst [9 or "9 inst-9"] value 217.8
 
-opentelemetry.source2.sample_summary0002 []
+opentelemetry.source2.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0006384920000000001
     inst [2 or "quantile: 0.5"] value 0.001276984
@@ -259,13 +259,13 @@ opentelemetry.source2.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.005107936
     inst [9 or "quantile: 2.25"] value 0.005746428
 
-opentelemetry.source2.sample_summary0002_count []
+opentelemetry.source2.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 7272
 
-opentelemetry.source2.sample_summary0002_sum []
+opentelemetry.source2.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 5.564827
 
-opentelemetry.source2.sample_counter0001 []
+opentelemetry.source2.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 851026970
     inst [2 or "2 inst-2"] value 1702053940
@@ -277,7 +277,7 @@ opentelemetry.source2.sample_counter0001 []
     inst [8 or "8 inst-8"] value 6808215760
     inst [9 or "9 inst-9"] value 7659242730
 
-opentelemetry.source2.sample_gauge0000 []
+opentelemetry.source2.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 48.4
     inst [2 or "2 inst-2"] value 96.8
@@ -289,7 +289,7 @@ opentelemetry.source2.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 387.2
     inst [9 or "9 inst-9"] value 435.6
 
-opentelemetry.source2.sample_summary0002 []
+opentelemetry.source2.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0009577380000000001
     inst [2 or "quantile: 0.5"] value 0.001915476
@@ -301,13 +301,13 @@ opentelemetry.source2.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.007661904000000001
     inst [9 or "quantile: 2.25"] value 0.008619642
 
-opentelemetry.source2.sample_summary0002_count []
+opentelemetry.source2.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 10908
 
-opentelemetry.source2.sample_summary0002_sum []
+opentelemetry.source2.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 8.347241
 
-opentelemetry.source2.sample_counter0001 []
+opentelemetry.source2.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1191437760
     inst [2 or "2 inst-2"] value 2382875520
@@ -319,7 +319,7 @@ opentelemetry.source2.sample_counter0001 []
     inst [8 or "8 inst-8"] value 9531502060
     inst [9 or "9 inst-9"] value 10722939800
 
-opentelemetry.source2.sample_gauge0000 []
+opentelemetry.source2.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 72.59999999999999
     inst [2 or "2 inst-2"] value 145.2
@@ -331,7 +331,7 @@ opentelemetry.source2.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 580.8
     inst [9 or "9 inst-9"] value 653.4
 
-opentelemetry.source2.sample_summary0002 []
+opentelemetry.source2.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001276984
     inst [2 or "quantile: 0.5"] value 0.002553968
@@ -343,13 +343,13 @@ opentelemetry.source2.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.010215872
     inst [9 or "quantile: 2.25"] value 0.011492856
 
-opentelemetry.source2.sample_summary0002_count []
+opentelemetry.source2.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 14544
 
-opentelemetry.source2.sample_summary0002_sum []
+opentelemetry.source2.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 11.129654
 
-opentelemetry.source3.sample_counter0001 []
+opentelemetry.source3.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 680821576
     inst [2 or "2 inst-2"] value 1361643150
@@ -361,7 +361,7 @@ opentelemetry.source3.sample_counter0001 []
     inst [8 or "8 inst-8"] value 5446572610
     inst [9 or "9 inst-9"] value 6127394180
 
-opentelemetry.source3.sample_gauge0000 []
+opentelemetry.source3.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 36.3
     inst [2 or "2 inst-2"] value 72.59999999999999
@@ -373,7 +373,7 @@ opentelemetry.source3.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 290.4
     inst [9 or "9 inst-9"] value 326.7
 
-opentelemetry.source3.sample_summary0002 []
+opentelemetry.source3.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0007981150000000001
     inst [2 or "quantile: 0.5"] value 0.00159623
@@ -385,13 +385,13 @@ opentelemetry.source3.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.006384920000000001
     inst [9 or "quantile: 2.25"] value 0.007183035000000001
 
-opentelemetry.source3.sample_summary0002_count []
+opentelemetry.source3.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 9090
 
-opentelemetry.source3.sample_summary0002_sum []
+opentelemetry.source3.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 6.956034
 
-opentelemetry.source3.sample_counter0001 []
+opentelemetry.source3.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1191437760
     inst [2 or "2 inst-2"] value 2382875520
@@ -403,7 +403,7 @@ opentelemetry.source3.sample_counter0001 []
     inst [8 or "8 inst-8"] value 9531502060
     inst [9 or "9 inst-9"] value 10722939800
 
-opentelemetry.source3.sample_gauge0000 []
+opentelemetry.source3.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 72.59999999999999
     inst [2 or "2 inst-2"] value 145.2
@@ -415,7 +415,7 @@ opentelemetry.source3.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 580.8
     inst [9 or "9 inst-9"] value 653.4
 
-opentelemetry.source3.sample_summary0002 []
+opentelemetry.source3.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001276984
     inst [2 or "quantile: 0.5"] value 0.002553968
@@ -427,13 +427,13 @@ opentelemetry.source3.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.010215872
     inst [9 or "quantile: 2.25"] value 0.011492856
 
-opentelemetry.source3.sample_summary0002_count []
+opentelemetry.source3.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 14544
 
-opentelemetry.source3.sample_summary0002_sum []
+opentelemetry.source3.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 11.129654
 
-opentelemetry.source3.sample_counter0001 []
+opentelemetry.source3.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1702053940
     inst [2 or "2 inst-2"] value 3404107880
@@ -445,7 +445,7 @@ opentelemetry.source3.sample_counter0001 []
     inst [8 or "8 inst-8"] value 13616431500
     inst [9 or "9 inst-9"] value 15318485500
 
-opentelemetry.source3.sample_gauge0000 []
+opentelemetry.source3.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 108.9
     inst [2 or "2 inst-2"] value 217.8
@@ -457,7 +457,7 @@ opentelemetry.source3.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 871.2
     inst [9 or "9 inst-9"] value 980.1
 
-opentelemetry.source3.sample_summary0002 []
+opentelemetry.source3.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001755853
     inst [2 or "quantile: 0.5"] value 0.003511706
@@ -469,13 +469,13 @@ opentelemetry.source3.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.014046824
     inst [9 or "quantile: 2.25"] value 0.015802677
 
-opentelemetry.source3.sample_summary0002_count []
+opentelemetry.source3.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 19998
 
-opentelemetry.source3.sample_summary0002_sum []
+opentelemetry.source3.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 15.303274
 
-opentelemetry.source4.sample_counter0001 []
+opentelemetry.source4.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 851026970
     inst [2 or "2 inst-2"] value 1702053940
@@ -487,7 +487,7 @@ opentelemetry.source4.sample_counter0001 []
     inst [8 or "8 inst-8"] value 6808215760
     inst [9 or "9 inst-9"] value 7659242730
 
-opentelemetry.source4.sample_gauge0000 []
+opentelemetry.source4.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 48.4
     inst [2 or "2 inst-2"] value 96.8
@@ -499,7 +499,7 @@ opentelemetry.source4.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 387.2
     inst [9 or "9 inst-9"] value 435.6
 
-opentelemetry.source4.sample_summary0002 []
+opentelemetry.source4.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0009577380000000001
     inst [2 or "quantile: 0.5"] value 0.001915476
@@ -511,13 +511,13 @@ opentelemetry.source4.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.007661904000000001
     inst [9 or "quantile: 2.25"] value 0.008619642
 
-opentelemetry.source4.sample_summary0002_count []
+opentelemetry.source4.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 10908
 
-opentelemetry.source4.sample_summary0002_sum []
+opentelemetry.source4.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 8.347241
 
-opentelemetry.source4.sample_counter0001 []
+opentelemetry.source4.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1531848550
     inst [2 or "2 inst-2"] value 3063697090
@@ -529,7 +529,7 @@ opentelemetry.source4.sample_counter0001 []
     inst [8 or "8 inst-8"] value 12254788400
     inst [9 or "9 inst-9"] value 13786636900
 
-opentelemetry.source4.sample_gauge0000 []
+opentelemetry.source4.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 96.8
     inst [2 or "2 inst-2"] value 193.6
@@ -541,7 +541,7 @@ opentelemetry.source4.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 774.4
     inst [9 or "9 inst-9"] value 871.2
 
-opentelemetry.source4.sample_summary0002 []
+opentelemetry.source4.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00159623
     inst [2 or "quantile: 0.5"] value 0.00319246
@@ -553,13 +553,13 @@ opentelemetry.source4.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.01276984
     inst [9 or "quantile: 2.25"] value 0.01436607
 
-opentelemetry.source4.sample_summary0002_count []
+opentelemetry.source4.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 18180
 
-opentelemetry.source4.sample_summary0002_sum []
+opentelemetry.source4.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 13.912068
 
-opentelemetry.source4.sample_counter0001 []
+opentelemetry.source4.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -571,7 +571,7 @@ opentelemetry.source4.sample_counter0001 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source4.sample_gauge0000 []
+opentelemetry.source4.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -583,7 +583,7 @@ opentelemetry.source4.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source4.sample_summary0002 []
+opentelemetry.source4.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -595,13 +595,13 @@ opentelemetry.source4.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source4.sample_summary0002_count []
+opentelemetry.source4.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source4.sample_summary0002_sum []
+opentelemetry.source4.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source5.sample_counter0001 []
+opentelemetry.source5.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1021232360
     inst [2 or "2 inst-2"] value 2042464730
@@ -613,7 +613,7 @@ opentelemetry.source5.sample_counter0001 []
     inst [8 or "8 inst-8"] value 8169858910
     inst [9 or "9 inst-9"] value 9191091280
 
-opentelemetry.source5.sample_gauge0000 []
+opentelemetry.source5.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 60.5
     inst [2 or "2 inst-2"] value 121
@@ -625,7 +625,7 @@ opentelemetry.source5.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 484
     inst [9 or "9 inst-9"] value 544.5
 
-opentelemetry.source5.sample_summary0002 []
+opentelemetry.source5.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001117361
     inst [2 or "quantile: 0.5"] value 0.002234722
@@ -637,13 +637,13 @@ opentelemetry.source5.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.008938888000000001
     inst [9 or "quantile: 2.25"] value 0.010056249
 
-opentelemetry.source5.sample_summary0002_count []
+opentelemetry.source5.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 12726
 
-opentelemetry.source5.sample_summary0002_sum []
+opentelemetry.source5.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 9.738447000000001
 
-opentelemetry.source5.sample_counter0001 []
+opentelemetry.source5.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1872259330
     inst [2 or "2 inst-2"] value 3744518670
@@ -655,7 +655,7 @@ opentelemetry.source5.sample_counter0001 []
     inst [8 or "8 inst-8"] value 14978074700
     inst [9 or "9 inst-9"] value 16850334000
 
-opentelemetry.source5.sample_gauge0000 []
+opentelemetry.source5.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 121
     inst [2 or "2 inst-2"] value 242
@@ -667,7 +667,7 @@ opentelemetry.source5.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 968
     inst [9 or "9 inst-9"] value 1089
 
-opentelemetry.source5.sample_summary0002 []
+opentelemetry.source5.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001915476
     inst [2 or "quantile: 0.5"] value 0.003830952
@@ -679,13 +679,13 @@ opentelemetry.source5.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.015323808
     inst [9 or "quantile: 2.25"] value 0.017239284
 
-opentelemetry.source5.sample_summary0002_count []
+opentelemetry.source5.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 21816
 
-opentelemetry.source5.sample_summary0002_sum []
+opentelemetry.source5.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 16.694481
 
-opentelemetry.source5.sample_counter0001 []
+opentelemetry.source5.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2723286300
     inst [2 or "2 inst-2"] value 5446572610
@@ -697,7 +697,7 @@ opentelemetry.source5.sample_counter0001 []
     inst [8 or "8 inst-8"] value 21786290400
     inst [9 or "9 inst-9"] value 24509576700
 
-opentelemetry.source5.sample_gauge0000 []
+opentelemetry.source5.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 181.5
     inst [2 or "2 inst-2"] value 363
@@ -709,7 +709,7 @@ opentelemetry.source5.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1452
     inst [9 or "9 inst-9"] value 1633.5
 
-opentelemetry.source5.sample_summary0002 []
+opentelemetry.source5.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002713591
     inst [2 or "quantile: 0.5"] value 0.005427182000000001
@@ -721,13 +721,13 @@ opentelemetry.source5.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.021708728
     inst [9 or "quantile: 2.25"] value 0.024422319
 
-opentelemetry.source5.sample_summary0002_count []
+opentelemetry.source5.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 30906
 
-opentelemetry.source5.sample_summary0002_sum []
+opentelemetry.source5.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 23.650515
 
-opentelemetry.source6.sample_counter0001 []
+opentelemetry.source6.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1191437760
     inst [2 or "2 inst-2"] value 2382875520
@@ -739,7 +739,7 @@ opentelemetry.source6.sample_counter0001 []
     inst [8 or "8 inst-8"] value 9531502060
     inst [9 or "9 inst-9"] value 10722939800
 
-opentelemetry.source6.sample_gauge0000 []
+opentelemetry.source6.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 72.59999999999999
     inst [2 or "2 inst-2"] value 145.2
@@ -751,7 +751,7 @@ opentelemetry.source6.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 580.8
     inst [9 or "9 inst-9"] value 653.4
 
-opentelemetry.source6.sample_summary0002 []
+opentelemetry.source6.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001276984
     inst [2 or "quantile: 0.5"] value 0.002553968
@@ -763,13 +763,13 @@ opentelemetry.source6.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.010215872
     inst [9 or "quantile: 2.25"] value 0.011492856
 
-opentelemetry.source6.sample_summary0002_count []
+opentelemetry.source6.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 14544
 
-opentelemetry.source6.sample_summary0002_sum []
+opentelemetry.source6.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 11.129654
 
-opentelemetry.source6.sample_counter0001 []
+opentelemetry.source6.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -781,7 +781,7 @@ opentelemetry.source6.sample_counter0001 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source6.sample_gauge0000 []
+opentelemetry.source6.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -793,7 +793,7 @@ opentelemetry.source6.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source6.sample_summary0002 []
+opentelemetry.source6.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -805,13 +805,13 @@ opentelemetry.source6.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source6.sample_summary0002_count []
+opentelemetry.source6.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source6.sample_summary0002_sum []
+opentelemetry.source6.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source6.sample_counter0001 []
+opentelemetry.source6.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3233902490
     inst [2 or "2 inst-2"] value 6467804970
@@ -823,7 +823,7 @@ opentelemetry.source6.sample_counter0001 []
     inst [8 or "8 inst-8"] value 25871219900
     inst [9 or "9 inst-9"] value 29105122400
 
-opentelemetry.source6.sample_gauge0000 []
+opentelemetry.source6.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 217.8
     inst [2 or "2 inst-2"] value 435.6
@@ -835,7 +835,7 @@ opentelemetry.source6.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1742.4
     inst [9 or "9 inst-9"] value 1960.2
 
-opentelemetry.source6.sample_summary0002 []
+opentelemetry.source6.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00319246
     inst [2 or "quantile: 0.5"] value 0.006384920000000001
@@ -847,13 +847,13 @@ opentelemetry.source6.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.02553968
     inst [9 or "quantile: 2.25"] value 0.02873214
 
-opentelemetry.source6.sample_summary0002_count []
+opentelemetry.source6.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 36360
 
-opentelemetry.source6.sample_summary0002_sum []
+opentelemetry.source6.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 27.824135
 
-opentelemetry.source7.sample_counter0001 []
+opentelemetry.source7.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1361643150
     inst [2 or "2 inst-2"] value 2723286300
@@ -865,7 +865,7 @@ opentelemetry.source7.sample_counter0001 []
     inst [8 or "8 inst-8"] value 10893145200
     inst [9 or "9 inst-9"] value 12254788400
 
-opentelemetry.source7.sample_gauge0000 []
+opentelemetry.source7.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 84.7
     inst [2 or "2 inst-2"] value 169.4
@@ -877,7 +877,7 @@ opentelemetry.source7.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 677.6
     inst [9 or "9 inst-9"] value 762.3
 
-opentelemetry.source7.sample_summary0002 []
+opentelemetry.source7.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001436607
     inst [2 or "quantile: 0.5"] value 0.002873214
@@ -889,13 +889,13 @@ opentelemetry.source7.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.011492856
     inst [9 or "quantile: 2.25"] value 0.012929463
 
-opentelemetry.source7.sample_summary0002_count []
+opentelemetry.source7.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 16362
 
-opentelemetry.source7.sample_summary0002_sum []
+opentelemetry.source7.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 12.520861
 
-opentelemetry.source7.sample_counter0001 []
+opentelemetry.source7.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2553080910
     inst [2 or "2 inst-2"] value 5106161820
@@ -907,7 +907,7 @@ opentelemetry.source7.sample_counter0001 []
     inst [8 or "8 inst-8"] value 20424647300
     inst [9 or "9 inst-9"] value 22977728200
 
-opentelemetry.source7.sample_gauge0000 []
+opentelemetry.source7.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 169.4
     inst [2 or "2 inst-2"] value 338.8
@@ -919,7 +919,7 @@ opentelemetry.source7.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1355.2
     inst [9 or "9 inst-9"] value 1524.6
 
-opentelemetry.source7.sample_summary0002 []
+opentelemetry.source7.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002553968
     inst [2 or "quantile: 0.5"] value 0.005107936
@@ -931,13 +931,13 @@ opentelemetry.source7.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.020431744
     inst [9 or "quantile: 2.25"] value 0.022985712
 
-opentelemetry.source7.sample_summary0002_count []
+opentelemetry.source7.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 29088
 
-opentelemetry.source7.sample_summary0002_sum []
+opentelemetry.source7.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 22.259308
 
-opentelemetry.source7.sample_counter0001 []
+opentelemetry.source7.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3744518670
     inst [2 or "2 inst-2"] value 7489037340
@@ -949,7 +949,7 @@ opentelemetry.source7.sample_counter0001 []
     inst [8 or "8 inst-8"] value 29956149300
     inst [9 or "9 inst-9"] value 33700668000
 
-opentelemetry.source7.sample_gauge0000 []
+opentelemetry.source7.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 254.1
     inst [2 or "2 inst-2"] value 508.2
@@ -961,7 +961,7 @@ opentelemetry.source7.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2032.8
     inst [9 or "9 inst-9"] value 2286.9
 
-opentelemetry.source7.sample_summary0002 []
+opentelemetry.source7.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003671329
     inst [2 or "quantile: 0.5"] value 0.007342658
@@ -973,13 +973,13 @@ opentelemetry.source7.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.029370632
     inst [9 or "quantile: 2.25"] value 0.033041961
 
-opentelemetry.source7.sample_summary0002_count []
+opentelemetry.source7.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 41814
 
-opentelemetry.source7.sample_summary0002_sum []
+opentelemetry.source7.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 31.997756
 
-opentelemetry.source8.sample_counter0001 []
+opentelemetry.source8.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1531848550
     inst [2 or "2 inst-2"] value 3063697090
@@ -991,7 +991,7 @@ opentelemetry.source8.sample_counter0001 []
     inst [8 or "8 inst-8"] value 12254788400
     inst [9 or "9 inst-9"] value 13786636900
 
-opentelemetry.source8.sample_gauge0000 []
+opentelemetry.source8.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 96.8
     inst [2 or "2 inst-2"] value 193.6
@@ -1003,7 +1003,7 @@ opentelemetry.source8.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 774.4
     inst [9 or "9 inst-9"] value 871.2
 
-opentelemetry.source8.sample_summary0002 []
+opentelemetry.source8.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00159623
     inst [2 or "quantile: 0.5"] value 0.00319246
@@ -1015,13 +1015,13 @@ opentelemetry.source8.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.01276984
     inst [9 or "quantile: 2.25"] value 0.01436607
 
-opentelemetry.source8.sample_summary0002_count []
+opentelemetry.source8.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 18180
 
-opentelemetry.source8.sample_summary0002_sum []
+opentelemetry.source8.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 13.912068
 
-opentelemetry.source8.sample_counter0001 []
+opentelemetry.source8.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -1033,7 +1033,7 @@ opentelemetry.source8.sample_counter0001 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source8.sample_gauge0000 []
+opentelemetry.source8.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -1045,7 +1045,7 @@ opentelemetry.source8.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source8.sample_summary0002 []
+opentelemetry.source8.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -1057,13 +1057,13 @@ opentelemetry.source8.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source8.sample_summary0002_count []
+opentelemetry.source8.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source8.sample_summary0002_sum []
+opentelemetry.source8.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source8.sample_counter0001 []
+opentelemetry.source8.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -1075,7 +1075,7 @@ opentelemetry.source8.sample_counter0001 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source8.sample_gauge0000 []
+opentelemetry.source8.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -1087,7 +1087,7 @@ opentelemetry.source8.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source8.sample_summary0002 []
+opentelemetry.source8.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -1099,13 +1099,13 @@ opentelemetry.source8.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source8.sample_summary0002_count []
+opentelemetry.source8.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source8.sample_summary0002_sum []
+opentelemetry.source8.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source9.sample_counter0001 []
+opentelemetry.source9.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1702053940
     inst [2 or "2 inst-2"] value 3404107880
@@ -1117,7 +1117,7 @@ opentelemetry.source9.sample_counter0001 []
     inst [8 or "8 inst-8"] value 13616431500
     inst [9 or "9 inst-9"] value 15318485500
 
-opentelemetry.source9.sample_gauge0000 []
+opentelemetry.source9.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 108.9
     inst [2 or "2 inst-2"] value 217.8
@@ -1129,7 +1129,7 @@ opentelemetry.source9.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 871.2
     inst [9 or "9 inst-9"] value 980.1
 
-opentelemetry.source9.sample_summary0002 []
+opentelemetry.source9.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001755853
     inst [2 or "quantile: 0.5"] value 0.003511706
@@ -1141,13 +1141,13 @@ opentelemetry.source9.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.014046824
     inst [9 or "quantile: 2.25"] value 0.015802677
 
-opentelemetry.source9.sample_summary0002_count []
+opentelemetry.source9.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 19998
 
-opentelemetry.source9.sample_summary0002_sum []
+opentelemetry.source9.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 15.303274
 
-opentelemetry.source9.sample_counter0001 []
+opentelemetry.source9.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3233902490
     inst [2 or "2 inst-2"] value 6467804970
@@ -1159,7 +1159,7 @@ opentelemetry.source9.sample_counter0001 []
     inst [8 or "8 inst-8"] value 25871219900
     inst [9 or "9 inst-9"] value 29105122400
 
-opentelemetry.source9.sample_gauge0000 []
+opentelemetry.source9.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 217.8
     inst [2 or "2 inst-2"] value 435.6
@@ -1171,7 +1171,7 @@ opentelemetry.source9.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1742.4
     inst [9 or "9 inst-9"] value 1960.2
 
-opentelemetry.source9.sample_summary0002 []
+opentelemetry.source9.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00319246
     inst [2 or "quantile: 0.5"] value 0.006384920000000001
@@ -1183,13 +1183,13 @@ opentelemetry.source9.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.02553968
     inst [9 or "quantile: 2.25"] value 0.02873214
 
-opentelemetry.source9.sample_summary0002_count []
+opentelemetry.source9.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 36360
 
-opentelemetry.source9.sample_summary0002_sum []
+opentelemetry.source9.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 27.824135
 
-opentelemetry.source9.sample_counter0001 []
+opentelemetry.source9.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4765751030
     inst [2 or "2 inst-2"] value 9531502060
@@ -1201,7 +1201,7 @@ opentelemetry.source9.sample_counter0001 []
     inst [8 or "8 inst-8"] value 38126008300
     inst [9 or "9 inst-9"] value 42891759300
 
-opentelemetry.source9.sample_gauge0000 []
+opentelemetry.source9.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 326.7
     inst [2 or "2 inst-2"] value 653.4
@@ -1213,7 +1213,7 @@ opentelemetry.source9.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2613.6
     inst [9 or "9 inst-9"] value 2940.3
 
-opentelemetry.source9.sample_summary0002 []
+opentelemetry.source9.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004629067000000001
     inst [2 or "quantile: 0.5"] value 0.009258134000000001
@@ -1225,13 +1225,13 @@ opentelemetry.source9.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.037032536
     inst [9 or "quantile: 2.25"] value 0.04166160300000001
 
-opentelemetry.source9.sample_summary0002_count []
+opentelemetry.source9.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 52722
 
-opentelemetry.source9.sample_summary0002_sum []
+opentelemetry.source9.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 40.344996
 
-opentelemetry.source10.sample_counter0001 []
+opentelemetry.source10.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1872259330
     inst [2 or "2 inst-2"] value 3744518670
@@ -1243,7 +1243,7 @@ opentelemetry.source10.sample_counter0001 []
     inst [8 or "8 inst-8"] value 14978074700
     inst [9 or "9 inst-9"] value 16850334000
 
-opentelemetry.source10.sample_gauge0000 []
+opentelemetry.source10.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 121
     inst [2 or "2 inst-2"] value 242
@@ -1255,7 +1255,7 @@ opentelemetry.source10.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 968
     inst [9 or "9 inst-9"] value 1089
 
-opentelemetry.source10.sample_summary0002 []
+opentelemetry.source10.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001915476
     inst [2 or "quantile: 0.5"] value 0.003830952
@@ -1267,13 +1267,13 @@ opentelemetry.source10.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.015323808
     inst [9 or "quantile: 2.25"] value 0.017239284
 
-opentelemetry.source10.sample_summary0002_count []
+opentelemetry.source10.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 21816
 
-opentelemetry.source10.sample_summary0002_sum []
+opentelemetry.source10.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 16.694481
 
-opentelemetry.source10.sample_counter0001 []
+opentelemetry.source10.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -1285,7 +1285,7 @@ opentelemetry.source10.sample_counter0001 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source10.sample_gauge0000 []
+opentelemetry.source10.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -1297,7 +1297,7 @@ opentelemetry.source10.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source10.sample_summary0002 []
+opentelemetry.source10.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -1309,13 +1309,13 @@ opentelemetry.source10.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source10.sample_summary0002_count []
+opentelemetry.source10.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source10.sample_summary0002_sum []
+opentelemetry.source10.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source10.sample_counter0001 []
+opentelemetry.source10.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5276367210
     inst [2 or "2 inst-2"] value 10552734400
@@ -1327,7 +1327,7 @@ opentelemetry.source10.sample_counter0001 []
     inst [8 or "8 inst-8"] value 42210937700
     inst [9 or "9 inst-9"] value 47487304900
 
-opentelemetry.source10.sample_gauge0000 []
+opentelemetry.source10.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 363
     inst [2 or "2 inst-2"] value 726
@@ -1339,7 +1339,7 @@ opentelemetry.source10.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2904
     inst [9 or "9 inst-9"] value 3267
 
-opentelemetry.source10.sample_summary0002 []
+opentelemetry.source10.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005107936
     inst [2 or "quantile: 0.5"] value 0.010215872
@@ -1351,13 +1351,13 @@ opentelemetry.source10.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.040863488
     inst [9 or "quantile: 2.25"] value 0.045971424
 
-opentelemetry.source10.sample_summary0002_count []
+opentelemetry.source10.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 58176
 
-opentelemetry.source10.sample_summary0002_sum []
+opentelemetry.source10.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 44.518617
 
-opentelemetry.source11.sample_counter0001 []
+opentelemetry.source11.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2042464730
     inst [2 or "2 inst-2"] value 4084929460
@@ -1369,7 +1369,7 @@ opentelemetry.source11.sample_counter0001 []
     inst [8 or "8 inst-8"] value 16339717800
     inst [9 or "9 inst-9"] value 18382182600
 
-opentelemetry.source11.sample_gauge0000 []
+opentelemetry.source11.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 133.1
     inst [2 or "2 inst-2"] value 266.2
@@ -1381,7 +1381,7 @@ opentelemetry.source11.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1064.8
     inst [9 or "9 inst-9"] value 1197.9
 
-opentelemetry.source11.sample_summary0002 []
+opentelemetry.source11.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002075099
     inst [2 or "quantile: 0.5"] value 0.004150198000000001
@@ -1393,13 +1393,13 @@ opentelemetry.source11.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.016600792
     inst [9 or "quantile: 2.25"] value 0.018675891
 
-opentelemetry.source11.sample_summary0002_count []
+opentelemetry.source11.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 23634
 
-opentelemetry.source11.sample_summary0002_sum []
+opentelemetry.source11.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 18.085688
 
-opentelemetry.source11.sample_counter0001 []
+opentelemetry.source11.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3914724060
     inst [2 or "2 inst-2"] value 7829448120
@@ -1411,7 +1411,7 @@ opentelemetry.source11.sample_counter0001 []
     inst [8 or "8 inst-8"] value 31317792500
     inst [9 or "9 inst-9"] value 35232516600
 
-opentelemetry.source11.sample_gauge0000 []
+opentelemetry.source11.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 266.2
     inst [2 or "2 inst-2"] value 532.4
@@ -1423,7 +1423,7 @@ opentelemetry.source11.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2129.6
     inst [9 or "9 inst-9"] value 2395.8
 
-opentelemetry.source11.sample_summary0002 []
+opentelemetry.source11.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003830952
     inst [2 or "quantile: 0.5"] value 0.007661904000000001
@@ -1435,13 +1435,13 @@ opentelemetry.source11.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.030647616
     inst [9 or "quantile: 2.25"] value 0.034478568
 
-opentelemetry.source11.sample_summary0002_count []
+opentelemetry.source11.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 43632
 
-opentelemetry.source11.sample_summary0002_sum []
+opentelemetry.source11.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 33.388962
 
-opentelemetry.source11.sample_counter0001 []
+opentelemetry.source11.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5786983400
     inst [2 or "2 inst-2"] value 11573966800
@@ -1453,7 +1453,7 @@ opentelemetry.source11.sample_counter0001 []
     inst [8 or "8 inst-8"] value 46295867200
     inst [9 or "9 inst-9"] value 52082850600
 
-opentelemetry.source11.sample_gauge0000 []
+opentelemetry.source11.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 399.3
     inst [2 or "2 inst-2"] value 798.6
@@ -1465,7 +1465,7 @@ opentelemetry.source11.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3194.4
     inst [9 or "9 inst-9"] value 3593.7
 
-opentelemetry.source11.sample_summary0002 []
+opentelemetry.source11.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005586805
     inst [2 or "quantile: 0.5"] value 0.01117361
@@ -1477,13 +1477,13 @@ opentelemetry.source11.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.04469444
     inst [9 or "quantile: 2.25"] value 0.050281245
 
-opentelemetry.source11.sample_summary0002_count []
+opentelemetry.source11.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 63630
 
-opentelemetry.source11.sample_summary0002_sum []
+opentelemetry.source11.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 48.692237
 
-opentelemetry.source12.sample_counter0001 []
+opentelemetry.source12.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -1495,7 +1495,7 @@ opentelemetry.source12.sample_counter0001 []
     inst [8 or "8 inst-8"] value 17701361000
     inst [9 or "9 inst-9"] value 19914031100
 
-opentelemetry.source12.sample_gauge0000 []
+opentelemetry.source12.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -1507,7 +1507,7 @@ opentelemetry.source12.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1161.6
     inst [9 or "9 inst-9"] value 1306.8
 
-opentelemetry.source12.sample_summary0002 []
+opentelemetry.source12.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -1519,13 +1519,13 @@ opentelemetry.source12.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.017877776
     inst [9 or "quantile: 2.25"] value 0.020112498
 
-opentelemetry.source12.sample_summary0002_count []
+opentelemetry.source12.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source12.sample_summary0002_sum []
+opentelemetry.source12.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source12.sample_counter0001 []
+opentelemetry.source12.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -1537,7 +1537,7 @@ opentelemetry.source12.sample_counter0001 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source12.sample_gauge0000 []
+opentelemetry.source12.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -1549,7 +1549,7 @@ opentelemetry.source12.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source12.sample_summary0002 []
+opentelemetry.source12.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -1561,13 +1561,13 @@ opentelemetry.source12.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source12.sample_summary0002_count []
+opentelemetry.source12.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source12.sample_summary0002_sum []
+opentelemetry.source12.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source12.sample_counter0001 []
+opentelemetry.source12.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -1579,7 +1579,7 @@ opentelemetry.source12.sample_counter0001 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source12.sample_gauge0000 []
+opentelemetry.source12.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -1591,7 +1591,7 @@ opentelemetry.source12.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source12.sample_summary0002 []
+opentelemetry.source12.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -1603,13 +1603,13 @@ opentelemetry.source12.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source12.sample_summary0002_count []
+opentelemetry.source12.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source12.sample_summary0002_sum []
+opentelemetry.source12.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source13.sample_counter0001 []
+opentelemetry.source13.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2382875520
     inst [2 or "2 inst-2"] value 4765751030
@@ -1621,7 +1621,7 @@ opentelemetry.source13.sample_counter0001 []
     inst [8 or "8 inst-8"] value 19063004100
     inst [9 or "9 inst-9"] value 21445879600
 
-opentelemetry.source13.sample_gauge0000 []
+opentelemetry.source13.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 157.3
     inst [2 or "2 inst-2"] value 314.6
@@ -1633,7 +1633,7 @@ opentelemetry.source13.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1258.4
     inst [9 or "9 inst-9"] value 1415.7
 
-opentelemetry.source13.sample_summary0002 []
+opentelemetry.source13.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002394345
     inst [2 or "quantile: 0.5"] value 0.00478869
@@ -1645,13 +1645,13 @@ opentelemetry.source13.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.01915476
     inst [9 or "quantile: 2.25"] value 0.021549105
 
-opentelemetry.source13.sample_summary0002_count []
+opentelemetry.source13.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 27270
 
-opentelemetry.source13.sample_summary0002_sum []
+opentelemetry.source13.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 20.868102
 
-opentelemetry.source13.sample_counter0001 []
+opentelemetry.source13.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4595545640
     inst [2 or "2 inst-2"] value 9191091280
@@ -1663,7 +1663,7 @@ opentelemetry.source13.sample_counter0001 []
     inst [8 or "8 inst-8"] value 36764365100
     inst [9 or "9 inst-9"] value 41359910700
 
-opentelemetry.source13.sample_gauge0000 []
+opentelemetry.source13.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 314.6
     inst [2 or "2 inst-2"] value 629.2
@@ -1675,7 +1675,7 @@ opentelemetry.source13.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2516.8
     inst [9 or "9 inst-9"] value 2831.4
 
-opentelemetry.source13.sample_summary0002 []
+opentelemetry.source13.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004469444
     inst [2 or "quantile: 0.5"] value 0.008938888000000001
@@ -1687,13 +1687,13 @@ opentelemetry.source13.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.035755552
     inst [9 or "quantile: 2.25"] value 0.04022499600000001
 
-opentelemetry.source13.sample_summary0002_count []
+opentelemetry.source13.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 50904
 
-opentelemetry.source13.sample_summary0002_sum []
+opentelemetry.source13.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 38.95379
 
-opentelemetry.source13.sample_counter0001 []
+opentelemetry.source13.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6808215760
     inst [2 or "2 inst-2"] value 13616431500
@@ -1705,7 +1705,7 @@ opentelemetry.source13.sample_counter0001 []
     inst [8 or "8 inst-8"] value 54465726100
     inst [9 or "9 inst-9"] value 61273941800
 
-opentelemetry.source13.sample_gauge0000 []
+opentelemetry.source13.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 471.9
     inst [2 or "2 inst-2"] value 943.8
@@ -1717,7 +1717,7 @@ opentelemetry.source13.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3775.2
     inst [9 or "9 inst-9"] value 4247.1
 
-opentelemetry.source13.sample_summary0002 []
+opentelemetry.source13.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006544543000000001
     inst [2 or "quantile: 0.5"] value 0.013089086
@@ -1729,13 +1729,13 @@ opentelemetry.source13.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.05235634400000001
     inst [9 or "quantile: 2.25"] value 0.05890088700000001
 
-opentelemetry.source13.sample_summary0002_count []
+opentelemetry.source13.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 74538
 
-opentelemetry.source13.sample_summary0002_sum []
+opentelemetry.source13.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 57.039478
 
-opentelemetry.source14.sample_counter0001 []
+opentelemetry.source14.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2553080910
     inst [2 or "2 inst-2"] value 5106161820
@@ -1747,7 +1747,7 @@ opentelemetry.source14.sample_counter0001 []
     inst [8 or "8 inst-8"] value 20424647300
     inst [9 or "9 inst-9"] value 22977728200
 
-opentelemetry.source14.sample_gauge0000 []
+opentelemetry.source14.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 169.4
     inst [2 or "2 inst-2"] value 338.8
@@ -1759,7 +1759,7 @@ opentelemetry.source14.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1355.2
     inst [9 or "9 inst-9"] value 1524.6
 
-opentelemetry.source14.sample_summary0002 []
+opentelemetry.source14.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002553968
     inst [2 or "quantile: 0.5"] value 0.005107936
@@ -1771,13 +1771,13 @@ opentelemetry.source14.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.020431744
     inst [9 or "quantile: 2.25"] value 0.022985712
 
-opentelemetry.source14.sample_summary0002_count []
+opentelemetry.source14.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 29088
 
-opentelemetry.source14.sample_summary0002_sum []
+opentelemetry.source14.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 22.259308
 
-opentelemetry.source14.sample_counter0001 []
+opentelemetry.source14.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -1789,7 +1789,7 @@ opentelemetry.source14.sample_counter0001 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source14.sample_gauge0000 []
+opentelemetry.source14.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -1801,7 +1801,7 @@ opentelemetry.source14.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source14.sample_summary0002 []
+opentelemetry.source14.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -1813,13 +1813,13 @@ opentelemetry.source14.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source14.sample_summary0002_count []
+opentelemetry.source14.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source14.sample_summary0002_sum []
+opentelemetry.source14.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source14.sample_counter0001 []
+opentelemetry.source14.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7318831940
     inst [2 or "2 inst-2"] value 14637663900
@@ -1831,7 +1831,7 @@ opentelemetry.source14.sample_counter0001 []
     inst [8 or "8 inst-8"] value 58550655500
     inst [9 or "9 inst-9"] value 65869487500
 
-opentelemetry.source14.sample_gauge0000 []
+opentelemetry.source14.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 508.2
     inst [2 or "2 inst-2"] value 1016.4
@@ -1843,7 +1843,7 @@ opentelemetry.source14.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4065.6
     inst [9 or "9 inst-9"] value 4573.8
 
-opentelemetry.source14.sample_summary0002 []
+opentelemetry.source14.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007023412000000001
     inst [2 or "quantile: 0.5"] value 0.014046824
@@ -1855,13 +1855,13 @@ opentelemetry.source14.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.056187296
     inst [9 or "quantile: 2.25"] value 0.063210708
 
-opentelemetry.source14.sample_summary0002_count []
+opentelemetry.source14.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 79992
 
-opentelemetry.source14.sample_summary0002_sum []
+opentelemetry.source14.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 61.213098
 
-opentelemetry.source15.sample_counter0001 []
+opentelemetry.source15.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2723286300
     inst [2 or "2 inst-2"] value 5446572610
@@ -1873,7 +1873,7 @@ opentelemetry.source15.sample_counter0001 []
     inst [8 or "8 inst-8"] value 21786290400
     inst [9 or "9 inst-9"] value 24509576700
 
-opentelemetry.source15.sample_gauge0000 []
+opentelemetry.source15.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 181.5
     inst [2 or "2 inst-2"] value 363
@@ -1885,7 +1885,7 @@ opentelemetry.source15.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1452
     inst [9 or "9 inst-9"] value 1633.5
 
-opentelemetry.source15.sample_summary0002 []
+opentelemetry.source15.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002713591
     inst [2 or "quantile: 0.5"] value 0.005427182000000001
@@ -1897,13 +1897,13 @@ opentelemetry.source15.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.021708728
     inst [9 or "quantile: 2.25"] value 0.024422319
 
-opentelemetry.source15.sample_summary0002_count []
+opentelemetry.source15.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 30906
 
-opentelemetry.source15.sample_summary0002_sum []
+opentelemetry.source15.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 23.650515
 
-opentelemetry.source15.sample_counter0001 []
+opentelemetry.source15.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5276367210
     inst [2 or "2 inst-2"] value 10552734400
@@ -1915,7 +1915,7 @@ opentelemetry.source15.sample_counter0001 []
     inst [8 or "8 inst-8"] value 42210937700
     inst [9 or "9 inst-9"] value 47487304900
 
-opentelemetry.source15.sample_gauge0000 []
+opentelemetry.source15.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 363
     inst [2 or "2 inst-2"] value 726
@@ -1927,7 +1927,7 @@ opentelemetry.source15.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2904
     inst [9 or "9 inst-9"] value 3267
 
-opentelemetry.source15.sample_summary0002 []
+opentelemetry.source15.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005107936
     inst [2 or "quantile: 0.5"] value 0.010215872
@@ -1939,13 +1939,13 @@ opentelemetry.source15.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.040863488
     inst [9 or "quantile: 2.25"] value 0.045971424
 
-opentelemetry.source15.sample_summary0002_count []
+opentelemetry.source15.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 58176
 
-opentelemetry.source15.sample_summary0002_sum []
+opentelemetry.source15.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 44.518617
 
-opentelemetry.source15.sample_counter0001 []
+opentelemetry.source15.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7829448120
     inst [2 or "2 inst-2"] value 15658896200
@@ -1957,7 +1957,7 @@ opentelemetry.source15.sample_counter0001 []
     inst [8 or "8 inst-8"] value 62635585000
     inst [9 or "9 inst-9"] value 70465033100
 
-opentelemetry.source15.sample_gauge0000 []
+opentelemetry.source15.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 544.5
     inst [2 or "2 inst-2"] value 1089
@@ -1969,7 +1969,7 @@ opentelemetry.source15.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4356
     inst [9 or "9 inst-9"] value 4900.5
 
-opentelemetry.source15.sample_summary0002 []
+opentelemetry.source15.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007502281
     inst [2 or "quantile: 0.5"] value 0.015004562
@@ -1981,13 +1981,13 @@ opentelemetry.source15.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.060018248
     inst [9 or "quantile: 2.25"] value 0.06752052900000001
 
-opentelemetry.source15.sample_summary0002_count []
+opentelemetry.source15.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 85446
 
-opentelemetry.source15.sample_summary0002_sum []
+opentelemetry.source15.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 65.386718
 
-opentelemetry.source16.sample_counter0001 []
+opentelemetry.source16.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -1999,7 +1999,7 @@ opentelemetry.source16.sample_counter0001 []
     inst [8 or "8 inst-8"] value 23147933600
     inst [9 or "9 inst-9"] value 26041425300
 
-opentelemetry.source16.sample_gauge0000 []
+opentelemetry.source16.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -2011,7 +2011,7 @@ opentelemetry.source16.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1548.8
     inst [9 or "9 inst-9"] value 1742.4
 
-opentelemetry.source16.sample_summary0002 []
+opentelemetry.source16.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -2023,13 +2023,13 @@ opentelemetry.source16.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.022985712
     inst [9 or "quantile: 2.25"] value 0.025858926
 
-opentelemetry.source16.sample_summary0002_count []
+opentelemetry.source16.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source16.sample_summary0002_sum []
+opentelemetry.source16.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source16.sample_counter0001 []
+opentelemetry.source16.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -2041,7 +2041,7 @@ opentelemetry.source16.sample_counter0001 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source16.sample_gauge0000 []
+opentelemetry.source16.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -2053,7 +2053,7 @@ opentelemetry.source16.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source16.sample_summary0002 []
+opentelemetry.source16.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -2065,13 +2065,13 @@ opentelemetry.source16.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source16.sample_summary0002_count []
+opentelemetry.source16.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source16.sample_summary0002_sum []
+opentelemetry.source16.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source16.sample_counter0001 []
+opentelemetry.source16.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -2083,7 +2083,7 @@ opentelemetry.source16.sample_counter0001 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source16.sample_gauge0000 []
+opentelemetry.source16.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -2095,7 +2095,7 @@ opentelemetry.source16.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source16.sample_summary0002 []
+opentelemetry.source16.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -2107,13 +2107,13 @@ opentelemetry.source16.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source16.sample_summary0002_count []
+opentelemetry.source16.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source16.sample_summary0002_sum []
+opentelemetry.source16.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source17.sample_counter0001 []
+opentelemetry.source17.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3063697090
     inst [2 or "2 inst-2"] value 6127394180
@@ -2125,7 +2125,7 @@ opentelemetry.source17.sample_counter0001 []
     inst [8 or "8 inst-8"] value 24509576700
     inst [9 or "9 inst-9"] value 27573273800
 
-opentelemetry.source17.sample_gauge0000 []
+opentelemetry.source17.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 205.7
     inst [2 or "2 inst-2"] value 411.4
@@ -2137,7 +2137,7 @@ opentelemetry.source17.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1645.6
     inst [9 or "9 inst-9"] value 1851.3
 
-opentelemetry.source17.sample_summary0002 []
+opentelemetry.source17.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003032837
     inst [2 or "quantile: 0.5"] value 0.006065674
@@ -2149,13 +2149,13 @@ opentelemetry.source17.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.024262696
     inst [9 or "quantile: 2.25"] value 0.027295533
 
-opentelemetry.source17.sample_summary0002_count []
+opentelemetry.source17.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 34542
 
-opentelemetry.source17.sample_summary0002_sum []
+opentelemetry.source17.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 26.432929
 
-opentelemetry.source17.sample_counter0001 []
+opentelemetry.source17.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5957188790
     inst [2 or "2 inst-2"] value 11914377600
@@ -2167,7 +2167,7 @@ opentelemetry.source17.sample_counter0001 []
     inst [8 or "8 inst-8"] value 47657510300
     inst [9 or "9 inst-9"] value 53614699100
 
-opentelemetry.source17.sample_gauge0000 []
+opentelemetry.source17.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 411.4
     inst [2 or "2 inst-2"] value 822.8
@@ -2179,7 +2179,7 @@ opentelemetry.source17.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3291.2
     inst [9 or "9 inst-9"] value 3702.6
 
-opentelemetry.source17.sample_summary0002 []
+opentelemetry.source17.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005746428
     inst [2 or "quantile: 0.5"] value 0.011492856
@@ -2191,13 +2191,13 @@ opentelemetry.source17.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.045971424
     inst [9 or "quantile: 2.25"] value 0.051717852
 
-opentelemetry.source17.sample_summary0002_count []
+opentelemetry.source17.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 65448
 
-opentelemetry.source17.sample_summary0002_sum []
+opentelemetry.source17.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 50.083444
 
-opentelemetry.source17.sample_counter0001 []
+opentelemetry.source17.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8850680490
     inst [2 or "2 inst-2"] value 17701361000
@@ -2209,7 +2209,7 @@ opentelemetry.source17.sample_counter0001 []
     inst [8 or "8 inst-8"] value 70805443900
     inst [9 or "9 inst-9"] value 79656124400
 
-opentelemetry.source17.sample_gauge0000 []
+opentelemetry.source17.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 617.1
     inst [2 or "2 inst-2"] value 1234.2
@@ -2221,7 +2221,7 @@ opentelemetry.source17.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4936.8
     inst [9 or "9 inst-9"] value 5553.9
 
-opentelemetry.source17.sample_summary0002 []
+opentelemetry.source17.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008460019000000001
     inst [2 or "quantile: 0.5"] value 0.016920038
@@ -2233,13 +2233,13 @@ opentelemetry.source17.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.06768015200000001
     inst [9 or "quantile: 2.25"] value 0.07614017100000001
 
-opentelemetry.source17.sample_summary0002_count []
+opentelemetry.source17.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 96354
 
-opentelemetry.source17.sample_summary0002_sum []
+opentelemetry.source17.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 73.733959
 
-opentelemetry.source18.sample_counter0001 []
+opentelemetry.source18.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3233902490
     inst [2 or "2 inst-2"] value 6467804970
@@ -2251,7 +2251,7 @@ opentelemetry.source18.sample_counter0001 []
     inst [8 or "8 inst-8"] value 25871219900
     inst [9 or "9 inst-9"] value 29105122400
 
-opentelemetry.source18.sample_gauge0000 []
+opentelemetry.source18.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 217.8
     inst [2 or "2 inst-2"] value 435.6
@@ -2263,7 +2263,7 @@ opentelemetry.source18.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1742.4
     inst [9 or "9 inst-9"] value 1960.2
 
-opentelemetry.source18.sample_summary0002 []
+opentelemetry.source18.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00319246
     inst [2 or "quantile: 0.5"] value 0.006384920000000001
@@ -2275,13 +2275,13 @@ opentelemetry.source18.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.02553968
     inst [9 or "quantile: 2.25"] value 0.02873214
 
-opentelemetry.source18.sample_summary0002_count []
+opentelemetry.source18.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 36360
 
-opentelemetry.source18.sample_summary0002_sum []
+opentelemetry.source18.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 27.824135
 
-opentelemetry.source18.sample_counter0001 []
+opentelemetry.source18.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -2293,7 +2293,7 @@ opentelemetry.source18.sample_counter0001 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source18.sample_gauge0000 []
+opentelemetry.source18.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -2305,7 +2305,7 @@ opentelemetry.source18.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source18.sample_summary0002 []
+opentelemetry.source18.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -2317,13 +2317,13 @@ opentelemetry.source18.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source18.sample_summary0002_count []
+opentelemetry.source18.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source18.sample_summary0002_sum []
+opentelemetry.source18.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source18.sample_counter0001 []
+opentelemetry.source18.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9361296670
     inst [2 or "2 inst-2"] value 18722593300
@@ -2335,7 +2335,7 @@ opentelemetry.source18.sample_counter0001 []
     inst [8 or "8 inst-8"] value 74890373400
     inst [9 or "9 inst-9"] value 84251670000
 
-opentelemetry.source18.sample_gauge0000 []
+opentelemetry.source18.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 653.4
     inst [2 or "2 inst-2"] value 1306.8
@@ -2347,7 +2347,7 @@ opentelemetry.source18.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5227.2
     inst [9 or "9 inst-9"] value 5880.6
 
-opentelemetry.source18.sample_summary0002 []
+opentelemetry.source18.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008938888000000001
     inst [2 or "quantile: 0.5"] value 0.017877776
@@ -2359,13 +2359,13 @@ opentelemetry.source18.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.07151110400000001
     inst [9 or "quantile: 2.25"] value 0.08044999200000001
 
-opentelemetry.source18.sample_summary0002_count []
+opentelemetry.source18.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 101808
 
-opentelemetry.source18.sample_summary0002_sum []
+opentelemetry.source18.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 77.907579
 
-opentelemetry.source19.sample_counter0001 []
+opentelemetry.source19.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3404107880
     inst [2 or "2 inst-2"] value 6808215760
@@ -2377,7 +2377,7 @@ opentelemetry.source19.sample_counter0001 []
     inst [8 or "8 inst-8"] value 27232863000
     inst [9 or "9 inst-9"] value 30636970900
 
-opentelemetry.source19.sample_gauge0000 []
+opentelemetry.source19.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 229.9
     inst [2 or "2 inst-2"] value 459.8
@@ -2389,7 +2389,7 @@ opentelemetry.source19.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1839.2
     inst [9 or "9 inst-9"] value 2069.1
 
-opentelemetry.source19.sample_summary0002 []
+opentelemetry.source19.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003352083
     inst [2 or "quantile: 0.5"] value 0.006704166000000001
@@ -2401,13 +2401,13 @@ opentelemetry.source19.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.026816664
     inst [9 or "quantile: 2.25"] value 0.030168747
 
-opentelemetry.source19.sample_summary0002_count []
+opentelemetry.source19.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 38178
 
-opentelemetry.source19.sample_summary0002_sum []
+opentelemetry.source19.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 29.215342
 
-opentelemetry.source19.sample_counter0001 []
+opentelemetry.source19.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6638010370
     inst [2 or "2 inst-2"] value 13276020700
@@ -2419,7 +2419,7 @@ opentelemetry.source19.sample_counter0001 []
     inst [8 or "8 inst-8"] value 53104082900
     inst [9 or "9 inst-9"] value 59742093300
 
-opentelemetry.source19.sample_gauge0000 []
+opentelemetry.source19.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 459.8
     inst [2 or "2 inst-2"] value 919.6
@@ -2431,7 +2431,7 @@ opentelemetry.source19.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3678.4
     inst [9 or "9 inst-9"] value 4138.2
 
-opentelemetry.source19.sample_summary0002 []
+opentelemetry.source19.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006384920000000001
     inst [2 or "quantile: 0.5"] value 0.01276984
@@ -2443,13 +2443,13 @@ opentelemetry.source19.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.05107936
     inst [9 or "quantile: 2.25"] value 0.05746428000000001
 
-opentelemetry.source19.sample_summary0002_count []
+opentelemetry.source19.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 72720
 
-opentelemetry.source19.sample_summary0002_sum []
+opentelemetry.source19.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 55.648271
 
-opentelemetry.source19.sample_counter0001 []
+opentelemetry.source19.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9871912850
     inst [2 or "2 inst-2"] value 19743825700
@@ -2461,7 +2461,7 @@ opentelemetry.source19.sample_counter0001 []
     inst [8 or "8 inst-8"] value 78975302800
     inst [9 or "9 inst-9"] value 88847215700
 
-opentelemetry.source19.sample_gauge0000 []
+opentelemetry.source19.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 689.7
     inst [2 or "2 inst-2"] value 1379.4
@@ -2473,7 +2473,7 @@ opentelemetry.source19.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5517.6
     inst [9 or "9 inst-9"] value 6207.3
 
-opentelemetry.source19.sample_summary0002 []
+opentelemetry.source19.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009417757000000001
     inst [2 or "quantile: 0.5"] value 0.018835514
@@ -2485,13 +2485,13 @@ opentelemetry.source19.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.075342056
     inst [9 or "quantile: 2.25"] value 0.084759813
 
-opentelemetry.source19.sample_summary0002_count []
+opentelemetry.source19.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 107262
 
-opentelemetry.source19.sample_summary0002_sum []
+opentelemetry.source19.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 82.081199
 
-opentelemetry.source20.sample_counter0001 []
+opentelemetry.source20.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3574313270
     inst [2 or "2 inst-2"] value 7148626550
@@ -2503,7 +2503,7 @@ opentelemetry.source20.sample_counter0001 []
     inst [8 or "8 inst-8"] value 28594506200
     inst [9 or "9 inst-9"] value 32168819500
 
-opentelemetry.source20.sample_gauge0000 []
+opentelemetry.source20.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 242
     inst [2 or "2 inst-2"] value 484
@@ -2515,7 +2515,7 @@ opentelemetry.source20.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 1936
     inst [9 or "9 inst-9"] value 2178
 
-opentelemetry.source20.sample_summary0002 []
+opentelemetry.source20.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003511706
     inst [2 or "quantile: 0.5"] value 0.007023412000000001
@@ -2527,13 +2527,13 @@ opentelemetry.source20.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.028093648
     inst [9 or "quantile: 2.25"] value 0.031605354
 
-opentelemetry.source20.sample_summary0002_count []
+opentelemetry.source20.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 39996
 
-opentelemetry.source20.sample_summary0002_sum []
+opentelemetry.source20.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 30.606549
 
-opentelemetry.source20.sample_counter0001 []
+opentelemetry.source20.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -2545,7 +2545,7 @@ opentelemetry.source20.sample_counter0001 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source20.sample_gauge0000 []
+opentelemetry.source20.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -2557,7 +2557,7 @@ opentelemetry.source20.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source20.sample_summary0002 []
+opentelemetry.source20.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -2569,13 +2569,13 @@ opentelemetry.source20.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source20.sample_summary0002_count []
+opentelemetry.source20.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source20.sample_summary0002_sum []
+opentelemetry.source20.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source20.sample_counter0001 []
+opentelemetry.source20.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -2587,7 +2587,7 @@ opentelemetry.source20.sample_counter0001 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source20.sample_gauge0000 []
+opentelemetry.source20.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -2599,7 +2599,7 @@ opentelemetry.source20.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source20.sample_summary0002 []
+opentelemetry.source20.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -2611,13 +2611,13 @@ opentelemetry.source20.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source20.sample_summary0002_count []
+opentelemetry.source20.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source20.sample_summary0002_sum []
+opentelemetry.source20.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source21.sample_counter0001 []
+opentelemetry.source21.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3744518670
     inst [2 or "2 inst-2"] value 7489037340
@@ -2629,7 +2629,7 @@ opentelemetry.source21.sample_counter0001 []
     inst [8 or "8 inst-8"] value 29956149300
     inst [9 or "9 inst-9"] value 33700668000
 
-opentelemetry.source21.sample_gauge0000 []
+opentelemetry.source21.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 254.1
     inst [2 or "2 inst-2"] value 508.2
@@ -2641,7 +2641,7 @@ opentelemetry.source21.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2032.8
     inst [9 or "9 inst-9"] value 2286.9
 
-opentelemetry.source21.sample_summary0002 []
+opentelemetry.source21.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003671329
     inst [2 or "quantile: 0.5"] value 0.007342658
@@ -2653,13 +2653,13 @@ opentelemetry.source21.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.029370632
     inst [9 or "quantile: 2.25"] value 0.033041961
 
-opentelemetry.source21.sample_summary0002_count []
+opentelemetry.source21.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 41814
 
-opentelemetry.source21.sample_summary0002_sum []
+opentelemetry.source21.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 31.997756
 
-opentelemetry.source21.sample_counter0001 []
+opentelemetry.source21.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7318831940
     inst [2 or "2 inst-2"] value 14637663900
@@ -2671,7 +2671,7 @@ opentelemetry.source21.sample_counter0001 []
     inst [8 or "8 inst-8"] value 58550655500
     inst [9 or "9 inst-9"] value 65869487500
 
-opentelemetry.source21.sample_gauge0000 []
+opentelemetry.source21.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 508.2
     inst [2 or "2 inst-2"] value 1016.4
@@ -2683,7 +2683,7 @@ opentelemetry.source21.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4065.6
     inst [9 or "9 inst-9"] value 4573.8
 
-opentelemetry.source21.sample_summary0002 []
+opentelemetry.source21.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007023412000000001
     inst [2 or "quantile: 0.5"] value 0.014046824
@@ -2695,13 +2695,13 @@ opentelemetry.source21.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.056187296
     inst [9 or "quantile: 2.25"] value 0.063210708
 
-opentelemetry.source21.sample_summary0002_count []
+opentelemetry.source21.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 79992
 
-opentelemetry.source21.sample_summary0002_sum []
+opentelemetry.source21.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 61.213098
 
-opentelemetry.source21.sample_counter0001 []
+opentelemetry.source21.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10893145200
     inst [2 or "2 inst-2"] value 21786290400
@@ -2713,7 +2713,7 @@ opentelemetry.source21.sample_counter0001 []
     inst [8 or "8 inst-8"] value 87145161700
     inst [9 or "9 inst-9"] value 98038306900
 
-opentelemetry.source21.sample_gauge0000 []
+opentelemetry.source21.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 762.3
     inst [2 or "2 inst-2"] value 1524.6
@@ -2725,7 +2725,7 @@ opentelemetry.source21.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6098.4
     inst [9 or "9 inst-9"] value 6860.7
 
-opentelemetry.source21.sample_summary0002 []
+opentelemetry.source21.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010375495
     inst [2 or "quantile: 0.5"] value 0.02075099
@@ -2737,13 +2737,13 @@ opentelemetry.source21.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08300396
     inst [9 or "quantile: 2.25"] value 0.09337945500000001
 
-opentelemetry.source21.sample_summary0002_count []
+opentelemetry.source21.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 118170
 
-opentelemetry.source21.sample_summary0002_sum []
+opentelemetry.source21.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 90.42843999999999
 
-opentelemetry.source22.sample_counter0001 []
+opentelemetry.source22.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3914724060
     inst [2 or "2 inst-2"] value 7829448120
@@ -2755,7 +2755,7 @@ opentelemetry.source22.sample_counter0001 []
     inst [8 or "8 inst-8"] value 31317792500
     inst [9 or "9 inst-9"] value 35232516600
 
-opentelemetry.source22.sample_gauge0000 []
+opentelemetry.source22.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 266.2
     inst [2 or "2 inst-2"] value 532.4
@@ -2767,7 +2767,7 @@ opentelemetry.source22.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2129.6
     inst [9 or "9 inst-9"] value 2395.8
 
-opentelemetry.source22.sample_summary0002 []
+opentelemetry.source22.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003830952
     inst [2 or "quantile: 0.5"] value 0.007661904000000001
@@ -2779,13 +2779,13 @@ opentelemetry.source22.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.030647616
     inst [9 or "quantile: 2.25"] value 0.034478568
 
-opentelemetry.source22.sample_summary0002_count []
+opentelemetry.source22.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 43632
 
-opentelemetry.source22.sample_summary0002_sum []
+opentelemetry.source22.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 33.388962
 
-opentelemetry.source22.sample_counter0001 []
+opentelemetry.source22.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -2797,7 +2797,7 @@ opentelemetry.source22.sample_counter0001 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source22.sample_gauge0000 []
+opentelemetry.source22.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -2809,7 +2809,7 @@ opentelemetry.source22.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source22.sample_summary0002 []
+opentelemetry.source22.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -2821,13 +2821,13 @@ opentelemetry.source22.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source22.sample_summary0002_count []
+opentelemetry.source22.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source22.sample_summary0002_sum []
+opentelemetry.source22.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source22.sample_counter0001 []
+opentelemetry.source22.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11403761400
     inst [2 or "2 inst-2"] value 22807522800
@@ -2839,7 +2839,7 @@ opentelemetry.source22.sample_counter0001 []
     inst [8 or "8 inst-8"] value 91230091200
     inst [9 or "9 inst-9"] value 102633853000
 
-opentelemetry.source22.sample_gauge0000 []
+opentelemetry.source22.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 798.6
     inst [2 or "2 inst-2"] value 1597.2
@@ -2851,7 +2851,7 @@ opentelemetry.source22.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6388.8
     inst [9 or "9 inst-9"] value 7187.4
 
-opentelemetry.source22.sample_summary0002 []
+opentelemetry.source22.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010854364
     inst [2 or "quantile: 0.5"] value 0.021708728
@@ -2863,13 +2863,13 @@ opentelemetry.source22.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08683491200000001
     inst [9 or "quantile: 2.25"] value 0.09768927600000001
 
-opentelemetry.source22.sample_summary0002_count []
+opentelemetry.source22.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 123624
 
-opentelemetry.source22.sample_summary0002_sum []
+opentelemetry.source22.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 94.60205999999999
 
-opentelemetry.source23.sample_counter0001 []
+opentelemetry.source23.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4084929460
     inst [2 or "2 inst-2"] value 8169858910
@@ -2881,7 +2881,7 @@ opentelemetry.source23.sample_counter0001 []
     inst [8 or "8 inst-8"] value 32679435600
     inst [9 or "9 inst-9"] value 36764365100
 
-opentelemetry.source23.sample_gauge0000 []
+opentelemetry.source23.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 278.3
     inst [2 or "2 inst-2"] value 556.6
@@ -2893,7 +2893,7 @@ opentelemetry.source23.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2226.4
     inst [9 or "9 inst-9"] value 2504.7
 
-opentelemetry.source23.sample_summary0002 []
+opentelemetry.source23.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.003990575000000001
     inst [2 or "quantile: 0.5"] value 0.007981150000000001
@@ -2905,13 +2905,13 @@ opentelemetry.source23.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.0319246
     inst [9 or "quantile: 2.25"] value 0.035915175
 
-opentelemetry.source23.sample_summary0002_count []
+opentelemetry.source23.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 45450
 
-opentelemetry.source23.sample_summary0002_sum []
+opentelemetry.source23.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 34.780169
 
-opentelemetry.source23.sample_counter0001 []
+opentelemetry.source23.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7999653520
     inst [2 or "2 inst-2"] value 15999307000
@@ -2923,7 +2923,7 @@ opentelemetry.source23.sample_counter0001 []
     inst [8 or "8 inst-8"] value 63997228100
     inst [9 or "9 inst-9"] value 71996881700
 
-opentelemetry.source23.sample_gauge0000 []
+opentelemetry.source23.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 556.6
     inst [2 or "2 inst-2"] value 1113.2
@@ -2935,7 +2935,7 @@ opentelemetry.source23.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4452.8
     inst [9 or "9 inst-9"] value 5009.4
 
-opentelemetry.source23.sample_summary0002 []
+opentelemetry.source23.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007661904000000001
     inst [2 or "quantile: 0.5"] value 0.015323808
@@ -2947,13 +2947,13 @@ opentelemetry.source23.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.06129523200000001
     inst [9 or "quantile: 2.25"] value 0.068957136
 
-opentelemetry.source23.sample_summary0002_count []
+opentelemetry.source23.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 87264
 
-opentelemetry.source23.sample_summary0002_sum []
+opentelemetry.source23.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 66.777925
 
-opentelemetry.source23.sample_counter0001 []
+opentelemetry.source23.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11914377600
     inst [2 or "2 inst-2"] value 23828755200
@@ -2965,7 +2965,7 @@ opentelemetry.source23.sample_counter0001 []
     inst [8 or "8 inst-8"] value 95315020600
     inst [9 or "9 inst-9"] value 107229398000
 
-opentelemetry.source23.sample_gauge0000 []
+opentelemetry.source23.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 834.9
     inst [2 or "2 inst-2"] value 1669.8
@@ -2977,7 +2977,7 @@ opentelemetry.source23.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6679.2
     inst [9 or "9 inst-9"] value 7514.1
 
-opentelemetry.source23.sample_summary0002 []
+opentelemetry.source23.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011333233
     inst [2 or "quantile: 0.5"] value 0.022666466
@@ -2989,13 +2989,13 @@ opentelemetry.source23.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.09066586400000001
     inst [9 or "quantile: 2.25"] value 0.101999097
 
-opentelemetry.source23.sample_summary0002_count []
+opentelemetry.source23.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 129078
 
-opentelemetry.source23.sample_summary0002_sum []
+opentelemetry.source23.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 98.77568100000001
 
-opentelemetry.source24.sample_counter0001 []
+opentelemetry.source24.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4255134850
     inst [2 or "2 inst-2"] value 8510269700
@@ -3007,7 +3007,7 @@ opentelemetry.source24.sample_counter0001 []
     inst [8 or "8 inst-8"] value 34041078800
     inst [9 or "9 inst-9"] value 38296213600
 
-opentelemetry.source24.sample_gauge0000 []
+opentelemetry.source24.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 290.4
     inst [2 or "2 inst-2"] value 580.8
@@ -3019,7 +3019,7 @@ opentelemetry.source24.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2323.2
     inst [9 or "9 inst-9"] value 2613.6
 
-opentelemetry.source24.sample_summary0002 []
+opentelemetry.source24.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004150198000000001
     inst [2 or "quantile: 0.5"] value 0.008300396000000002
@@ -3031,13 +3031,13 @@ opentelemetry.source24.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.03320158400000001
     inst [9 or "quantile: 2.25"] value 0.037351782
 
-opentelemetry.source24.sample_summary0002_count []
+opentelemetry.source24.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 47268
 
-opentelemetry.source24.sample_summary0002_sum []
+opentelemetry.source24.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 36.171376
 
-opentelemetry.source24.sample_counter0001 []
+opentelemetry.source24.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -3049,7 +3049,7 @@ opentelemetry.source24.sample_counter0001 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source24.sample_gauge0000 []
+opentelemetry.source24.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -3061,7 +3061,7 @@ opentelemetry.source24.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source24.sample_summary0002 []
+opentelemetry.source24.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -3073,13 +3073,13 @@ opentelemetry.source24.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source24.sample_summary0002_count []
+opentelemetry.source24.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source24.sample_summary0002_sum []
+opentelemetry.source24.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source24.sample_counter0001 []
+opentelemetry.source24.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -3091,7 +3091,7 @@ opentelemetry.source24.sample_counter0001 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source24.sample_gauge0000 []
+opentelemetry.source24.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -3103,7 +3103,7 @@ opentelemetry.source24.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source24.sample_summary0002 []
+opentelemetry.source24.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -3115,13 +3115,13 @@ opentelemetry.source24.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source24.sample_summary0002_count []
+opentelemetry.source24.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source24.sample_summary0002_sum []
+opentelemetry.source24.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source25.sample_counter0001 []
+opentelemetry.source25.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4425340240
     inst [2 or "2 inst-2"] value 8850680490
@@ -3133,7 +3133,7 @@ opentelemetry.source25.sample_counter0001 []
     inst [8 or "8 inst-8"] value 35402722000
     inst [9 or "9 inst-9"] value 39828062200
 
-opentelemetry.source25.sample_gauge0000 []
+opentelemetry.source25.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 302.5
     inst [2 or "2 inst-2"] value 605
@@ -3145,7 +3145,7 @@ opentelemetry.source25.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2420
     inst [9 or "9 inst-9"] value 2722.5
 
-opentelemetry.source25.sample_summary0002 []
+opentelemetry.source25.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004309821
     inst [2 or "quantile: 0.5"] value 0.008619642
@@ -3157,13 +3157,13 @@ opentelemetry.source25.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.034478568
     inst [9 or "quantile: 2.25"] value 0.03878838900000001
 
-opentelemetry.source25.sample_summary0002_count []
+opentelemetry.source25.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 49086
 
-opentelemetry.source25.sample_summary0002_sum []
+opentelemetry.source25.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 37.562583
 
-opentelemetry.source25.sample_counter0001 []
+opentelemetry.source25.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8680475090
     inst [2 or "2 inst-2"] value 17360950200
@@ -3175,7 +3175,7 @@ opentelemetry.source25.sample_counter0001 []
     inst [8 or "8 inst-8"] value 69443800800
     inst [9 or "9 inst-9"] value 78124275800
 
-opentelemetry.source25.sample_gauge0000 []
+opentelemetry.source25.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 605
     inst [2 or "2 inst-2"] value 1210
@@ -3187,7 +3187,7 @@ opentelemetry.source25.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4840
     inst [9 or "9 inst-9"] value 5445
 
-opentelemetry.source25.sample_summary0002 []
+opentelemetry.source25.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008300396000000002
     inst [2 or "quantile: 0.5"] value 0.016600792
@@ -3199,13 +3199,13 @@ opentelemetry.source25.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.06640316800000001
     inst [9 or "quantile: 2.25"] value 0.074703564
 
-opentelemetry.source25.sample_summary0002_count []
+opentelemetry.source25.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 94536
 
-opentelemetry.source25.sample_summary0002_sum []
+opentelemetry.source25.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 72.342752
 
-opentelemetry.source25.sample_counter0001 []
+opentelemetry.source25.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12935609900
     inst [2 or "2 inst-2"] value 25871219900
@@ -3217,7 +3217,7 @@ opentelemetry.source25.sample_counter0001 []
     inst [8 or "8 inst-8"] value 103484880000
     inst [9 or "9 inst-9"] value 116420489000
 
-opentelemetry.source25.sample_gauge0000 []
+opentelemetry.source25.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 907.5
     inst [2 or "2 inst-2"] value 1815
@@ -3229,7 +3229,7 @@ opentelemetry.source25.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7260
     inst [9 or "9 inst-9"] value 8167.5
 
-opentelemetry.source25.sample_summary0002 []
+opentelemetry.source25.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012290971
     inst [2 or "quantile: 0.5"] value 0.024581942
@@ -3241,13 +3241,13 @@ opentelemetry.source25.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.09832776800000001
     inst [9 or "quantile: 2.25"] value 0.110618739
 
-opentelemetry.source25.sample_summary0002_count []
+opentelemetry.source25.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 139986
 
-opentelemetry.source25.sample_summary0002_sum []
+opentelemetry.source25.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 107.122921
 
-opentelemetry.source26.sample_counter0001 []
+opentelemetry.source26.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4595545640
     inst [2 or "2 inst-2"] value 9191091280
@@ -3259,7 +3259,7 @@ opentelemetry.source26.sample_counter0001 []
     inst [8 or "8 inst-8"] value 36764365100
     inst [9 or "9 inst-9"] value 41359910700
 
-opentelemetry.source26.sample_gauge0000 []
+opentelemetry.source26.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 314.6
     inst [2 or "2 inst-2"] value 629.2
@@ -3271,7 +3271,7 @@ opentelemetry.source26.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2516.8
     inst [9 or "9 inst-9"] value 2831.4
 
-opentelemetry.source26.sample_summary0002 []
+opentelemetry.source26.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004469444
     inst [2 or "quantile: 0.5"] value 0.008938888000000001
@@ -3283,13 +3283,13 @@ opentelemetry.source26.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.035755552
     inst [9 or "quantile: 2.25"] value 0.04022499600000001
 
-opentelemetry.source26.sample_summary0002_count []
+opentelemetry.source26.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 50904
 
-opentelemetry.source26.sample_summary0002_sum []
+opentelemetry.source26.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 38.95379
 
-opentelemetry.source26.sample_counter0001 []
+opentelemetry.source26.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -3301,7 +3301,7 @@ opentelemetry.source26.sample_counter0001 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source26.sample_gauge0000 []
+opentelemetry.source26.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -3313,7 +3313,7 @@ opentelemetry.source26.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source26.sample_summary0002 []
+opentelemetry.source26.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -3325,13 +3325,13 @@ opentelemetry.source26.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source26.sample_summary0002_count []
+opentelemetry.source26.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source26.sample_summary0002_sum []
+opentelemetry.source26.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source26.sample_counter0001 []
+opentelemetry.source26.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13446226100
     inst [2 or "2 inst-2"] value 26892452300
@@ -3343,7 +3343,7 @@ opentelemetry.source26.sample_counter0001 []
     inst [8 or "8 inst-8"] value 107569809000
     inst [9 or "9 inst-9"] value 121016035000
 
-opentelemetry.source26.sample_gauge0000 []
+opentelemetry.source26.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 943.8
     inst [2 or "2 inst-2"] value 1887.6
@@ -3355,7 +3355,7 @@ opentelemetry.source26.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7550.4
     inst [9 or "9 inst-9"] value 8494.200000000001
 
-opentelemetry.source26.sample_summary0002 []
+opentelemetry.source26.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01276984
     inst [2 or "quantile: 0.5"] value 0.02553968
@@ -3367,13 +3367,13 @@ opentelemetry.source26.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.10215872
     inst [9 or "quantile: 2.25"] value 0.11492856
 
-opentelemetry.source26.sample_summary0002_count []
+opentelemetry.source26.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 145440
 
-opentelemetry.source26.sample_summary0002_sum []
+opentelemetry.source26.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 111.296542
 
-opentelemetry.source27.sample_counter0001 []
+opentelemetry.source27.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4765751030
     inst [2 or "2 inst-2"] value 9531502060
@@ -3385,7 +3385,7 @@ opentelemetry.source27.sample_counter0001 []
     inst [8 or "8 inst-8"] value 38126008300
     inst [9 or "9 inst-9"] value 42891759300
 
-opentelemetry.source27.sample_gauge0000 []
+opentelemetry.source27.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 326.7
     inst [2 or "2 inst-2"] value 653.4
@@ -3397,7 +3397,7 @@ opentelemetry.source27.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2613.6
     inst [9 or "9 inst-9"] value 2940.3
 
-opentelemetry.source27.sample_summary0002 []
+opentelemetry.source27.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004629067000000001
     inst [2 or "quantile: 0.5"] value 0.009258134000000001
@@ -3409,13 +3409,13 @@ opentelemetry.source27.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.037032536
     inst [9 or "quantile: 2.25"] value 0.04166160300000001
 
-opentelemetry.source27.sample_summary0002_count []
+opentelemetry.source27.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 52722
 
-opentelemetry.source27.sample_summary0002_sum []
+opentelemetry.source27.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 40.344996
 
-opentelemetry.source27.sample_counter0001 []
+opentelemetry.source27.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9361296670
     inst [2 or "2 inst-2"] value 18722593300
@@ -3427,7 +3427,7 @@ opentelemetry.source27.sample_counter0001 []
     inst [8 or "8 inst-8"] value 74890373400
     inst [9 or "9 inst-9"] value 84251670000
 
-opentelemetry.source27.sample_gauge0000 []
+opentelemetry.source27.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 653.4
     inst [2 or "2 inst-2"] value 1306.8
@@ -3439,7 +3439,7 @@ opentelemetry.source27.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5227.2
     inst [9 or "9 inst-9"] value 5880.6
 
-opentelemetry.source27.sample_summary0002 []
+opentelemetry.source27.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008938888000000001
     inst [2 or "quantile: 0.5"] value 0.017877776
@@ -3451,13 +3451,13 @@ opentelemetry.source27.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.07151110400000001
     inst [9 or "quantile: 2.25"] value 0.08044999200000001
 
-opentelemetry.source27.sample_summary0002_count []
+opentelemetry.source27.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 101808
 
-opentelemetry.source27.sample_summary0002_sum []
+opentelemetry.source27.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 77.907579
 
-opentelemetry.source27.sample_counter0001 []
+opentelemetry.source27.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13956842300
     inst [2 or "2 inst-2"] value 27913684600
@@ -3469,7 +3469,7 @@ opentelemetry.source27.sample_counter0001 []
     inst [8 or "8 inst-8"] value 111654738000
     inst [9 or "9 inst-9"] value 125611581000
 
-opentelemetry.source27.sample_gauge0000 []
+opentelemetry.source27.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 980.1
     inst [2 or "2 inst-2"] value 1960.2
@@ -3481,7 +3481,7 @@ opentelemetry.source27.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7840.8
     inst [9 or "9 inst-9"] value 8820.9
 
-opentelemetry.source27.sample_summary0002 []
+opentelemetry.source27.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013248709
     inst [2 or "quantile: 0.5"] value 0.026497418
@@ -3493,13 +3493,13 @@ opentelemetry.source27.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.105989672
     inst [9 or "quantile: 2.25"] value 0.119238381
 
-opentelemetry.source27.sample_summary0002_count []
+opentelemetry.source27.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 150894
 
-opentelemetry.source27.sample_summary0002_sum []
+opentelemetry.source27.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 115.470162
 
-opentelemetry.source28.sample_counter0001 []
+opentelemetry.source28.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 4935956430
     inst [2 or "2 inst-2"] value 9871912850
@@ -3511,7 +3511,7 @@ opentelemetry.source28.sample_counter0001 []
     inst [8 or "8 inst-8"] value 39487651400
     inst [9 or "9 inst-9"] value 44423607800
 
-opentelemetry.source28.sample_gauge0000 []
+opentelemetry.source28.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 338.8
     inst [2 or "2 inst-2"] value 677.6
@@ -3523,7 +3523,7 @@ opentelemetry.source28.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2710.4
     inst [9 or "9 inst-9"] value 3049.2
 
-opentelemetry.source28.sample_summary0002 []
+opentelemetry.source28.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00478869
     inst [2 or "quantile: 0.5"] value 0.00957738
@@ -3535,13 +3535,13 @@ opentelemetry.source28.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.03830952
     inst [9 or "quantile: 2.25"] value 0.04309821
 
-opentelemetry.source28.sample_summary0002_count []
+opentelemetry.source28.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 54540
 
-opentelemetry.source28.sample_summary0002_sum []
+opentelemetry.source28.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 41.736203
 
-opentelemetry.source28.sample_counter0001 []
+opentelemetry.source28.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -3553,7 +3553,7 @@ opentelemetry.source28.sample_counter0001 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source28.sample_gauge0000 []
+opentelemetry.source28.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -3565,7 +3565,7 @@ opentelemetry.source28.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source28.sample_summary0002 []
+opentelemetry.source28.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -3577,13 +3577,13 @@ opentelemetry.source28.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source28.sample_summary0002_count []
+opentelemetry.source28.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source28.sample_summary0002_sum []
+opentelemetry.source28.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source28.sample_counter0001 []
+opentelemetry.source28.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14467458500
     inst [2 or "2 inst-2"] value 28934917000
@@ -3595,7 +3595,7 @@ opentelemetry.source28.sample_counter0001 []
     inst [8 or "8 inst-8"] value 115739668000
     inst [9 or "9 inst-9"] value 130207126000
 
-opentelemetry.source28.sample_gauge0000 []
+opentelemetry.source28.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1016.4
     inst [2 or "2 inst-2"] value 2032.8
@@ -3607,7 +3607,7 @@ opentelemetry.source28.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8131.2
     inst [9 or "9 inst-9"] value 9147.6
 
-opentelemetry.source28.sample_summary0002 []
+opentelemetry.source28.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013727578
     inst [2 or "quantile: 0.5"] value 0.027455156
@@ -3619,13 +3619,13 @@ opentelemetry.source28.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.109820624
     inst [9 or "quantile: 2.25"] value 0.123548202
 
-opentelemetry.source28.sample_summary0002_count []
+opentelemetry.source28.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 156348
 
-opentelemetry.source28.sample_summary0002_sum []
+opentelemetry.source28.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 119.643782
 
-opentelemetry.source29.sample_counter0001 []
+opentelemetry.source29.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5106161820
     inst [2 or "2 inst-2"] value 10212323600
@@ -3637,7 +3637,7 @@ opentelemetry.source29.sample_counter0001 []
     inst [8 or "8 inst-8"] value 40849294600
     inst [9 or "9 inst-9"] value 45955456400
 
-opentelemetry.source29.sample_gauge0000 []
+opentelemetry.source29.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 350.9
     inst [2 or "2 inst-2"] value 701.8
@@ -3649,7 +3649,7 @@ opentelemetry.source29.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2807.2
     inst [9 or "9 inst-9"] value 3158.1
 
-opentelemetry.source29.sample_summary0002 []
+opentelemetry.source29.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.004948313
     inst [2 or "quantile: 0.5"] value 0.009896626
@@ -3661,13 +3661,13 @@ opentelemetry.source29.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.039586504
     inst [9 or "quantile: 2.25"] value 0.044534817
 
-opentelemetry.source29.sample_summary0002_count []
+opentelemetry.source29.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 56358
 
-opentelemetry.source29.sample_summary0002_sum []
+opentelemetry.source29.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 43.12741
 
-opentelemetry.source29.sample_counter0001 []
+opentelemetry.source29.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10042118200
     inst [2 or "2 inst-2"] value 20084236500
@@ -3679,7 +3679,7 @@ opentelemetry.source29.sample_counter0001 []
     inst [8 or "8 inst-8"] value 80336946000
     inst [9 or "9 inst-9"] value 90379064200
 
-opentelemetry.source29.sample_gauge0000 []
+opentelemetry.source29.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 701.8
     inst [2 or "2 inst-2"] value 1403.6
@@ -3691,7 +3691,7 @@ opentelemetry.source29.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5614.4
     inst [9 or "9 inst-9"] value 6316.2
 
-opentelemetry.source29.sample_summary0002 []
+opentelemetry.source29.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00957738
     inst [2 or "quantile: 0.5"] value 0.01915476
@@ -3703,13 +3703,13 @@ opentelemetry.source29.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.07661904
     inst [9 or "quantile: 2.25"] value 0.08619642000000001
 
-opentelemetry.source29.sample_summary0002_count []
+opentelemetry.source29.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 109080
 
-opentelemetry.source29.sample_summary0002_sum []
+opentelemetry.source29.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 83.47240600000001
 
-opentelemetry.source29.sample_counter0001 []
+opentelemetry.source29.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14978074700
     inst [2 or "2 inst-2"] value 29956149300
@@ -3721,7 +3721,7 @@ opentelemetry.source29.sample_counter0001 []
     inst [8 or "8 inst-8"] value 119824597000
     inst [9 or "9 inst-9"] value 134802672000
 
-opentelemetry.source29.sample_gauge0000 []
+opentelemetry.source29.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1052.7
     inst [2 or "2 inst-2"] value 2105.4
@@ -3733,7 +3733,7 @@ opentelemetry.source29.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8421.6
     inst [9 or "9 inst-9"] value 9474.299999999999
 
-opentelemetry.source29.sample_summary0002 []
+opentelemetry.source29.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.014206447
     inst [2 or "quantile: 0.5"] value 0.028412894
@@ -3745,13 +3745,13 @@ opentelemetry.source29.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.113651576
     inst [9 or "quantile: 2.25"] value 0.127858023
 
-opentelemetry.source29.sample_summary0002_count []
+opentelemetry.source29.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 161802
 
-opentelemetry.source29.sample_summary0002_sum []
+opentelemetry.source29.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 123.817403
 
-opentelemetry.source30.sample_counter0001 []
+opentelemetry.source30.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5276367210
     inst [2 or "2 inst-2"] value 10552734400
@@ -3763,7 +3763,7 @@ opentelemetry.source30.sample_counter0001 []
     inst [8 or "8 inst-8"] value 42210937700
     inst [9 or "9 inst-9"] value 47487304900
 
-opentelemetry.source30.sample_gauge0000 []
+opentelemetry.source30.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 363
     inst [2 or "2 inst-2"] value 726
@@ -3775,7 +3775,7 @@ opentelemetry.source30.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 2904
     inst [9 or "9 inst-9"] value 3267
 
-opentelemetry.source30.sample_summary0002 []
+opentelemetry.source30.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005107936
     inst [2 or "quantile: 0.5"] value 0.010215872
@@ -3787,13 +3787,13 @@ opentelemetry.source30.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.040863488
     inst [9 or "quantile: 2.25"] value 0.045971424
 
-opentelemetry.source30.sample_summary0002_count []
+opentelemetry.source30.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 58176
 
-opentelemetry.source30.sample_summary0002_sum []
+opentelemetry.source30.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 44.518617
 
-opentelemetry.source30.sample_counter0001 []
+opentelemetry.source30.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -3805,7 +3805,7 @@ opentelemetry.source30.sample_counter0001 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source30.sample_gauge0000 []
+opentelemetry.source30.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -3817,7 +3817,7 @@ opentelemetry.source30.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source30.sample_summary0002 []
+opentelemetry.source30.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -3829,13 +3829,13 @@ opentelemetry.source30.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source30.sample_summary0002_count []
+opentelemetry.source30.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source30.sample_summary0002_sum []
+opentelemetry.source30.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source30.sample_counter0001 []
+opentelemetry.source30.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 15488690900
     inst [2 or "2 inst-2"] value 30977381700
@@ -3847,7 +3847,7 @@ opentelemetry.source30.sample_counter0001 []
     inst [8 or "8 inst-8"] value 123909527000
     inst [9 or "9 inst-9"] value 139398218000
 
-opentelemetry.source30.sample_gauge0000 []
+opentelemetry.source30.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1089
     inst [2 or "2 inst-2"] value 2178
@@ -3859,7 +3859,7 @@ opentelemetry.source30.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8712
     inst [9 or "9 inst-9"] value 9801
 
-opentelemetry.source30.sample_summary0002 []
+opentelemetry.source30.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.014685316
     inst [2 or "quantile: 0.5"] value 0.029370632
@@ -3871,13 +3871,13 @@ opentelemetry.source30.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.117482528
     inst [9 or "quantile: 2.25"] value 0.132167844
 
-opentelemetry.source30.sample_summary0002_count []
+opentelemetry.source30.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 167256
 
-opentelemetry.source30.sample_summary0002_sum []
+opentelemetry.source30.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 127.991023
 
-opentelemetry.source31.sample_counter0001 []
+opentelemetry.source31.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5446572610
     inst [2 or "2 inst-2"] value 10893145200
@@ -3889,7 +3889,7 @@ opentelemetry.source31.sample_counter0001 []
     inst [8 or "8 inst-8"] value 43572580900
     inst [9 or "9 inst-9"] value 49019153500
 
-opentelemetry.source31.sample_gauge0000 []
+opentelemetry.source31.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 375.1
     inst [2 or "2 inst-2"] value 750.2
@@ -3901,7 +3901,7 @@ opentelemetry.source31.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3000.8
     inst [9 or "9 inst-9"] value 3375.9
 
-opentelemetry.source31.sample_summary0002 []
+opentelemetry.source31.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005267559000000001
     inst [2 or "quantile: 0.5"] value 0.010535118
@@ -3913,13 +3913,13 @@ opentelemetry.source31.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.04214047200000001
     inst [9 or "quantile: 2.25"] value 0.047408031
 
-opentelemetry.source31.sample_summary0002_count []
+opentelemetry.source31.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 59994
 
-opentelemetry.source31.sample_summary0002_sum []
+opentelemetry.source31.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 45.909823
 
-opentelemetry.source31.sample_counter0001 []
+opentelemetry.source31.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10722939800
     inst [2 or "2 inst-2"] value 21445879600
@@ -3931,7 +3931,7 @@ opentelemetry.source31.sample_counter0001 []
     inst [8 or "8 inst-8"] value 85783518600
     inst [9 or "9 inst-9"] value 96506458400
 
-opentelemetry.source31.sample_gauge0000 []
+opentelemetry.source31.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 750.2
     inst [2 or "2 inst-2"] value 1500.4
@@ -3943,7 +3943,7 @@ opentelemetry.source31.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6001.6
     inst [9 or "9 inst-9"] value 6751.8
 
-opentelemetry.source31.sample_summary0002 []
+opentelemetry.source31.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010215872
     inst [2 or "quantile: 0.5"] value 0.020431744
@@ -3955,13 +3955,13 @@ opentelemetry.source31.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08172697600000001
     inst [9 or "quantile: 2.25"] value 0.09194284800000001
 
-opentelemetry.source31.sample_summary0002_count []
+opentelemetry.source31.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 116352
 
-opentelemetry.source31.sample_summary0002_sum []
+opentelemetry.source31.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 89.037233
 
-opentelemetry.source31.sample_counter0001 []
+opentelemetry.source31.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 15999307000
     inst [2 or "2 inst-2"] value 31998614100
@@ -3973,7 +3973,7 @@ opentelemetry.source31.sample_counter0001 []
     inst [8 or "8 inst-8"] value 127994456000
     inst [9 or "9 inst-9"] value 143993763000
 
-opentelemetry.source31.sample_gauge0000 []
+opentelemetry.source31.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1125.3
     inst [2 or "2 inst-2"] value 2250.6
@@ -3985,7 +3985,7 @@ opentelemetry.source31.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9002.4
     inst [9 or "9 inst-9"] value 10127.7
 
-opentelemetry.source31.sample_summary0002 []
+opentelemetry.source31.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.015164185
     inst [2 or "quantile: 0.5"] value 0.03032837
@@ -3997,13 +3997,13 @@ opentelemetry.source31.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.12131348
     inst [9 or "quantile: 2.25"] value 0.136477665
 
-opentelemetry.source31.sample_summary0002_count []
+opentelemetry.source31.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 172710
 
-opentelemetry.source31.sample_summary0002_sum []
+opentelemetry.source31.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 132.164643
 
-opentelemetry.source32.sample_counter0001 []
+opentelemetry.source32.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5616778000
     inst [2 or "2 inst-2"] value 11233556000
@@ -4015,7 +4015,7 @@ opentelemetry.source32.sample_counter0001 []
     inst [8 or "8 inst-8"] value 44934224000
     inst [9 or "9 inst-9"] value 50551002000
 
-opentelemetry.source32.sample_gauge0000 []
+opentelemetry.source32.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 387.2
     inst [2 or "2 inst-2"] value 774.4
@@ -4027,7 +4027,7 @@ opentelemetry.source32.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3097.6
     inst [9 or "9 inst-9"] value 3484.8
 
-opentelemetry.source32.sample_summary0002 []
+opentelemetry.source32.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005427182000000001
     inst [2 or "quantile: 0.5"] value 0.010854364
@@ -4039,13 +4039,13 @@ opentelemetry.source32.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.04341745600000001
     inst [9 or "quantile: 2.25"] value 0.048844638
 
-opentelemetry.source32.sample_summary0002_count []
+opentelemetry.source32.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 61812
 
-opentelemetry.source32.sample_summary0002_sum []
+opentelemetry.source32.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 47.30103
 
-opentelemetry.source32.sample_counter0001 []
+opentelemetry.source32.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -4057,7 +4057,7 @@ opentelemetry.source32.sample_counter0001 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source32.sample_gauge0000 []
+opentelemetry.source32.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -4069,7 +4069,7 @@ opentelemetry.source32.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source32.sample_summary0002 []
+opentelemetry.source32.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -4081,13 +4081,13 @@ opentelemetry.source32.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source32.sample_summary0002_count []
+opentelemetry.source32.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source32.sample_summary0002_sum []
+opentelemetry.source32.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source32.sample_counter0001 []
+opentelemetry.source32.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 16509923200
     inst [2 or "2 inst-2"] value 33019846400
@@ -4099,7 +4099,7 @@ opentelemetry.source32.sample_counter0001 []
     inst [8 or "8 inst-8"] value 132079386000
     inst [9 or "9 inst-9"] value 148589309000
 
-opentelemetry.source32.sample_gauge0000 []
+opentelemetry.source32.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1161.6
     inst [2 or "2 inst-2"] value 2323.2
@@ -4111,7 +4111,7 @@ opentelemetry.source32.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9292.799999999999
     inst [9 or "9 inst-9"] value 10454.4
 
-opentelemetry.source32.sample_summary0002 []
+opentelemetry.source32.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.015643054
     inst [2 or "quantile: 0.5"] value 0.031286108
@@ -4123,13 +4123,13 @@ opentelemetry.source32.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.125144432
     inst [9 or "quantile: 2.25"] value 0.140787486
 
-opentelemetry.source32.sample_summary0002_count []
+opentelemetry.source32.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 178164
 
-opentelemetry.source32.sample_summary0002_sum []
+opentelemetry.source32.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 136.338263
 
-opentelemetry.source33.sample_counter0001 []
+opentelemetry.source33.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5786983400
     inst [2 or "2 inst-2"] value 11573966800
@@ -4141,7 +4141,7 @@ opentelemetry.source33.sample_counter0001 []
     inst [8 or "8 inst-8"] value 46295867200
     inst [9 or "9 inst-9"] value 52082850600
 
-opentelemetry.source33.sample_gauge0000 []
+opentelemetry.source33.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 399.3
     inst [2 or "2 inst-2"] value 798.6
@@ -4153,7 +4153,7 @@ opentelemetry.source33.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3194.4
     inst [9 or "9 inst-9"] value 3593.7
 
-opentelemetry.source33.sample_summary0002 []
+opentelemetry.source33.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005586805
     inst [2 or "quantile: 0.5"] value 0.01117361
@@ -4165,13 +4165,13 @@ opentelemetry.source33.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.04469444
     inst [9 or "quantile: 2.25"] value 0.050281245
 
-opentelemetry.source33.sample_summary0002_count []
+opentelemetry.source33.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 63630
 
-opentelemetry.source33.sample_summary0002_sum []
+opentelemetry.source33.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 48.692237
 
-opentelemetry.source33.sample_counter0001 []
+opentelemetry.source33.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11403761400
     inst [2 or "2 inst-2"] value 22807522800
@@ -4183,7 +4183,7 @@ opentelemetry.source33.sample_counter0001 []
     inst [8 or "8 inst-8"] value 91230091200
     inst [9 or "9 inst-9"] value 102633853000
 
-opentelemetry.source33.sample_gauge0000 []
+opentelemetry.source33.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 798.6
     inst [2 or "2 inst-2"] value 1597.2
@@ -4195,7 +4195,7 @@ opentelemetry.source33.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6388.8
     inst [9 or "9 inst-9"] value 7187.4
 
-opentelemetry.source33.sample_summary0002 []
+opentelemetry.source33.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010854364
     inst [2 or "quantile: 0.5"] value 0.021708728
@@ -4207,13 +4207,13 @@ opentelemetry.source33.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08683491200000001
     inst [9 or "quantile: 2.25"] value 0.09768927600000001
 
-opentelemetry.source33.sample_summary0002_count []
+opentelemetry.source33.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 123624
 
-opentelemetry.source33.sample_summary0002_sum []
+opentelemetry.source33.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 94.60205999999999
 
-opentelemetry.source33.sample_counter0001 []
+opentelemetry.source33.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 17020539400
     inst [2 or "2 inst-2"] value 34041078800
@@ -4225,7 +4225,7 @@ opentelemetry.source33.sample_counter0001 []
     inst [8 or "8 inst-8"] value 136164315000
     inst [9 or "9 inst-9"] value 153184855000
 
-opentelemetry.source33.sample_gauge0000 []
+opentelemetry.source33.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1197.9
     inst [2 or "2 inst-2"] value 2395.8
@@ -4237,7 +4237,7 @@ opentelemetry.source33.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9583.200000000001
     inst [9 or "9 inst-9"] value 10781.1
 
-opentelemetry.source33.sample_summary0002 []
+opentelemetry.source33.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.016121923
     inst [2 or "quantile: 0.5"] value 0.032243846
@@ -4249,13 +4249,13 @@ opentelemetry.source33.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.128975384
     inst [9 or "quantile: 2.25"] value 0.145097307
 
-opentelemetry.source33.sample_summary0002_count []
+opentelemetry.source33.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 183618
 
-opentelemetry.source33.sample_summary0002_sum []
+opentelemetry.source33.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 140.511884
 
-opentelemetry.source34.sample_counter0001 []
+opentelemetry.source34.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 5957188790
     inst [2 or "2 inst-2"] value 11914377600
@@ -4267,7 +4267,7 @@ opentelemetry.source34.sample_counter0001 []
     inst [8 or "8 inst-8"] value 47657510300
     inst [9 or "9 inst-9"] value 53614699100
 
-opentelemetry.source34.sample_gauge0000 []
+opentelemetry.source34.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 411.4
     inst [2 or "2 inst-2"] value 822.8
@@ -4279,7 +4279,7 @@ opentelemetry.source34.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3291.2
     inst [9 or "9 inst-9"] value 3702.6
 
-opentelemetry.source34.sample_summary0002 []
+opentelemetry.source34.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005746428
     inst [2 or "quantile: 0.5"] value 0.011492856
@@ -4291,13 +4291,13 @@ opentelemetry.source34.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.045971424
     inst [9 or "quantile: 2.25"] value 0.051717852
 
-opentelemetry.source34.sample_summary0002_count []
+opentelemetry.source34.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 65448
 
-opentelemetry.source34.sample_summary0002_sum []
+opentelemetry.source34.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 50.083444
 
-opentelemetry.source34.sample_counter0001 []
+opentelemetry.source34.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -4309,7 +4309,7 @@ opentelemetry.source34.sample_counter0001 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source34.sample_gauge0000 []
+opentelemetry.source34.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -4321,7 +4321,7 @@ opentelemetry.source34.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source34.sample_summary0002 []
+opentelemetry.source34.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -4333,13 +4333,13 @@ opentelemetry.source34.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source34.sample_summary0002_count []
+opentelemetry.source34.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source34.sample_summary0002_sum []
+opentelemetry.source34.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source34.sample_counter0001 []
+opentelemetry.source34.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 17531155600
     inst [2 or "2 inst-2"] value 35062311200
@@ -4351,7 +4351,7 @@ opentelemetry.source34.sample_counter0001 []
     inst [8 or "8 inst-8"] value 140249245000
     inst [9 or "9 inst-9"] value 157780400000
 
-opentelemetry.source34.sample_gauge0000 []
+opentelemetry.source34.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1234.2
     inst [2 or "2 inst-2"] value 2468.4
@@ -4363,7 +4363,7 @@ opentelemetry.source34.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9873.6
     inst [9 or "9 inst-9"] value 11107.8
 
-opentelemetry.source34.sample_summary0002 []
+opentelemetry.source34.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.016600792
     inst [2 or "quantile: 0.5"] value 0.03320158400000001
@@ -4375,13 +4375,13 @@ opentelemetry.source34.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.132806336
     inst [9 or "quantile: 2.25"] value 0.149407128
 
-opentelemetry.source34.sample_summary0002_count []
+opentelemetry.source34.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 189072
 
-opentelemetry.source34.sample_summary0002_sum []
+opentelemetry.source34.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 144.685504
 
-opentelemetry.source35.sample_counter0001 []
+opentelemetry.source35.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6127394180
     inst [2 or "2 inst-2"] value 12254788400
@@ -4393,7 +4393,7 @@ opentelemetry.source35.sample_counter0001 []
     inst [8 or "8 inst-8"] value 49019153500
     inst [9 or "9 inst-9"] value 55146547700
 
-opentelemetry.source35.sample_gauge0000 []
+opentelemetry.source35.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 423.5
     inst [2 or "2 inst-2"] value 847
@@ -4405,7 +4405,7 @@ opentelemetry.source35.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3388
     inst [9 or "9 inst-9"] value 3811.5
 
-opentelemetry.source35.sample_summary0002 []
+opentelemetry.source35.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.005906051000000001
     inst [2 or "quantile: 0.5"] value 0.011812102
@@ -4417,13 +4417,13 @@ opentelemetry.source35.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.04724840800000001
     inst [9 or "quantile: 2.25"] value 0.053154459
 
-opentelemetry.source35.sample_summary0002_count []
+opentelemetry.source35.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 67266
 
-opentelemetry.source35.sample_summary0002_sum []
+opentelemetry.source35.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 51.47465
 
-opentelemetry.source35.sample_counter0001 []
+opentelemetry.source35.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12084583000
     inst [2 or "2 inst-2"] value 24169165900
@@ -4435,7 +4435,7 @@ opentelemetry.source35.sample_counter0001 []
     inst [8 or "8 inst-8"] value 96676663800
     inst [9 or "9 inst-9"] value 108761247000
 
-opentelemetry.source35.sample_gauge0000 []
+opentelemetry.source35.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 847
     inst [2 or "2 inst-2"] value 1694
@@ -4447,7 +4447,7 @@ opentelemetry.source35.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6776
     inst [9 or "9 inst-9"] value 7623
 
-opentelemetry.source35.sample_summary0002 []
+opentelemetry.source35.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011492856
     inst [2 or "quantile: 0.5"] value 0.022985712
@@ -4459,13 +4459,13 @@ opentelemetry.source35.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.09194284800000001
     inst [9 or "quantile: 2.25"] value 0.103435704
 
-opentelemetry.source35.sample_summary0002_count []
+opentelemetry.source35.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 130896
 
-opentelemetry.source35.sample_summary0002_sum []
+opentelemetry.source35.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 100.166887
 
-opentelemetry.source35.sample_counter0001 []
+opentelemetry.source35.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 18041771800
     inst [2 or "2 inst-2"] value 36083543500
@@ -4477,7 +4477,7 @@ opentelemetry.source35.sample_counter0001 []
     inst [8 or "8 inst-8"] value 144334174000
     inst [9 or "9 inst-9"] value 162375946000
 
-opentelemetry.source35.sample_gauge0000 []
+opentelemetry.source35.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1270.5
     inst [2 or "2 inst-2"] value 2541
@@ -4489,7 +4489,7 @@ opentelemetry.source35.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 10164
     inst [9 or "9 inst-9"] value 11434.5
 
-opentelemetry.source35.sample_summary0002 []
+opentelemetry.source35.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.017079661
     inst [2 or "quantile: 0.5"] value 0.03415932200000001
@@ -4501,13 +4501,13 @@ opentelemetry.source35.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.136637288
     inst [9 or "quantile: 2.25"] value 0.153716949
 
-opentelemetry.source35.sample_summary0002_count []
+opentelemetry.source35.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 194526
 
-opentelemetry.source35.sample_summary0002_sum []
+opentelemetry.source35.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 148.859124
 
-opentelemetry.source36.sample_counter0001 []
+opentelemetry.source36.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6297599580
     inst [2 or "2 inst-2"] value 12595199200
@@ -4519,7 +4519,7 @@ opentelemetry.source36.sample_counter0001 []
     inst [8 or "8 inst-8"] value 50380796600
     inst [9 or "9 inst-9"] value 56678396200
 
-opentelemetry.source36.sample_gauge0000 []
+opentelemetry.source36.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 435.6
     inst [2 or "2 inst-2"] value 871.2
@@ -4531,7 +4531,7 @@ opentelemetry.source36.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3484.8
     inst [9 or "9 inst-9"] value 3920.4
 
-opentelemetry.source36.sample_summary0002 []
+opentelemetry.source36.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006065674
     inst [2 or "quantile: 0.5"] value 0.012131348
@@ -4543,13 +4543,13 @@ opentelemetry.source36.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.048525392
     inst [9 or "quantile: 2.25"] value 0.05459106600000001
 
-opentelemetry.source36.sample_summary0002_count []
+opentelemetry.source36.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 69084
 
-opentelemetry.source36.sample_summary0002_sum []
+opentelemetry.source36.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 52.865857
 
-opentelemetry.source36.sample_counter0001 []
+opentelemetry.source36.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -4561,7 +4561,7 @@ opentelemetry.source36.sample_counter0001 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source36.sample_gauge0000 []
+opentelemetry.source36.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -4573,7 +4573,7 @@ opentelemetry.source36.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source36.sample_summary0002 []
+opentelemetry.source36.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -4585,13 +4585,13 @@ opentelemetry.source36.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source36.sample_summary0002_count []
+opentelemetry.source36.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source36.sample_summary0002_sum []
+opentelemetry.source36.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source36.sample_counter0001 []
+opentelemetry.source36.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 18552387900
     inst [2 or "2 inst-2"] value 37104775900
@@ -4603,7 +4603,7 @@ opentelemetry.source36.sample_counter0001 []
     inst [8 or "8 inst-8"] value 148419104000
     inst [9 or "9 inst-9"] value 166971492000
 
-opentelemetry.source36.sample_gauge0000 []
+opentelemetry.source36.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1306.8
     inst [2 or "2 inst-2"] value 2613.6
@@ -4615,7 +4615,7 @@ opentelemetry.source36.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 10454.4
     inst [9 or "9 inst-9"] value 11761.2
 
-opentelemetry.source36.sample_summary0002 []
+opentelemetry.source36.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01755853
     inst [2 or "quantile: 0.5"] value 0.03511706000000001
@@ -4627,13 +4627,13 @@ opentelemetry.source36.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.14046824
     inst [9 or "quantile: 2.25"] value 0.15802677
 
-opentelemetry.source36.sample_summary0002_count []
+opentelemetry.source36.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 199980
 
-opentelemetry.source36.sample_summary0002_sum []
+opentelemetry.source36.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 153.032745
 
-opentelemetry.source37.sample_counter0001 []
+opentelemetry.source37.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6467804970
     inst [2 or "2 inst-2"] value 12935609900
@@ -4645,7 +4645,7 @@ opentelemetry.source37.sample_counter0001 []
     inst [8 or "8 inst-8"] value 51742439800
     inst [9 or "9 inst-9"] value 58210244700
 
-opentelemetry.source37.sample_gauge0000 []
+opentelemetry.source37.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 447.7
     inst [2 or "2 inst-2"] value 895.4
@@ -4657,7 +4657,7 @@ opentelemetry.source37.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3581.6
     inst [9 or "9 inst-9"] value 4029.3
 
-opentelemetry.source37.sample_summary0002 []
+opentelemetry.source37.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006225297
     inst [2 or "quantile: 0.5"] value 0.012450594
@@ -4669,13 +4669,13 @@ opentelemetry.source37.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.049802376
     inst [9 or "quantile: 2.25"] value 0.05602767300000001
 
-opentelemetry.source37.sample_summary0002_count []
+opentelemetry.source37.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 70902
 
-opentelemetry.source37.sample_summary0002_sum []
+opentelemetry.source37.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 54.257064
 
-opentelemetry.source37.sample_counter0001 []
+opentelemetry.source37.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12765404600
     inst [2 or "2 inst-2"] value 25530809100
@@ -4687,7 +4687,7 @@ opentelemetry.source37.sample_counter0001 []
     inst [8 or "8 inst-8"] value 102123236000
     inst [9 or "9 inst-9"] value 114888641000
 
-opentelemetry.source37.sample_gauge0000 []
+opentelemetry.source37.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 895.4
     inst [2 or "2 inst-2"] value 1790.8
@@ -4699,7 +4699,7 @@ opentelemetry.source37.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7163.2
     inst [9 or "9 inst-9"] value 8058.6
 
-opentelemetry.source37.sample_summary0002 []
+opentelemetry.source37.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012131348
     inst [2 or "quantile: 0.5"] value 0.024262696
@@ -4711,13 +4711,13 @@ opentelemetry.source37.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.097050784
     inst [9 or "quantile: 2.25"] value 0.109182132
 
-opentelemetry.source37.sample_summary0002_count []
+opentelemetry.source37.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 138168
 
-opentelemetry.source37.sample_summary0002_sum []
+opentelemetry.source37.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 105.731715
 
-opentelemetry.source37.sample_counter0001 []
+opentelemetry.source37.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 19063004100
     inst [2 or "2 inst-2"] value 38126008300
@@ -4729,7 +4729,7 @@ opentelemetry.source37.sample_counter0001 []
     inst [8 or "8 inst-8"] value 152504033000
     inst [9 or "9 inst-9"] value 171567037000
 
-opentelemetry.source37.sample_gauge0000 []
+opentelemetry.source37.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1343.1
     inst [2 or "2 inst-2"] value 2686.2
@@ -4741,7 +4741,7 @@ opentelemetry.source37.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 10744.8
     inst [9 or "9 inst-9"] value 12087.9
 
-opentelemetry.source37.sample_summary0002 []
+opentelemetry.source37.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.018037399
     inst [2 or "quantile: 0.5"] value 0.03607479800000001
@@ -4753,13 +4753,13 @@ opentelemetry.source37.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.144299192
     inst [9 or "quantile: 2.25"] value 0.162336591
 
-opentelemetry.source37.sample_summary0002_count []
+opentelemetry.source37.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 205434
 
-opentelemetry.source37.sample_summary0002_sum []
+opentelemetry.source37.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 157.206365
 
-opentelemetry.source38.sample_counter0001 []
+opentelemetry.source38.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6638010370
     inst [2 or "2 inst-2"] value 13276020700
@@ -4771,7 +4771,7 @@ opentelemetry.source38.sample_counter0001 []
     inst [8 or "8 inst-8"] value 53104082900
     inst [9 or "9 inst-9"] value 59742093300
 
-opentelemetry.source38.sample_gauge0000 []
+opentelemetry.source38.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 459.8
     inst [2 or "2 inst-2"] value 919.6
@@ -4783,7 +4783,7 @@ opentelemetry.source38.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3678.4
     inst [9 or "9 inst-9"] value 4138.2
 
-opentelemetry.source38.sample_summary0002 []
+opentelemetry.source38.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006384920000000001
     inst [2 or "quantile: 0.5"] value 0.01276984
@@ -4795,13 +4795,13 @@ opentelemetry.source38.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.05107936
     inst [9 or "quantile: 2.25"] value 0.05746428000000001
 
-opentelemetry.source38.sample_summary0002_count []
+opentelemetry.source38.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 72720
 
-opentelemetry.source38.sample_summary0002_sum []
+opentelemetry.source38.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 55.648271
 
-opentelemetry.source38.sample_counter0001 []
+opentelemetry.source38.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13105815300
     inst [2 or "2 inst-2"] value 26211630700
@@ -4813,7 +4813,7 @@ opentelemetry.source38.sample_counter0001 []
     inst [8 or "8 inst-8"] value 104846523000
     inst [9 or "9 inst-9"] value 117952338000
 
-opentelemetry.source38.sample_gauge0000 []
+opentelemetry.source38.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 919.6
     inst [2 or "2 inst-2"] value 1839.2
@@ -4825,7 +4825,7 @@ opentelemetry.source38.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7356.8
     inst [9 or "9 inst-9"] value 8276.4
 
-opentelemetry.source38.sample_summary0002 []
+opentelemetry.source38.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012450594
     inst [2 or "quantile: 0.5"] value 0.024901188
@@ -4837,13 +4837,13 @@ opentelemetry.source38.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.099604752
     inst [9 or "quantile: 2.25"] value 0.112055346
 
-opentelemetry.source38.sample_summary0002_count []
+opentelemetry.source38.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 141804
 
-opentelemetry.source38.sample_summary0002_sum []
+opentelemetry.source38.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 108.514128
 
-opentelemetry.source38.sample_counter0001 []
+opentelemetry.source38.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 19573620300
     inst [2 or "2 inst-2"] value 39147240600
@@ -4855,7 +4855,7 @@ opentelemetry.source38.sample_counter0001 []
     inst [8 or "8 inst-8"] value 156588962000
     inst [9 or "9 inst-9"] value 176162583000
 
-opentelemetry.source38.sample_gauge0000 []
+opentelemetry.source38.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1379.4
     inst [2 or "2 inst-2"] value 2758.8
@@ -4867,7 +4867,7 @@ opentelemetry.source38.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 11035.2
     inst [9 or "9 inst-9"] value 12414.6
 
-opentelemetry.source38.sample_summary0002 []
+opentelemetry.source38.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.018516268
     inst [2 or "quantile: 0.5"] value 0.037032536
@@ -4879,13 +4879,13 @@ opentelemetry.source38.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.148130144
     inst [9 or "quantile: 2.25"] value 0.166646412
 
-opentelemetry.source38.sample_summary0002_count []
+opentelemetry.source38.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 210888
 
-opentelemetry.source38.sample_summary0002_sum []
+opentelemetry.source38.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 161.379985
 
-opentelemetry.source39.sample_counter0001 []
+opentelemetry.source39.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6808215760
     inst [2 or "2 inst-2"] value 13616431500
@@ -4897,7 +4897,7 @@ opentelemetry.source39.sample_counter0001 []
     inst [8 or "8 inst-8"] value 54465726100
     inst [9 or "9 inst-9"] value 61273941800
 
-opentelemetry.source39.sample_gauge0000 []
+opentelemetry.source39.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 471.9
     inst [2 or "2 inst-2"] value 943.8
@@ -4909,7 +4909,7 @@ opentelemetry.source39.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3775.2
     inst [9 or "9 inst-9"] value 4247.1
 
-opentelemetry.source39.sample_summary0002 []
+opentelemetry.source39.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006544543000000001
     inst [2 or "quantile: 0.5"] value 0.013089086
@@ -4921,13 +4921,13 @@ opentelemetry.source39.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.05235634400000001
     inst [9 or "quantile: 2.25"] value 0.05890088700000001
 
-opentelemetry.source39.sample_summary0002_count []
+opentelemetry.source39.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 74538
 
-opentelemetry.source39.sample_summary0002_sum []
+opentelemetry.source39.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 57.039478
 
-opentelemetry.source39.sample_counter0001 []
+opentelemetry.source39.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13446226100
     inst [2 or "2 inst-2"] value 26892452300
@@ -4939,7 +4939,7 @@ opentelemetry.source39.sample_counter0001 []
     inst [8 or "8 inst-8"] value 107569809000
     inst [9 or "9 inst-9"] value 121016035000
 
-opentelemetry.source39.sample_gauge0000 []
+opentelemetry.source39.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 943.8
     inst [2 or "2 inst-2"] value 1887.6
@@ -4951,7 +4951,7 @@ opentelemetry.source39.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7550.4
     inst [9 or "9 inst-9"] value 8494.200000000001
 
-opentelemetry.source39.sample_summary0002 []
+opentelemetry.source39.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01276984
     inst [2 or "quantile: 0.5"] value 0.02553968
@@ -4963,13 +4963,13 @@ opentelemetry.source39.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.10215872
     inst [9 or "quantile: 2.25"] value 0.11492856
 
-opentelemetry.source39.sample_summary0002_count []
+opentelemetry.source39.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 145440
 
-opentelemetry.source39.sample_summary0002_sum []
+opentelemetry.source39.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 111.296542
 
-opentelemetry.source39.sample_counter0001 []
+opentelemetry.source39.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 20084236500
     inst [2 or "2 inst-2"] value 40168473000
@@ -4981,7 +4981,7 @@ opentelemetry.source39.sample_counter0001 []
     inst [8 or "8 inst-8"] value 160673892000
     inst [9 or "9 inst-9"] value 180758128000
 
-opentelemetry.source39.sample_gauge0000 []
+opentelemetry.source39.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1415.7
     inst [2 or "2 inst-2"] value 2831.4
@@ -4993,7 +4993,7 @@ opentelemetry.source39.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 11325.6
     inst [9 or "9 inst-9"] value 12741.3
 
-opentelemetry.source39.sample_summary0002 []
+opentelemetry.source39.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.018995137
     inst [2 or "quantile: 0.5"] value 0.037990274
@@ -5005,13 +5005,13 @@ opentelemetry.source39.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.151961096
     inst [9 or "quantile: 2.25"] value 0.170956233
 
-opentelemetry.source39.sample_summary0002_count []
+opentelemetry.source39.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 216342
 
-opentelemetry.source39.sample_summary0002_sum []
+opentelemetry.source39.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 165.553606
 
-opentelemetry.source40.sample_counter0001 []
+opentelemetry.source40.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 6978421150
     inst [2 or "2 inst-2"] value 13956842300
@@ -5023,7 +5023,7 @@ opentelemetry.source40.sample_counter0001 []
     inst [8 or "8 inst-8"] value 55827369200
     inst [9 or "9 inst-9"] value 62805790400
 
-opentelemetry.source40.sample_gauge0000 []
+opentelemetry.source40.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 484
     inst [2 or "2 inst-2"] value 968
@@ -5035,7 +5035,7 @@ opentelemetry.source40.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3872
     inst [9 or "9 inst-9"] value 4356
 
-opentelemetry.source40.sample_summary0002 []
+opentelemetry.source40.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006704166000000001
     inst [2 or "quantile: 0.5"] value 0.013408332
@@ -5047,13 +5047,13 @@ opentelemetry.source40.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.05363332800000001
     inst [9 or "quantile: 2.25"] value 0.06033749400000001
 
-opentelemetry.source40.sample_summary0002_count []
+opentelemetry.source40.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 76356
 
-opentelemetry.source40.sample_summary0002_sum []
+opentelemetry.source40.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 58.430684
 
-opentelemetry.source40.sample_counter0001 []
+opentelemetry.source40.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13786636900
     inst [2 or "2 inst-2"] value 27573273800
@@ -5065,7 +5065,7 @@ opentelemetry.source40.sample_counter0001 []
     inst [8 or "8 inst-8"] value 110293095000
     inst [9 or "9 inst-9"] value 124079732000
 
-opentelemetry.source40.sample_gauge0000 []
+opentelemetry.source40.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 968
     inst [2 or "2 inst-2"] value 1936
@@ -5077,7 +5077,7 @@ opentelemetry.source40.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7744
     inst [9 or "9 inst-9"] value 8712
 
-opentelemetry.source40.sample_summary0002 []
+opentelemetry.source40.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013089086
     inst [2 or "quantile: 0.5"] value 0.026178172
@@ -5089,13 +5089,13 @@ opentelemetry.source40.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.104712688
     inst [9 or "quantile: 2.25"] value 0.117801774
 
-opentelemetry.source40.sample_summary0002_count []
+opentelemetry.source40.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 149076
 
-opentelemetry.source40.sample_summary0002_sum []
+opentelemetry.source40.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 114.078955
 
-opentelemetry.source40.sample_counter0001 []
+opentelemetry.source40.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 20594852700
     inst [2 or "2 inst-2"] value 41189705300
@@ -5107,7 +5107,7 @@ opentelemetry.source40.sample_counter0001 []
     inst [8 or "8 inst-8"] value 164758821000
     inst [9 or "9 inst-9"] value 185353674000
 
-opentelemetry.source40.sample_gauge0000 []
+opentelemetry.source40.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1452
     inst [2 or "2 inst-2"] value 2904
@@ -5119,7 +5119,7 @@ opentelemetry.source40.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 11616
     inst [9 or "9 inst-9"] value 13068
 
-opentelemetry.source40.sample_summary0002 []
+opentelemetry.source40.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.019474006
     inst [2 or "quantile: 0.5"] value 0.038948012
@@ -5131,13 +5131,13 @@ opentelemetry.source40.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.155792048
     inst [9 or "quantile: 2.25"] value 0.175266054
 
-opentelemetry.source40.sample_summary0002_count []
+opentelemetry.source40.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 221796
 
-opentelemetry.source40.sample_summary0002_sum []
+opentelemetry.source40.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 169.727226
 
-opentelemetry.source41.sample_counter0001 []
+opentelemetry.source41.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7148626550
     inst [2 or "2 inst-2"] value 14297253100
@@ -5149,7 +5149,7 @@ opentelemetry.source41.sample_counter0001 []
     inst [8 or "8 inst-8"] value 57189012400
     inst [9 or "9 inst-9"] value 64337638900
 
-opentelemetry.source41.sample_gauge0000 []
+opentelemetry.source41.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 496.1
     inst [2 or "2 inst-2"] value 992.2
@@ -5161,7 +5161,7 @@ opentelemetry.source41.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 3968.8
     inst [9 or "9 inst-9"] value 4464.9
 
-opentelemetry.source41.sample_summary0002 []
+opentelemetry.source41.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.006863789
     inst [2 or "quantile: 0.5"] value 0.013727578
@@ -5173,13 +5173,13 @@ opentelemetry.source41.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.054910312
     inst [9 or "quantile: 2.25"] value 0.061774101
 
-opentelemetry.source41.sample_summary0002_count []
+opentelemetry.source41.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 78174
 
-opentelemetry.source41.sample_summary0002_sum []
+opentelemetry.source41.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 59.821891
 
-opentelemetry.source41.sample_counter0001 []
+opentelemetry.source41.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14127047700
     inst [2 or "2 inst-2"] value 28254095400
@@ -5191,7 +5191,7 @@ opentelemetry.source41.sample_counter0001 []
     inst [8 or "8 inst-8"] value 113016382000
     inst [9 or "9 inst-9"] value 127143429000
 
-opentelemetry.source41.sample_gauge0000 []
+opentelemetry.source41.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 992.2
     inst [2 or "2 inst-2"] value 1984.4
@@ -5203,7 +5203,7 @@ opentelemetry.source41.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7937.6
     inst [9 or "9 inst-9"] value 8929.799999999999
 
-opentelemetry.source41.sample_summary0002 []
+opentelemetry.source41.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013408332
     inst [2 or "quantile: 0.5"] value 0.026816664
@@ -5215,13 +5215,13 @@ opentelemetry.source41.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.107266656
     inst [9 or "quantile: 2.25"] value 0.120674988
 
-opentelemetry.source41.sample_summary0002_count []
+opentelemetry.source41.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 152712
 
-opentelemetry.source41.sample_summary0002_sum []
+opentelemetry.source41.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 116.861369
 
-opentelemetry.source41.sample_counter0001 []
+opentelemetry.source41.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 21105468900
     inst [2 or "2 inst-2"] value 42210937700
@@ -5233,7 +5233,7 @@ opentelemetry.source41.sample_counter0001 []
     inst [8 or "8 inst-8"] value 168843751000
     inst [9 or "9 inst-9"] value 189949220000
 
-opentelemetry.source41.sample_gauge0000 []
+opentelemetry.source41.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1488.3
     inst [2 or "2 inst-2"] value 2976.6
@@ -5245,7 +5245,7 @@ opentelemetry.source41.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 11906.4
     inst [9 or "9 inst-9"] value 13394.7
 
-opentelemetry.source41.sample_summary0002 []
+opentelemetry.source41.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.019952875
     inst [2 or "quantile: 0.5"] value 0.03990575
@@ -5257,13 +5257,13 @@ opentelemetry.source41.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.159623
     inst [9 or "quantile: 2.25"] value 0.179575875
 
-opentelemetry.source41.sample_summary0002_count []
+opentelemetry.source41.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 227250
 
-opentelemetry.source41.sample_summary0002_sum []
+opentelemetry.source41.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 173.900846
 
-opentelemetry.source42.sample_counter0001 []
+opentelemetry.source42.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7318831940
     inst [2 or "2 inst-2"] value 14637663900
@@ -5275,7 +5275,7 @@ opentelemetry.source42.sample_counter0001 []
     inst [8 or "8 inst-8"] value 58550655500
     inst [9 or "9 inst-9"] value 65869487500
 
-opentelemetry.source42.sample_gauge0000 []
+opentelemetry.source42.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 508.2
     inst [2 or "2 inst-2"] value 1016.4
@@ -5287,7 +5287,7 @@ opentelemetry.source42.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4065.6
     inst [9 or "9 inst-9"] value 4573.8
 
-opentelemetry.source42.sample_summary0002 []
+opentelemetry.source42.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007023412000000001
     inst [2 or "quantile: 0.5"] value 0.014046824
@@ -5299,13 +5299,13 @@ opentelemetry.source42.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.056187296
     inst [9 or "quantile: 2.25"] value 0.063210708
 
-opentelemetry.source42.sample_summary0002_count []
+opentelemetry.source42.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 79992
 
-opentelemetry.source42.sample_summary0002_sum []
+opentelemetry.source42.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 61.213098
 
-opentelemetry.source42.sample_counter0001 []
+opentelemetry.source42.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14467458500
     inst [2 or "2 inst-2"] value 28934917000
@@ -5317,7 +5317,7 @@ opentelemetry.source42.sample_counter0001 []
     inst [8 or "8 inst-8"] value 115739668000
     inst [9 or "9 inst-9"] value 130207126000
 
-opentelemetry.source42.sample_gauge0000 []
+opentelemetry.source42.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1016.4
     inst [2 or "2 inst-2"] value 2032.8
@@ -5329,7 +5329,7 @@ opentelemetry.source42.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8131.2
     inst [9 or "9 inst-9"] value 9147.6
 
-opentelemetry.source42.sample_summary0002 []
+opentelemetry.source42.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013727578
     inst [2 or "quantile: 0.5"] value 0.027455156
@@ -5341,13 +5341,13 @@ opentelemetry.source42.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.109820624
     inst [9 or "quantile: 2.25"] value 0.123548202
 
-opentelemetry.source42.sample_summary0002_count []
+opentelemetry.source42.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 156348
 
-opentelemetry.source42.sample_summary0002_sum []
+opentelemetry.source42.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 119.643782
 
-opentelemetry.source42.sample_counter0001 []
+opentelemetry.source42.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 21616085000
     inst [2 or "2 inst-2"] value 43232170100
@@ -5359,7 +5359,7 @@ opentelemetry.source42.sample_counter0001 []
     inst [8 or "8 inst-8"] value 172928680000
     inst [9 or "9 inst-9"] value 194544765000
 
-opentelemetry.source42.sample_gauge0000 []
+opentelemetry.source42.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1524.6
     inst [2 or "2 inst-2"] value 3049.2
@@ -5371,7 +5371,7 @@ opentelemetry.source42.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 12196.8
     inst [9 or "9 inst-9"] value 13721.4
 
-opentelemetry.source42.sample_summary0002 []
+opentelemetry.source42.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.020431744
     inst [2 or "quantile: 0.5"] value 0.040863488
@@ -5383,13 +5383,13 @@ opentelemetry.source42.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.163453952
     inst [9 or "quantile: 2.25"] value 0.183885696
 
-opentelemetry.source42.sample_summary0002_count []
+opentelemetry.source42.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 232704
 
-opentelemetry.source42.sample_summary0002_sum []
+opentelemetry.source42.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 178.074467
 
-opentelemetry.source43.sample_counter0001 []
+opentelemetry.source43.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7489037340
     inst [2 or "2 inst-2"] value 14978074700
@@ -5401,7 +5401,7 @@ opentelemetry.source43.sample_counter0001 []
     inst [8 or "8 inst-8"] value 59912298700
     inst [9 or "9 inst-9"] value 67401336000
 
-opentelemetry.source43.sample_gauge0000 []
+opentelemetry.source43.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 520.3
     inst [2 or "2 inst-2"] value 1040.6
@@ -5413,7 +5413,7 @@ opentelemetry.source43.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4162.4
     inst [9 or "9 inst-9"] value 4682.7
 
-opentelemetry.source43.sample_summary0002 []
+opentelemetry.source43.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007183035000000001
     inst [2 or "quantile: 0.5"] value 0.01436607
@@ -5425,13 +5425,13 @@ opentelemetry.source43.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.05746428000000001
     inst [9 or "quantile: 2.25"] value 0.06464731500000001
 
-opentelemetry.source43.sample_summary0002_count []
+opentelemetry.source43.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 81810
 
-opentelemetry.source43.sample_summary0002_sum []
+opentelemetry.source43.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 62.604305
 
-opentelemetry.source43.sample_counter0001 []
+opentelemetry.source43.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14807869300
     inst [2 or "2 inst-2"] value 29615738600
@@ -5443,7 +5443,7 @@ opentelemetry.source43.sample_counter0001 []
     inst [8 or "8 inst-8"] value 118462954000
     inst [9 or "9 inst-9"] value 133270824000
 
-opentelemetry.source43.sample_gauge0000 []
+opentelemetry.source43.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1040.6
     inst [2 or "2 inst-2"] value 2081.2
@@ -5455,7 +5455,7 @@ opentelemetry.source43.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8324.799999999999
     inst [9 or "9 inst-9"] value 9365.4
 
-opentelemetry.source43.sample_summary0002 []
+opentelemetry.source43.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.014046824
     inst [2 or "quantile: 0.5"] value 0.028093648
@@ -5467,13 +5467,13 @@ opentelemetry.source43.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.112374592
     inst [9 or "quantile: 2.25"] value 0.126421416
 
-opentelemetry.source43.sample_summary0002_count []
+opentelemetry.source43.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 159984
 
-opentelemetry.source43.sample_summary0002_sum []
+opentelemetry.source43.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 122.426196
 
-opentelemetry.source43.sample_counter0001 []
+opentelemetry.source43.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 22126701200
     inst [2 or "2 inst-2"] value 44253402400
@@ -5485,7 +5485,7 @@ opentelemetry.source43.sample_counter0001 []
     inst [8 or "8 inst-8"] value 177013610000
     inst [9 or "9 inst-9"] value 199140311000
 
-opentelemetry.source43.sample_gauge0000 []
+opentelemetry.source43.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1560.9
     inst [2 or "2 inst-2"] value 3121.8
@@ -5497,7 +5497,7 @@ opentelemetry.source43.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 12487.2
     inst [9 or "9 inst-9"] value 14048.1
 
-opentelemetry.source43.sample_summary0002 []
+opentelemetry.source43.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.020910613
     inst [2 or "quantile: 0.5"] value 0.041821226
@@ -5509,13 +5509,13 @@ opentelemetry.source43.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.167284904
     inst [9 or "quantile: 2.25"] value 0.188195517
 
-opentelemetry.source43.sample_summary0002_count []
+opentelemetry.source43.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 238158
 
-opentelemetry.source43.sample_summary0002_sum []
+opentelemetry.source43.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 182.248087
 
-opentelemetry.source44.sample_counter0001 []
+opentelemetry.source44.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7659242730
     inst [2 or "2 inst-2"] value 15318485500
@@ -5527,7 +5527,7 @@ opentelemetry.source44.sample_counter0001 []
     inst [8 or "8 inst-8"] value 61273941800
     inst [9 or "9 inst-9"] value 68933184600
 
-opentelemetry.source44.sample_gauge0000 []
+opentelemetry.source44.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 532.4
     inst [2 or "2 inst-2"] value 1064.8
@@ -5539,7 +5539,7 @@ opentelemetry.source44.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4259.2
     inst [9 or "9 inst-9"] value 4791.6
 
-opentelemetry.source44.sample_summary0002 []
+opentelemetry.source44.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007342658
     inst [2 or "quantile: 0.5"] value 0.014685316
@@ -5551,13 +5551,13 @@ opentelemetry.source44.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.058741264
     inst [9 or "quantile: 2.25"] value 0.066083922
 
-opentelemetry.source44.sample_summary0002_count []
+opentelemetry.source44.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 83628
 
-opentelemetry.source44.sample_summary0002_sum []
+opentelemetry.source44.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 63.995511
 
-opentelemetry.source44.sample_counter0001 []
+opentelemetry.source44.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 15148280100
     inst [2 or "2 inst-2"] value 30296560100
@@ -5569,7 +5569,7 @@ opentelemetry.source44.sample_counter0001 []
     inst [8 or "8 inst-8"] value 121186241000
     inst [9 or "9 inst-9"] value 136334521000
 
-opentelemetry.source44.sample_gauge0000 []
+opentelemetry.source44.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1064.8
     inst [2 or "2 inst-2"] value 2129.6
@@ -5581,7 +5581,7 @@ opentelemetry.source44.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8518.4
     inst [9 or "9 inst-9"] value 9583.200000000001
 
-opentelemetry.source44.sample_summary0002 []
+opentelemetry.source44.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01436607
     inst [2 or "quantile: 0.5"] value 0.02873214
@@ -5593,13 +5593,13 @@ opentelemetry.source44.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.11492856
     inst [9 or "quantile: 2.25"] value 0.12929463
 
-opentelemetry.source44.sample_summary0002_count []
+opentelemetry.source44.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 163620
 
-opentelemetry.source44.sample_summary0002_sum []
+opentelemetry.source44.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 125.208609
 
-opentelemetry.source44.sample_counter0001 []
+opentelemetry.source44.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 22637317400
     inst [2 or "2 inst-2"] value 45274634800
@@ -5611,7 +5611,7 @@ opentelemetry.source44.sample_counter0001 []
     inst [8 or "8 inst-8"] value 181098539000
     inst [9 or "9 inst-9"] value 203735857000
 
-opentelemetry.source44.sample_gauge0000 []
+opentelemetry.source44.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1597.2
     inst [2 or "2 inst-2"] value 3194.4
@@ -5623,7 +5623,7 @@ opentelemetry.source44.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 12777.6
     inst [9 or "9 inst-9"] value 14374.8
 
-opentelemetry.source44.sample_summary0002 []
+opentelemetry.source44.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.021389482
     inst [2 or "quantile: 0.5"] value 0.042778964
@@ -5635,13 +5635,13 @@ opentelemetry.source44.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.171115856
     inst [9 or "quantile: 2.25"] value 0.192505338
 
-opentelemetry.source44.sample_summary0002_count []
+opentelemetry.source44.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 243612
 
-opentelemetry.source44.sample_summary0002_sum []
+opentelemetry.source44.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 186.421707
 
-opentelemetry.source45.sample_counter0001 []
+opentelemetry.source45.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7829448120
     inst [2 or "2 inst-2"] value 15658896200
@@ -5653,7 +5653,7 @@ opentelemetry.source45.sample_counter0001 []
     inst [8 or "8 inst-8"] value 62635585000
     inst [9 or "9 inst-9"] value 70465033100
 
-opentelemetry.source45.sample_gauge0000 []
+opentelemetry.source45.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 544.5
     inst [2 or "2 inst-2"] value 1089
@@ -5665,7 +5665,7 @@ opentelemetry.source45.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4356
     inst [9 or "9 inst-9"] value 4900.5
 
-opentelemetry.source45.sample_summary0002 []
+opentelemetry.source45.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007502281
     inst [2 or "quantile: 0.5"] value 0.015004562
@@ -5677,13 +5677,13 @@ opentelemetry.source45.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.060018248
     inst [9 or "quantile: 2.25"] value 0.06752052900000001
 
-opentelemetry.source45.sample_summary0002_count []
+opentelemetry.source45.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 85446
 
-opentelemetry.source45.sample_summary0002_sum []
+opentelemetry.source45.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 65.386718
 
-opentelemetry.source45.sample_counter0001 []
+opentelemetry.source45.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 15488690900
     inst [2 or "2 inst-2"] value 30977381700
@@ -5695,7 +5695,7 @@ opentelemetry.source45.sample_counter0001 []
     inst [8 or "8 inst-8"] value 123909527000
     inst [9 or "9 inst-9"] value 139398218000
 
-opentelemetry.source45.sample_gauge0000 []
+opentelemetry.source45.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1089
     inst [2 or "2 inst-2"] value 2178
@@ -5707,7 +5707,7 @@ opentelemetry.source45.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8712
     inst [9 or "9 inst-9"] value 9801
 
-opentelemetry.source45.sample_summary0002 []
+opentelemetry.source45.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.014685316
     inst [2 or "quantile: 0.5"] value 0.029370632
@@ -5719,13 +5719,13 @@ opentelemetry.source45.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.117482528
     inst [9 or "quantile: 2.25"] value 0.132167844
 
-opentelemetry.source45.sample_summary0002_count []
+opentelemetry.source45.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 167256
 
-opentelemetry.source45.sample_summary0002_sum []
+opentelemetry.source45.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 127.991023
 
-opentelemetry.source45.sample_counter0001 []
+opentelemetry.source45.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 23147933600
     inst [2 or "2 inst-2"] value 46295867200
@@ -5737,7 +5737,7 @@ opentelemetry.source45.sample_counter0001 []
     inst [8 or "8 inst-8"] value 185183469000
     inst [9 or "9 inst-9"] value 208331402000
 
-opentelemetry.source45.sample_gauge0000 []
+opentelemetry.source45.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1633.5
     inst [2 or "2 inst-2"] value 3267
@@ -5749,7 +5749,7 @@ opentelemetry.source45.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 13068
     inst [9 or "9 inst-9"] value 14701.5
 
-opentelemetry.source45.sample_summary0002 []
+opentelemetry.source45.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.021868351
     inst [2 or "quantile: 0.5"] value 0.043736702
@@ -5761,13 +5761,13 @@ opentelemetry.source45.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.174946808
     inst [9 or "quantile: 2.25"] value 0.196815159
 
-opentelemetry.source45.sample_summary0002_count []
+opentelemetry.source45.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 249066
 
-opentelemetry.source45.sample_summary0002_sum []
+opentelemetry.source45.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 190.595327
 
-opentelemetry.source46.sample_counter0001 []
+opentelemetry.source46.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 7999653520
     inst [2 or "2 inst-2"] value 15999307000
@@ -5779,7 +5779,7 @@ opentelemetry.source46.sample_counter0001 []
     inst [8 or "8 inst-8"] value 63997228100
     inst [9 or "9 inst-9"] value 71996881700
 
-opentelemetry.source46.sample_gauge0000 []
+opentelemetry.source46.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 556.6
     inst [2 or "2 inst-2"] value 1113.2
@@ -5791,7 +5791,7 @@ opentelemetry.source46.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4452.8
     inst [9 or "9 inst-9"] value 5009.4
 
-opentelemetry.source46.sample_summary0002 []
+opentelemetry.source46.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007661904000000001
     inst [2 or "quantile: 0.5"] value 0.015323808
@@ -5803,13 +5803,13 @@ opentelemetry.source46.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.06129523200000001
     inst [9 or "quantile: 2.25"] value 0.068957136
 
-opentelemetry.source46.sample_summary0002_count []
+opentelemetry.source46.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 87264
 
-opentelemetry.source46.sample_summary0002_sum []
+opentelemetry.source46.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 66.777925
 
-opentelemetry.source46.sample_counter0001 []
+opentelemetry.source46.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 15829101600
     inst [2 or "2 inst-2"] value 31658203300
@@ -5821,7 +5821,7 @@ opentelemetry.source46.sample_counter0001 []
     inst [8 or "8 inst-8"] value 126632813000
     inst [9 or "9 inst-9"] value 142461915000
 
-opentelemetry.source46.sample_gauge0000 []
+opentelemetry.source46.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1113.2
     inst [2 or "2 inst-2"] value 2226.4
@@ -5833,7 +5833,7 @@ opentelemetry.source46.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8905.6
     inst [9 or "9 inst-9"] value 10018.8
 
-opentelemetry.source46.sample_summary0002 []
+opentelemetry.source46.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.015004562
     inst [2 or "quantile: 0.5"] value 0.030009124
@@ -5845,13 +5845,13 @@ opentelemetry.source46.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.120036496
     inst [9 or "quantile: 2.25"] value 0.135041058
 
-opentelemetry.source46.sample_summary0002_count []
+opentelemetry.source46.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 170892
 
-opentelemetry.source46.sample_summary0002_sum []
+opentelemetry.source46.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 130.773436
 
-opentelemetry.source46.sample_counter0001 []
+opentelemetry.source46.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 23658549800
     inst [2 or "2 inst-2"] value 47317099500
@@ -5863,7 +5863,7 @@ opentelemetry.source46.sample_counter0001 []
     inst [8 or "8 inst-8"] value 189268398000
     inst [9 or "9 inst-9"] value 212926948000
 
-opentelemetry.source46.sample_gauge0000 []
+opentelemetry.source46.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1669.8
     inst [2 or "2 inst-2"] value 3339.6
@@ -5875,7 +5875,7 @@ opentelemetry.source46.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 13358.4
     inst [9 or "9 inst-9"] value 15028.2
 
-opentelemetry.source46.sample_summary0002 []
+opentelemetry.source46.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.02234722
     inst [2 or "quantile: 0.5"] value 0.04469444
@@ -5887,13 +5887,13 @@ opentelemetry.source46.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.17877776
     inst [9 or "quantile: 2.25"] value 0.20112498
 
-opentelemetry.source46.sample_summary0002_count []
+opentelemetry.source46.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 254520
 
-opentelemetry.source46.sample_summary0002_sum []
+opentelemetry.source46.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 194.768948
 
-opentelemetry.source47.sample_counter0001 []
+opentelemetry.source47.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8169858910
     inst [2 or "2 inst-2"] value 16339717800
@@ -5905,7 +5905,7 @@ opentelemetry.source47.sample_counter0001 []
     inst [8 or "8 inst-8"] value 65358871300
     inst [9 or "9 inst-9"] value 73528730200
 
-opentelemetry.source47.sample_gauge0000 []
+opentelemetry.source47.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 568.7
     inst [2 or "2 inst-2"] value 1137.4
@@ -5917,7 +5917,7 @@ opentelemetry.source47.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4549.6
     inst [9 or "9 inst-9"] value 5118.3
 
-opentelemetry.source47.sample_summary0002 []
+opentelemetry.source47.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007821527
     inst [2 or "quantile: 0.5"] value 0.015643054
@@ -5929,13 +5929,13 @@ opentelemetry.source47.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.062572216
     inst [9 or "quantile: 2.25"] value 0.07039374300000001
 
-opentelemetry.source47.sample_summary0002_count []
+opentelemetry.source47.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 89082
 
-opentelemetry.source47.sample_summary0002_sum []
+opentelemetry.source47.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 68.169132
 
-opentelemetry.source47.sample_counter0001 []
+opentelemetry.source47.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 16169512400
     inst [2 or "2 inst-2"] value 32339024900
@@ -5947,7 +5947,7 @@ opentelemetry.source47.sample_counter0001 []
     inst [8 or "8 inst-8"] value 129356099000
     inst [9 or "9 inst-9"] value 145525612000
 
-opentelemetry.source47.sample_gauge0000 []
+opentelemetry.source47.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1137.4
     inst [2 or "2 inst-2"] value 2274.8
@@ -5959,7 +5959,7 @@ opentelemetry.source47.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9099.200000000001
     inst [9 or "9 inst-9"] value 10236.6
 
-opentelemetry.source47.sample_summary0002 []
+opentelemetry.source47.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.015323808
     inst [2 or "quantile: 0.5"] value 0.030647616
@@ -5971,13 +5971,13 @@ opentelemetry.source47.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.122590464
     inst [9 or "quantile: 2.25"] value 0.137914272
 
-opentelemetry.source47.sample_summary0002_count []
+opentelemetry.source47.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 174528
 
-opentelemetry.source47.sample_summary0002_sum []
+opentelemetry.source47.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 133.55585
 
-opentelemetry.source47.sample_counter0001 []
+opentelemetry.source47.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 24169165900
     inst [2 or "2 inst-2"] value 48338331900
@@ -5989,7 +5989,7 @@ opentelemetry.source47.sample_counter0001 []
     inst [8 or "8 inst-8"] value 193353328000
     inst [9 or "9 inst-9"] value 217522494000
 
-opentelemetry.source47.sample_gauge0000 []
+opentelemetry.source47.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1706.1
     inst [2 or "2 inst-2"] value 3412.2
@@ -6001,7 +6001,7 @@ opentelemetry.source47.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 13648.8
     inst [9 or "9 inst-9"] value 15354.9
 
-opentelemetry.source47.sample_summary0002 []
+opentelemetry.source47.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.022826089
     inst [2 or "quantile: 0.5"] value 0.045652178
@@ -6013,13 +6013,13 @@ opentelemetry.source47.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.182608712
     inst [9 or "quantile: 2.25"] value 0.205434801
 
-opentelemetry.source47.sample_summary0002_count []
+opentelemetry.source47.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 259974
 
-opentelemetry.source47.sample_summary0002_sum []
+opentelemetry.source47.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 198.942568
 
-opentelemetry.source48.sample_counter0001 []
+opentelemetry.source48.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8340064310
     inst [2 or "2 inst-2"] value 16680128600
@@ -6031,7 +6031,7 @@ opentelemetry.source48.sample_counter0001 []
     inst [8 or "8 inst-8"] value 66720514400
     inst [9 or "9 inst-9"] value 75060578800
 
-opentelemetry.source48.sample_gauge0000 []
+opentelemetry.source48.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 580.8
     inst [2 or "2 inst-2"] value 1161.6
@@ -6043,7 +6043,7 @@ opentelemetry.source48.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4646.4
     inst [9 or "9 inst-9"] value 5227.2
 
-opentelemetry.source48.sample_summary0002 []
+opentelemetry.source48.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.007981150000000001
     inst [2 or "quantile: 0.5"] value 0.0159623
@@ -6055,13 +6055,13 @@ opentelemetry.source48.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.06384920000000001
     inst [9 or "quantile: 2.25"] value 0.07183035
 
-opentelemetry.source48.sample_summary0002_count []
+opentelemetry.source48.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 90900
 
-opentelemetry.source48.sample_summary0002_sum []
+opentelemetry.source48.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 69.560339
 
-opentelemetry.source48.sample_counter0001 []
+opentelemetry.source48.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 16509923200
     inst [2 or "2 inst-2"] value 33019846400
@@ -6073,7 +6073,7 @@ opentelemetry.source48.sample_counter0001 []
     inst [8 or "8 inst-8"] value 132079386000
     inst [9 or "9 inst-9"] value 148589309000
 
-opentelemetry.source48.sample_gauge0000 []
+opentelemetry.source48.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1161.6
     inst [2 or "2 inst-2"] value 2323.2
@@ -6085,7 +6085,7 @@ opentelemetry.source48.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9292.799999999999
     inst [9 or "9 inst-9"] value 10454.4
 
-opentelemetry.source48.sample_summary0002 []
+opentelemetry.source48.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.015643054
     inst [2 or "quantile: 0.5"] value 0.031286108
@@ -6097,13 +6097,13 @@ opentelemetry.source48.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.125144432
     inst [9 or "quantile: 2.25"] value 0.140787486
 
-opentelemetry.source48.sample_summary0002_count []
+opentelemetry.source48.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 178164
 
-opentelemetry.source48.sample_summary0002_sum []
+opentelemetry.source48.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 136.338263
 
-opentelemetry.source48.sample_counter0001 []
+opentelemetry.source48.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 24679782100
     inst [2 or "2 inst-2"] value 49359564300
@@ -6115,7 +6115,7 @@ opentelemetry.source48.sample_counter0001 []
     inst [8 or "8 inst-8"] value 197438257000
     inst [9 or "9 inst-9"] value 222118039000
 
-opentelemetry.source48.sample_gauge0000 []
+opentelemetry.source48.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1742.4
     inst [2 or "2 inst-2"] value 3484.8
@@ -6127,7 +6127,7 @@ opentelemetry.source48.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 13939.2
     inst [9 or "9 inst-9"] value 15681.6
 
-opentelemetry.source48.sample_summary0002 []
+opentelemetry.source48.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.023304958
     inst [2 or "quantile: 0.5"] value 0.046609916
@@ -6139,13 +6139,13 @@ opentelemetry.source48.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.186439664
     inst [9 or "quantile: 2.25"] value 0.209744622
 
-opentelemetry.source48.sample_summary0002_count []
+opentelemetry.source48.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 265428
 
-opentelemetry.source48.sample_summary0002_sum []
+opentelemetry.source48.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 203.116188
 
-opentelemetry.source49.sample_counter0001 []
+opentelemetry.source49.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8510269700
     inst [2 or "2 inst-2"] value 17020539400
@@ -6157,7 +6157,7 @@ opentelemetry.source49.sample_counter0001 []
     inst [8 or "8 inst-8"] value 68082157600
     inst [9 or "9 inst-9"] value 76592427300
 
-opentelemetry.source49.sample_gauge0000 []
+opentelemetry.source49.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 592.9
     inst [2 or "2 inst-2"] value 1185.8
@@ -6169,7 +6169,7 @@ opentelemetry.source49.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4743.2
     inst [9 or "9 inst-9"] value 5336.1
 
-opentelemetry.source49.sample_summary0002 []
+opentelemetry.source49.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008140773
     inst [2 or "quantile: 0.5"] value 0.016281546
@@ -6181,13 +6181,13 @@ opentelemetry.source49.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.065126184
     inst [9 or "quantile: 2.25"] value 0.07326695700000001
 
-opentelemetry.source49.sample_summary0002_count []
+opentelemetry.source49.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 92718
 
-opentelemetry.source49.sample_summary0002_sum []
+opentelemetry.source49.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 70.951545
 
-opentelemetry.source49.sample_counter0001 []
+opentelemetry.source49.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 16850334000
     inst [2 or "2 inst-2"] value 33700668000
@@ -6199,7 +6199,7 @@ opentelemetry.source49.sample_counter0001 []
     inst [8 or "8 inst-8"] value 134802672000
     inst [9 or "9 inst-9"] value 151653006000
 
-opentelemetry.source49.sample_gauge0000 []
+opentelemetry.source49.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1185.8
     inst [2 or "2 inst-2"] value 2371.6
@@ -6211,7 +6211,7 @@ opentelemetry.source49.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9486.4
     inst [9 or "9 inst-9"] value 10672.2
 
-opentelemetry.source49.sample_summary0002 []
+opentelemetry.source49.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0159623
     inst [2 or "quantile: 0.5"] value 0.0319246
@@ -6223,13 +6223,13 @@ opentelemetry.source49.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.1276984
     inst [9 or "quantile: 2.25"] value 0.1436607
 
-opentelemetry.source49.sample_summary0002_count []
+opentelemetry.source49.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 181800
 
-opentelemetry.source49.sample_summary0002_sum []
+opentelemetry.source49.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 139.120677
 
-opentelemetry.source49.sample_counter0001 []
+opentelemetry.source49.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 25190398300
     inst [2 or "2 inst-2"] value 50380796600
@@ -6241,7 +6241,7 @@ opentelemetry.source49.sample_counter0001 []
     inst [8 or "8 inst-8"] value 201523186000
     inst [9 or "9 inst-9"] value 226713585000
 
-opentelemetry.source49.sample_gauge0000 []
+opentelemetry.source49.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1778.7
     inst [2 or "2 inst-2"] value 3557.4
@@ -6253,7 +6253,7 @@ opentelemetry.source49.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 14229.6
     inst [9 or "9 inst-9"] value 16008.3
 
-opentelemetry.source49.sample_summary0002 []
+opentelemetry.source49.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.023783827
     inst [2 or "quantile: 0.5"] value 0.047567654
@@ -6265,13 +6265,13 @@ opentelemetry.source49.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.190270616
     inst [9 or "quantile: 2.25"] value 0.214054443
 
-opentelemetry.source49.sample_summary0002_count []
+opentelemetry.source49.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 270882
 
-opentelemetry.source49.sample_summary0002_sum []
+opentelemetry.source49.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 207.289809
 
-opentelemetry.source50.sample_counter0001 []
+opentelemetry.source50.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8680475090
     inst [2 or "2 inst-2"] value 17360950200
@@ -6283,7 +6283,7 @@ opentelemetry.source50.sample_counter0001 []
     inst [8 or "8 inst-8"] value 69443800800
     inst [9 or "9 inst-9"] value 78124275800
 
-opentelemetry.source50.sample_gauge0000 []
+opentelemetry.source50.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 605
     inst [2 or "2 inst-2"] value 1210
@@ -6295,7 +6295,7 @@ opentelemetry.source50.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4840
     inst [9 or "9 inst-9"] value 5445
 
-opentelemetry.source50.sample_summary0002 []
+opentelemetry.source50.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008300396000000002
     inst [2 or "quantile: 0.5"] value 0.016600792
@@ -6307,13 +6307,13 @@ opentelemetry.source50.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.06640316800000001
     inst [9 or "quantile: 2.25"] value 0.074703564
 
-opentelemetry.source50.sample_summary0002_count []
+opentelemetry.source50.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 94536
 
-opentelemetry.source50.sample_summary0002_sum []
+opentelemetry.source50.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 72.342752
 
-opentelemetry.source50.sample_counter0001 []
+opentelemetry.source50.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 17190744800
     inst [2 or "2 inst-2"] value 34381489600
@@ -6325,7 +6325,7 @@ opentelemetry.source50.sample_counter0001 []
     inst [8 or "8 inst-8"] value 137525958000
     inst [9 or "9 inst-9"] value 154716703000
 
-opentelemetry.source50.sample_gauge0000 []
+opentelemetry.source50.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1210
     inst [2 or "2 inst-2"] value 2420
@@ -6337,7 +6337,7 @@ opentelemetry.source50.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9680
     inst [9 or "9 inst-9"] value 10890
 
-opentelemetry.source50.sample_summary0002 []
+opentelemetry.source50.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.016281546
     inst [2 or "quantile: 0.5"] value 0.032563092
@@ -6349,13 +6349,13 @@ opentelemetry.source50.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.130252368
     inst [9 or "quantile: 2.25"] value 0.146533914
 
-opentelemetry.source50.sample_summary0002_count []
+opentelemetry.source50.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 185436
 
-opentelemetry.source50.sample_summary0002_sum []
+opentelemetry.source50.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 141.903091
 
-opentelemetry.source50.sample_counter0001 []
+opentelemetry.source50.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 25701014500
     inst [2 or "2 inst-2"] value 51402029000
@@ -6367,7 +6367,7 @@ opentelemetry.source50.sample_counter0001 []
     inst [8 or "8 inst-8"] value 205608116000
     inst [9 or "9 inst-9"] value 231309130000
 
-opentelemetry.source50.sample_gauge0000 []
+opentelemetry.source50.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1815
     inst [2 or "2 inst-2"] value 3630
@@ -6379,7 +6379,7 @@ opentelemetry.source50.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 14520
     inst [9 or "9 inst-9"] value 16335
 
-opentelemetry.source50.sample_summary0002 []
+opentelemetry.source50.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.024262696
     inst [2 or "quantile: 0.5"] value 0.048525392
@@ -6391,13 +6391,13 @@ opentelemetry.source50.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.194101568
     inst [9 or "quantile: 2.25"] value 0.218364264
 
-opentelemetry.source50.sample_summary0002_count []
+opentelemetry.source50.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 276336
 
-opentelemetry.source50.sample_summary0002_sum []
+opentelemetry.source50.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 211.463429
 
-opentelemetry.source51.sample_counter0001 []
+opentelemetry.source51.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 8850680490
     inst [2 or "2 inst-2"] value 17701361000
@@ -6409,7 +6409,7 @@ opentelemetry.source51.sample_counter0001 []
     inst [8 or "8 inst-8"] value 70805443900
     inst [9 or "9 inst-9"] value 79656124400
 
-opentelemetry.source51.sample_gauge0000 []
+opentelemetry.source51.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 617.1
     inst [2 or "2 inst-2"] value 1234.2
@@ -6421,7 +6421,7 @@ opentelemetry.source51.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 4936.8
     inst [9 or "9 inst-9"] value 5553.9
 
-opentelemetry.source51.sample_summary0002 []
+opentelemetry.source51.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008460019000000001
     inst [2 or "quantile: 0.5"] value 0.016920038
@@ -6433,13 +6433,13 @@ opentelemetry.source51.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.06768015200000001
     inst [9 or "quantile: 2.25"] value 0.07614017100000001
 
-opentelemetry.source51.sample_summary0002_count []
+opentelemetry.source51.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 96354
 
-opentelemetry.source51.sample_summary0002_sum []
+opentelemetry.source51.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 73.733959
 
-opentelemetry.source51.sample_counter0001 []
+opentelemetry.source51.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 17531155600
     inst [2 or "2 inst-2"] value 35062311200
@@ -6451,7 +6451,7 @@ opentelemetry.source51.sample_counter0001 []
     inst [8 or "8 inst-8"] value 140249245000
     inst [9 or "9 inst-9"] value 157780400000
 
-opentelemetry.source51.sample_gauge0000 []
+opentelemetry.source51.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1234.2
     inst [2 or "2 inst-2"] value 2468.4
@@ -6463,7 +6463,7 @@ opentelemetry.source51.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9873.6
     inst [9 or "9 inst-9"] value 11107.8
 
-opentelemetry.source51.sample_summary0002 []
+opentelemetry.source51.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.016600792
     inst [2 or "quantile: 0.5"] value 0.03320158400000001
@@ -6475,13 +6475,13 @@ opentelemetry.source51.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.132806336
     inst [9 or "quantile: 2.25"] value 0.149407128
 
-opentelemetry.source51.sample_summary0002_count []
+opentelemetry.source51.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 189072
 
-opentelemetry.source51.sample_summary0002_sum []
+opentelemetry.source51.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 144.685504
 
-opentelemetry.source51.sample_counter0001 []
+opentelemetry.source51.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 26211630700
     inst [2 or "2 inst-2"] value 52423261400
@@ -6493,7 +6493,7 @@ opentelemetry.source51.sample_counter0001 []
     inst [8 or "8 inst-8"] value 209693045000
     inst [9 or "9 inst-9"] value 235904676000
 
-opentelemetry.source51.sample_gauge0000 []
+opentelemetry.source51.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1851.3
     inst [2 or "2 inst-2"] value 3702.6
@@ -6505,7 +6505,7 @@ opentelemetry.source51.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 14810.4
     inst [9 or "9 inst-9"] value 16661.7
 
-opentelemetry.source51.sample_summary0002 []
+opentelemetry.source51.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.024741565
     inst [2 or "quantile: 0.5"] value 0.04948313000000001
@@ -6517,13 +6517,13 @@ opentelemetry.source51.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.19793252
     inst [9 or "quantile: 2.25"] value 0.222674085
 
-opentelemetry.source51.sample_summary0002_count []
+opentelemetry.source51.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 281790
 
-opentelemetry.source51.sample_summary0002_sum []
+opentelemetry.source51.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 215.637049
 
-opentelemetry.source52.sample_counter0001 []
+opentelemetry.source52.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9020885880
     inst [2 or "2 inst-2"] value 18041771800
@@ -6535,7 +6535,7 @@ opentelemetry.source52.sample_counter0001 []
     inst [8 or "8 inst-8"] value 72167087100
     inst [9 or "9 inst-9"] value 81187972900
 
-opentelemetry.source52.sample_gauge0000 []
+opentelemetry.source52.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 629.2
     inst [2 or "2 inst-2"] value 1258.4
@@ -6547,7 +6547,7 @@ opentelemetry.source52.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5033.6
     inst [9 or "9 inst-9"] value 5662.8
 
-opentelemetry.source52.sample_summary0002 []
+opentelemetry.source52.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008619642
     inst [2 or "quantile: 0.5"] value 0.017239284
@@ -6559,13 +6559,13 @@ opentelemetry.source52.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.068957136
     inst [9 or "quantile: 2.25"] value 0.07757677800000001
 
-opentelemetry.source52.sample_summary0002_count []
+opentelemetry.source52.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 98172
 
-opentelemetry.source52.sample_summary0002_sum []
+opentelemetry.source52.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 75.12516599999999
 
-opentelemetry.source52.sample_counter0001 []
+opentelemetry.source52.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 17871566400
     inst [2 or "2 inst-2"] value 35743132700
@@ -6577,7 +6577,7 @@ opentelemetry.source52.sample_counter0001 []
     inst [8 or "8 inst-8"] value 142972531000
     inst [9 or "9 inst-9"] value 160844097000
 
-opentelemetry.source52.sample_gauge0000 []
+opentelemetry.source52.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1258.4
     inst [2 or "2 inst-2"] value 2516.8
@@ -6589,7 +6589,7 @@ opentelemetry.source52.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 10067.2
     inst [9 or "9 inst-9"] value 11325.6
 
-opentelemetry.source52.sample_summary0002 []
+opentelemetry.source52.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.016920038
     inst [2 or "quantile: 0.5"] value 0.033840076
@@ -6601,13 +6601,13 @@ opentelemetry.source52.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.135360304
     inst [9 or "quantile: 2.25"] value 0.152280342
 
-opentelemetry.source52.sample_summary0002_count []
+opentelemetry.source52.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 192708
 
-opentelemetry.source52.sample_summary0002_sum []
+opentelemetry.source52.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 147.467918
 
-opentelemetry.source52.sample_counter0001 []
+opentelemetry.source52.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 26722246900
     inst [2 or "2 inst-2"] value 53444493700
@@ -6619,7 +6619,7 @@ opentelemetry.source52.sample_counter0001 []
     inst [8 or "8 inst-8"] value 213777975000
     inst [9 or "9 inst-9"] value 240500222000
 
-opentelemetry.source52.sample_gauge0000 []
+opentelemetry.source52.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1887.6
     inst [2 or "2 inst-2"] value 3775.2
@@ -6631,7 +6631,7 @@ opentelemetry.source52.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 15100.8
     inst [9 or "9 inst-9"] value 16988.4
 
-opentelemetry.source52.sample_summary0002 []
+opentelemetry.source52.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.025220434
     inst [2 or "quantile: 0.5"] value 0.05044086800000001
@@ -6643,13 +6643,13 @@ opentelemetry.source52.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.201763472
     inst [9 or "quantile: 2.25"] value 0.226983906
 
-opentelemetry.source52.sample_summary0002_count []
+opentelemetry.source52.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 287244
 
-opentelemetry.source52.sample_summary0002_sum []
+opentelemetry.source52.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 219.81067
 
-opentelemetry.source53.sample_counter0001 []
+opentelemetry.source53.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9191091280
     inst [2 or "2 inst-2"] value 18382182600
@@ -6661,7 +6661,7 @@ opentelemetry.source53.sample_counter0001 []
     inst [8 or "8 inst-8"] value 73528730200
     inst [9 or "9 inst-9"] value 82719821500
 
-opentelemetry.source53.sample_gauge0000 []
+opentelemetry.source53.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 641.3
     inst [2 or "2 inst-2"] value 1282.6
@@ -6673,7 +6673,7 @@ opentelemetry.source53.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5130.4
     inst [9 or "9 inst-9"] value 5771.7
 
-opentelemetry.source53.sample_summary0002 []
+opentelemetry.source53.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008779265000000001
     inst [2 or "quantile: 0.5"] value 0.01755853
@@ -6685,13 +6685,13 @@ opentelemetry.source53.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.07023412000000001
     inst [9 or "quantile: 2.25"] value 0.07901338500000001
 
-opentelemetry.source53.sample_summary0002_count []
+opentelemetry.source53.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 99990
 
-opentelemetry.source53.sample_summary0002_sum []
+opentelemetry.source53.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 76.516372
 
-opentelemetry.source53.sample_counter0001 []
+opentelemetry.source53.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 18211977200
     inst [2 or "2 inst-2"] value 36423954300
@@ -6703,7 +6703,7 @@ opentelemetry.source53.sample_counter0001 []
     inst [8 or "8 inst-8"] value 145695817000
     inst [9 or "9 inst-9"] value 163907794000
 
-opentelemetry.source53.sample_gauge0000 []
+opentelemetry.source53.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1282.6
     inst [2 or "2 inst-2"] value 2565.2
@@ -6715,7 +6715,7 @@ opentelemetry.source53.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 10260.8
     inst [9 or "9 inst-9"] value 11543.4
 
-opentelemetry.source53.sample_summary0002 []
+opentelemetry.source53.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.017239284
     inst [2 or "quantile: 0.5"] value 0.034478568
@@ -6727,13 +6727,13 @@ opentelemetry.source53.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.137914272
     inst [9 or "quantile: 2.25"] value 0.155153556
 
-opentelemetry.source53.sample_summary0002_count []
+opentelemetry.source53.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 196344
 
-opentelemetry.source53.sample_summary0002_sum []
+opentelemetry.source53.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 150.250331
 
-opentelemetry.source53.sample_counter0001 []
+opentelemetry.source53.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 27232863000
     inst [2 or "2 inst-2"] value 54465726100
@@ -6745,7 +6745,7 @@ opentelemetry.source53.sample_counter0001 []
     inst [8 or "8 inst-8"] value 217862904000
     inst [9 or "9 inst-9"] value 245095767000
 
-opentelemetry.source53.sample_gauge0000 []
+opentelemetry.source53.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1923.9
     inst [2 or "2 inst-2"] value 3847.8
@@ -6757,7 +6757,7 @@ opentelemetry.source53.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 15391.2
     inst [9 or "9 inst-9"] value 17315.1
 
-opentelemetry.source53.sample_summary0002 []
+opentelemetry.source53.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.025699303
     inst [2 or "quantile: 0.5"] value 0.05139860600000001
@@ -6769,13 +6769,13 @@ opentelemetry.source53.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.205594424
     inst [9 or "quantile: 2.25"] value 0.231293727
 
-opentelemetry.source53.sample_summary0002_count []
+opentelemetry.source53.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 292698
 
-opentelemetry.source53.sample_summary0002_sum []
+opentelemetry.source53.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 223.98429
 
-opentelemetry.source54.sample_counter0001 []
+opentelemetry.source54.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9361296670
     inst [2 or "2 inst-2"] value 18722593300
@@ -6787,7 +6787,7 @@ opentelemetry.source54.sample_counter0001 []
     inst [8 or "8 inst-8"] value 74890373400
     inst [9 or "9 inst-9"] value 84251670000
 
-opentelemetry.source54.sample_gauge0000 []
+opentelemetry.source54.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 653.4
     inst [2 or "2 inst-2"] value 1306.8
@@ -6799,7 +6799,7 @@ opentelemetry.source54.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5227.2
     inst [9 or "9 inst-9"] value 5880.6
 
-opentelemetry.source54.sample_summary0002 []
+opentelemetry.source54.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.008938888000000001
     inst [2 or "quantile: 0.5"] value 0.017877776
@@ -6811,13 +6811,13 @@ opentelemetry.source54.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.07151110400000001
     inst [9 or "quantile: 2.25"] value 0.08044999200000001
 
-opentelemetry.source54.sample_summary0002_count []
+opentelemetry.source54.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 101808
 
-opentelemetry.source54.sample_summary0002_sum []
+opentelemetry.source54.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 77.907579
 
-opentelemetry.source54.sample_counter0001 []
+opentelemetry.source54.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 18552387900
     inst [2 or "2 inst-2"] value 37104775900
@@ -6829,7 +6829,7 @@ opentelemetry.source54.sample_counter0001 []
     inst [8 or "8 inst-8"] value 148419104000
     inst [9 or "9 inst-9"] value 166971492000
 
-opentelemetry.source54.sample_gauge0000 []
+opentelemetry.source54.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1306.8
     inst [2 or "2 inst-2"] value 2613.6
@@ -6841,7 +6841,7 @@ opentelemetry.source54.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 10454.4
     inst [9 or "9 inst-9"] value 11761.2
 
-opentelemetry.source54.sample_summary0002 []
+opentelemetry.source54.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01755853
     inst [2 or "quantile: 0.5"] value 0.03511706000000001
@@ -6853,13 +6853,13 @@ opentelemetry.source54.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.14046824
     inst [9 or "quantile: 2.25"] value 0.15802677
 
-opentelemetry.source54.sample_summary0002_count []
+opentelemetry.source54.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 199980
 
-opentelemetry.source54.sample_summary0002_sum []
+opentelemetry.source54.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 153.032745
 
-opentelemetry.source54.sample_counter0001 []
+opentelemetry.source54.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 27743479200
     inst [2 or "2 inst-2"] value 55486958400
@@ -6871,7 +6871,7 @@ opentelemetry.source54.sample_counter0001 []
     inst [8 or "8 inst-8"] value 221947834000
     inst [9 or "9 inst-9"] value 249691313000
 
-opentelemetry.source54.sample_gauge0000 []
+opentelemetry.source54.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1960.2
     inst [2 or "2 inst-2"] value 3920.4
@@ -6883,7 +6883,7 @@ opentelemetry.source54.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 15681.6
     inst [9 or "9 inst-9"] value 17641.8
 
-opentelemetry.source54.sample_summary0002 []
+opentelemetry.source54.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.026178172
     inst [2 or "quantile: 0.5"] value 0.05235634400000001
@@ -6895,13 +6895,13 @@ opentelemetry.source54.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.209425376
     inst [9 or "quantile: 2.25"] value 0.235603548
 
-opentelemetry.source54.sample_summary0002_count []
+opentelemetry.source54.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 298152
 
-opentelemetry.source54.sample_summary0002_sum []
+opentelemetry.source54.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 228.15791
 
-opentelemetry.source55.sample_counter0001 []
+opentelemetry.source55.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9531502060
     inst [2 or "2 inst-2"] value 19063004100
@@ -6913,7 +6913,7 @@ opentelemetry.source55.sample_counter0001 []
     inst [8 or "8 inst-8"] value 76252016500
     inst [9 or "9 inst-9"] value 85783518600
 
-opentelemetry.source55.sample_gauge0000 []
+opentelemetry.source55.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 665.5
     inst [2 or "2 inst-2"] value 1331
@@ -6925,7 +6925,7 @@ opentelemetry.source55.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5324
     inst [9 or "9 inst-9"] value 5989.5
 
-opentelemetry.source55.sample_summary0002 []
+opentelemetry.source55.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009098511
     inst [2 or "quantile: 0.5"] value 0.018197022
@@ -6937,13 +6937,13 @@ opentelemetry.source55.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.072788088
     inst [9 or "quantile: 2.25"] value 0.081886599
 
-opentelemetry.source55.sample_summary0002_count []
+opentelemetry.source55.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 103626
 
-opentelemetry.source55.sample_summary0002_sum []
+opentelemetry.source55.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 79.29878600000001
 
-opentelemetry.source55.sample_counter0001 []
+opentelemetry.source55.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 18892798700
     inst [2 or "2 inst-2"] value 37785597500
@@ -6955,7 +6955,7 @@ opentelemetry.source55.sample_counter0001 []
     inst [8 or "8 inst-8"] value 151142390000
     inst [9 or "9 inst-9"] value 170035189000
 
-opentelemetry.source55.sample_gauge0000 []
+opentelemetry.source55.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1331
     inst [2 or "2 inst-2"] value 2662
@@ -6967,7 +6967,7 @@ opentelemetry.source55.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 10648
     inst [9 or "9 inst-9"] value 11979
 
-opentelemetry.source55.sample_summary0002 []
+opentelemetry.source55.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.017877776
     inst [2 or "quantile: 0.5"] value 0.035755552
@@ -6979,13 +6979,13 @@ opentelemetry.source55.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.143022208
     inst [9 or "quantile: 2.25"] value 0.160899984
 
-opentelemetry.source55.sample_summary0002_count []
+opentelemetry.source55.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 203616
 
-opentelemetry.source55.sample_summary0002_sum []
+opentelemetry.source55.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 155.815158
 
-opentelemetry.source55.sample_counter0001 []
+opentelemetry.source55.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 28254095400
     inst [2 or "2 inst-2"] value 56508190800
@@ -6997,7 +6997,7 @@ opentelemetry.source55.sample_counter0001 []
     inst [8 or "8 inst-8"] value 226032763000
     inst [9 or "9 inst-9"] value 254286859000
 
-opentelemetry.source55.sample_gauge0000 []
+opentelemetry.source55.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1996.5
     inst [2 or "2 inst-2"] value 3993
@@ -7009,7 +7009,7 @@ opentelemetry.source55.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 15972
     inst [9 or "9 inst-9"] value 17968.5
 
-opentelemetry.source55.sample_summary0002 []
+opentelemetry.source55.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.026657041
     inst [2 or "quantile: 0.5"] value 0.05331408200000001
@@ -7021,13 +7021,13 @@ opentelemetry.source55.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.213256328
     inst [9 or "quantile: 2.25"] value 0.239913369
 
-opentelemetry.source55.sample_summary0002_count []
+opentelemetry.source55.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 303606
 
-opentelemetry.source55.sample_summary0002_sum []
+opentelemetry.source55.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 232.331531
 
-opentelemetry.source56.sample_counter0001 []
+opentelemetry.source56.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9701707460
     inst [2 or "2 inst-2"] value 19403414900
@@ -7039,7 +7039,7 @@ opentelemetry.source56.sample_counter0001 []
     inst [8 or "8 inst-8"] value 77613659700
     inst [9 or "9 inst-9"] value 87315367100
 
-opentelemetry.source56.sample_gauge0000 []
+opentelemetry.source56.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 677.6
     inst [2 or "2 inst-2"] value 1355.2
@@ -7051,7 +7051,7 @@ opentelemetry.source56.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5420.8
     inst [9 or "9 inst-9"] value 6098.4
 
-opentelemetry.source56.sample_summary0002 []
+opentelemetry.source56.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009258134000000001
     inst [2 or "quantile: 0.5"] value 0.018516268
@@ -7063,13 +7063,13 @@ opentelemetry.source56.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.07406507200000001
     inst [9 or "quantile: 2.25"] value 0.08332320600000001
 
-opentelemetry.source56.sample_summary0002_count []
+opentelemetry.source56.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 105444
 
-opentelemetry.source56.sample_summary0002_sum []
+opentelemetry.source56.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 80.689993
 
-opentelemetry.source56.sample_counter0001 []
+opentelemetry.source56.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 19233209500
     inst [2 or "2 inst-2"] value 38466419000
@@ -7081,7 +7081,7 @@ opentelemetry.source56.sample_counter0001 []
     inst [8 or "8 inst-8"] value 153865676000
     inst [9 or "9 inst-9"] value 173098886000
 
-opentelemetry.source56.sample_gauge0000 []
+opentelemetry.source56.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1355.2
     inst [2 or "2 inst-2"] value 2710.4
@@ -7093,7 +7093,7 @@ opentelemetry.source56.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 10841.6
     inst [9 or "9 inst-9"] value 12196.8
 
-opentelemetry.source56.sample_summary0002 []
+opentelemetry.source56.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.018197022
     inst [2 or "quantile: 0.5"] value 0.036394044
@@ -7105,13 +7105,13 @@ opentelemetry.source56.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.145576176
     inst [9 or "quantile: 2.25"] value 0.163773198
 
-opentelemetry.source56.sample_summary0002_count []
+opentelemetry.source56.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 207252
 
-opentelemetry.source56.sample_summary0002_sum []
+opentelemetry.source56.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 158.597572
 
-opentelemetry.source56.sample_counter0001 []
+opentelemetry.source56.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 28764711600
     inst [2 or "2 inst-2"] value 57529423200
@@ -7123,7 +7123,7 @@ opentelemetry.source56.sample_counter0001 []
     inst [8 or "8 inst-8"] value 230117693000
     inst [9 or "9 inst-9"] value 258882404000
 
-opentelemetry.source56.sample_gauge0000 []
+opentelemetry.source56.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2032.8
     inst [2 or "2 inst-2"] value 4065.6
@@ -7135,7 +7135,7 @@ opentelemetry.source56.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 16262.4
     inst [9 or "9 inst-9"] value 18295.2
 
-opentelemetry.source56.sample_summary0002 []
+opentelemetry.source56.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.02713591
     inst [2 or "quantile: 0.5"] value 0.05427182000000001
@@ -7147,13 +7147,13 @@ opentelemetry.source56.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.21708728
     inst [9 or "quantile: 2.25"] value 0.24422319
 
-opentelemetry.source56.sample_summary0002_count []
+opentelemetry.source56.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 309060
 
-opentelemetry.source56.sample_summary0002_sum []
+opentelemetry.source56.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 236.505151
 
-opentelemetry.source57.sample_counter0001 []
+opentelemetry.source57.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 9871912850
     inst [2 or "2 inst-2"] value 19743825700
@@ -7165,7 +7165,7 @@ opentelemetry.source57.sample_counter0001 []
     inst [8 or "8 inst-8"] value 78975302800
     inst [9 or "9 inst-9"] value 88847215700
 
-opentelemetry.source57.sample_gauge0000 []
+opentelemetry.source57.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 689.7
     inst [2 or "2 inst-2"] value 1379.4
@@ -7177,7 +7177,7 @@ opentelemetry.source57.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5517.6
     inst [9 or "9 inst-9"] value 6207.3
 
-opentelemetry.source57.sample_summary0002 []
+opentelemetry.source57.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009417757000000001
     inst [2 or "quantile: 0.5"] value 0.018835514
@@ -7189,13 +7189,13 @@ opentelemetry.source57.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.075342056
     inst [9 or "quantile: 2.25"] value 0.084759813
 
-opentelemetry.source57.sample_summary0002_count []
+opentelemetry.source57.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 107262
 
-opentelemetry.source57.sample_summary0002_sum []
+opentelemetry.source57.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 82.081199
 
-opentelemetry.source57.sample_counter0001 []
+opentelemetry.source57.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 19573620300
     inst [2 or "2 inst-2"] value 39147240600
@@ -7207,7 +7207,7 @@ opentelemetry.source57.sample_counter0001 []
     inst [8 or "8 inst-8"] value 156588962000
     inst [9 or "9 inst-9"] value 176162583000
 
-opentelemetry.source57.sample_gauge0000 []
+opentelemetry.source57.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1379.4
     inst [2 or "2 inst-2"] value 2758.8
@@ -7219,7 +7219,7 @@ opentelemetry.source57.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 11035.2
     inst [9 or "9 inst-9"] value 12414.6
 
-opentelemetry.source57.sample_summary0002 []
+opentelemetry.source57.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.018516268
     inst [2 or "quantile: 0.5"] value 0.037032536
@@ -7231,13 +7231,13 @@ opentelemetry.source57.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.148130144
     inst [9 or "quantile: 2.25"] value 0.166646412
 
-opentelemetry.source57.sample_summary0002_count []
+opentelemetry.source57.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 210888
 
-opentelemetry.source57.sample_summary0002_sum []
+opentelemetry.source57.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 161.379985
 
-opentelemetry.source57.sample_counter0001 []
+opentelemetry.source57.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 29275327800
     inst [2 or "2 inst-2"] value 58550655500
@@ -7249,7 +7249,7 @@ opentelemetry.source57.sample_counter0001 []
     inst [8 or "8 inst-8"] value 234202622000
     inst [9 or "9 inst-9"] value 263477950000
 
-opentelemetry.source57.sample_gauge0000 []
+opentelemetry.source57.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2069.1
     inst [2 or "2 inst-2"] value 4138.2
@@ -7261,7 +7261,7 @@ opentelemetry.source57.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 16552.8
     inst [9 or "9 inst-9"] value 18621.9
 
-opentelemetry.source57.sample_summary0002 []
+opentelemetry.source57.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.027614779
     inst [2 or "quantile: 0.5"] value 0.055229558
@@ -7273,13 +7273,13 @@ opentelemetry.source57.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.220918232
     inst [9 or "quantile: 2.25"] value 0.248533011
 
-opentelemetry.source57.sample_summary0002_count []
+opentelemetry.source57.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 314514
 
-opentelemetry.source57.sample_summary0002_sum []
+opentelemetry.source57.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 240.678771
 
-opentelemetry.source58.sample_counter0001 []
+opentelemetry.source58.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10042118200
     inst [2 or "2 inst-2"] value 20084236500
@@ -7291,7 +7291,7 @@ opentelemetry.source58.sample_counter0001 []
     inst [8 or "8 inst-8"] value 80336946000
     inst [9 or "9 inst-9"] value 90379064200
 
-opentelemetry.source58.sample_gauge0000 []
+opentelemetry.source58.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 701.8
     inst [2 or "2 inst-2"] value 1403.6
@@ -7303,7 +7303,7 @@ opentelemetry.source58.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5614.4
     inst [9 or "9 inst-9"] value 6316.2
 
-opentelemetry.source58.sample_summary0002 []
+opentelemetry.source58.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00957738
     inst [2 or "quantile: 0.5"] value 0.01915476
@@ -7315,13 +7315,13 @@ opentelemetry.source58.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.07661904
     inst [9 or "quantile: 2.25"] value 0.08619642000000001
 
-opentelemetry.source58.sample_summary0002_count []
+opentelemetry.source58.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 109080
 
-opentelemetry.source58.sample_summary0002_sum []
+opentelemetry.source58.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 83.47240600000001
 
-opentelemetry.source58.sample_counter0001 []
+opentelemetry.source58.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 19914031100
     inst [2 or "2 inst-2"] value 39828062200
@@ -7333,7 +7333,7 @@ opentelemetry.source58.sample_counter0001 []
     inst [8 or "8 inst-8"] value 159312249000
     inst [9 or "9 inst-9"] value 179226280000
 
-opentelemetry.source58.sample_gauge0000 []
+opentelemetry.source58.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1403.6
     inst [2 or "2 inst-2"] value 2807.2
@@ -7345,7 +7345,7 @@ opentelemetry.source58.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 11228.8
     inst [9 or "9 inst-9"] value 12632.4
 
-opentelemetry.source58.sample_summary0002 []
+opentelemetry.source58.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.018835514
     inst [2 or "quantile: 0.5"] value 0.037671028
@@ -7357,13 +7357,13 @@ opentelemetry.source58.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.150684112
     inst [9 or "quantile: 2.25"] value 0.169519626
 
-opentelemetry.source58.sample_summary0002_count []
+opentelemetry.source58.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 214524
 
-opentelemetry.source58.sample_summary0002_sum []
+opentelemetry.source58.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 164.162399
 
-opentelemetry.source58.sample_counter0001 []
+opentelemetry.source58.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 29785944000
     inst [2 or "2 inst-2"] value 59571887900
@@ -7375,7 +7375,7 @@ opentelemetry.source58.sample_counter0001 []
     inst [8 or "8 inst-8"] value 238287552000
     inst [9 or "9 inst-9"] value 268073496000
 
-opentelemetry.source58.sample_gauge0000 []
+opentelemetry.source58.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2105.4
     inst [2 or "2 inst-2"] value 4210.8
@@ -7387,7 +7387,7 @@ opentelemetry.source58.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 16843.2
     inst [9 or "9 inst-9"] value 18948.6
 
-opentelemetry.source58.sample_summary0002 []
+opentelemetry.source58.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.028093648
     inst [2 or "quantile: 0.5"] value 0.056187296
@@ -7399,13 +7399,13 @@ opentelemetry.source58.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.224749184
     inst [9 or "quantile: 2.25"] value 0.252842832
 
-opentelemetry.source58.sample_summary0002_count []
+opentelemetry.source58.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 319968
 
-opentelemetry.source58.sample_summary0002_sum []
+opentelemetry.source58.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 244.852392
 
-opentelemetry.source59.sample_counter0001 []
+opentelemetry.source59.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10212323600
     inst [2 or "2 inst-2"] value 20424647300
@@ -7417,7 +7417,7 @@ opentelemetry.source59.sample_counter0001 []
     inst [8 or "8 inst-8"] value 81698589100
     inst [9 or "9 inst-9"] value 91910912800
 
-opentelemetry.source59.sample_gauge0000 []
+opentelemetry.source59.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 713.9
     inst [2 or "2 inst-2"] value 1427.8
@@ -7429,7 +7429,7 @@ opentelemetry.source59.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5711.2
     inst [9 or "9 inst-9"] value 6425.1
 
-opentelemetry.source59.sample_summary0002 []
+opentelemetry.source59.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009737003000000001
     inst [2 or "quantile: 0.5"] value 0.019474006
@@ -7441,13 +7441,13 @@ opentelemetry.source59.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.07789602400000001
     inst [9 or "quantile: 2.25"] value 0.087633027
 
-opentelemetry.source59.sample_summary0002_count []
+opentelemetry.source59.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 110898
 
-opentelemetry.source59.sample_summary0002_sum []
+opentelemetry.source59.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 84.863613
 
-opentelemetry.source59.sample_counter0001 []
+opentelemetry.source59.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 20254441900
     inst [2 or "2 inst-2"] value 40508883800
@@ -7459,7 +7459,7 @@ opentelemetry.source59.sample_counter0001 []
     inst [8 or "8 inst-8"] value 162035535000
     inst [9 or "9 inst-9"] value 182289977000
 
-opentelemetry.source59.sample_gauge0000 []
+opentelemetry.source59.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1427.8
     inst [2 or "2 inst-2"] value 2855.6
@@ -7471,7 +7471,7 @@ opentelemetry.source59.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 11422.4
     inst [9 or "9 inst-9"] value 12850.2
 
-opentelemetry.source59.sample_summary0002 []
+opentelemetry.source59.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01915476
     inst [2 or "quantile: 0.5"] value 0.03830952
@@ -7483,13 +7483,13 @@ opentelemetry.source59.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.15323808
     inst [9 or "quantile: 2.25"] value 0.17239284
 
-opentelemetry.source59.sample_summary0002_count []
+opentelemetry.source59.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 218160
 
-opentelemetry.source59.sample_summary0002_sum []
+opentelemetry.source59.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 166.944812
 
-opentelemetry.source59.sample_counter0001 []
+opentelemetry.source59.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 30296560100
     inst [2 or "2 inst-2"] value 60593120300
@@ -7501,7 +7501,7 @@ opentelemetry.source59.sample_counter0001 []
     inst [8 or "8 inst-8"] value 242372481000
     inst [9 or "9 inst-9"] value 272669041000
 
-opentelemetry.source59.sample_gauge0000 []
+opentelemetry.source59.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2141.7
     inst [2 or "2 inst-2"] value 4283.4
@@ -7513,7 +7513,7 @@ opentelemetry.source59.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 17133.6
     inst [9 or "9 inst-9"] value 19275.3
 
-opentelemetry.source59.sample_summary0002 []
+opentelemetry.source59.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.028572517
     inst [2 or "quantile: 0.5"] value 0.057145034
@@ -7525,13 +7525,13 @@ opentelemetry.source59.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.228580136
     inst [9 or "quantile: 2.25"] value 0.257152653
 
-opentelemetry.source59.sample_summary0002_count []
+opentelemetry.source59.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 325422
 
-opentelemetry.source59.sample_summary0002_sum []
+opentelemetry.source59.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 249.026012
 
-opentelemetry.source60.sample_counter0001 []
+opentelemetry.source60.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10382529000
     inst [2 or "2 inst-2"] value 20765058100
@@ -7543,7 +7543,7 @@ opentelemetry.source60.sample_counter0001 []
     inst [8 or "8 inst-8"] value 83060232300
     inst [9 or "9 inst-9"] value 93442761300
 
-opentelemetry.source60.sample_gauge0000 []
+opentelemetry.source60.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 726
     inst [2 or "2 inst-2"] value 1452
@@ -7555,7 +7555,7 @@ opentelemetry.source60.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5808
     inst [9 or "9 inst-9"] value 6534
 
-opentelemetry.source60.sample_summary0002 []
+opentelemetry.source60.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.009896626
     inst [2 or "quantile: 0.5"] value 0.019793252
@@ -7567,13 +7567,13 @@ opentelemetry.source60.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.079173008
     inst [9 or "quantile: 2.25"] value 0.08906963400000001
 
-opentelemetry.source60.sample_summary0002_count []
+opentelemetry.source60.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 112716
 
-opentelemetry.source60.sample_summary0002_sum []
+opentelemetry.source60.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 86.25482
 
-opentelemetry.source60.sample_counter0001 []
+opentelemetry.source60.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 20594852700
     inst [2 or "2 inst-2"] value 41189705300
@@ -7585,7 +7585,7 @@ opentelemetry.source60.sample_counter0001 []
     inst [8 or "8 inst-8"] value 164758821000
     inst [9 or "9 inst-9"] value 185353674000
 
-opentelemetry.source60.sample_gauge0000 []
+opentelemetry.source60.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1452
     inst [2 or "2 inst-2"] value 2904
@@ -7597,7 +7597,7 @@ opentelemetry.source60.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 11616
     inst [9 or "9 inst-9"] value 13068
 
-opentelemetry.source60.sample_summary0002 []
+opentelemetry.source60.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.019474006
     inst [2 or "quantile: 0.5"] value 0.038948012
@@ -7609,13 +7609,13 @@ opentelemetry.source60.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.155792048
     inst [9 or "quantile: 2.25"] value 0.175266054
 
-opentelemetry.source60.sample_summary0002_count []
+opentelemetry.source60.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 221796
 
-opentelemetry.source60.sample_summary0002_sum []
+opentelemetry.source60.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 169.727226
 
-opentelemetry.source60.sample_counter0001 []
+opentelemetry.source60.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 30807176300
     inst [2 or "2 inst-2"] value 61614352600
@@ -7627,7 +7627,7 @@ opentelemetry.source60.sample_counter0001 []
     inst [8 or "8 inst-8"] value 246457411000
     inst [9 or "9 inst-9"] value 277264587000
 
-opentelemetry.source60.sample_gauge0000 []
+opentelemetry.source60.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2178
     inst [2 or "2 inst-2"] value 4356
@@ -7639,7 +7639,7 @@ opentelemetry.source60.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 17424
     inst [9 or "9 inst-9"] value 19602
 
-opentelemetry.source60.sample_summary0002 []
+opentelemetry.source60.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.029051386
     inst [2 or "quantile: 0.5"] value 0.058102772
@@ -7651,13 +7651,13 @@ opentelemetry.source60.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.232411088
     inst [9 or "quantile: 2.25"] value 0.261462474
 
-opentelemetry.source60.sample_summary0002_count []
+opentelemetry.source60.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 330876
 
-opentelemetry.source60.sample_summary0002_sum []
+opentelemetry.source60.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 253.199632
 
-opentelemetry.source61.sample_counter0001 []
+opentelemetry.source61.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10552734400
     inst [2 or "2 inst-2"] value 21105468900
@@ -7669,7 +7669,7 @@ opentelemetry.source61.sample_counter0001 []
     inst [8 or "8 inst-8"] value 84421875400
     inst [9 or "9 inst-9"] value 94974609900
 
-opentelemetry.source61.sample_gauge0000 []
+opentelemetry.source61.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 738.1
     inst [2 or "2 inst-2"] value 1476.2
@@ -7681,7 +7681,7 @@ opentelemetry.source61.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 5904.8
     inst [9 or "9 inst-9"] value 6642.9
 
-opentelemetry.source61.sample_summary0002 []
+opentelemetry.source61.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010056249
     inst [2 or "quantile: 0.5"] value 0.020112498
@@ -7693,13 +7693,13 @@ opentelemetry.source61.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08044999200000001
     inst [9 or "quantile: 2.25"] value 0.090506241
 
-opentelemetry.source61.sample_summary0002_count []
+opentelemetry.source61.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 114534
 
-opentelemetry.source61.sample_summary0002_sum []
+opentelemetry.source61.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 87.646027
 
-opentelemetry.source61.sample_counter0001 []
+opentelemetry.source61.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 20935263500
     inst [2 or "2 inst-2"] value 41870526900
@@ -7711,7 +7711,7 @@ opentelemetry.source61.sample_counter0001 []
     inst [8 or "8 inst-8"] value 167482108000
     inst [9 or "9 inst-9"] value 188417371000
 
-opentelemetry.source61.sample_gauge0000 []
+opentelemetry.source61.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1476.2
     inst [2 or "2 inst-2"] value 2952.4
@@ -7723,7 +7723,7 @@ opentelemetry.source61.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 11809.6
     inst [9 or "9 inst-9"] value 13285.8
 
-opentelemetry.source61.sample_summary0002 []
+opentelemetry.source61.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.019793252
     inst [2 or "quantile: 0.5"] value 0.039586504
@@ -7735,13 +7735,13 @@ opentelemetry.source61.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.158346016
     inst [9 or "quantile: 2.25"] value 0.178139268
 
-opentelemetry.source61.sample_summary0002_count []
+opentelemetry.source61.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 225432
 
-opentelemetry.source61.sample_summary0002_sum []
+opentelemetry.source61.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 172.509639
 
-opentelemetry.source61.sample_counter0001 []
+opentelemetry.source61.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 31317792500
     inst [2 or "2 inst-2"] value 62635585000
@@ -7753,7 +7753,7 @@ opentelemetry.source61.sample_counter0001 []
     inst [8 or "8 inst-8"] value 250542340000
     inst [9 or "9 inst-9"] value 281860132000
 
-opentelemetry.source61.sample_gauge0000 []
+opentelemetry.source61.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2214.3
     inst [2 or "2 inst-2"] value 4428.6
@@ -7765,7 +7765,7 @@ opentelemetry.source61.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 17714.4
     inst [9 or "9 inst-9"] value 19928.7
 
-opentelemetry.source61.sample_summary0002 []
+opentelemetry.source61.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.029530255
     inst [2 or "quantile: 0.5"] value 0.05906051
@@ -7777,13 +7777,13 @@ opentelemetry.source61.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.23624204
     inst [9 or "quantile: 2.25"] value 0.265772295
 
-opentelemetry.source61.sample_summary0002_count []
+opentelemetry.source61.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 336330
 
-opentelemetry.source61.sample_summary0002_sum []
+opentelemetry.source61.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 257.373252
 
-opentelemetry.source62.sample_counter0001 []
+opentelemetry.source62.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10722939800
     inst [2 or "2 inst-2"] value 21445879600
@@ -7795,7 +7795,7 @@ opentelemetry.source62.sample_counter0001 []
     inst [8 or "8 inst-8"] value 85783518600
     inst [9 or "9 inst-9"] value 96506458400
 
-opentelemetry.source62.sample_gauge0000 []
+opentelemetry.source62.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 750.2
     inst [2 or "2 inst-2"] value 1500.4
@@ -7807,7 +7807,7 @@ opentelemetry.source62.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6001.6
     inst [9 or "9 inst-9"] value 6751.8
 
-opentelemetry.source62.sample_summary0002 []
+opentelemetry.source62.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010215872
     inst [2 or "quantile: 0.5"] value 0.020431744
@@ -7819,13 +7819,13 @@ opentelemetry.source62.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08172697600000001
     inst [9 or "quantile: 2.25"] value 0.09194284800000001
 
-opentelemetry.source62.sample_summary0002_count []
+opentelemetry.source62.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 116352
 
-opentelemetry.source62.sample_summary0002_sum []
+opentelemetry.source62.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 89.037233
 
-opentelemetry.source62.sample_counter0001 []
+opentelemetry.source62.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 21275674200
     inst [2 or "2 inst-2"] value 42551348500
@@ -7837,7 +7837,7 @@ opentelemetry.source62.sample_counter0001 []
     inst [8 or "8 inst-8"] value 170205394000
     inst [9 or "9 inst-9"] value 191481068000
 
-opentelemetry.source62.sample_gauge0000 []
+opentelemetry.source62.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1500.4
     inst [2 or "2 inst-2"] value 3000.8
@@ -7849,7 +7849,7 @@ opentelemetry.source62.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 12003.2
     inst [9 or "9 inst-9"] value 13503.6
 
-opentelemetry.source62.sample_summary0002 []
+opentelemetry.source62.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.020112498
     inst [2 or "quantile: 0.5"] value 0.04022499600000001
@@ -7861,13 +7861,13 @@ opentelemetry.source62.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.160899984
     inst [9 or "quantile: 2.25"] value 0.181012482
 
-opentelemetry.source62.sample_summary0002_count []
+opentelemetry.source62.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 229068
 
-opentelemetry.source62.sample_summary0002_sum []
+opentelemetry.source62.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 175.292053
 
-opentelemetry.source62.sample_counter0001 []
+opentelemetry.source62.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 31828408700
     inst [2 or "2 inst-2"] value 63656817400
@@ -7879,7 +7879,7 @@ opentelemetry.source62.sample_counter0001 []
     inst [8 or "8 inst-8"] value 254627269000
     inst [9 or "9 inst-9"] value 286455678000
 
-opentelemetry.source62.sample_gauge0000 []
+opentelemetry.source62.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2250.6
     inst [2 or "2 inst-2"] value 4501.2
@@ -7891,7 +7891,7 @@ opentelemetry.source62.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 18004.8
     inst [9 or "9 inst-9"] value 20255.4
 
-opentelemetry.source62.sample_summary0002 []
+opentelemetry.source62.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.030009124
     inst [2 or "quantile: 0.5"] value 0.060018248
@@ -7903,13 +7903,13 @@ opentelemetry.source62.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.240072992
     inst [9 or "quantile: 2.25"] value 0.270082116
 
-opentelemetry.source62.sample_summary0002_count []
+opentelemetry.source62.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 341784
 
-opentelemetry.source62.sample_summary0002_sum []
+opentelemetry.source62.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 261.546873
 
-opentelemetry.source63.sample_counter0001 []
+opentelemetry.source63.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 10893145200
     inst [2 or "2 inst-2"] value 21786290400
@@ -7921,7 +7921,7 @@ opentelemetry.source63.sample_counter0001 []
     inst [8 or "8 inst-8"] value 87145161700
     inst [9 or "9 inst-9"] value 98038306900
 
-opentelemetry.source63.sample_gauge0000 []
+opentelemetry.source63.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 762.3
     inst [2 or "2 inst-2"] value 1524.6
@@ -7933,7 +7933,7 @@ opentelemetry.source63.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6098.4
     inst [9 or "9 inst-9"] value 6860.7
 
-opentelemetry.source63.sample_summary0002 []
+opentelemetry.source63.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010375495
     inst [2 or "quantile: 0.5"] value 0.02075099
@@ -7945,13 +7945,13 @@ opentelemetry.source63.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08300396
     inst [9 or "quantile: 2.25"] value 0.09337945500000001
 
-opentelemetry.source63.sample_summary0002_count []
+opentelemetry.source63.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 118170
 
-opentelemetry.source63.sample_summary0002_sum []
+opentelemetry.source63.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 90.42843999999999
 
-opentelemetry.source63.sample_counter0001 []
+opentelemetry.source63.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 21616085000
     inst [2 or "2 inst-2"] value 43232170100
@@ -7963,7 +7963,7 @@ opentelemetry.source63.sample_counter0001 []
     inst [8 or "8 inst-8"] value 172928680000
     inst [9 or "9 inst-9"] value 194544765000
 
-opentelemetry.source63.sample_gauge0000 []
+opentelemetry.source63.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1524.6
     inst [2 or "2 inst-2"] value 3049.2
@@ -7975,7 +7975,7 @@ opentelemetry.source63.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 12196.8
     inst [9 or "9 inst-9"] value 13721.4
 
-opentelemetry.source63.sample_summary0002 []
+opentelemetry.source63.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.020431744
     inst [2 or "quantile: 0.5"] value 0.040863488
@@ -7987,13 +7987,13 @@ opentelemetry.source63.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.163453952
     inst [9 or "quantile: 2.25"] value 0.183885696
 
-opentelemetry.source63.sample_summary0002_count []
+opentelemetry.source63.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 232704
 
-opentelemetry.source63.sample_summary0002_sum []
+opentelemetry.source63.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 178.074467
 
-opentelemetry.source63.sample_counter0001 []
+opentelemetry.source63.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 32339024900
     inst [2 or "2 inst-2"] value 64678049700
@@ -8005,7 +8005,7 @@ opentelemetry.source63.sample_counter0001 []
     inst [8 or "8 inst-8"] value 258712199000
     inst [9 or "9 inst-9"] value 291051224000
 
-opentelemetry.source63.sample_gauge0000 []
+opentelemetry.source63.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2286.9
     inst [2 or "2 inst-2"] value 4573.8
@@ -8017,7 +8017,7 @@ opentelemetry.source63.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 18295.2
     inst [9 or "9 inst-9"] value 20582.1
 
-opentelemetry.source63.sample_summary0002 []
+opentelemetry.source63.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.030487993
     inst [2 or "quantile: 0.5"] value 0.060975986
@@ -8029,13 +8029,13 @@ opentelemetry.source63.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.243903944
     inst [9 or "quantile: 2.25"] value 0.274391937
 
-opentelemetry.source63.sample_summary0002_count []
+opentelemetry.source63.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 347238
 
-opentelemetry.source63.sample_summary0002_sum []
+opentelemetry.source63.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 265.720493
 
-opentelemetry.source64.sample_counter0001 []
+opentelemetry.source64.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11063350600
     inst [2 or "2 inst-2"] value 22126701200
@@ -8047,7 +8047,7 @@ opentelemetry.source64.sample_counter0001 []
     inst [8 or "8 inst-8"] value 88506804900
     inst [9 or "9 inst-9"] value 99570155500
 
-opentelemetry.source64.sample_gauge0000 []
+opentelemetry.source64.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 774.4
     inst [2 or "2 inst-2"] value 1548.8
@@ -8059,7 +8059,7 @@ opentelemetry.source64.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6195.2
     inst [9 or "9 inst-9"] value 6969.6
 
-opentelemetry.source64.sample_summary0002 []
+opentelemetry.source64.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010535118
     inst [2 or "quantile: 0.5"] value 0.021070236
@@ -8071,13 +8071,13 @@ opentelemetry.source64.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08428094400000001
     inst [9 or "quantile: 2.25"] value 0.09481606200000001
 
-opentelemetry.source64.sample_summary0002_count []
+opentelemetry.source64.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 119988
 
-opentelemetry.source64.sample_summary0002_sum []
+opentelemetry.source64.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 91.819647
 
-opentelemetry.source64.sample_counter0001 []
+opentelemetry.source64.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 21956495800
     inst [2 or "2 inst-2"] value 43912991700
@@ -8089,7 +8089,7 @@ opentelemetry.source64.sample_counter0001 []
     inst [8 or "8 inst-8"] value 175651967000
     inst [9 or "9 inst-9"] value 197608462000
 
-opentelemetry.source64.sample_gauge0000 []
+opentelemetry.source64.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1548.8
     inst [2 or "2 inst-2"] value 3097.6
@@ -8101,7 +8101,7 @@ opentelemetry.source64.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 12390.4
     inst [9 or "9 inst-9"] value 13939.2
 
-opentelemetry.source64.sample_summary0002 []
+opentelemetry.source64.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.02075099
     inst [2 or "quantile: 0.5"] value 0.04150198
@@ -8113,13 +8113,13 @@ opentelemetry.source64.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.16600792
     inst [9 or "quantile: 2.25"] value 0.18675891
 
-opentelemetry.source64.sample_summary0002_count []
+opentelemetry.source64.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 236340
 
-opentelemetry.source64.sample_summary0002_sum []
+opentelemetry.source64.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 180.85688
 
-opentelemetry.source64.sample_counter0001 []
+opentelemetry.source64.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 32849641000
     inst [2 or "2 inst-2"] value 65699282100
@@ -8131,7 +8131,7 @@ opentelemetry.source64.sample_counter0001 []
     inst [8 or "8 inst-8"] value 262797128000
     inst [9 or "9 inst-9"] value 295646769000
 
-opentelemetry.source64.sample_gauge0000 []
+opentelemetry.source64.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2323.2
     inst [2 or "2 inst-2"] value 4646.4
@@ -8143,7 +8143,7 @@ opentelemetry.source64.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 18585.6
     inst [9 or "9 inst-9"] value 20908.8
 
-opentelemetry.source64.sample_summary0002 []
+opentelemetry.source64.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.030966862
     inst [2 or "quantile: 0.5"] value 0.061933724
@@ -8155,13 +8155,13 @@ opentelemetry.source64.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.247734896
     inst [9 or "quantile: 2.25"] value 0.278701758
 
-opentelemetry.source64.sample_summary0002_count []
+opentelemetry.source64.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 352692
 
-opentelemetry.source64.sample_summary0002_sum []
+opentelemetry.source64.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 269.894113
 
-opentelemetry.source65.sample_counter0001 []
+opentelemetry.source65.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11233556000
     inst [2 or "2 inst-2"] value 22467112000
@@ -8173,7 +8173,7 @@ opentelemetry.source65.sample_counter0001 []
     inst [8 or "8 inst-8"] value 89868448000
     inst [9 or "9 inst-9"] value 101102004000
 
-opentelemetry.source65.sample_gauge0000 []
+opentelemetry.source65.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 786.5
     inst [2 or "2 inst-2"] value 1573
@@ -8185,7 +8185,7 @@ opentelemetry.source65.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6292
     inst [9 or "9 inst-9"] value 7078.5
 
-opentelemetry.source65.sample_summary0002 []
+opentelemetry.source65.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010694741
     inst [2 or "quantile: 0.5"] value 0.021389482
@@ -8197,13 +8197,13 @@ opentelemetry.source65.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08555792800000001
     inst [9 or "quantile: 2.25"] value 0.09625266900000001
 
-opentelemetry.source65.sample_summary0002_count []
+opentelemetry.source65.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 121806
 
-opentelemetry.source65.sample_summary0002_sum []
+opentelemetry.source65.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 93.210854
 
-opentelemetry.source65.sample_counter0001 []
+opentelemetry.source65.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 22296906600
     inst [2 or "2 inst-2"] value 44593813200
@@ -8215,7 +8215,7 @@ opentelemetry.source65.sample_counter0001 []
     inst [8 or "8 inst-8"] value 178375253000
     inst [9 or "9 inst-9"] value 200672160000
 
-opentelemetry.source65.sample_gauge0000 []
+opentelemetry.source65.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1573
     inst [2 or "2 inst-2"] value 3146
@@ -8227,7 +8227,7 @@ opentelemetry.source65.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 12584
     inst [9 or "9 inst-9"] value 14157
 
-opentelemetry.source65.sample_summary0002 []
+opentelemetry.source65.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.021070236
     inst [2 or "quantile: 0.5"] value 0.04214047200000001
@@ -8239,13 +8239,13 @@ opentelemetry.source65.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.168561888
     inst [9 or "quantile: 2.25"] value 0.189632124
 
-opentelemetry.source65.sample_summary0002_count []
+opentelemetry.source65.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 239976
 
-opentelemetry.source65.sample_summary0002_sum []
+opentelemetry.source65.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 183.639294
 
-opentelemetry.source65.sample_counter0001 []
+opentelemetry.source65.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 33360257200
     inst [2 or "2 inst-2"] value 66720514400
@@ -8257,7 +8257,7 @@ opentelemetry.source65.sample_counter0001 []
     inst [8 or "8 inst-8"] value 266882058000
     inst [9 or "9 inst-9"] value 300242315000
 
-opentelemetry.source65.sample_gauge0000 []
+opentelemetry.source65.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2359.5
     inst [2 or "2 inst-2"] value 4719
@@ -8269,7 +8269,7 @@ opentelemetry.source65.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 18876
     inst [9 or "9 inst-9"] value 21235.5
 
-opentelemetry.source65.sample_summary0002 []
+opentelemetry.source65.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.031445731
     inst [2 or "quantile: 0.5"] value 0.06289146200000001
@@ -8281,13 +8281,13 @@ opentelemetry.source65.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.251565848
     inst [9 or "quantile: 2.25"] value 0.283011579
 
-opentelemetry.source65.sample_summary0002_count []
+opentelemetry.source65.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 358146
 
-opentelemetry.source65.sample_summary0002_sum []
+opentelemetry.source65.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 274.067734
 
-opentelemetry.source66.sample_counter0001 []
+opentelemetry.source66.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11403761400
     inst [2 or "2 inst-2"] value 22807522800
@@ -8299,7 +8299,7 @@ opentelemetry.source66.sample_counter0001 []
     inst [8 or "8 inst-8"] value 91230091200
     inst [9 or "9 inst-9"] value 102633853000
 
-opentelemetry.source66.sample_gauge0000 []
+opentelemetry.source66.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 798.6
     inst [2 or "2 inst-2"] value 1597.2
@@ -8311,7 +8311,7 @@ opentelemetry.source66.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6388.8
     inst [9 or "9 inst-9"] value 7187.4
 
-opentelemetry.source66.sample_summary0002 []
+opentelemetry.source66.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.010854364
     inst [2 or "quantile: 0.5"] value 0.021708728
@@ -8323,13 +8323,13 @@ opentelemetry.source66.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08683491200000001
     inst [9 or "quantile: 2.25"] value 0.09768927600000001
 
-opentelemetry.source66.sample_summary0002_count []
+opentelemetry.source66.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 123624
 
-opentelemetry.source66.sample_summary0002_sum []
+opentelemetry.source66.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 94.60205999999999
 
-opentelemetry.source66.sample_counter0001 []
+opentelemetry.source66.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 22637317400
     inst [2 or "2 inst-2"] value 45274634800
@@ -8341,7 +8341,7 @@ opentelemetry.source66.sample_counter0001 []
     inst [8 or "8 inst-8"] value 181098539000
     inst [9 or "9 inst-9"] value 203735857000
 
-opentelemetry.source66.sample_gauge0000 []
+opentelemetry.source66.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1597.2
     inst [2 or "2 inst-2"] value 3194.4
@@ -8353,7 +8353,7 @@ opentelemetry.source66.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 12777.6
     inst [9 or "9 inst-9"] value 14374.8
 
-opentelemetry.source66.sample_summary0002 []
+opentelemetry.source66.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.021389482
     inst [2 or "quantile: 0.5"] value 0.042778964
@@ -8365,13 +8365,13 @@ opentelemetry.source66.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.171115856
     inst [9 or "quantile: 2.25"] value 0.192505338
 
-opentelemetry.source66.sample_summary0002_count []
+opentelemetry.source66.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 243612
 
-opentelemetry.source66.sample_summary0002_sum []
+opentelemetry.source66.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 186.421707
 
-opentelemetry.source66.sample_counter0001 []
+opentelemetry.source66.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 33870873400
     inst [2 or "2 inst-2"] value 67741746800
@@ -8383,7 +8383,7 @@ opentelemetry.source66.sample_counter0001 []
     inst [8 or "8 inst-8"] value 270966987000
     inst [9 or "9 inst-9"] value 304837861000
 
-opentelemetry.source66.sample_gauge0000 []
+opentelemetry.source66.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2395.8
     inst [2 or "2 inst-2"] value 4791.6
@@ -8395,7 +8395,7 @@ opentelemetry.source66.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 19166.4
     inst [9 or "9 inst-9"] value 21562.2
 
-opentelemetry.source66.sample_summary0002 []
+opentelemetry.source66.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0319246
     inst [2 or "quantile: 0.5"] value 0.06384920000000001
@@ -8407,13 +8407,13 @@ opentelemetry.source66.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.2553968
     inst [9 or "quantile: 2.25"] value 0.2873214
 
-opentelemetry.source66.sample_summary0002_count []
+opentelemetry.source66.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 363600
 
-opentelemetry.source66.sample_summary0002_sum []
+opentelemetry.source66.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 278.241354
 
-opentelemetry.source67.sample_counter0001 []
+opentelemetry.source67.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11573966800
     inst [2 or "2 inst-2"] value 23147933600
@@ -8425,7 +8425,7 @@ opentelemetry.source67.sample_counter0001 []
     inst [8 or "8 inst-8"] value 92591734300
     inst [9 or "9 inst-9"] value 104165701000
 
-opentelemetry.source67.sample_gauge0000 []
+opentelemetry.source67.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 810.7
     inst [2 or "2 inst-2"] value 1621.4
@@ -8437,7 +8437,7 @@ opentelemetry.source67.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6485.6
     inst [9 or "9 inst-9"] value 7296.3
 
-opentelemetry.source67.sample_summary0002 []
+opentelemetry.source67.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011013987
     inst [2 or "quantile: 0.5"] value 0.022027974
@@ -8449,13 +8449,13 @@ opentelemetry.source67.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08811189600000001
     inst [9 or "quantile: 2.25"] value 0.09912588300000001
 
-opentelemetry.source67.sample_summary0002_count []
+opentelemetry.source67.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 125442
 
-opentelemetry.source67.sample_summary0002_sum []
+opentelemetry.source67.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 95.993267
 
-opentelemetry.source67.sample_counter0001 []
+opentelemetry.source67.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 22977728200
     inst [2 or "2 inst-2"] value 45955456400
@@ -8467,7 +8467,7 @@ opentelemetry.source67.sample_counter0001 []
     inst [8 or "8 inst-8"] value 183821826000
     inst [9 or "9 inst-9"] value 206799554000
 
-opentelemetry.source67.sample_gauge0000 []
+opentelemetry.source67.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1621.4
     inst [2 or "2 inst-2"] value 3242.8
@@ -8479,7 +8479,7 @@ opentelemetry.source67.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 12971.2
     inst [9 or "9 inst-9"] value 14592.6
 
-opentelemetry.source67.sample_summary0002 []
+opentelemetry.source67.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.021708728
     inst [2 or "quantile: 0.5"] value 0.04341745600000001
@@ -8491,13 +8491,13 @@ opentelemetry.source67.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.173669824
     inst [9 or "quantile: 2.25"] value 0.195378552
 
-opentelemetry.source67.sample_summary0002_count []
+opentelemetry.source67.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 247248
 
-opentelemetry.source67.sample_summary0002_sum []
+opentelemetry.source67.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 189.204121
 
-opentelemetry.source67.sample_counter0001 []
+opentelemetry.source67.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 34381489600
     inst [2 or "2 inst-2"] value 68762979200
@@ -8509,7 +8509,7 @@ opentelemetry.source67.sample_counter0001 []
     inst [8 or "8 inst-8"] value 275051917000
     inst [9 or "9 inst-9"] value 309433406000
 
-opentelemetry.source67.sample_gauge0000 []
+opentelemetry.source67.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2432.1
     inst [2 or "2 inst-2"] value 4864.2
@@ -8521,7 +8521,7 @@ opentelemetry.source67.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 19456.8
     inst [9 or "9 inst-9"] value 21888.9
 
-opentelemetry.source67.sample_summary0002 []
+opentelemetry.source67.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.032403469
     inst [2 or "quantile: 0.5"] value 0.06480693800000001
@@ -8533,13 +8533,13 @@ opentelemetry.source67.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.259227752
     inst [9 or "quantile: 2.25"] value 0.2916312210000001
 
-opentelemetry.source67.sample_summary0002_count []
+opentelemetry.source67.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 369054
 
-opentelemetry.source67.sample_summary0002_sum []
+opentelemetry.source67.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 282.414974
 
-opentelemetry.source68.sample_counter0001 []
+opentelemetry.source68.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11744172200
     inst [2 or "2 inst-2"] value 23488344400
@@ -8551,7 +8551,7 @@ opentelemetry.source68.sample_counter0001 []
     inst [8 or "8 inst-8"] value 93953377500
     inst [9 or "9 inst-9"] value 105697550000
 
-opentelemetry.source68.sample_gauge0000 []
+opentelemetry.source68.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 822.8
     inst [2 or "2 inst-2"] value 1645.6
@@ -8563,7 +8563,7 @@ opentelemetry.source68.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6582.4
     inst [9 or "9 inst-9"] value 7405.2
 
-opentelemetry.source68.sample_summary0002 []
+opentelemetry.source68.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01117361
     inst [2 or "quantile: 0.5"] value 0.02234722
@@ -8575,13 +8575,13 @@ opentelemetry.source68.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.08938888
     inst [9 or "quantile: 2.25"] value 0.10056249
 
-opentelemetry.source68.sample_summary0002_count []
+opentelemetry.source68.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 127260
 
-opentelemetry.source68.sample_summary0002_sum []
+opentelemetry.source68.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 97.384474
 
-opentelemetry.source68.sample_counter0001 []
+opentelemetry.source68.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 23318139000
     inst [2 or "2 inst-2"] value 46636278000
@@ -8593,7 +8593,7 @@ opentelemetry.source68.sample_counter0001 []
     inst [8 or "8 inst-8"] value 186545112000
     inst [9 or "9 inst-9"] value 209863251000
 
-opentelemetry.source68.sample_gauge0000 []
+opentelemetry.source68.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1645.6
     inst [2 or "2 inst-2"] value 3291.2
@@ -8605,7 +8605,7 @@ opentelemetry.source68.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 13164.8
     inst [9 or "9 inst-9"] value 14810.4
 
-opentelemetry.source68.sample_summary0002 []
+opentelemetry.source68.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.022027974
     inst [2 or "quantile: 0.5"] value 0.044055948
@@ -8617,13 +8617,13 @@ opentelemetry.source68.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.176223792
     inst [9 or "quantile: 2.25"] value 0.198251766
 
-opentelemetry.source68.sample_summary0002_count []
+opentelemetry.source68.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 250884
 
-opentelemetry.source68.sample_summary0002_sum []
+opentelemetry.source68.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 191.986534
 
-opentelemetry.source68.sample_counter0001 []
+opentelemetry.source68.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 34892105800
     inst [2 or "2 inst-2"] value 69784211500
@@ -8635,7 +8635,7 @@ opentelemetry.source68.sample_counter0001 []
     inst [8 or "8 inst-8"] value 279136846000
     inst [9 or "9 inst-9"] value 314028952000
 
-opentelemetry.source68.sample_gauge0000 []
+opentelemetry.source68.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2468.4
     inst [2 or "2 inst-2"] value 4936.8
@@ -8647,7 +8647,7 @@ opentelemetry.source68.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 19747.2
     inst [9 or "9 inst-9"] value 22215.6
 
-opentelemetry.source68.sample_summary0002 []
+opentelemetry.source68.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.032882338
     inst [2 or "quantile: 0.5"] value 0.06576467600000001
@@ -8659,13 +8659,13 @@ opentelemetry.source68.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.263058704
     inst [9 or "quantile: 2.25"] value 0.295941042
 
-opentelemetry.source68.sample_summary0002_count []
+opentelemetry.source68.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 374508
 
-opentelemetry.source68.sample_summary0002_sum []
+opentelemetry.source68.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 286.588595
 
-opentelemetry.source69.sample_counter0001 []
+opentelemetry.source69.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 11914377600
     inst [2 or "2 inst-2"] value 23828755200
@@ -8677,7 +8677,7 @@ opentelemetry.source69.sample_counter0001 []
     inst [8 or "8 inst-8"] value 95315020600
     inst [9 or "9 inst-9"] value 107229398000
 
-opentelemetry.source69.sample_gauge0000 []
+opentelemetry.source69.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 834.9
     inst [2 or "2 inst-2"] value 1669.8
@@ -8689,7 +8689,7 @@ opentelemetry.source69.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6679.2
     inst [9 or "9 inst-9"] value 7514.1
 
-opentelemetry.source69.sample_summary0002 []
+opentelemetry.source69.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011333233
     inst [2 or "quantile: 0.5"] value 0.022666466
@@ -8701,13 +8701,13 @@ opentelemetry.source69.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.09066586400000001
     inst [9 or "quantile: 2.25"] value 0.101999097
 
-opentelemetry.source69.sample_summary0002_count []
+opentelemetry.source69.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 129078
 
-opentelemetry.source69.sample_summary0002_sum []
+opentelemetry.source69.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 98.77568100000001
 
-opentelemetry.source69.sample_counter0001 []
+opentelemetry.source69.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 23658549800
     inst [2 or "2 inst-2"] value 47317099500
@@ -8719,7 +8719,7 @@ opentelemetry.source69.sample_counter0001 []
     inst [8 or "8 inst-8"] value 189268398000
     inst [9 or "9 inst-9"] value 212926948000
 
-opentelemetry.source69.sample_gauge0000 []
+opentelemetry.source69.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1669.8
     inst [2 or "2 inst-2"] value 3339.6
@@ -8731,7 +8731,7 @@ opentelemetry.source69.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 13358.4
     inst [9 or "9 inst-9"] value 15028.2
 
-opentelemetry.source69.sample_summary0002 []
+opentelemetry.source69.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.02234722
     inst [2 or "quantile: 0.5"] value 0.04469444
@@ -8743,13 +8743,13 @@ opentelemetry.source69.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.17877776
     inst [9 or "quantile: 2.25"] value 0.20112498
 
-opentelemetry.source69.sample_summary0002_count []
+opentelemetry.source69.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 254520
 
-opentelemetry.source69.sample_summary0002_sum []
+opentelemetry.source69.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 194.768948
 
-opentelemetry.source69.sample_counter0001 []
+opentelemetry.source69.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 35402722000
     inst [2 or "2 inst-2"] value 70805443900
@@ -8761,7 +8761,7 @@ opentelemetry.source69.sample_counter0001 []
     inst [8 or "8 inst-8"] value 283221776000
     inst [9 or "9 inst-9"] value 318624498000
 
-opentelemetry.source69.sample_gauge0000 []
+opentelemetry.source69.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2504.7
     inst [2 or "2 inst-2"] value 5009.4
@@ -8773,7 +8773,7 @@ opentelemetry.source69.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 20037.6
     inst [9 or "9 inst-9"] value 22542.3
 
-opentelemetry.source69.sample_summary0002 []
+opentelemetry.source69.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.033361207
     inst [2 or "quantile: 0.5"] value 0.06672241400000001
@@ -8785,13 +8785,13 @@ opentelemetry.source69.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.266889656
     inst [9 or "quantile: 2.25"] value 0.300250863
 
-opentelemetry.source69.sample_summary0002_count []
+opentelemetry.source69.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 379962
 
-opentelemetry.source69.sample_summary0002_sum []
+opentelemetry.source69.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 290.762215
 
-opentelemetry.source70.sample_counter0001 []
+opentelemetry.source70.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12084583000
     inst [2 or "2 inst-2"] value 24169165900
@@ -8803,7 +8803,7 @@ opentelemetry.source70.sample_counter0001 []
     inst [8 or "8 inst-8"] value 96676663800
     inst [9 or "9 inst-9"] value 108761247000
 
-opentelemetry.source70.sample_gauge0000 []
+opentelemetry.source70.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 847
     inst [2 or "2 inst-2"] value 1694
@@ -8815,7 +8815,7 @@ opentelemetry.source70.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6776
     inst [9 or "9 inst-9"] value 7623
 
-opentelemetry.source70.sample_summary0002 []
+opentelemetry.source70.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011492856
     inst [2 or "quantile: 0.5"] value 0.022985712
@@ -8827,13 +8827,13 @@ opentelemetry.source70.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.09194284800000001
     inst [9 or "quantile: 2.25"] value 0.103435704
 
-opentelemetry.source70.sample_summary0002_count []
+opentelemetry.source70.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 130896
 
-opentelemetry.source70.sample_summary0002_sum []
+opentelemetry.source70.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 100.166887
 
-opentelemetry.source70.sample_counter0001 []
+opentelemetry.source70.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 23998960600
     inst [2 or "2 inst-2"] value 47997921100
@@ -8845,7 +8845,7 @@ opentelemetry.source70.sample_counter0001 []
     inst [8 or "8 inst-8"] value 191991684000
     inst [9 or "9 inst-9"] value 215990645000
 
-opentelemetry.source70.sample_gauge0000 []
+opentelemetry.source70.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1694
     inst [2 or "2 inst-2"] value 3388
@@ -8857,7 +8857,7 @@ opentelemetry.source70.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 13552
     inst [9 or "9 inst-9"] value 15246
 
-opentelemetry.source70.sample_summary0002 []
+opentelemetry.source70.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.022666466
     inst [2 or "quantile: 0.5"] value 0.04533293200000001
@@ -8869,13 +8869,13 @@ opentelemetry.source70.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.181331728
     inst [9 or "quantile: 2.25"] value 0.203998194
 
-opentelemetry.source70.sample_summary0002_count []
+opentelemetry.source70.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 258156
 
-opentelemetry.source70.sample_summary0002_sum []
+opentelemetry.source70.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 197.551361
 
-opentelemetry.source70.sample_counter0001 []
+opentelemetry.source70.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 35913338100
     inst [2 or "2 inst-2"] value 71826676300
@@ -8887,7 +8887,7 @@ opentelemetry.source70.sample_counter0001 []
     inst [8 or "8 inst-8"] value 287306705000
     inst [9 or "9 inst-9"] value 323220043000
 
-opentelemetry.source70.sample_gauge0000 []
+opentelemetry.source70.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2541
     inst [2 or "2 inst-2"] value 5082
@@ -8899,7 +8899,7 @@ opentelemetry.source70.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 20328
     inst [9 or "9 inst-9"] value 22869
 
-opentelemetry.source70.sample_summary0002 []
+opentelemetry.source70.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.033840076
     inst [2 or "quantile: 0.5"] value 0.06768015200000001
@@ -8911,13 +8911,13 @@ opentelemetry.source70.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.270720608
     inst [9 or "quantile: 2.25"] value 0.304560684
 
-opentelemetry.source70.sample_summary0002_count []
+opentelemetry.source70.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 385416
 
-opentelemetry.source70.sample_summary0002_sum []
+opentelemetry.source70.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 294.935835
 
-opentelemetry.source71.sample_counter0001 []
+opentelemetry.source71.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12254788400
     inst [2 or "2 inst-2"] value 24509576700
@@ -8929,7 +8929,7 @@ opentelemetry.source71.sample_counter0001 []
     inst [8 or "8 inst-8"] value 98038306900
     inst [9 or "9 inst-9"] value 110293095000
 
-opentelemetry.source71.sample_gauge0000 []
+opentelemetry.source71.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 859.1
     inst [2 or "2 inst-2"] value 1718.2
@@ -8941,7 +8941,7 @@ opentelemetry.source71.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6872.8
     inst [9 or "9 inst-9"] value 7731.9
 
-opentelemetry.source71.sample_summary0002 []
+opentelemetry.source71.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011652479
     inst [2 or "quantile: 0.5"] value 0.023304958
@@ -8953,13 +8953,13 @@ opentelemetry.source71.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.093219832
     inst [9 or "quantile: 2.25"] value 0.104872311
 
-opentelemetry.source71.sample_summary0002_count []
+opentelemetry.source71.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 132714
 
-opentelemetry.source71.sample_summary0002_sum []
+opentelemetry.source71.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 101.558094
 
-opentelemetry.source71.sample_counter0001 []
+opentelemetry.source71.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 24339371300
     inst [2 or "2 inst-2"] value 48678742700
@@ -8971,7 +8971,7 @@ opentelemetry.source71.sample_counter0001 []
     inst [8 or "8 inst-8"] value 194714971000
     inst [9 or "9 inst-9"] value 219054342000
 
-opentelemetry.source71.sample_gauge0000 []
+opentelemetry.source71.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1718.2
     inst [2 or "2 inst-2"] value 3436.4
@@ -8983,7 +8983,7 @@ opentelemetry.source71.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 13745.6
     inst [9 or "9 inst-9"] value 15463.8
 
-opentelemetry.source71.sample_summary0002 []
+opentelemetry.source71.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.022985712
     inst [2 or "quantile: 0.5"] value 0.045971424
@@ -8995,13 +8995,13 @@ opentelemetry.source71.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.183885696
     inst [9 or "quantile: 2.25"] value 0.206871408
 
-opentelemetry.source71.sample_summary0002_count []
+opentelemetry.source71.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 261792
 
-opentelemetry.source71.sample_summary0002_sum []
+opentelemetry.source71.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 200.333775
 
-opentelemetry.source71.sample_counter0001 []
+opentelemetry.source71.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 36423954300
     inst [2 or "2 inst-2"] value 72847908600
@@ -9013,7 +9013,7 @@ opentelemetry.source71.sample_counter0001 []
     inst [8 or "8 inst-8"] value 291391635000
     inst [9 or "9 inst-9"] value 327815589000
 
-opentelemetry.source71.sample_gauge0000 []
+opentelemetry.source71.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2577.3
     inst [2 or "2 inst-2"] value 5154.6
@@ -9025,7 +9025,7 @@ opentelemetry.source71.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 20618.4
     inst [9 or "9 inst-9"] value 23195.7
 
-opentelemetry.source71.sample_summary0002 []
+opentelemetry.source71.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.034318945
     inst [2 or "quantile: 0.5"] value 0.06863789000000001
@@ -9037,13 +9037,13 @@ opentelemetry.source71.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.27455156
     inst [9 or "quantile: 2.25"] value 0.308870505
 
-opentelemetry.source71.sample_summary0002_count []
+opentelemetry.source71.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 390870
 
-opentelemetry.source71.sample_summary0002_sum []
+opentelemetry.source71.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 299.109456
 
-opentelemetry.source72.sample_counter0001 []
+opentelemetry.source72.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12424993800
     inst [2 or "2 inst-2"] value 24849987500
@@ -9055,7 +9055,7 @@ opentelemetry.source72.sample_counter0001 []
     inst [8 or "8 inst-8"] value 99399950100
     inst [9 or "9 inst-9"] value 111824944000
 
-opentelemetry.source72.sample_gauge0000 []
+opentelemetry.source72.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 871.2
     inst [2 or "2 inst-2"] value 1742.4
@@ -9067,7 +9067,7 @@ opentelemetry.source72.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 6969.6
     inst [9 or "9 inst-9"] value 7840.8
 
-opentelemetry.source72.sample_summary0002 []
+opentelemetry.source72.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011812102
     inst [2 or "quantile: 0.5"] value 0.023624204
@@ -9079,13 +9079,13 @@ opentelemetry.source72.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.09449681600000001
     inst [9 or "quantile: 2.25"] value 0.106308918
 
-opentelemetry.source72.sample_summary0002_count []
+opentelemetry.source72.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 134532
 
-opentelemetry.source72.sample_summary0002_sum []
+opentelemetry.source72.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 102.949301
 
-opentelemetry.source72.sample_counter0001 []
+opentelemetry.source72.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 24679782100
     inst [2 or "2 inst-2"] value 49359564300
@@ -9097,7 +9097,7 @@ opentelemetry.source72.sample_counter0001 []
     inst [8 or "8 inst-8"] value 197438257000
     inst [9 or "9 inst-9"] value 222118039000
 
-opentelemetry.source72.sample_gauge0000 []
+opentelemetry.source72.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1742.4
     inst [2 or "2 inst-2"] value 3484.8
@@ -9109,7 +9109,7 @@ opentelemetry.source72.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 13939.2
     inst [9 or "9 inst-9"] value 15681.6
 
-opentelemetry.source72.sample_summary0002 []
+opentelemetry.source72.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.023304958
     inst [2 or "quantile: 0.5"] value 0.046609916
@@ -9121,13 +9121,13 @@ opentelemetry.source72.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.186439664
     inst [9 or "quantile: 2.25"] value 0.209744622
 
-opentelemetry.source72.sample_summary0002_count []
+opentelemetry.source72.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 265428
 
-opentelemetry.source72.sample_summary0002_sum []
+opentelemetry.source72.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 203.116188
 
-opentelemetry.source72.sample_counter0001 []
+opentelemetry.source72.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 36934570500
     inst [2 or "2 inst-2"] value 73869141000
@@ -9139,7 +9139,7 @@ opentelemetry.source72.sample_counter0001 []
     inst [8 or "8 inst-8"] value 295476564000
     inst [9 or "9 inst-9"] value 332411134000
 
-opentelemetry.source72.sample_gauge0000 []
+opentelemetry.source72.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2613.6
     inst [2 or "2 inst-2"] value 5227.2
@@ -9151,7 +9151,7 @@ opentelemetry.source72.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 20908.8
     inst [9 or "9 inst-9"] value 23522.4
 
-opentelemetry.source72.sample_summary0002 []
+opentelemetry.source72.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.034797814
     inst [2 or "quantile: 0.5"] value 0.06959562800000001
@@ -9163,13 +9163,13 @@ opentelemetry.source72.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.278382512
     inst [9 or "quantile: 2.25"] value 0.313180326
 
-opentelemetry.source72.sample_summary0002_count []
+opentelemetry.source72.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 396324
 
-opentelemetry.source72.sample_summary0002_sum []
+opentelemetry.source72.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 303.283076
 
-opentelemetry.source73.sample_counter0001 []
+opentelemetry.source73.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12595199200
     inst [2 or "2 inst-2"] value 25190398300
@@ -9181,7 +9181,7 @@ opentelemetry.source73.sample_counter0001 []
     inst [8 or "8 inst-8"] value 100761593000
     inst [9 or "9 inst-9"] value 113356792000
 
-opentelemetry.source73.sample_gauge0000 []
+opentelemetry.source73.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 883.3
     inst [2 or "2 inst-2"] value 1766.6
@@ -9193,7 +9193,7 @@ opentelemetry.source73.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7066.4
     inst [9 or "9 inst-9"] value 7949.7
 
-opentelemetry.source73.sample_summary0002 []
+opentelemetry.source73.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.011971725
     inst [2 or "quantile: 0.5"] value 0.02394345
@@ -9205,13 +9205,13 @@ opentelemetry.source73.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.09577380000000001
     inst [9 or "quantile: 2.25"] value 0.107745525
 
-opentelemetry.source73.sample_summary0002_count []
+opentelemetry.source73.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 136350
 
-opentelemetry.source73.sample_summary0002_sum []
+opentelemetry.source73.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 104.340508
 
-opentelemetry.source73.sample_counter0001 []
+opentelemetry.source73.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 25020192900
     inst [2 or "2 inst-2"] value 50040385800
@@ -9223,7 +9223,7 @@ opentelemetry.source73.sample_counter0001 []
     inst [8 or "8 inst-8"] value 200161543000
     inst [9 or "9 inst-9"] value 225181736000
 
-opentelemetry.source73.sample_gauge0000 []
+opentelemetry.source73.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1766.6
     inst [2 or "2 inst-2"] value 3533.2
@@ -9235,7 +9235,7 @@ opentelemetry.source73.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 14132.8
     inst [9 or "9 inst-9"] value 15899.4
 
-opentelemetry.source73.sample_summary0002 []
+opentelemetry.source73.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.023624204
     inst [2 or "quantile: 0.5"] value 0.04724840800000001
@@ -9247,13 +9247,13 @@ opentelemetry.source73.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.188993632
     inst [9 or "quantile: 2.25"] value 0.212617836
 
-opentelemetry.source73.sample_summary0002_count []
+opentelemetry.source73.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 269064
 
-opentelemetry.source73.sample_summary0002_sum []
+opentelemetry.source73.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 205.898602
 
-opentelemetry.source73.sample_counter0001 []
+opentelemetry.source73.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 37445186700
     inst [2 or "2 inst-2"] value 74890373400
@@ -9265,7 +9265,7 @@ opentelemetry.source73.sample_counter0001 []
     inst [8 or "8 inst-8"] value 299561493000
     inst [9 or "9 inst-9"] value 337006680000
 
-opentelemetry.source73.sample_gauge0000 []
+opentelemetry.source73.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2649.9
     inst [2 or "2 inst-2"] value 5299.8
@@ -9277,7 +9277,7 @@ opentelemetry.source73.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 21199.2
     inst [9 or "9 inst-9"] value 23849.1
 
-opentelemetry.source73.sample_summary0002 []
+opentelemetry.source73.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.035276683
     inst [2 or "quantile: 0.5"] value 0.07055336600000001
@@ -9289,13 +9289,13 @@ opentelemetry.source73.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.282213464
     inst [9 or "quantile: 2.25"] value 0.317490147
 
-opentelemetry.source73.sample_summary0002_count []
+opentelemetry.source73.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 401778
 
-opentelemetry.source73.sample_summary0002_sum []
+opentelemetry.source73.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 307.456696
 
-opentelemetry.source74.sample_counter0001 []
+opentelemetry.source74.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12765404600
     inst [2 or "2 inst-2"] value 25530809100
@@ -9307,7 +9307,7 @@ opentelemetry.source74.sample_counter0001 []
     inst [8 or "8 inst-8"] value 102123236000
     inst [9 or "9 inst-9"] value 114888641000
 
-opentelemetry.source74.sample_gauge0000 []
+opentelemetry.source74.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 895.4
     inst [2 or "2 inst-2"] value 1790.8
@@ -9319,7 +9319,7 @@ opentelemetry.source74.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7163.2
     inst [9 or "9 inst-9"] value 8058.6
 
-opentelemetry.source74.sample_summary0002 []
+opentelemetry.source74.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012131348
     inst [2 or "quantile: 0.5"] value 0.024262696
@@ -9331,13 +9331,13 @@ opentelemetry.source74.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.097050784
     inst [9 or "quantile: 2.25"] value 0.109182132
 
-opentelemetry.source74.sample_summary0002_count []
+opentelemetry.source74.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 138168
 
-opentelemetry.source74.sample_summary0002_sum []
+opentelemetry.source74.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 105.731715
 
-opentelemetry.source74.sample_counter0001 []
+opentelemetry.source74.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 25360603700
     inst [2 or "2 inst-2"] value 50721207400
@@ -9349,7 +9349,7 @@ opentelemetry.source74.sample_counter0001 []
     inst [8 or "8 inst-8"] value 202884830000
     inst [9 or "9 inst-9"] value 228245433000
 
-opentelemetry.source74.sample_gauge0000 []
+opentelemetry.source74.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1790.8
     inst [2 or "2 inst-2"] value 3581.6
@@ -9361,7 +9361,7 @@ opentelemetry.source74.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 14326.4
     inst [9 or "9 inst-9"] value 16117.2
 
-opentelemetry.source74.sample_summary0002 []
+opentelemetry.source74.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.02394345
     inst [2 or "quantile: 0.5"] value 0.0478869
@@ -9373,13 +9373,13 @@ opentelemetry.source74.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.1915476
     inst [9 or "quantile: 2.25"] value 0.21549105
 
-opentelemetry.source74.sample_summary0002_count []
+opentelemetry.source74.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 272700
 
-opentelemetry.source74.sample_summary0002_sum []
+opentelemetry.source74.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 208.681016
 
-opentelemetry.source74.sample_counter0001 []
+opentelemetry.source74.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 37955802900
     inst [2 or "2 inst-2"] value 75911605700
@@ -9391,7 +9391,7 @@ opentelemetry.source74.sample_counter0001 []
     inst [8 or "8 inst-8"] value 303646423000
     inst [9 or "9 inst-9"] value 341602226000
 
-opentelemetry.source74.sample_gauge0000 []
+opentelemetry.source74.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2686.2
     inst [2 or "2 inst-2"] value 5372.4
@@ -9403,7 +9403,7 @@ opentelemetry.source74.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 21489.6
     inst [9 or "9 inst-9"] value 24175.8
 
-opentelemetry.source74.sample_summary0002 []
+opentelemetry.source74.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.035755552
     inst [2 or "quantile: 0.5"] value 0.07151110400000001
@@ -9415,13 +9415,13 @@ opentelemetry.source74.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.286044416
     inst [9 or "quantile: 2.25"] value 0.321799968
 
-opentelemetry.source74.sample_summary0002_count []
+opentelemetry.source74.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 407232
 
-opentelemetry.source74.sample_summary0002_sum []
+opentelemetry.source74.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 311.630316
 
-opentelemetry.source75.sample_counter0001 []
+opentelemetry.source75.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 12935609900
     inst [2 or "2 inst-2"] value 25871219900
@@ -9433,7 +9433,7 @@ opentelemetry.source75.sample_counter0001 []
     inst [8 or "8 inst-8"] value 103484880000
     inst [9 or "9 inst-9"] value 116420489000
 
-opentelemetry.source75.sample_gauge0000 []
+opentelemetry.source75.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 907.5
     inst [2 or "2 inst-2"] value 1815
@@ -9445,7 +9445,7 @@ opentelemetry.source75.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7260
     inst [9 or "9 inst-9"] value 8167.5
 
-opentelemetry.source75.sample_summary0002 []
+opentelemetry.source75.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012290971
     inst [2 or "quantile: 0.5"] value 0.024581942
@@ -9457,13 +9457,13 @@ opentelemetry.source75.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.09832776800000001
     inst [9 or "quantile: 2.25"] value 0.110618739
 
-opentelemetry.source75.sample_summary0002_count []
+opentelemetry.source75.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 139986
 
-opentelemetry.source75.sample_summary0002_sum []
+opentelemetry.source75.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 107.122921
 
-opentelemetry.source75.sample_counter0001 []
+opentelemetry.source75.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 25701014500
     inst [2 or "2 inst-2"] value 51402029000
@@ -9475,7 +9475,7 @@ opentelemetry.source75.sample_counter0001 []
     inst [8 or "8 inst-8"] value 205608116000
     inst [9 or "9 inst-9"] value 231309130000
 
-opentelemetry.source75.sample_gauge0000 []
+opentelemetry.source75.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1815
     inst [2 or "2 inst-2"] value 3630
@@ -9487,7 +9487,7 @@ opentelemetry.source75.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 14520
     inst [9 or "9 inst-9"] value 16335
 
-opentelemetry.source75.sample_summary0002 []
+opentelemetry.source75.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.024262696
     inst [2 or "quantile: 0.5"] value 0.048525392
@@ -9499,13 +9499,13 @@ opentelemetry.source75.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.194101568
     inst [9 or "quantile: 2.25"] value 0.218364264
 
-opentelemetry.source75.sample_summary0002_count []
+opentelemetry.source75.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 276336
 
-opentelemetry.source75.sample_summary0002_sum []
+opentelemetry.source75.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 211.463429
 
-opentelemetry.source75.sample_counter0001 []
+opentelemetry.source75.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 38466419000
     inst [2 or "2 inst-2"] value 76932838100
@@ -9517,7 +9517,7 @@ opentelemetry.source75.sample_counter0001 []
     inst [8 or "8 inst-8"] value 307731352000
     inst [9 or "9 inst-9"] value 346197771000
 
-opentelemetry.source75.sample_gauge0000 []
+opentelemetry.source75.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2722.5
     inst [2 or "2 inst-2"] value 5445
@@ -9529,7 +9529,7 @@ opentelemetry.source75.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 21780
     inst [9 or "9 inst-9"] value 24502.5
 
-opentelemetry.source75.sample_summary0002 []
+opentelemetry.source75.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.036234421
     inst [2 or "quantile: 0.5"] value 0.07246884200000001
@@ -9541,13 +9541,13 @@ opentelemetry.source75.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.289875368
     inst [9 or "quantile: 2.25"] value 0.326109789
 
-opentelemetry.source75.sample_summary0002_count []
+opentelemetry.source75.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 412686
 
-opentelemetry.source75.sample_summary0002_sum []
+opentelemetry.source75.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 315.803937
 
-opentelemetry.source76.sample_counter0001 []
+opentelemetry.source76.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13105815300
     inst [2 or "2 inst-2"] value 26211630700
@@ -9559,7 +9559,7 @@ opentelemetry.source76.sample_counter0001 []
     inst [8 or "8 inst-8"] value 104846523000
     inst [9 or "9 inst-9"] value 117952338000
 
-opentelemetry.source76.sample_gauge0000 []
+opentelemetry.source76.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 919.6
     inst [2 or "2 inst-2"] value 1839.2
@@ -9571,7 +9571,7 @@ opentelemetry.source76.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7356.8
     inst [9 or "9 inst-9"] value 8276.4
 
-opentelemetry.source76.sample_summary0002 []
+opentelemetry.source76.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012450594
     inst [2 or "quantile: 0.5"] value 0.024901188
@@ -9583,13 +9583,13 @@ opentelemetry.source76.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.099604752
     inst [9 or "quantile: 2.25"] value 0.112055346
 
-opentelemetry.source76.sample_summary0002_count []
+opentelemetry.source76.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 141804
 
-opentelemetry.source76.sample_summary0002_sum []
+opentelemetry.source76.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 108.514128
 
-opentelemetry.source76.sample_counter0001 []
+opentelemetry.source76.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 26041425300
     inst [2 or "2 inst-2"] value 52082850600
@@ -9601,7 +9601,7 @@ opentelemetry.source76.sample_counter0001 []
     inst [8 or "8 inst-8"] value 208331402000
     inst [9 or "9 inst-9"] value 234372828000
 
-opentelemetry.source76.sample_gauge0000 []
+opentelemetry.source76.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1839.2
     inst [2 or "2 inst-2"] value 3678.4
@@ -9613,7 +9613,7 @@ opentelemetry.source76.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 14713.6
     inst [9 or "9 inst-9"] value 16552.8
 
-opentelemetry.source76.sample_summary0002 []
+opentelemetry.source76.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.024581942
     inst [2 or "quantile: 0.5"] value 0.049163884
@@ -9625,13 +9625,13 @@ opentelemetry.source76.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.196655536
     inst [9 or "quantile: 2.25"] value 0.221237478
 
-opentelemetry.source76.sample_summary0002_count []
+opentelemetry.source76.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 279972
 
-opentelemetry.source76.sample_summary0002_sum []
+opentelemetry.source76.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 214.245843
 
-opentelemetry.source76.sample_counter0001 []
+opentelemetry.source76.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 38977035200
     inst [2 or "2 inst-2"] value 77954070500
@@ -9643,7 +9643,7 @@ opentelemetry.source76.sample_counter0001 []
     inst [8 or "8 inst-8"] value 311816282000
     inst [9 or "9 inst-9"] value 350793317000
 
-opentelemetry.source76.sample_gauge0000 []
+opentelemetry.source76.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2758.8
     inst [2 or "2 inst-2"] value 5517.6
@@ -9655,7 +9655,7 @@ opentelemetry.source76.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 22070.4
     inst [9 or "9 inst-9"] value 24829.2
 
-opentelemetry.source76.sample_summary0002 []
+opentelemetry.source76.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.03671329
     inst [2 or "quantile: 0.5"] value 0.07342658000000001
@@ -9667,13 +9667,13 @@ opentelemetry.source76.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.29370632
     inst [9 or "quantile: 2.25"] value 0.33041961
 
-opentelemetry.source76.sample_summary0002_count []
+opentelemetry.source76.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 418140
 
-opentelemetry.source76.sample_summary0002_sum []
+opentelemetry.source76.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 319.977557
 
-opentelemetry.source77.sample_counter0001 []
+opentelemetry.source77.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13276020700
     inst [2 or "2 inst-2"] value 26552041500
@@ -9685,7 +9685,7 @@ opentelemetry.source77.sample_counter0001 []
     inst [8 or "8 inst-8"] value 106208166000
     inst [9 or "9 inst-9"] value 119484187000
 
-opentelemetry.source77.sample_gauge0000 []
+opentelemetry.source77.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 931.7
     inst [2 or "2 inst-2"] value 1863.4
@@ -9697,7 +9697,7 @@ opentelemetry.source77.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7453.6
     inst [9 or "9 inst-9"] value 8385.299999999999
 
-opentelemetry.source77.sample_summary0002 []
+opentelemetry.source77.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012610217
     inst [2 or "quantile: 0.5"] value 0.025220434
@@ -9709,13 +9709,13 @@ opentelemetry.source77.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.100881736
     inst [9 or "quantile: 2.25"] value 0.113491953
 
-opentelemetry.source77.sample_summary0002_count []
+opentelemetry.source77.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 143622
 
-opentelemetry.source77.sample_summary0002_sum []
+opentelemetry.source77.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 109.905335
 
-opentelemetry.source77.sample_counter0001 []
+opentelemetry.source77.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 26381836100
     inst [2 or "2 inst-2"] value 52763672100
@@ -9727,7 +9727,7 @@ opentelemetry.source77.sample_counter0001 []
     inst [8 or "8 inst-8"] value 211054689000
     inst [9 or "9 inst-9"] value 237436525000
 
-opentelemetry.source77.sample_gauge0000 []
+opentelemetry.source77.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1863.4
     inst [2 or "2 inst-2"] value 3726.8
@@ -9739,7 +9739,7 @@ opentelemetry.source77.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 14907.2
     inst [9 or "9 inst-9"] value 16770.6
 
-opentelemetry.source77.sample_summary0002 []
+opentelemetry.source77.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.024901188
     inst [2 or "quantile: 0.5"] value 0.049802376
@@ -9751,13 +9751,13 @@ opentelemetry.source77.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.199209504
     inst [9 or "quantile: 2.25"] value 0.224110692
 
-opentelemetry.source77.sample_summary0002_count []
+opentelemetry.source77.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 283608
 
-opentelemetry.source77.sample_summary0002_sum []
+opentelemetry.source77.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 217.028256
 
-opentelemetry.source77.sample_counter0001 []
+opentelemetry.source77.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 39487651400
     inst [2 or "2 inst-2"] value 78975302800
@@ -9769,7 +9769,7 @@ opentelemetry.source77.sample_counter0001 []
     inst [8 or "8 inst-8"] value 315901211000
     inst [9 or "9 inst-9"] value 355388863000
 
-opentelemetry.source77.sample_gauge0000 []
+opentelemetry.source77.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2795.1
     inst [2 or "2 inst-2"] value 5590.2
@@ -9781,7 +9781,7 @@ opentelemetry.source77.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 22360.8
     inst [9 or "9 inst-9"] value 25155.9
 
-opentelemetry.source77.sample_summary0002 []
+opentelemetry.source77.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.037192159
     inst [2 or "quantile: 0.5"] value 0.074384318
@@ -9793,13 +9793,13 @@ opentelemetry.source77.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.297537272
     inst [9 or "quantile: 2.25"] value 0.334729431
 
-opentelemetry.source77.sample_summary0002_count []
+opentelemetry.source77.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 423594
 
-opentelemetry.source77.sample_summary0002_sum []
+opentelemetry.source77.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 324.151177
 
-opentelemetry.source78.sample_counter0001 []
+opentelemetry.source78.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13446226100
     inst [2 or "2 inst-2"] value 26892452300
@@ -9811,7 +9811,7 @@ opentelemetry.source78.sample_counter0001 []
     inst [8 or "8 inst-8"] value 107569809000
     inst [9 or "9 inst-9"] value 121016035000
 
-opentelemetry.source78.sample_gauge0000 []
+opentelemetry.source78.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 943.8
     inst [2 or "2 inst-2"] value 1887.6
@@ -9823,7 +9823,7 @@ opentelemetry.source78.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7550.4
     inst [9 or "9 inst-9"] value 8494.200000000001
 
-opentelemetry.source78.sample_summary0002 []
+opentelemetry.source78.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01276984
     inst [2 or "quantile: 0.5"] value 0.02553968
@@ -9835,13 +9835,13 @@ opentelemetry.source78.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.10215872
     inst [9 or "quantile: 2.25"] value 0.11492856
 
-opentelemetry.source78.sample_summary0002_count []
+opentelemetry.source78.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 145440
 
-opentelemetry.source78.sample_summary0002_sum []
+opentelemetry.source78.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 111.296542
 
-opentelemetry.source78.sample_counter0001 []
+opentelemetry.source78.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 26722246900
     inst [2 or "2 inst-2"] value 53444493700
@@ -9853,7 +9853,7 @@ opentelemetry.source78.sample_counter0001 []
     inst [8 or "8 inst-8"] value 213777975000
     inst [9 or "9 inst-9"] value 240500222000
 
-opentelemetry.source78.sample_gauge0000 []
+opentelemetry.source78.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1887.6
     inst [2 or "2 inst-2"] value 3775.2
@@ -9865,7 +9865,7 @@ opentelemetry.source78.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 15100.8
     inst [9 or "9 inst-9"] value 16988.4
 
-opentelemetry.source78.sample_summary0002 []
+opentelemetry.source78.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.025220434
     inst [2 or "quantile: 0.5"] value 0.05044086800000001
@@ -9877,13 +9877,13 @@ opentelemetry.source78.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.201763472
     inst [9 or "quantile: 2.25"] value 0.226983906
 
-opentelemetry.source78.sample_summary0002_count []
+opentelemetry.source78.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 287244
 
-opentelemetry.source78.sample_summary0002_sum []
+opentelemetry.source78.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 219.81067
 
-opentelemetry.source78.sample_counter0001 []
+opentelemetry.source78.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 39998267600
     inst [2 or "2 inst-2"] value 79996535200
@@ -9895,7 +9895,7 @@ opentelemetry.source78.sample_counter0001 []
     inst [8 or "8 inst-8"] value 319986141000
     inst [9 or "9 inst-9"] value 359984408000
 
-opentelemetry.source78.sample_gauge0000 []
+opentelemetry.source78.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2831.4
     inst [2 or "2 inst-2"] value 5662.8
@@ -9907,7 +9907,7 @@ opentelemetry.source78.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 22651.2
     inst [9 or "9 inst-9"] value 25482.6
 
-opentelemetry.source78.sample_summary0002 []
+opentelemetry.source78.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.037671028
     inst [2 or "quantile: 0.5"] value 0.075342056
@@ -9919,13 +9919,13 @@ opentelemetry.source78.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.301368224
     inst [9 or "quantile: 2.25"] value 0.339039252
 
-opentelemetry.source78.sample_summary0002_count []
+opentelemetry.source78.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 429048
 
-opentelemetry.source78.sample_summary0002_sum []
+opentelemetry.source78.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 328.324798
 
-opentelemetry.source79.sample_counter0001 []
+opentelemetry.source79.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13616431500
     inst [2 or "2 inst-2"] value 27232863000
@@ -9937,7 +9937,7 @@ opentelemetry.source79.sample_counter0001 []
     inst [8 or "8 inst-8"] value 108931452000
     inst [9 or "9 inst-9"] value 122547884000
 
-opentelemetry.source79.sample_gauge0000 []
+opentelemetry.source79.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 955.9
     inst [2 or "2 inst-2"] value 1911.8
@@ -9949,7 +9949,7 @@ opentelemetry.source79.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7647.2
     inst [9 or "9 inst-9"] value 8603.1
 
-opentelemetry.source79.sample_summary0002 []
+opentelemetry.source79.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.012929463
     inst [2 or "quantile: 0.5"] value 0.025858926
@@ -9961,13 +9961,13 @@ opentelemetry.source79.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.103435704
     inst [9 or "quantile: 2.25"] value 0.116365167
 
-opentelemetry.source79.sample_summary0002_count []
+opentelemetry.source79.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 147258
 
-opentelemetry.source79.sample_summary0002_sum []
+opentelemetry.source79.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 112.687748
 
-opentelemetry.source79.sample_counter0001 []
+opentelemetry.source79.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 27062657600
     inst [2 or "2 inst-2"] value 54125315300
@@ -9979,7 +9979,7 @@ opentelemetry.source79.sample_counter0001 []
     inst [8 or "8 inst-8"] value 216501261000
     inst [9 or "9 inst-9"] value 243563919000
 
-opentelemetry.source79.sample_gauge0000 []
+opentelemetry.source79.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1911.8
     inst [2 or "2 inst-2"] value 3823.6
@@ -9991,7 +9991,7 @@ opentelemetry.source79.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 15294.4
     inst [9 or "9 inst-9"] value 17206.2
 
-opentelemetry.source79.sample_summary0002 []
+opentelemetry.source79.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.02553968
     inst [2 or "quantile: 0.5"] value 0.05107936
@@ -10003,13 +10003,13 @@ opentelemetry.source79.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.20431744
     inst [9 or "quantile: 2.25"] value 0.22985712
 
-opentelemetry.source79.sample_summary0002_count []
+opentelemetry.source79.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 290880
 
-opentelemetry.source79.sample_summary0002_sum []
+opentelemetry.source79.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 222.593083
 
-opentelemetry.source79.sample_counter0001 []
+opentelemetry.source79.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 40508883800
     inst [2 or "2 inst-2"] value 81017767500
@@ -10021,7 +10021,7 @@ opentelemetry.source79.sample_counter0001 []
     inst [8 or "8 inst-8"] value 324071070000
     inst [9 or "9 inst-9"] value 364579954000
 
-opentelemetry.source79.sample_gauge0000 []
+opentelemetry.source79.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2867.7
     inst [2 or "2 inst-2"] value 5735.4
@@ -10033,7 +10033,7 @@ opentelemetry.source79.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 22941.6
     inst [9 or "9 inst-9"] value 25809.3
 
-opentelemetry.source79.sample_summary0002 []
+opentelemetry.source79.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.038149897
     inst [2 or "quantile: 0.5"] value 0.076299794
@@ -10045,13 +10045,13 @@ opentelemetry.source79.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.305199176
     inst [9 or "quantile: 2.25"] value 0.343349073
 
-opentelemetry.source79.sample_summary0002_count []
+opentelemetry.source79.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 434502
 
-opentelemetry.source79.sample_summary0002_sum []
+opentelemetry.source79.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 332.498418
 
-opentelemetry.source80.sample_counter0001 []
+opentelemetry.source80.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13786636900
     inst [2 or "2 inst-2"] value 27573273800
@@ -10063,7 +10063,7 @@ opentelemetry.source80.sample_counter0001 []
     inst [8 or "8 inst-8"] value 110293095000
     inst [9 or "9 inst-9"] value 124079732000
 
-opentelemetry.source80.sample_gauge0000 []
+opentelemetry.source80.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 968
     inst [2 or "2 inst-2"] value 1936
@@ -10075,7 +10075,7 @@ opentelemetry.source80.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7744
     inst [9 or "9 inst-9"] value 8712
 
-opentelemetry.source80.sample_summary0002 []
+opentelemetry.source80.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013089086
     inst [2 or "quantile: 0.5"] value 0.026178172
@@ -10087,13 +10087,13 @@ opentelemetry.source80.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.104712688
     inst [9 or "quantile: 2.25"] value 0.117801774
 
-opentelemetry.source80.sample_summary0002_count []
+opentelemetry.source80.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 149076
 
-opentelemetry.source80.sample_summary0002_sum []
+opentelemetry.source80.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 114.078955
 
-opentelemetry.source80.sample_counter0001 []
+opentelemetry.source80.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 27403068400
     inst [2 or "2 inst-2"] value 54806136900
@@ -10105,7 +10105,7 @@ opentelemetry.source80.sample_counter0001 []
     inst [8 or "8 inst-8"] value 219224547000
     inst [9 or "9 inst-9"] value 246627616000
 
-opentelemetry.source80.sample_gauge0000 []
+opentelemetry.source80.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1936
     inst [2 or "2 inst-2"] value 3872
@@ -10117,7 +10117,7 @@ opentelemetry.source80.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 15488
     inst [9 or "9 inst-9"] value 17424
 
-opentelemetry.source80.sample_summary0002 []
+opentelemetry.source80.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.025858926
     inst [2 or "quantile: 0.5"] value 0.051717852
@@ -10129,13 +10129,13 @@ opentelemetry.source80.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.206871408
     inst [9 or "quantile: 2.25"] value 0.232730334
 
-opentelemetry.source80.sample_summary0002_count []
+opentelemetry.source80.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 294516
 
-opentelemetry.source80.sample_summary0002_sum []
+opentelemetry.source80.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 225.375497
 
-opentelemetry.source80.sample_counter0001 []
+opentelemetry.source80.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 41019500000
     inst [2 or "2 inst-2"] value 82038999900
@@ -10147,7 +10147,7 @@ opentelemetry.source80.sample_counter0001 []
     inst [8 or "8 inst-8"] value 328156000000
     inst [9 or "9 inst-9"] value 369175500000
 
-opentelemetry.source80.sample_gauge0000 []
+opentelemetry.source80.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2904
     inst [2 or "2 inst-2"] value 5808
@@ -10159,7 +10159,7 @@ opentelemetry.source80.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 23232
     inst [9 or "9 inst-9"] value 26136
 
-opentelemetry.source80.sample_summary0002 []
+opentelemetry.source80.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.038628766
     inst [2 or "quantile: 0.5"] value 0.077257532
@@ -10171,13 +10171,13 @@ opentelemetry.source80.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.309030128
     inst [9 or "quantile: 2.25"] value 0.3476588940000001
 
-opentelemetry.source80.sample_summary0002_count []
+opentelemetry.source80.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 439956
 
-opentelemetry.source80.sample_summary0002_sum []
+opentelemetry.source80.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 336.672038
 
-opentelemetry.source81.sample_counter0001 []
+opentelemetry.source81.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 13956842300
     inst [2 or "2 inst-2"] value 27913684600
@@ -10189,7 +10189,7 @@ opentelemetry.source81.sample_counter0001 []
     inst [8 or "8 inst-8"] value 111654738000
     inst [9 or "9 inst-9"] value 125611581000
 
-opentelemetry.source81.sample_gauge0000 []
+opentelemetry.source81.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 980.1
     inst [2 or "2 inst-2"] value 1960.2
@@ -10201,7 +10201,7 @@ opentelemetry.source81.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7840.8
     inst [9 or "9 inst-9"] value 8820.9
 
-opentelemetry.source81.sample_summary0002 []
+opentelemetry.source81.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013248709
     inst [2 or "quantile: 0.5"] value 0.026497418
@@ -10213,13 +10213,13 @@ opentelemetry.source81.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.105989672
     inst [9 or "quantile: 2.25"] value 0.119238381
 
-opentelemetry.source81.sample_summary0002_count []
+opentelemetry.source81.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 150894
 
-opentelemetry.source81.sample_summary0002_sum []
+opentelemetry.source81.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 115.470162
 
-opentelemetry.source81.sample_counter0001 []
+opentelemetry.source81.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 27743479200
     inst [2 or "2 inst-2"] value 55486958400
@@ -10231,7 +10231,7 @@ opentelemetry.source81.sample_counter0001 []
     inst [8 or "8 inst-8"] value 221947834000
     inst [9 or "9 inst-9"] value 249691313000
 
-opentelemetry.source81.sample_gauge0000 []
+opentelemetry.source81.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1960.2
     inst [2 or "2 inst-2"] value 3920.4
@@ -10243,7 +10243,7 @@ opentelemetry.source81.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 15681.6
     inst [9 or "9 inst-9"] value 17641.8
 
-opentelemetry.source81.sample_summary0002 []
+opentelemetry.source81.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.026178172
     inst [2 or "quantile: 0.5"] value 0.05235634400000001
@@ -10255,13 +10255,13 @@ opentelemetry.source81.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.209425376
     inst [9 or "quantile: 2.25"] value 0.235603548
 
-opentelemetry.source81.sample_summary0002_count []
+opentelemetry.source81.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 298152
 
-opentelemetry.source81.sample_summary0002_sum []
+opentelemetry.source81.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 228.15791
 
-opentelemetry.source81.sample_counter0001 []
+opentelemetry.source81.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 41530116100
     inst [2 or "2 inst-2"] value 83060232300
@@ -10273,7 +10273,7 @@ opentelemetry.source81.sample_counter0001 []
     inst [8 or "8 inst-8"] value 332240929000
     inst [9 or "9 inst-9"] value 373771045000
 
-opentelemetry.source81.sample_gauge0000 []
+opentelemetry.source81.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2940.3
     inst [2 or "2 inst-2"] value 5880.6
@@ -10285,7 +10285,7 @@ opentelemetry.source81.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 23522.4
     inst [9 or "9 inst-9"] value 26462.7
 
-opentelemetry.source81.sample_summary0002 []
+opentelemetry.source81.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.039107635
     inst [2 or "quantile: 0.5"] value 0.07821527
@@ -10297,13 +10297,13 @@ opentelemetry.source81.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.31286108
     inst [9 or "quantile: 2.25"] value 0.351968715
 
-opentelemetry.source81.sample_summary0002_count []
+opentelemetry.source81.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 445410
 
-opentelemetry.source81.sample_summary0002_sum []
+opentelemetry.source81.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 340.845659
 
-opentelemetry.source82.sample_counter0001 []
+opentelemetry.source82.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14127047700
     inst [2 or "2 inst-2"] value 28254095400
@@ -10315,7 +10315,7 @@ opentelemetry.source82.sample_counter0001 []
     inst [8 or "8 inst-8"] value 113016382000
     inst [9 or "9 inst-9"] value 127143429000
 
-opentelemetry.source82.sample_gauge0000 []
+opentelemetry.source82.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 992.2
     inst [2 or "2 inst-2"] value 1984.4
@@ -10327,7 +10327,7 @@ opentelemetry.source82.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 7937.6
     inst [9 or "9 inst-9"] value 8929.799999999999
 
-opentelemetry.source82.sample_summary0002 []
+opentelemetry.source82.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013408332
     inst [2 or "quantile: 0.5"] value 0.026816664
@@ -10339,13 +10339,13 @@ opentelemetry.source82.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.107266656
     inst [9 or "quantile: 2.25"] value 0.120674988
 
-opentelemetry.source82.sample_summary0002_count []
+opentelemetry.source82.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 152712
 
-opentelemetry.source82.sample_summary0002_sum []
+opentelemetry.source82.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 116.861369
 
-opentelemetry.source82.sample_counter0001 []
+opentelemetry.source82.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 28083890000
     inst [2 or "2 inst-2"] value 56167780000
@@ -10357,7 +10357,7 @@ opentelemetry.source82.sample_counter0001 []
     inst [8 or "8 inst-8"] value 224671120000
     inst [9 or "9 inst-9"] value 252755010000
 
-opentelemetry.source82.sample_gauge0000 []
+opentelemetry.source82.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1984.4
     inst [2 or "2 inst-2"] value 3968.8
@@ -10369,7 +10369,7 @@ opentelemetry.source82.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 15875.2
     inst [9 or "9 inst-9"] value 17859.6
 
-opentelemetry.source82.sample_summary0002 []
+opentelemetry.source82.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.026497418
     inst [2 or "quantile: 0.5"] value 0.052994836
@@ -10381,13 +10381,13 @@ opentelemetry.source82.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.211979344
     inst [9 or "quantile: 2.25"] value 0.238476762
 
-opentelemetry.source82.sample_summary0002_count []
+opentelemetry.source82.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 301788
 
-opentelemetry.source82.sample_summary0002_sum []
+opentelemetry.source82.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 230.940324
 
-opentelemetry.source82.sample_counter0001 []
+opentelemetry.source82.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 42040732300
     inst [2 or "2 inst-2"] value 84081464600
@@ -10399,7 +10399,7 @@ opentelemetry.source82.sample_counter0001 []
     inst [8 or "8 inst-8"] value 336325859000
     inst [9 or "9 inst-9"] value 378366591000
 
-opentelemetry.source82.sample_gauge0000 []
+opentelemetry.source82.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2976.6
     inst [2 or "2 inst-2"] value 5953.2
@@ -10411,7 +10411,7 @@ opentelemetry.source82.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 23812.8
     inst [9 or "9 inst-9"] value 26789.4
 
-opentelemetry.source82.sample_summary0002 []
+opentelemetry.source82.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.039586504
     inst [2 or "quantile: 0.5"] value 0.079173008
@@ -10423,13 +10423,13 @@ opentelemetry.source82.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.316692032
     inst [9 or "quantile: 2.25"] value 0.356278536
 
-opentelemetry.source82.sample_summary0002_count []
+opentelemetry.source82.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 450864
 
-opentelemetry.source82.sample_summary0002_sum []
+opentelemetry.source82.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 345.019279
 
-opentelemetry.source83.sample_counter0001 []
+opentelemetry.source83.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14297253100
     inst [2 or "2 inst-2"] value 28594506200
@@ -10441,7 +10441,7 @@ opentelemetry.source83.sample_counter0001 []
     inst [8 or "8 inst-8"] value 114378025000
     inst [9 or "9 inst-9"] value 128675278000
 
-opentelemetry.source83.sample_gauge0000 []
+opentelemetry.source83.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1004.3
     inst [2 or "2 inst-2"] value 2008.6
@@ -10453,7 +10453,7 @@ opentelemetry.source83.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8034.4
     inst [9 or "9 inst-9"] value 9038.700000000001
 
-opentelemetry.source83.sample_summary0002 []
+opentelemetry.source83.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013567955
     inst [2 or "quantile: 0.5"] value 0.02713591
@@ -10465,13 +10465,13 @@ opentelemetry.source83.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.10854364
     inst [9 or "quantile: 2.25"] value 0.122111595
 
-opentelemetry.source83.sample_summary0002_count []
+opentelemetry.source83.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 154530
 
-opentelemetry.source83.sample_summary0002_sum []
+opentelemetry.source83.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 118.252575
 
-opentelemetry.source83.sample_counter0001 []
+opentelemetry.source83.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 28424300800
     inst [2 or "2 inst-2"] value 56848601600
@@ -10483,7 +10483,7 @@ opentelemetry.source83.sample_counter0001 []
     inst [8 or "8 inst-8"] value 227394406000
     inst [9 or "9 inst-9"] value 255818707000
 
-opentelemetry.source83.sample_gauge0000 []
+opentelemetry.source83.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2008.6
     inst [2 or "2 inst-2"] value 4017.2
@@ -10495,7 +10495,7 @@ opentelemetry.source83.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 16068.8
     inst [9 or "9 inst-9"] value 18077.4
 
-opentelemetry.source83.sample_summary0002 []
+opentelemetry.source83.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.026816664
     inst [2 or "quantile: 0.5"] value 0.05363332800000001
@@ -10507,13 +10507,13 @@ opentelemetry.source83.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.214533312
     inst [9 or "quantile: 2.25"] value 0.241349976
 
-opentelemetry.source83.sample_summary0002_count []
+opentelemetry.source83.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 305424
 
-opentelemetry.source83.sample_summary0002_sum []
+opentelemetry.source83.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 233.722737
 
-opentelemetry.source83.sample_counter0001 []
+opentelemetry.source83.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 42551348500
     inst [2 or "2 inst-2"] value 85102697000
@@ -10525,7 +10525,7 @@ opentelemetry.source83.sample_counter0001 []
     inst [8 or "8 inst-8"] value 340410788000
     inst [9 or "9 inst-9"] value 382962136000
 
-opentelemetry.source83.sample_gauge0000 []
+opentelemetry.source83.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3012.9
     inst [2 or "2 inst-2"] value 6025.8
@@ -10537,7 +10537,7 @@ opentelemetry.source83.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 24103.2
     inst [9 or "9 inst-9"] value 27116.1
 
-opentelemetry.source83.sample_summary0002 []
+opentelemetry.source83.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.040065373
     inst [2 or "quantile: 0.5"] value 0.080130746
@@ -10549,13 +10549,13 @@ opentelemetry.source83.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.320522984
     inst [9 or "quantile: 2.25"] value 0.360588357
 
-opentelemetry.source83.sample_summary0002_count []
+opentelemetry.source83.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 456318
 
-opentelemetry.source83.sample_summary0002_sum []
+opentelemetry.source83.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 349.192899
 
-opentelemetry.source84.sample_counter0001 []
+opentelemetry.source84.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14467458500
     inst [2 or "2 inst-2"] value 28934917000
@@ -10567,7 +10567,7 @@ opentelemetry.source84.sample_counter0001 []
     inst [8 or "8 inst-8"] value 115739668000
     inst [9 or "9 inst-9"] value 130207126000
 
-opentelemetry.source84.sample_gauge0000 []
+opentelemetry.source84.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1016.4
     inst [2 or "2 inst-2"] value 2032.8
@@ -10579,7 +10579,7 @@ opentelemetry.source84.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8131.2
     inst [9 or "9 inst-9"] value 9147.6
 
-opentelemetry.source84.sample_summary0002 []
+opentelemetry.source84.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013727578
     inst [2 or "quantile: 0.5"] value 0.027455156
@@ -10591,13 +10591,13 @@ opentelemetry.source84.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.109820624
     inst [9 or "quantile: 2.25"] value 0.123548202
 
-opentelemetry.source84.sample_summary0002_count []
+opentelemetry.source84.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 156348
 
-opentelemetry.source84.sample_summary0002_sum []
+opentelemetry.source84.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 119.643782
 
-opentelemetry.source84.sample_counter0001 []
+opentelemetry.source84.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 28764711600
     inst [2 or "2 inst-2"] value 57529423200
@@ -10609,7 +10609,7 @@ opentelemetry.source84.sample_counter0001 []
     inst [8 or "8 inst-8"] value 230117693000
     inst [9 or "9 inst-9"] value 258882404000
 
-opentelemetry.source84.sample_gauge0000 []
+opentelemetry.source84.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2032.8
     inst [2 or "2 inst-2"] value 4065.6
@@ -10621,7 +10621,7 @@ opentelemetry.source84.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 16262.4
     inst [9 or "9 inst-9"] value 18295.2
 
-opentelemetry.source84.sample_summary0002 []
+opentelemetry.source84.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.02713591
     inst [2 or "quantile: 0.5"] value 0.05427182000000001
@@ -10633,13 +10633,13 @@ opentelemetry.source84.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.21708728
     inst [9 or "quantile: 2.25"] value 0.24422319
 
-opentelemetry.source84.sample_summary0002_count []
+opentelemetry.source84.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 309060
 
-opentelemetry.source84.sample_summary0002_sum []
+opentelemetry.source84.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 236.505151
 
-opentelemetry.source84.sample_counter0001 []
+opentelemetry.source84.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 43061964700
     inst [2 or "2 inst-2"] value 86123929400
@@ -10651,7 +10651,7 @@ opentelemetry.source84.sample_counter0001 []
     inst [8 or "8 inst-8"] value 344495717000
     inst [9 or "9 inst-9"] value 387557682000
 
-opentelemetry.source84.sample_gauge0000 []
+opentelemetry.source84.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3049.2
     inst [2 or "2 inst-2"] value 6098.4
@@ -10663,7 +10663,7 @@ opentelemetry.source84.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 24393.6
     inst [9 or "9 inst-9"] value 27442.8
 
-opentelemetry.source84.sample_summary0002 []
+opentelemetry.source84.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.040544242
     inst [2 or "quantile: 0.5"] value 0.081088484
@@ -10675,13 +10675,13 @@ opentelemetry.source84.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.324353936
     inst [9 or "quantile: 2.25"] value 0.364898178
 
-opentelemetry.source84.sample_summary0002_count []
+opentelemetry.source84.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 461772
 
-opentelemetry.source84.sample_summary0002_sum []
+opentelemetry.source84.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 353.36652
 
-opentelemetry.source85.sample_counter0001 []
+opentelemetry.source85.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14637663900
     inst [2 or "2 inst-2"] value 29275327800
@@ -10693,7 +10693,7 @@ opentelemetry.source85.sample_counter0001 []
     inst [8 or "8 inst-8"] value 117101311000
     inst [9 or "9 inst-9"] value 131738975000
 
-opentelemetry.source85.sample_gauge0000 []
+opentelemetry.source85.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1028.5
     inst [2 or "2 inst-2"] value 2057
@@ -10705,7 +10705,7 @@ opentelemetry.source85.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8228
     inst [9 or "9 inst-9"] value 9256.5
 
-opentelemetry.source85.sample_summary0002 []
+opentelemetry.source85.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.013887201
     inst [2 or "quantile: 0.5"] value 0.027774402
@@ -10717,13 +10717,13 @@ opentelemetry.source85.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.111097608
     inst [9 or "quantile: 2.25"] value 0.124984809
 
-opentelemetry.source85.sample_summary0002_count []
+opentelemetry.source85.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 158166
 
-opentelemetry.source85.sample_summary0002_sum []
+opentelemetry.source85.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 121.034989
 
-opentelemetry.source85.sample_counter0001 []
+opentelemetry.source85.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 29105122400
     inst [2 or "2 inst-2"] value 58210244700
@@ -10735,7 +10735,7 @@ opentelemetry.source85.sample_counter0001 []
     inst [8 or "8 inst-8"] value 232840979000
     inst [9 or "9 inst-9"] value 261946101000
 
-opentelemetry.source85.sample_gauge0000 []
+opentelemetry.source85.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2057
     inst [2 or "2 inst-2"] value 4114
@@ -10747,7 +10747,7 @@ opentelemetry.source85.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 16456
     inst [9 or "9 inst-9"] value 18513
 
-opentelemetry.source85.sample_summary0002 []
+opentelemetry.source85.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.027455156
     inst [2 or "quantile: 0.5"] value 0.054910312
@@ -10759,13 +10759,13 @@ opentelemetry.source85.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.219641248
     inst [9 or "quantile: 2.25"] value 0.247096404
 
-opentelemetry.source85.sample_summary0002_count []
+opentelemetry.source85.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 312696
 
-opentelemetry.source85.sample_summary0002_sum []
+opentelemetry.source85.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 239.287564
 
-opentelemetry.source85.sample_counter0001 []
+opentelemetry.source85.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 43572580900
     inst [2 or "2 inst-2"] value 87145161700
@@ -10777,7 +10777,7 @@ opentelemetry.source85.sample_counter0001 []
     inst [8 or "8 inst-8"] value 348580647000
     inst [9 or "9 inst-9"] value 392153228000
 
-opentelemetry.source85.sample_gauge0000 []
+opentelemetry.source85.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3085.5
     inst [2 or "2 inst-2"] value 6171
@@ -10789,7 +10789,7 @@ opentelemetry.source85.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 24684
     inst [9 or "9 inst-9"] value 27769.5
 
-opentelemetry.source85.sample_summary0002 []
+opentelemetry.source85.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.041023111
     inst [2 or "quantile: 0.5"] value 0.082046222
@@ -10801,13 +10801,13 @@ opentelemetry.source85.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.328184888
     inst [9 or "quantile: 2.25"] value 0.369207999
 
-opentelemetry.source85.sample_summary0002_count []
+opentelemetry.source85.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 467226
 
-opentelemetry.source85.sample_summary0002_sum []
+opentelemetry.source85.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 357.54014
 
-opentelemetry.source86.sample_counter0001 []
+opentelemetry.source86.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14807869300
     inst [2 or "2 inst-2"] value 29615738600
@@ -10819,7 +10819,7 @@ opentelemetry.source86.sample_counter0001 []
     inst [8 or "8 inst-8"] value 118462954000
     inst [9 or "9 inst-9"] value 133270824000
 
-opentelemetry.source86.sample_gauge0000 []
+opentelemetry.source86.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1040.6
     inst [2 or "2 inst-2"] value 2081.2
@@ -10831,7 +10831,7 @@ opentelemetry.source86.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8324.799999999999
     inst [9 or "9 inst-9"] value 9365.4
 
-opentelemetry.source86.sample_summary0002 []
+opentelemetry.source86.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.014046824
     inst [2 or "quantile: 0.5"] value 0.028093648
@@ -10843,13 +10843,13 @@ opentelemetry.source86.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.112374592
     inst [9 or "quantile: 2.25"] value 0.126421416
 
-opentelemetry.source86.sample_summary0002_count []
+opentelemetry.source86.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 159984
 
-opentelemetry.source86.sample_summary0002_sum []
+opentelemetry.source86.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 122.426196
 
-opentelemetry.source86.sample_counter0001 []
+opentelemetry.source86.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 29445533200
     inst [2 or "2 inst-2"] value 58891066300
@@ -10861,7 +10861,7 @@ opentelemetry.source86.sample_counter0001 []
     inst [8 or "8 inst-8"] value 235564265000
     inst [9 or "9 inst-9"] value 265009798000
 
-opentelemetry.source86.sample_gauge0000 []
+opentelemetry.source86.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2081.2
     inst [2 or "2 inst-2"] value 4162.4
@@ -10873,7 +10873,7 @@ opentelemetry.source86.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 16649.6
     inst [9 or "9 inst-9"] value 18730.8
 
-opentelemetry.source86.sample_summary0002 []
+opentelemetry.source86.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.027774402
     inst [2 or "quantile: 0.5"] value 0.05554880400000001
@@ -10885,13 +10885,13 @@ opentelemetry.source86.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.222195216
     inst [9 or "quantile: 2.25"] value 0.249969618
 
-opentelemetry.source86.sample_summary0002_count []
+opentelemetry.source86.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 316332
 
-opentelemetry.source86.sample_summary0002_sum []
+opentelemetry.source86.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 242.069978
 
-opentelemetry.source86.sample_counter0001 []
+opentelemetry.source86.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 44083197000
     inst [2 or "2 inst-2"] value 88166394100
@@ -10903,7 +10903,7 @@ opentelemetry.source86.sample_counter0001 []
     inst [8 or "8 inst-8"] value 352665576000
     inst [9 or "9 inst-9"] value 396748773000
 
-opentelemetry.source86.sample_gauge0000 []
+opentelemetry.source86.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3121.8
     inst [2 or "2 inst-2"] value 6243.6
@@ -10915,7 +10915,7 @@ opentelemetry.source86.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 24974.4
     inst [9 or "9 inst-9"] value 28096.2
 
-opentelemetry.source86.sample_summary0002 []
+opentelemetry.source86.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.04150198
     inst [2 or "quantile: 0.5"] value 0.08300396
@@ -10927,13 +10927,13 @@ opentelemetry.source86.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.33201584
     inst [9 or "quantile: 2.25"] value 0.3735178200000001
 
-opentelemetry.source86.sample_summary0002_count []
+opentelemetry.source86.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 472680
 
-opentelemetry.source86.sample_summary0002_sum []
+opentelemetry.source86.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 361.71376
 
-opentelemetry.source87.sample_counter0001 []
+opentelemetry.source87.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 14978074700
     inst [2 or "2 inst-2"] value 29956149300
@@ -10945,7 +10945,7 @@ opentelemetry.source87.sample_counter0001 []
     inst [8 or "8 inst-8"] value 119824597000
     inst [9 or "9 inst-9"] value 134802672000
 
-opentelemetry.source87.sample_gauge0000 []
+opentelemetry.source87.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1052.7
     inst [2 or "2 inst-2"] value 2105.4
@@ -10957,7 +10957,7 @@ opentelemetry.source87.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8421.6
     inst [9 or "9 inst-9"] value 9474.299999999999
 
-opentelemetry.source87.sample_summary0002 []
+opentelemetry.source87.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.014206447
     inst [2 or "quantile: 0.5"] value 0.028412894
@@ -10969,13 +10969,13 @@ opentelemetry.source87.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.113651576
     inst [9 or "quantile: 2.25"] value 0.127858023
 
-opentelemetry.source87.sample_summary0002_count []
+opentelemetry.source87.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 161802
 
-opentelemetry.source87.sample_summary0002_sum []
+opentelemetry.source87.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 123.817403
 
-opentelemetry.source87.sample_counter0001 []
+opentelemetry.source87.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 29785944000
     inst [2 or "2 inst-2"] value 59571887900
@@ -10987,7 +10987,7 @@ opentelemetry.source87.sample_counter0001 []
     inst [8 or "8 inst-8"] value 238287552000
     inst [9 or "9 inst-9"] value 268073496000
 
-opentelemetry.source87.sample_gauge0000 []
+opentelemetry.source87.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2105.4
     inst [2 or "2 inst-2"] value 4210.8
@@ -10999,7 +10999,7 @@ opentelemetry.source87.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 16843.2
     inst [9 or "9 inst-9"] value 18948.6
 
-opentelemetry.source87.sample_summary0002 []
+opentelemetry.source87.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.028093648
     inst [2 or "quantile: 0.5"] value 0.056187296
@@ -11011,13 +11011,13 @@ opentelemetry.source87.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.224749184
     inst [9 or "quantile: 2.25"] value 0.252842832
 
-opentelemetry.source87.sample_summary0002_count []
+opentelemetry.source87.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 319968
 
-opentelemetry.source87.sample_summary0002_sum []
+opentelemetry.source87.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 244.852392
 
-opentelemetry.source87.sample_counter0001 []
+opentelemetry.source87.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 44593813200
     inst [2 or "2 inst-2"] value 89187626500
@@ -11029,7 +11029,7 @@ opentelemetry.source87.sample_counter0001 []
     inst [8 or "8 inst-8"] value 356750506000
     inst [9 or "9 inst-9"] value 401344319000
 
-opentelemetry.source87.sample_gauge0000 []
+opentelemetry.source87.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3158.1
     inst [2 or "2 inst-2"] value 6316.2
@@ -11041,7 +11041,7 @@ opentelemetry.source87.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 25264.8
     inst [9 or "9 inst-9"] value 28422.9
 
-opentelemetry.source87.sample_summary0002 []
+opentelemetry.source87.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.041980849
     inst [2 or "quantile: 0.5"] value 0.083961698
@@ -11053,13 +11053,13 @@ opentelemetry.source87.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.335846792
     inst [9 or "quantile: 2.25"] value 0.377827641
 
-opentelemetry.source87.sample_summary0002_count []
+opentelemetry.source87.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 478134
 
-opentelemetry.source87.sample_summary0002_sum []
+opentelemetry.source87.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 365.887381
 
-opentelemetry.source88.sample_counter0001 []
+opentelemetry.source88.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 15148280100
     inst [2 or "2 inst-2"] value 30296560100
@@ -11071,7 +11071,7 @@ opentelemetry.source88.sample_counter0001 []
     inst [8 or "8 inst-8"] value 121186241000
     inst [9 or "9 inst-9"] value 136334521000
 
-opentelemetry.source88.sample_gauge0000 []
+opentelemetry.source88.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1064.8
     inst [2 or "2 inst-2"] value 2129.6
@@ -11083,7 +11083,7 @@ opentelemetry.source88.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8518.4
     inst [9 or "9 inst-9"] value 9583.200000000001
 
-opentelemetry.source88.sample_summary0002 []
+opentelemetry.source88.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.01436607
     inst [2 or "quantile: 0.5"] value 0.02873214
@@ -11095,13 +11095,13 @@ opentelemetry.source88.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.11492856
     inst [9 or "quantile: 2.25"] value 0.12929463
 
-opentelemetry.source88.sample_summary0002_count []
+opentelemetry.source88.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 163620
 
-opentelemetry.source88.sample_summary0002_sum []
+opentelemetry.source88.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 125.208609
 
-opentelemetry.source88.sample_counter0001 []
+opentelemetry.source88.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 30126354700
     inst [2 or "2 inst-2"] value 60252709500
@@ -11113,7 +11113,7 @@ opentelemetry.source88.sample_counter0001 []
     inst [8 or "8 inst-8"] value 241010838000
     inst [9 or "9 inst-9"] value 271137193000
 
-opentelemetry.source88.sample_gauge0000 []
+opentelemetry.source88.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2129.6
     inst [2 or "2 inst-2"] value 4259.2
@@ -11125,7 +11125,7 @@ opentelemetry.source88.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 17036.8
     inst [9 or "9 inst-9"] value 19166.4
 
-opentelemetry.source88.sample_summary0002 []
+opentelemetry.source88.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.028412894
     inst [2 or "quantile: 0.5"] value 0.056825788
@@ -11137,13 +11137,13 @@ opentelemetry.source88.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.227303152
     inst [9 or "quantile: 2.25"] value 0.255716046
 
-opentelemetry.source88.sample_summary0002_count []
+opentelemetry.source88.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 323604
 
-opentelemetry.source88.sample_summary0002_sum []
+opentelemetry.source88.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 247.634805
 
-opentelemetry.source88.sample_counter0001 []
+opentelemetry.source88.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 45104429400
     inst [2 or "2 inst-2"] value 90208858800
@@ -11155,7 +11155,7 @@ opentelemetry.source88.sample_counter0001 []
     inst [8 or "8 inst-8"] value 360835435000
     inst [9 or "9 inst-9"] value 405939865000
 
-opentelemetry.source88.sample_gauge0000 []
+opentelemetry.source88.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3194.4
     inst [2 or "2 inst-2"] value 6388.8
@@ -11167,7 +11167,7 @@ opentelemetry.source88.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 25555.2
     inst [9 or "9 inst-9"] value 28749.6
 
-opentelemetry.source88.sample_summary0002 []
+opentelemetry.source88.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.042459718
     inst [2 or "quantile: 0.5"] value 0.084919436
@@ -11179,13 +11179,13 @@ opentelemetry.source88.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.339677744
     inst [9 or "quantile: 2.25"] value 0.382137462
 
-opentelemetry.source88.sample_summary0002_count []
+opentelemetry.source88.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 483588
 
-opentelemetry.source88.sample_summary0002_sum []
+opentelemetry.source88.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 370.061001
 
-opentelemetry.source89.sample_counter0001 []
+opentelemetry.source89.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 15318485500
     inst [2 or "2 inst-2"] value 30636970900
@@ -11197,7 +11197,7 @@ opentelemetry.source89.sample_counter0001 []
     inst [8 or "8 inst-8"] value 122547884000
     inst [9 or "9 inst-9"] value 137866369000
 
-opentelemetry.source89.sample_gauge0000 []
+opentelemetry.source89.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1076.9
     inst [2 or "2 inst-2"] value 2153.8
@@ -11209,7 +11209,7 @@ opentelemetry.source89.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8615.200000000001
     inst [9 or "9 inst-9"] value 9692.1
 
-opentelemetry.source89.sample_summary0002 []
+opentelemetry.source89.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.014525693
     inst [2 or "quantile: 0.5"] value 0.029051386
@@ -11221,13 +11221,13 @@ opentelemetry.source89.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.116205544
     inst [9 or "quantile: 2.25"] value 0.130731237
 
-opentelemetry.source89.sample_summary0002_count []
+opentelemetry.source89.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 165438
 
-opentelemetry.source89.sample_summary0002_sum []
+opentelemetry.source89.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 126.599816
 
-opentelemetry.source89.sample_counter0001 []
+opentelemetry.source89.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 30466765500
     inst [2 or "2 inst-2"] value 60933531100
@@ -11239,7 +11239,7 @@ opentelemetry.source89.sample_counter0001 []
     inst [8 or "8 inst-8"] value 243734124000
     inst [9 or "9 inst-9"] value 274200890000
 
-opentelemetry.source89.sample_gauge0000 []
+opentelemetry.source89.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2153.8
     inst [2 or "2 inst-2"] value 4307.6
@@ -11251,7 +11251,7 @@ opentelemetry.source89.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 17230.4
     inst [9 or "9 inst-9"] value 19384.2
 
-opentelemetry.source89.sample_summary0002 []
+opentelemetry.source89.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.02873214
     inst [2 or "quantile: 0.5"] value 0.05746428000000001
@@ -11263,13 +11263,13 @@ opentelemetry.source89.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.22985712
     inst [9 or "quantile: 2.25"] value 0.25858926
 
-opentelemetry.source89.sample_summary0002_count []
+opentelemetry.source89.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 327240
 
-opentelemetry.source89.sample_summary0002_sum []
+opentelemetry.source89.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 250.417219
 
-opentelemetry.source89.sample_counter0001 []
+opentelemetry.source89.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 45615045600
     inst [2 or "2 inst-2"] value 91230091200
@@ -11281,7 +11281,7 @@ opentelemetry.source89.sample_counter0001 []
     inst [8 or "8 inst-8"] value 364920365000
     inst [9 or "9 inst-9"] value 410535410000
 
-opentelemetry.source89.sample_gauge0000 []
+opentelemetry.source89.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3230.7
     inst [2 or "2 inst-2"] value 6461.4
@@ -11293,7 +11293,7 @@ opentelemetry.source89.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 25845.6
     inst [9 or "9 inst-9"] value 29076.3
 
-opentelemetry.source89.sample_summary0002 []
+opentelemetry.source89.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.042938587
     inst [2 or "quantile: 0.5"] value 0.085877174
@@ -11305,13 +11305,13 @@ opentelemetry.source89.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.343508696
     inst [9 or "quantile: 2.25"] value 0.386447283
 
-opentelemetry.source89.sample_summary0002_count []
+opentelemetry.source89.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 489042
 
-opentelemetry.source89.sample_summary0002_sum []
+opentelemetry.source89.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 374.234621
 
-opentelemetry.source90.sample_counter0001 []
+opentelemetry.source90.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 15488690900
     inst [2 or "2 inst-2"] value 30977381700
@@ -11323,7 +11323,7 @@ opentelemetry.source90.sample_counter0001 []
     inst [8 or "8 inst-8"] value 123909527000
     inst [9 or "9 inst-9"] value 139398218000
 
-opentelemetry.source90.sample_gauge0000 []
+opentelemetry.source90.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1089
     inst [2 or "2 inst-2"] value 2178
@@ -11335,7 +11335,7 @@ opentelemetry.source90.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8712
     inst [9 or "9 inst-9"] value 9801
 
-opentelemetry.source90.sample_summary0002 []
+opentelemetry.source90.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.014685316
     inst [2 or "quantile: 0.5"] value 0.029370632
@@ -11347,13 +11347,13 @@ opentelemetry.source90.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.117482528
     inst [9 or "quantile: 2.25"] value 0.132167844
 
-opentelemetry.source90.sample_summary0002_count []
+opentelemetry.source90.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 167256
 
-opentelemetry.source90.sample_summary0002_sum []
+opentelemetry.source90.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 127.991023
 
-opentelemetry.source90.sample_counter0001 []
+opentelemetry.source90.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 30807176300
     inst [2 or "2 inst-2"] value 61614352600
@@ -11365,7 +11365,7 @@ opentelemetry.source90.sample_counter0001 []
     inst [8 or "8 inst-8"] value 246457411000
     inst [9 or "9 inst-9"] value 277264587000
 
-opentelemetry.source90.sample_gauge0000 []
+opentelemetry.source90.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2178
     inst [2 or "2 inst-2"] value 4356
@@ -11377,7 +11377,7 @@ opentelemetry.source90.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 17424
     inst [9 or "9 inst-9"] value 19602
 
-opentelemetry.source90.sample_summary0002 []
+opentelemetry.source90.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.029051386
     inst [2 or "quantile: 0.5"] value 0.058102772
@@ -11389,13 +11389,13 @@ opentelemetry.source90.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.232411088
     inst [9 or "quantile: 2.25"] value 0.261462474
 
-opentelemetry.source90.sample_summary0002_count []
+opentelemetry.source90.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 330876
 
-opentelemetry.source90.sample_summary0002_sum []
+opentelemetry.source90.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 253.199632
 
-opentelemetry.source90.sample_counter0001 []
+opentelemetry.source90.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 46125661800
     inst [2 or "2 inst-2"] value 92251323500
@@ -11407,7 +11407,7 @@ opentelemetry.source90.sample_counter0001 []
     inst [8 or "8 inst-8"] value 369005294000
     inst [9 or "9 inst-9"] value 415130956000
 
-opentelemetry.source90.sample_gauge0000 []
+opentelemetry.source90.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3267
     inst [2 or "2 inst-2"] value 6534
@@ -11419,7 +11419,7 @@ opentelemetry.source90.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 26136
     inst [9 or "9 inst-9"] value 29403
 
-opentelemetry.source90.sample_summary0002 []
+opentelemetry.source90.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.04341745600000001
     inst [2 or "quantile: 0.5"] value 0.08683491200000001
@@ -11431,13 +11431,13 @@ opentelemetry.source90.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.3473396480000001
     inst [9 or "quantile: 2.25"] value 0.390757104
 
-opentelemetry.source90.sample_summary0002_count []
+opentelemetry.source90.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 494496
 
-opentelemetry.source90.sample_summary0002_sum []
+opentelemetry.source90.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 378.408241
 
-opentelemetry.source91.sample_counter0001 []
+opentelemetry.source91.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 15658896200
     inst [2 or "2 inst-2"] value 31317792500
@@ -11449,7 +11449,7 @@ opentelemetry.source91.sample_counter0001 []
     inst [8 or "8 inst-8"] value 125271170000
     inst [9 or "9 inst-9"] value 140930066000
 
-opentelemetry.source91.sample_gauge0000 []
+opentelemetry.source91.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1101.1
     inst [2 or "2 inst-2"] value 2202.2
@@ -11461,7 +11461,7 @@ opentelemetry.source91.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8808.799999999999
     inst [9 or "9 inst-9"] value 9909.9
 
-opentelemetry.source91.sample_summary0002 []
+opentelemetry.source91.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.014844939
     inst [2 or "quantile: 0.5"] value 0.029689878
@@ -11473,13 +11473,13 @@ opentelemetry.source91.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.118759512
     inst [9 or "quantile: 2.25"] value 0.133604451
 
-opentelemetry.source91.sample_summary0002_count []
+opentelemetry.source91.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 169074
 
-opentelemetry.source91.sample_summary0002_sum []
+opentelemetry.source91.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 129.38223
 
-opentelemetry.source91.sample_counter0001 []
+opentelemetry.source91.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 31147587100
     inst [2 or "2 inst-2"] value 62295174200
@@ -11491,7 +11491,7 @@ opentelemetry.source91.sample_counter0001 []
     inst [8 or "8 inst-8"] value 249180697000
     inst [9 or "9 inst-9"] value 280328284000
 
-opentelemetry.source91.sample_gauge0000 []
+opentelemetry.source91.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2202.2
     inst [2 or "2 inst-2"] value 4404.4
@@ -11503,7 +11503,7 @@ opentelemetry.source91.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 17617.6
     inst [9 or "9 inst-9"] value 19819.8
 
-opentelemetry.source91.sample_summary0002 []
+opentelemetry.source91.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.029370632
     inst [2 or "quantile: 0.5"] value 0.058741264
@@ -11515,13 +11515,13 @@ opentelemetry.source91.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.234965056
     inst [9 or "quantile: 2.25"] value 0.264335688
 
-opentelemetry.source91.sample_summary0002_count []
+opentelemetry.source91.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 334512
 
-opentelemetry.source91.sample_summary0002_sum []
+opentelemetry.source91.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 255.982046
 
-opentelemetry.source91.sample_counter0001 []
+opentelemetry.source91.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 46636278000
     inst [2 or "2 inst-2"] value 93272555900
@@ -11533,7 +11533,7 @@ opentelemetry.source91.sample_counter0001 []
     inst [8 or "8 inst-8"] value 373090224000
     inst [9 or "9 inst-9"] value 419726502000
 
-opentelemetry.source91.sample_gauge0000 []
+opentelemetry.source91.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3303.3
     inst [2 or "2 inst-2"] value 6606.6
@@ -11545,7 +11545,7 @@ opentelemetry.source91.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 26426.4
     inst [9 or "9 inst-9"] value 29729.7
 
-opentelemetry.source91.sample_summary0002 []
+opentelemetry.source91.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.04389632500000001
     inst [2 or "quantile: 0.5"] value 0.08779265000000001
@@ -11557,13 +11557,13 @@ opentelemetry.source91.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.3511706000000001
     inst [9 or "quantile: 2.25"] value 0.395066925
 
-opentelemetry.source91.sample_summary0002_count []
+opentelemetry.source91.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 499950
 
-opentelemetry.source91.sample_summary0002_sum []
+opentelemetry.source91.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 382.581862
 
-opentelemetry.source92.sample_counter0001 []
+opentelemetry.source92.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 15829101600
     inst [2 or "2 inst-2"] value 31658203300
@@ -11575,7 +11575,7 @@ opentelemetry.source92.sample_counter0001 []
     inst [8 or "8 inst-8"] value 126632813000
     inst [9 or "9 inst-9"] value 142461915000
 
-opentelemetry.source92.sample_gauge0000 []
+opentelemetry.source92.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1113.2
     inst [2 or "2 inst-2"] value 2226.4
@@ -11587,7 +11587,7 @@ opentelemetry.source92.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 8905.6
     inst [9 or "9 inst-9"] value 10018.8
 
-opentelemetry.source92.sample_summary0002 []
+opentelemetry.source92.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.015004562
     inst [2 or "quantile: 0.5"] value 0.030009124
@@ -11599,13 +11599,13 @@ opentelemetry.source92.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.120036496
     inst [9 or "quantile: 2.25"] value 0.135041058
 
-opentelemetry.source92.sample_summary0002_count []
+opentelemetry.source92.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 170892
 
-opentelemetry.source92.sample_summary0002_sum []
+opentelemetry.source92.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 130.773436
 
-opentelemetry.source92.sample_counter0001 []
+opentelemetry.source92.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 31487997900
     inst [2 or "2 inst-2"] value 62975995800
@@ -11617,7 +11617,7 @@ opentelemetry.source92.sample_counter0001 []
     inst [8 or "8 inst-8"] value 251903983000
     inst [9 or "9 inst-9"] value 283391981000
 
-opentelemetry.source92.sample_gauge0000 []
+opentelemetry.source92.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2226.4
     inst [2 or "2 inst-2"] value 4452.8
@@ -11629,7 +11629,7 @@ opentelemetry.source92.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 17811.2
     inst [9 or "9 inst-9"] value 20037.6
 
-opentelemetry.source92.sample_summary0002 []
+opentelemetry.source92.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.029689878
     inst [2 or "quantile: 0.5"] value 0.05937975600000001
@@ -11641,13 +11641,13 @@ opentelemetry.source92.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.237519024
     inst [9 or "quantile: 2.25"] value 0.267208902
 
-opentelemetry.source92.sample_summary0002_count []
+opentelemetry.source92.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 338148
 
-opentelemetry.source92.sample_summary0002_sum []
+opentelemetry.source92.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 258.764459
 
-opentelemetry.source92.sample_counter0001 []
+opentelemetry.source92.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 47146894100
     inst [2 or "2 inst-2"] value 94293788300
@@ -11659,7 +11659,7 @@ opentelemetry.source92.sample_counter0001 []
     inst [8 or "8 inst-8"] value 377175153000
     inst [9 or "9 inst-9"] value 424322047000
 
-opentelemetry.source92.sample_gauge0000 []
+opentelemetry.source92.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3339.6
     inst [2 or "2 inst-2"] value 6679.2
@@ -11671,7 +11671,7 @@ opentelemetry.source92.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 26716.8
     inst [9 or "9 inst-9"] value 30056.4
 
-opentelemetry.source92.sample_summary0002 []
+opentelemetry.source92.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.04437519400000001
     inst [2 or "quantile: 0.5"] value 0.08875038800000001
@@ -11683,13 +11683,13 @@ opentelemetry.source92.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.3550015520000001
     inst [9 or "quantile: 2.25"] value 0.3993767460000001
 
-opentelemetry.source92.sample_summary0002_count []
+opentelemetry.source92.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 505404
 
-opentelemetry.source92.sample_summary0002_sum []
+opentelemetry.source92.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 386.755482
 
-opentelemetry.source93.sample_counter0001 []
+opentelemetry.source93.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 15999307000
     inst [2 or "2 inst-2"] value 31998614100
@@ -11701,7 +11701,7 @@ opentelemetry.source93.sample_counter0001 []
     inst [8 or "8 inst-8"] value 127994456000
     inst [9 or "9 inst-9"] value 143993763000
 
-opentelemetry.source93.sample_gauge0000 []
+opentelemetry.source93.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1125.3
     inst [2 or "2 inst-2"] value 2250.6
@@ -11713,7 +11713,7 @@ opentelemetry.source93.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9002.4
     inst [9 or "9 inst-9"] value 10127.7
 
-opentelemetry.source93.sample_summary0002 []
+opentelemetry.source93.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.015164185
     inst [2 or "quantile: 0.5"] value 0.03032837
@@ -11725,13 +11725,13 @@ opentelemetry.source93.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.12131348
     inst [9 or "quantile: 2.25"] value 0.136477665
 
-opentelemetry.source93.sample_summary0002_count []
+opentelemetry.source93.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 172710
 
-opentelemetry.source93.sample_summary0002_sum []
+opentelemetry.source93.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 132.164643
 
-opentelemetry.source93.sample_counter0001 []
+opentelemetry.source93.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 31828408700
     inst [2 or "2 inst-2"] value 63656817400
@@ -11743,7 +11743,7 @@ opentelemetry.source93.sample_counter0001 []
     inst [8 or "8 inst-8"] value 254627269000
     inst [9 or "9 inst-9"] value 286455678000
 
-opentelemetry.source93.sample_gauge0000 []
+opentelemetry.source93.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2250.6
     inst [2 or "2 inst-2"] value 4501.2
@@ -11755,7 +11755,7 @@ opentelemetry.source93.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 18004.8
     inst [9 or "9 inst-9"] value 20255.4
 
-opentelemetry.source93.sample_summary0002 []
+opentelemetry.source93.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.030009124
     inst [2 or "quantile: 0.5"] value 0.060018248
@@ -11767,13 +11767,13 @@ opentelemetry.source93.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.240072992
     inst [9 or "quantile: 2.25"] value 0.270082116
 
-opentelemetry.source93.sample_summary0002_count []
+opentelemetry.source93.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 341784
 
-opentelemetry.source93.sample_summary0002_sum []
+opentelemetry.source93.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 261.546873
 
-opentelemetry.source93.sample_counter0001 []
+opentelemetry.source93.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 47657510300
     inst [2 or "2 inst-2"] value 95315020600
@@ -11785,7 +11785,7 @@ opentelemetry.source93.sample_counter0001 []
     inst [8 or "8 inst-8"] value 381260083000
     inst [9 or "9 inst-9"] value 428917593000
 
-opentelemetry.source93.sample_gauge0000 []
+opentelemetry.source93.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3375.9
     inst [2 or "2 inst-2"] value 6751.8
@@ -11797,7 +11797,7 @@ opentelemetry.source93.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 27007.2
     inst [9 or "9 inst-9"] value 30383.1
 
-opentelemetry.source93.sample_summary0002 []
+opentelemetry.source93.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.04485406300000001
     inst [2 or "quantile: 0.5"] value 0.08970812600000001
@@ -11809,13 +11809,13 @@ opentelemetry.source93.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.3588325040000001
     inst [9 or "quantile: 2.25"] value 0.4036865670000001
 
-opentelemetry.source93.sample_summary0002_count []
+opentelemetry.source93.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 510858
 
-opentelemetry.source93.sample_summary0002_sum []
+opentelemetry.source93.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 390.929102
 
-opentelemetry.source94.sample_counter0001 []
+opentelemetry.source94.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 16169512400
     inst [2 or "2 inst-2"] value 32339024900
@@ -11827,7 +11827,7 @@ opentelemetry.source94.sample_counter0001 []
     inst [8 or "8 inst-8"] value 129356099000
     inst [9 or "9 inst-9"] value 145525612000
 
-opentelemetry.source94.sample_gauge0000 []
+opentelemetry.source94.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1137.4
     inst [2 or "2 inst-2"] value 2274.8
@@ -11839,7 +11839,7 @@ opentelemetry.source94.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9099.200000000001
     inst [9 or "9 inst-9"] value 10236.6
 
-opentelemetry.source94.sample_summary0002 []
+opentelemetry.source94.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.015323808
     inst [2 or "quantile: 0.5"] value 0.030647616
@@ -11851,13 +11851,13 @@ opentelemetry.source94.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.122590464
     inst [9 or "quantile: 2.25"] value 0.137914272
 
-opentelemetry.source94.sample_summary0002_count []
+opentelemetry.source94.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 174528
 
-opentelemetry.source94.sample_summary0002_sum []
+opentelemetry.source94.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 133.55585
 
-opentelemetry.source94.sample_counter0001 []
+opentelemetry.source94.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 32168819500
     inst [2 or "2 inst-2"] value 64337638900
@@ -11869,7 +11869,7 @@ opentelemetry.source94.sample_counter0001 []
     inst [8 or "8 inst-8"] value 257350556000
     inst [9 or "9 inst-9"] value 289519375000
 
-opentelemetry.source94.sample_gauge0000 []
+opentelemetry.source94.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2274.8
     inst [2 or "2 inst-2"] value 4549.6
@@ -11881,7 +11881,7 @@ opentelemetry.source94.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 18198.4
     inst [9 or "9 inst-9"] value 20473.2
 
-opentelemetry.source94.sample_summary0002 []
+opentelemetry.source94.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.03032837
     inst [2 or "quantile: 0.5"] value 0.06065674000000001
@@ -11893,13 +11893,13 @@ opentelemetry.source94.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.24262696
     inst [9 or "quantile: 2.25"] value 0.27295533
 
-opentelemetry.source94.sample_summary0002_count []
+opentelemetry.source94.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 345420
 
-opentelemetry.source94.sample_summary0002_sum []
+opentelemetry.source94.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 264.329286
 
-opentelemetry.source94.sample_counter0001 []
+opentelemetry.source94.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 48168126500
     inst [2 or "2 inst-2"] value 96336253000
@@ -11911,7 +11911,7 @@ opentelemetry.source94.sample_counter0001 []
     inst [8 or "8 inst-8"] value 385345012000
     inst [9 or "9 inst-9"] value 433513139000
 
-opentelemetry.source94.sample_gauge0000 []
+opentelemetry.source94.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3412.2
     inst [2 or "2 inst-2"] value 6824.4
@@ -11923,7 +11923,7 @@ opentelemetry.source94.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 27297.6
     inst [9 or "9 inst-9"] value 30709.8
 
-opentelemetry.source94.sample_summary0002 []
+opentelemetry.source94.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.04533293200000001
     inst [2 or "quantile: 0.5"] value 0.09066586400000001
@@ -11935,13 +11935,13 @@ opentelemetry.source94.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.3626634560000001
     inst [9 or "quantile: 2.25"] value 0.407996388
 
-opentelemetry.source94.sample_summary0002_count []
+opentelemetry.source94.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 516312
 
-opentelemetry.source94.sample_summary0002_sum []
+opentelemetry.source94.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 395.102723
 
-opentelemetry.source95.sample_counter0001 []
+opentelemetry.source95.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 16339717800
     inst [2 or "2 inst-2"] value 32679435600
@@ -11953,7 +11953,7 @@ opentelemetry.source95.sample_counter0001 []
     inst [8 or "8 inst-8"] value 130717743000
     inst [9 or "9 inst-9"] value 147057460000
 
-opentelemetry.source95.sample_gauge0000 []
+opentelemetry.source95.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1149.5
     inst [2 or "2 inst-2"] value 2299
@@ -11965,7 +11965,7 @@ opentelemetry.source95.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9196
     inst [9 or "9 inst-9"] value 10345.5
 
-opentelemetry.source95.sample_summary0002 []
+opentelemetry.source95.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.015483431
     inst [2 or "quantile: 0.5"] value 0.030966862
@@ -11977,13 +11977,13 @@ opentelemetry.source95.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.123867448
     inst [9 or "quantile: 2.25"] value 0.139350879
 
-opentelemetry.source95.sample_summary0002_count []
+opentelemetry.source95.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 176346
 
-opentelemetry.source95.sample_summary0002_sum []
+opentelemetry.source95.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 134.947057
 
-opentelemetry.source95.sample_counter0001 []
+opentelemetry.source95.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 32509230300
     inst [2 or "2 inst-2"] value 65018460500
@@ -11995,7 +11995,7 @@ opentelemetry.source95.sample_counter0001 []
     inst [8 or "8 inst-8"] value 260073842000
     inst [9 or "9 inst-9"] value 292583072000
 
-opentelemetry.source95.sample_gauge0000 []
+opentelemetry.source95.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2299
     inst [2 or "2 inst-2"] value 4598
@@ -12007,7 +12007,7 @@ opentelemetry.source95.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 18392
     inst [9 or "9 inst-9"] value 20691
 
-opentelemetry.source95.sample_summary0002 []
+opentelemetry.source95.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.030647616
     inst [2 or "quantile: 0.5"] value 0.06129523200000001
@@ -12019,13 +12019,13 @@ opentelemetry.source95.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.245180928
     inst [9 or "quantile: 2.25"] value 0.275828544
 
-opentelemetry.source95.sample_summary0002_count []
+opentelemetry.source95.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 349056
 
-opentelemetry.source95.sample_summary0002_sum []
+opentelemetry.source95.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 267.1117
 
-opentelemetry.source95.sample_counter0001 []
+opentelemetry.source95.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 48678742700
     inst [2 or "2 inst-2"] value 97357485400
@@ -12037,7 +12037,7 @@ opentelemetry.source95.sample_counter0001 []
     inst [8 or "8 inst-8"] value 389429941000
     inst [9 or "9 inst-9"] value 438108684000
 
-opentelemetry.source95.sample_gauge0000 []
+opentelemetry.source95.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3448.5
     inst [2 or "2 inst-2"] value 6897
@@ -12049,7 +12049,7 @@ opentelemetry.source95.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 27588
     inst [9 or "9 inst-9"] value 31036.5
 
-opentelemetry.source95.sample_summary0002 []
+opentelemetry.source95.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.04581180100000001
     inst [2 or "quantile: 0.5"] value 0.09162360200000001
@@ -12061,13 +12061,13 @@ opentelemetry.source95.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.366494408
     inst [9 or "quantile: 2.25"] value 0.412306209
 
-opentelemetry.source95.sample_summary0002_count []
+opentelemetry.source95.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 521766
 
-opentelemetry.source95.sample_summary0002_sum []
+opentelemetry.source95.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 399.276343
 
-opentelemetry.source96.sample_counter0001 []
+opentelemetry.source96.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 16509923200
     inst [2 or "2 inst-2"] value 33019846400
@@ -12079,7 +12079,7 @@ opentelemetry.source96.sample_counter0001 []
     inst [8 or "8 inst-8"] value 132079386000
     inst [9 or "9 inst-9"] value 148589309000
 
-opentelemetry.source96.sample_gauge0000 []
+opentelemetry.source96.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1161.6
     inst [2 or "2 inst-2"] value 2323.2
@@ -12091,7 +12091,7 @@ opentelemetry.source96.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9292.799999999999
     inst [9 or "9 inst-9"] value 10454.4
 
-opentelemetry.source96.sample_summary0002 []
+opentelemetry.source96.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.015643054
     inst [2 or "quantile: 0.5"] value 0.031286108
@@ -12103,13 +12103,13 @@ opentelemetry.source96.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.125144432
     inst [9 or "quantile: 2.25"] value 0.140787486
 
-opentelemetry.source96.sample_summary0002_count []
+opentelemetry.source96.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 178164
 
-opentelemetry.source96.sample_summary0002_sum []
+opentelemetry.source96.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 136.338263
 
-opentelemetry.source96.sample_counter0001 []
+opentelemetry.source96.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 32849641000
     inst [2 or "2 inst-2"] value 65699282100
@@ -12121,7 +12121,7 @@ opentelemetry.source96.sample_counter0001 []
     inst [8 or "8 inst-8"] value 262797128000
     inst [9 or "9 inst-9"] value 295646769000
 
-opentelemetry.source96.sample_gauge0000 []
+opentelemetry.source96.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2323.2
     inst [2 or "2 inst-2"] value 4646.4
@@ -12133,7 +12133,7 @@ opentelemetry.source96.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 18585.6
     inst [9 or "9 inst-9"] value 20908.8
 
-opentelemetry.source96.sample_summary0002 []
+opentelemetry.source96.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.030966862
     inst [2 or "quantile: 0.5"] value 0.061933724
@@ -12145,13 +12145,13 @@ opentelemetry.source96.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.247734896
     inst [9 or "quantile: 2.25"] value 0.278701758
 
-opentelemetry.source96.sample_summary0002_count []
+opentelemetry.source96.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 352692
 
-opentelemetry.source96.sample_summary0002_sum []
+opentelemetry.source96.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 269.894113
 
-opentelemetry.source96.sample_counter0001 []
+opentelemetry.source96.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 49189358900
     inst [2 or "2 inst-2"] value 98378717700
@@ -12163,7 +12163,7 @@ opentelemetry.source96.sample_counter0001 []
     inst [8 or "8 inst-8"] value 393514871000
     inst [9 or "9 inst-9"] value 442704230000
 
-opentelemetry.source96.sample_gauge0000 []
+opentelemetry.source96.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3484.8
     inst [2 or "2 inst-2"] value 6969.6
@@ -12175,7 +12175,7 @@ opentelemetry.source96.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 27878.4
     inst [9 or "9 inst-9"] value 31363.2
 
-opentelemetry.source96.sample_summary0002 []
+opentelemetry.source96.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.04629067000000001
     inst [2 or "quantile: 0.5"] value 0.09258134000000001
@@ -12187,13 +12187,13 @@ opentelemetry.source96.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.37032536
     inst [9 or "quantile: 2.25"] value 0.41661603
 
-opentelemetry.source96.sample_summary0002_count []
+opentelemetry.source96.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 527220
 
-opentelemetry.source96.sample_summary0002_sum []
+opentelemetry.source96.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 403.449963
 
-opentelemetry.source97.sample_counter0001 []
+opentelemetry.source97.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 16680128600
     inst [2 or "2 inst-2"] value 33360257200
@@ -12205,7 +12205,7 @@ opentelemetry.source97.sample_counter0001 []
     inst [8 or "8 inst-8"] value 133441029000
     inst [9 or "9 inst-9"] value 150121158000
 
-opentelemetry.source97.sample_gauge0000 []
+opentelemetry.source97.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1173.7
     inst [2 or "2 inst-2"] value 2347.4
@@ -12217,7 +12217,7 @@ opentelemetry.source97.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9389.6
     inst [9 or "9 inst-9"] value 10563.3
 
-opentelemetry.source97.sample_summary0002 []
+opentelemetry.source97.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.015802677
     inst [2 or "quantile: 0.5"] value 0.031605354
@@ -12229,13 +12229,13 @@ opentelemetry.source97.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.126421416
     inst [9 or "quantile: 2.25"] value 0.142224093
 
-opentelemetry.source97.sample_summary0002_count []
+opentelemetry.source97.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 179982
 
-opentelemetry.source97.sample_summary0002_sum []
+opentelemetry.source97.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 137.72947
 
-opentelemetry.source97.sample_counter0001 []
+opentelemetry.source97.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 33190051800
     inst [2 or "2 inst-2"] value 66380103700
@@ -12247,7 +12247,7 @@ opentelemetry.source97.sample_counter0001 []
     inst [8 or "8 inst-8"] value 265520415000
     inst [9 or "9 inst-9"] value 298710466000
 
-opentelemetry.source97.sample_gauge0000 []
+opentelemetry.source97.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2347.4
     inst [2 or "2 inst-2"] value 4694.8
@@ -12259,7 +12259,7 @@ opentelemetry.source97.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 18779.2
     inst [9 or "9 inst-9"] value 21126.6
 
-opentelemetry.source97.sample_summary0002 []
+opentelemetry.source97.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.031286108
     inst [2 or "quantile: 0.5"] value 0.062572216
@@ -12271,13 +12271,13 @@ opentelemetry.source97.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.250288864
     inst [9 or "quantile: 2.25"] value 0.281574972
 
-opentelemetry.source97.sample_summary0002_count []
+opentelemetry.source97.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 356328
 
-opentelemetry.source97.sample_summary0002_sum []
+opentelemetry.source97.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 272.676527
 
-opentelemetry.source97.sample_counter0001 []
+opentelemetry.source97.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 49699975000
     inst [2 or "2 inst-2"] value 99399950100
@@ -12289,7 +12289,7 @@ opentelemetry.source97.sample_counter0001 []
     inst [8 or "8 inst-8"] value 397599800000
     inst [9 or "9 inst-9"] value 447299775000
 
-opentelemetry.source97.sample_gauge0000 []
+opentelemetry.source97.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3521.1
     inst [2 or "2 inst-2"] value 7042.2
@@ -12301,7 +12301,7 @@ opentelemetry.source97.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 28168.8
     inst [9 or "9 inst-9"] value 31689.9
 
-opentelemetry.source97.sample_summary0002 []
+opentelemetry.source97.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.04676953900000001
     inst [2 or "quantile: 0.5"] value 0.09353907800000001
@@ -12313,13 +12313,13 @@ opentelemetry.source97.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.374156312
     inst [9 or "quantile: 2.25"] value 0.420925851
 
-opentelemetry.source97.sample_summary0002_count []
+opentelemetry.source97.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 532674
 
-opentelemetry.source97.sample_summary0002_sum []
+opentelemetry.source97.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 407.623584
 
-opentelemetry.source98.sample_counter0001 []
+opentelemetry.source98.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 16850334000
     inst [2 or "2 inst-2"] value 33700668000
@@ -12331,7 +12331,7 @@ opentelemetry.source98.sample_counter0001 []
     inst [8 or "8 inst-8"] value 134802672000
     inst [9 or "9 inst-9"] value 151653006000
 
-opentelemetry.source98.sample_gauge0000 []
+opentelemetry.source98.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1185.8
     inst [2 or "2 inst-2"] value 2371.6
@@ -12343,7 +12343,7 @@ opentelemetry.source98.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9486.4
     inst [9 or "9 inst-9"] value 10672.2
 
-opentelemetry.source98.sample_summary0002 []
+opentelemetry.source98.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0159623
     inst [2 or "quantile: 0.5"] value 0.0319246
@@ -12355,13 +12355,13 @@ opentelemetry.source98.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.1276984
     inst [9 or "quantile: 2.25"] value 0.1436607
 
-opentelemetry.source98.sample_summary0002_count []
+opentelemetry.source98.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 181800
 
-opentelemetry.source98.sample_summary0002_sum []
+opentelemetry.source98.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 139.120677
 
-opentelemetry.source98.sample_counter0001 []
+opentelemetry.source98.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 33530462600
     inst [2 or "2 inst-2"] value 67060925200
@@ -12373,7 +12373,7 @@ opentelemetry.source98.sample_counter0001 []
     inst [8 or "8 inst-8"] value 268243701000
     inst [9 or "9 inst-9"] value 301774164000
 
-opentelemetry.source98.sample_gauge0000 []
+opentelemetry.source98.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2371.6
     inst [2 or "2 inst-2"] value 4743.2
@@ -12385,7 +12385,7 @@ opentelemetry.source98.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 18972.8
     inst [9 or "9 inst-9"] value 21344.4
 
-opentelemetry.source98.sample_summary0002 []
+opentelemetry.source98.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.031605354
     inst [2 or "quantile: 0.5"] value 0.063210708
@@ -12397,13 +12397,13 @@ opentelemetry.source98.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.252842832
     inst [9 or "quantile: 2.25"] value 0.284448186
 
-opentelemetry.source98.sample_summary0002_count []
+opentelemetry.source98.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 359964
 
-opentelemetry.source98.sample_summary0002_sum []
+opentelemetry.source98.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 275.45894
 
-opentelemetry.source98.sample_counter0001 []
+opentelemetry.source98.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 50210591200
     inst [2 or "2 inst-2"] value 100421182000
@@ -12415,7 +12415,7 @@ opentelemetry.source98.sample_counter0001 []
     inst [8 or "8 inst-8"] value 401684730000
     inst [9 or "9 inst-9"] value 451895321000
 
-opentelemetry.source98.sample_gauge0000 []
+opentelemetry.source98.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3557.4
     inst [2 or "2 inst-2"] value 7114.8
@@ -12427,7 +12427,7 @@ opentelemetry.source98.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 28459.2
     inst [9 or "9 inst-9"] value 32016.6
 
-opentelemetry.source98.sample_summary0002 []
+opentelemetry.source98.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.04724840800000001
     inst [2 or "quantile: 0.5"] value 0.09449681600000001
@@ -12439,13 +12439,13 @@ opentelemetry.source98.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.377987264
     inst [9 or "quantile: 2.25"] value 0.425235672
 
-opentelemetry.source98.sample_summary0002_count []
+opentelemetry.source98.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 538128
 
-opentelemetry.source98.sample_summary0002_sum []
+opentelemetry.source98.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 411.797204
 
-opentelemetry.source99.sample_counter0001 []
+opentelemetry.source99.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 17020539400
     inst [2 or "2 inst-2"] value 34041078800
@@ -12457,7 +12457,7 @@ opentelemetry.source99.sample_counter0001 []
     inst [8 or "8 inst-8"] value 136164315000
     inst [9 or "9 inst-9"] value 153184855000
 
-opentelemetry.source99.sample_gauge0000 []
+opentelemetry.source99.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1197.9
     inst [2 or "2 inst-2"] value 2395.8
@@ -12469,7 +12469,7 @@ opentelemetry.source99.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 9583.200000000001
     inst [9 or "9 inst-9"] value 10781.1
 
-opentelemetry.source99.sample_summary0002 []
+opentelemetry.source99.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.016121923
     inst [2 or "quantile: 0.5"] value 0.032243846
@@ -12481,13 +12481,13 @@ opentelemetry.source99.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.128975384
     inst [9 or "quantile: 2.25"] value 0.145097307
 
-opentelemetry.source99.sample_summary0002_count []
+opentelemetry.source99.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 183618
 
-opentelemetry.source99.sample_summary0002_sum []
+opentelemetry.source99.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 140.511884
 
-opentelemetry.source99.sample_counter0001 []
+opentelemetry.source99.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 33870873400
     inst [2 or "2 inst-2"] value 67741746800
@@ -12499,7 +12499,7 @@ opentelemetry.source99.sample_counter0001 []
     inst [8 or "8 inst-8"] value 270966987000
     inst [9 or "9 inst-9"] value 304837861000
 
-opentelemetry.source99.sample_gauge0000 []
+opentelemetry.source99.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2395.8
     inst [2 or "2 inst-2"] value 4791.6
@@ -12511,7 +12511,7 @@ opentelemetry.source99.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 19166.4
     inst [9 or "9 inst-9"] value 21562.2
 
-opentelemetry.source99.sample_summary0002 []
+opentelemetry.source99.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0319246
     inst [2 or "quantile: 0.5"] value 0.06384920000000001
@@ -12523,13 +12523,13 @@ opentelemetry.source99.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.2553968
     inst [9 or "quantile: 2.25"] value 0.2873214
 
-opentelemetry.source99.sample_summary0002_count []
+opentelemetry.source99.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 363600
 
-opentelemetry.source99.sample_summary0002_sum []
+opentelemetry.source99.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 278.241354
 
-opentelemetry.source99.sample_counter0001 []
+opentelemetry.source99.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 50721207400
     inst [2 or "2 inst-2"] value 101442415000
@@ -12541,7 +12541,7 @@ opentelemetry.source99.sample_counter0001 []
     inst [8 or "8 inst-8"] value 405769659000
     inst [9 or "9 inst-9"] value 456490867000
 
-opentelemetry.source99.sample_gauge0000 []
+opentelemetry.source99.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 3593.7
     inst [2 or "2 inst-2"] value 7187.4
@@ -12553,7 +12553,7 @@ opentelemetry.source99.sample_gauge0000 []
     inst [8 or "8 inst-8"] value 28749.6
     inst [9 or "9 inst-9"] value 32343.3
 
-opentelemetry.source99.sample_summary0002 []
+opentelemetry.source99.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.04772727700000001
     inst [2 or "quantile: 0.5"] value 0.09545455400000001
@@ -12565,10 +12565,10 @@ opentelemetry.source99.sample_summary0002 []
     inst [8 or "quantile: 2.0"] value 0.381818216
     inst [9 or "quantile: 2.25"] value 0.4295454930000001
 
-opentelemetry.source99.sample_summary0002_count []
+opentelemetry.source99.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 543582
 
-opentelemetry.source99.sample_summary0002_sum []
+opentelemetry.source99.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 415.970824
 
 === remove opentelemetry agent ===

--- a/qa/1726
+++ b/qa/1726
@@ -15,8 +15,6 @@ echo "QA output created by $seq"
 
 _pmdaopentelemetry_check || _notrun "opentelemetry pmda and/or load generator not installed"
 
-_notrun "currently failing, needs analysis and updates"
-
 status=1        # failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 
@@ -40,14 +38,11 @@ do
     echo 'file://'$file > $PCP_PMDAS_DIR/opentelemetry/config.d/$urlbase.url
 done
 
-ls $PCP_PMDAS_DIR/opentelemetry/config.d/
-
 # add all the sample scripts
 cp -a $here/opentelemetry/scripts/* $PCP_PMDAS_DIR/opentelemetry/config.d
 find $PCP_PMDAS_DIR/opentelemetry/config.d -name GNU\* -exec rm -f {} ";"
 
 _pmdaopentelemetry_install
-
 if ! _pmdaopentelemetry_wait_for_metric opentelemetry.simplemetric.metric1
 then
     status=1

--- a/qa/1726.out
+++ b/qa/1726.out
@@ -1,11 +1,22 @@
 QA output created by 1726
-duplicate.url
-labels.url
-simplemetric.url
 
 === opentelemetry agent installation ===
 
-opentelemetry.labels.labelMetric [I am a Counter Metric to test the labels]
+opentelemetry.curl_scripted.some_metric [I am a Counter]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
+Help:
+I am a Counter
+    value 10
+
+opentelemetry.duplicate.somemetric [metric to test duplicate labels]
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
+Help:
+metric to test duplicate labels
+    value 5
+
+opentelemetry.labelfiltering.labelMetric [I am a Counter Metric to test the labels]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
@@ -27,7 +38,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 88.7170 0x16001c02
+    Data Type: 64-bit int  InDom: 164.10242 0x29002802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -42,7 +53,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram

--- a/qa/1787
+++ b/qa/1787
@@ -12,8 +12,6 @@ echo "QA output created by $seq"
 
 _pmdaopentelemetry_check || _notrun "opentelemetry pmda and/or load generator not installed"
 
-_notrun "currently failing, needs analysis and updates"
-
 status=1        # failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 

--- a/qa/1787.out
+++ b/qa/1787.out
@@ -28,7 +28,7 @@ FILTER: EXCLUDE LABEL random
 === pminfo listing. Note some labels in the pminfo listing have been removed, see _filter
 
 opentelemetry.labelfiltering.labelMetric
-    labels {"agent":"opentelemetry","label1":"someLabel","scope_name":"my.library","some_optional_label":"someValue","source":"labelfiltering"}
+    labels {"agent":"opentelemetry","label1":"someLabel","some_optional_label":"someValue","source":"labelfiltering"}
     value 5
 == Note: check 1787.full for details
 

--- a/qa/1888
+++ b/qa/1888
@@ -16,8 +16,6 @@ echo "QA output created by $seq"
 
 _pmdaopentelemetry_check || _notrun "opentelemetry pmda and/or load generator not installed"
 
-_notrun "currently failing, needs analysis and updates"
-
 status=1        # failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 
@@ -52,7 +50,6 @@ $sudo rm -rf $PCP_ETC_DIR/pcp/labels/*
 
 _pmdaopentelemetry_save_config
 _pmdaopentelemetry_install
-
 # add all the sample text files as urls.
 ls -1 $here/opentelemetry/samples/*.txt | LC_COLLATE=POSIX sort | while read file
 do

--- a/qa/1888.out
+++ b/qa/1888.out
@@ -2,42 +2,54 @@ QA output created by 1888
 
 === opentelemetry agent installation ===
 
-opentelemetry.labels.labelMetric
-    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"label1":"someLabel","machineid":MACHINEID,"random":"someValue","scope_name":"my.library","source":"labels","uninteresting":"someValue","url":FILEURL,"userid":NUM}
+opentelemetry.curl_scripted.some_metric
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_counter_attr":"someValue","script":"PCP_PMDAS_DIR/opentelemetry/config.d/curl_scripted.sh","source":"curl_scripted","userid":NUM}
+
+opentelemetry.duplicate.somemetric
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_sum_attribute":"someValue","source":"duplicate","url":FILEURL,"userid":NUM}
+
+opentelemetry.labelfiltering.labelMetric
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"label1":"someLabel","machineid":MACHINEID,"random":"someValue","some_optional_label":"someValue","source":"labelfiltering","url":FILEURL,"userid":NUM}
 
 opentelemetry.simplemetric.metric1
-    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_counter_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
 
 opentelemetry.simplemetric.metric2
-    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_gauge_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
 
 opentelemetry.simplemetric.metric3
-    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
-    inst [0 or "le=1"] labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
-    inst [1 or "le=inf"] labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_histogram_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
+    inst [0 or "le=1"] labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_histogram_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
+    inst [1 or "le=inf"] labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_histogram_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
 
 opentelemetry.simplemetric.metric3_count
-    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_histogram_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
 
 opentelemetry.simplemetric.metric3_sum
-    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_histogram_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
 
-opentelemetry.labels.labelMetric
-    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"label1":"someLabel","machineid":MACHINEID,"random":"someValue","scope_name":"my.library","source":"labels","uninteresting":"someValue","url":FILEURL,"userid":NUM}
+opentelemetry.curl_scripted.some_metric
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_counter_attr":"someValue","script":"PCP_PMDAS_DIR/opentelemetry/config.d/curl_scripted.sh","source":"curl_scripted","userid":NUM}
+
+opentelemetry.duplicate.somemetric
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_sum_attribute":"someValue","source":"duplicate","url":FILEURL,"userid":NUM}
+
+opentelemetry.labelfiltering.labelMetric
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"label1":"someLabel","machineid":MACHINEID,"random":"someValue","some_optional_label":"someValue","source":"labelfiltering","url":FILEURL,"userid":NUM}
 
 opentelemetry.simplemetric.metric1
-    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_counter_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
 
 opentelemetry.simplemetric.metric2
-    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_gauge_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
 
 opentelemetry.simplemetric.metric3
-    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
-    inst [0 or "le=1"] labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
-    inst [1 or "le=inf"] labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_histogram_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
+    inst [0 or "le=1"] labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_histogram_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
+    inst [1 or "le=inf"] labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_histogram_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
 
 opentelemetry.simplemetric.metric3_count
-    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_histogram_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}
 
 opentelemetry.simplemetric.metric3_sum
-    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"source":"simplemetric","url":FILEURL,"userid":NUM}
+    labels {"agent":"opentelemetry","domainname":DOMAINNAME,"groupid":NUM,"hostname":HOSTNAME,"machineid":MACHINEID,"my_histogram_attr":"someValue","source":"simplemetric","url":FILEURL,"userid":NUM}

--- a/qa/1890
+++ b/qa/1890
@@ -16,8 +16,6 @@ _check_series   # ensure pmproxy makes a REST API available
 _pmdaopentelemetry_check || _notrun "opentelemetry pmda not installed"
 which curl >/dev/null 2>&1 || _notrun curl not installed
 
-_notrun "currently failing, needs analysis and updates"
-
 status=1        # failure is the default!
 
 # only stop pmproxy if it was not running before the QA test starts
@@ -49,6 +47,7 @@ _filter_opentelemetry_labels()
     sed \
     -e "s;$PCP_PMDAS_DIR;PCP_PMDAS_DIR;g" \
     -e 's;machineid="[a-z0-9]*";machineid=MACHINEID;g' \
+    -e 's;url="[^"]*";url=URL;g' \
     -e 's;hostname="[a-zA-Z0-9_\.\-]*";hostname=HOSTNAME;g' \
     -e 's;hostname:[a-zA-Z0-9_\.\-]*";hostname:HOSTNAME";g' \
     -e 's;domainname="[a-zA-Z0-9_\.\-]*";domainname=DOMAINNAME;g' \

--- a/qa/1890.out
+++ b/qa/1890.out
@@ -3,10 +3,10 @@ QA output created by 1890
 === opentelemetry agent installation ===
 
 === /metrics webapi listing. The instname label should appear only once.
-# PCP5 opentelemetry.duplicate.somemetric 164.1.0 64 PM_INDOM_NULL counter none
+# PCP5 opentelemetry.duplicate.somemetric 164.1.0 double PM_INDOM_NULL counter none
 # HELP opentelemetry_duplicate_somemetric metric to test duplicate labels
 # TYPE opentelemetry_duplicate_somemetric counter
-opentelemetry_duplicate_somemetric{scope_name="my.library",url="file:////home/lchilton/git/pcp/qa/opentelemetry/samples/duplicate.txt",agent="opentelemetry",hostname=HOSTNAME,instname="my.instname",domainname=DOMAINNAME,machineid=MACHINEID,source="duplicate"} 5
+opentelemetry_duplicate_somemetric{url=URL,agent="opentelemetry",hostname=HOSTNAME,domainname=DOMAINNAME,machineid=MACHINEID,source="duplicate",my_sum_attribute="someValue"} 5
 
 === verify metric name validity using pminfo
 

--- a/qa/1942
+++ b/qa/1942
@@ -17,8 +17,6 @@ echo "QA output created by $seq"
 
 _pmdaopentelemetry_check || _notrun "opentelemetry pmda and/or load generator not installed"
 
-_notrun "currently failing, needs analysis and updates"
-
 status=1        # failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 
@@ -44,7 +42,6 @@ do
 done
 
 _pmdaopentelemetry_install
-
 if ! _pmdaopentelemetry_wait_for_metric opentelemetry.control.calls
 then
     exit

--- a/qa/1942.out
+++ b/qa/1942.out
@@ -22,7 +22,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric1.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.5122 0x16001402
+    Data Type: 64-bit int  InDom: 164.5122 0x29001402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -37,7 +37,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric1.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -58,7 +58,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric10.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.6146 0x16001802
+    Data Type: 64-bit int  InDom: 164.6146 0x29001802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -73,7 +73,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric10.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -94,7 +94,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric100.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.7170 0x16001c02
+    Data Type: 64-bit int  InDom: 164.7170 0x29001c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -109,7 +109,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric100.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -130,7 +130,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric101.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.8194 0x16002002
+    Data Type: 64-bit int  InDom: 164.8194 0x29002002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -145,7 +145,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric101.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -166,7 +166,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric102.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.9218 0x16002402
+    Data Type: 64-bit int  InDom: 164.9218 0x29002402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -181,7 +181,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric102.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -202,7 +202,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric103.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.10242 0x16002802
+    Data Type: 64-bit int  InDom: 164.10242 0x29002802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -217,7 +217,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric103.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -238,7 +238,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric104.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.11266 0x16002c02
+    Data Type: 64-bit int  InDom: 164.11266 0x29002c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -253,7 +253,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric104.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -274,7 +274,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric105.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.12290 0x16003002
+    Data Type: 64-bit int  InDom: 164.12290 0x29003002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -289,7 +289,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric105.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -310,7 +310,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric106.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.13314 0x16003402
+    Data Type: 64-bit int  InDom: 164.13314 0x29003402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -325,7 +325,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric106.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -346,7 +346,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric107.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.14338 0x16003802
+    Data Type: 64-bit int  InDom: 164.14338 0x29003802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -361,7 +361,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric107.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -382,7 +382,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric108.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.15362 0x16003c02
+    Data Type: 64-bit int  InDom: 164.15362 0x29003c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -397,7 +397,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric108.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -418,7 +418,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric109.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.16386 0x16004002
+    Data Type: 64-bit int  InDom: 164.16386 0x29004002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -433,7 +433,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric109.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -454,7 +454,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric11.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.17410 0x16004402
+    Data Type: 64-bit int  InDom: 164.17410 0x29004402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -469,7 +469,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric11.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -490,7 +490,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric110.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.18434 0x16004802
+    Data Type: 64-bit int  InDom: 164.18434 0x29004802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -505,7 +505,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric110.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -526,7 +526,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric111.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.19458 0x16004c02
+    Data Type: 64-bit int  InDom: 164.19458 0x29004c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -541,7 +541,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric111.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -562,7 +562,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric112.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.20482 0x16005002
+    Data Type: 64-bit int  InDom: 164.20482 0x29005002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -577,7 +577,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric112.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -598,7 +598,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric113.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.21506 0x16005402
+    Data Type: 64-bit int  InDom: 164.21506 0x29005402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -613,7 +613,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric113.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -634,7 +634,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric114.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.22530 0x16005802
+    Data Type: 64-bit int  InDom: 164.22530 0x29005802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -649,7 +649,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric114.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -670,7 +670,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric115.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.23554 0x16005c02
+    Data Type: 64-bit int  InDom: 164.23554 0x29005c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -685,7 +685,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric115.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -706,7 +706,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric116.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.24578 0x16006002
+    Data Type: 64-bit int  InDom: 164.24578 0x29006002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -721,7 +721,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric116.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -742,7 +742,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric117.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.25602 0x16006402
+    Data Type: 64-bit int  InDom: 164.25602 0x29006402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -757,7 +757,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric117.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -778,7 +778,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric118.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.26626 0x16006802
+    Data Type: 64-bit int  InDom: 164.26626 0x29006802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -793,7 +793,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric118.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -814,7 +814,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric119.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.27650 0x16006c02
+    Data Type: 64-bit int  InDom: 164.27650 0x29006c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -829,7 +829,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric119.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -850,7 +850,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric12.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.28674 0x16007002
+    Data Type: 64-bit int  InDom: 164.28674 0x29007002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -865,7 +865,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric12.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -886,7 +886,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric120.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.29698 0x16007402
+    Data Type: 64-bit int  InDom: 164.29698 0x29007402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -901,7 +901,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric120.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -922,7 +922,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric121.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.30722 0x16007802
+    Data Type: 64-bit int  InDom: 164.30722 0x29007802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -937,7 +937,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric121.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -958,7 +958,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric122.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.31746 0x16007c02
+    Data Type: 64-bit int  InDom: 164.31746 0x29007c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -973,7 +973,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric122.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -994,7 +994,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric123.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.32770 0x16008002
+    Data Type: 64-bit int  InDom: 164.32770 0x29008002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1009,7 +1009,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric123.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1030,7 +1030,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric124.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.33794 0x16008402
+    Data Type: 64-bit int  InDom: 164.33794 0x29008402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1045,7 +1045,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric124.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1066,7 +1066,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric125.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.34818 0x160016402
+    Data Type: 64-bit int  InDom: 164.34818 0x29008802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1081,7 +1081,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric125.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1102,7 +1102,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric126.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.35842 0x16008c02
+    Data Type: 64-bit int  InDom: 164.35842 0x29008c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1117,7 +1117,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric126.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1138,7 +1138,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric127.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.36866 0x16009002
+    Data Type: 64-bit int  InDom: 164.36866 0x29009002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1153,7 +1153,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric127.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1174,7 +1174,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric128.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.37890 0x16009402
+    Data Type: 64-bit int  InDom: 164.37890 0x29009402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1189,7 +1189,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric128.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1210,7 +1210,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric129.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.38914 0x16009802
+    Data Type: 64-bit int  InDom: 164.38914 0x29009802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1225,7 +1225,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric129.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1246,7 +1246,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric13.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.39938 0x16009c02
+    Data Type: 64-bit int  InDom: 164.39938 0x29009c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1261,7 +1261,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric13.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1282,7 +1282,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric130.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.40962 0x1600a002
+    Data Type: 64-bit int  InDom: 164.40962 0x2900a002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1297,7 +1297,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric130.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1318,7 +1318,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric131.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.41986 0x1600a402
+    Data Type: 64-bit int  InDom: 164.41986 0x2900a402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1333,7 +1333,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric131.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1354,7 +1354,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric132.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.43010 0x1600a802
+    Data Type: 64-bit int  InDom: 164.43010 0x2900a802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1369,7 +1369,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric132.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1390,7 +1390,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric133.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.44034 0x1600ac02
+    Data Type: 64-bit int  InDom: 164.44034 0x2900ac02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1405,7 +1405,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric133.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1426,7 +1426,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric134.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.45058 0x1600b002
+    Data Type: 64-bit int  InDom: 164.45058 0x2900b002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1441,7 +1441,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric134.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1462,7 +1462,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric135.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.46082 0x1600b402
+    Data Type: 64-bit int  InDom: 164.46082 0x2900b402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1477,7 +1477,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric135.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1498,7 +1498,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric136.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.47106 0x1600b802
+    Data Type: 64-bit int  InDom: 164.47106 0x2900b802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1513,7 +1513,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric136.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1534,7 +1534,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric137.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.48130 0x1600bc02
+    Data Type: 64-bit int  InDom: 164.48130 0x2900bc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1549,7 +1549,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric137.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1570,7 +1570,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric138.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.49154 0x1600c002
+    Data Type: 64-bit int  InDom: 164.49154 0x2900c002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1585,7 +1585,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric138.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1606,7 +1606,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric139.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.50178 0x1600c402
+    Data Type: 64-bit int  InDom: 164.50178 0x2900c402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1621,7 +1621,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric139.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1642,7 +1642,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric14.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.51202 0x1600c802
+    Data Type: 64-bit int  InDom: 164.51202 0x2900c802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1657,7 +1657,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric14.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1678,7 +1678,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric140.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.52226 0x1600cc02
+    Data Type: 64-bit int  InDom: 164.52226 0x2900cc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1693,7 +1693,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric140.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1714,7 +1714,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric141.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.53250 0x1600d002
+    Data Type: 64-bit int  InDom: 164.53250 0x2900d002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1729,7 +1729,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric141.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1750,7 +1750,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric142.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.54274 0x1600d402
+    Data Type: 64-bit int  InDom: 164.54274 0x2900d402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1765,7 +1765,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric142.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1786,7 +1786,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric143.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.55298 0x1600d802
+    Data Type: 64-bit int  InDom: 164.55298 0x2900d802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1801,7 +1801,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric143.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1822,7 +1822,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric144.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.56322 0x1600dc02
+    Data Type: 64-bit int  InDom: 164.56322 0x2900dc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1837,7 +1837,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric144.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1858,7 +1858,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric145.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.57346 0x1600e002
+    Data Type: 64-bit int  InDom: 164.57346 0x2900e002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1873,7 +1873,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric145.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1894,7 +1894,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric146.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.58370 0x1600e402
+    Data Type: 64-bit int  InDom: 164.58370 0x2900e402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1909,7 +1909,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric146.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1930,7 +1930,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric147.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.59394 0x1600e802
+    Data Type: 64-bit int  InDom: 164.59394 0x2900e802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1945,7 +1945,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric147.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1966,7 +1966,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric148.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.60418 0x1600ec02
+    Data Type: 64-bit int  InDom: 164.60418 0x2900ec02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -1981,7 +1981,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric148.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2002,7 +2002,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric149.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.61442 0x1600f002
+    Data Type: 64-bit int  InDom: 164.61442 0x2900f002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2017,7 +2017,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric149.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2038,7 +2038,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric15.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.62466 0x1600f402
+    Data Type: 64-bit int  InDom: 164.62466 0x2900f402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2053,7 +2053,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric15.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2074,7 +2074,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric150.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.63490 0x1600f802
+    Data Type: 64-bit int  InDom: 164.63490 0x2900f802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2089,7 +2089,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric150.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2110,7 +2110,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric151.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.64514 0x1600fc02
+    Data Type: 64-bit int  InDom: 164.64514 0x2900fc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2125,7 +2125,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric151.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2146,7 +2146,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric152.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.65538 0x16010002
+    Data Type: 64-bit int  InDom: 164.65538 0x29010002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2161,7 +2161,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric152.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2182,7 +2182,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric153.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.66562 0x16010402
+    Data Type: 64-bit int  InDom: 164.66562 0x29010402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2197,7 +2197,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric153.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2218,7 +2218,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric154.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.67586 0x16010802
+    Data Type: 64-bit int  InDom: 164.67586 0x29010802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2233,7 +2233,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric154.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2254,7 +2254,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric155.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.68610 0x16010c02
+    Data Type: 64-bit int  InDom: 164.68610 0x29010c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2269,7 +2269,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric155.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2290,7 +2290,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric156.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.69634 0x16011002
+    Data Type: 64-bit int  InDom: 164.69634 0x29011002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2305,7 +2305,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric156.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2326,7 +2326,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric157.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.70658 0x16011402
+    Data Type: 64-bit int  InDom: 164.70658 0x29011402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2341,7 +2341,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric157.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2362,7 +2362,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric158.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.71682 0x16011802
+    Data Type: 64-bit int  InDom: 164.71682 0x29011802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2377,7 +2377,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric158.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2398,7 +2398,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric159.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.72706 0x16011c02
+    Data Type: 64-bit int  InDom: 164.72706 0x29011c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2413,7 +2413,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric159.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2434,7 +2434,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric16.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.73730 0x16012002
+    Data Type: 64-bit int  InDom: 164.73730 0x29012002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2449,7 +2449,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric16.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2470,7 +2470,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric160.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.74754 0x16012402
+    Data Type: 64-bit int  InDom: 164.74754 0x29012402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2485,7 +2485,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric160.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2506,7 +2506,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric161.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.75778 0x16012802
+    Data Type: 64-bit int  InDom: 164.75778 0x29012802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2521,7 +2521,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric161.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2542,7 +2542,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric162.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.76802 0x16012c02
+    Data Type: 64-bit int  InDom: 164.76802 0x29012c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2557,7 +2557,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric162.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2578,7 +2578,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric163.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.77826 0x16013002
+    Data Type: 64-bit int  InDom: 164.77826 0x29013002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2593,7 +2593,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric163.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2614,7 +2614,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric164.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.716450 0x16013402
+    Data Type: 64-bit int  InDom: 164.78850 0x29013402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2629,7 +2629,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric164.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2650,7 +2650,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric165.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.79874 0x16013802
+    Data Type: 64-bit int  InDom: 164.79874 0x29013802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2665,7 +2665,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric165.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2686,7 +2686,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric166.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.80898 0x16013c02
+    Data Type: 64-bit int  InDom: 164.80898 0x29013c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2701,7 +2701,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric166.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2722,7 +2722,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric167.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.81922 0x16014002
+    Data Type: 64-bit int  InDom: 164.81922 0x29014002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2737,7 +2737,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric167.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2758,7 +2758,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric168.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.82946 0x16014402
+    Data Type: 64-bit int  InDom: 164.82946 0x29014402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2773,7 +2773,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric168.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2794,7 +2794,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric169.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.83970 0x16014802
+    Data Type: 64-bit int  InDom: 164.83970 0x29014802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2809,7 +2809,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric169.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2830,7 +2830,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric17.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.84994 0x16014c02
+    Data Type: 64-bit int  InDom: 164.84994 0x29014c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2845,7 +2845,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric17.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2866,7 +2866,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric170.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.86018 0x16015002
+    Data Type: 64-bit int  InDom: 164.86018 0x29015002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2881,7 +2881,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric170.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2902,7 +2902,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric171.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.87042 0x16015402
+    Data Type: 64-bit int  InDom: 164.87042 0x29015402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2917,7 +2917,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric171.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2938,7 +2938,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric172.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.164066 0x16015802
+    Data Type: 64-bit int  InDom: 164.88066 0x29015802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2953,7 +2953,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric172.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2974,7 +2974,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric173.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.89090 0x16015c02
+    Data Type: 64-bit int  InDom: 164.89090 0x29015c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -2989,7 +2989,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric173.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3010,7 +3010,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric174.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.90114 0x16016002
+    Data Type: 64-bit int  InDom: 164.90114 0x29016002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3025,7 +3025,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric174.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3046,7 +3046,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric175.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.91138 0x16016402
+    Data Type: 64-bit int  InDom: 164.91138 0x29016402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3061,7 +3061,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric175.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3082,7 +3082,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric176.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.92162 0x16016802
+    Data Type: 64-bit int  InDom: 164.92162 0x29016802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3097,7 +3097,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric176.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3118,7 +3118,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric177.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.93186 0x16016c02
+    Data Type: 64-bit int  InDom: 164.93186 0x29016c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3133,7 +3133,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric177.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3154,7 +3154,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric178.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.94210 0x16017002
+    Data Type: 64-bit int  InDom: 164.94210 0x29017002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3169,7 +3169,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric178.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3190,7 +3190,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric179.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.95234 0x16017402
+    Data Type: 64-bit int  InDom: 164.95234 0x29017402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3205,7 +3205,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric179.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3226,7 +3226,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric18.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.96258 0x16017802
+    Data Type: 64-bit int  InDom: 164.96258 0x29017802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3241,7 +3241,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric18.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3262,7 +3262,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric180.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.97282 0x16017c02
+    Data Type: 64-bit int  InDom: 164.97282 0x29017c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3277,7 +3277,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric180.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3298,7 +3298,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric181.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.98306 0x16018002
+    Data Type: 64-bit int  InDom: 164.98306 0x29018002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3313,7 +3313,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric181.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3334,7 +3334,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric182.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.99330 0x16018402
+    Data Type: 64-bit int  InDom: 164.99330 0x29018402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3349,7 +3349,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric182.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3370,7 +3370,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric183.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.100354 0x160116402
+    Data Type: 64-bit int  InDom: 164.100354 0x29018802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3385,7 +3385,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric183.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3406,7 +3406,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric184.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.101378 0x16018c02
+    Data Type: 64-bit int  InDom: 164.101378 0x29018c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3421,7 +3421,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric184.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3442,7 +3442,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric185.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.102402 0x16019002
+    Data Type: 64-bit int  InDom: 164.102402 0x29019002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3457,7 +3457,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric185.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3478,7 +3478,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric186.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.103426 0x16019402
+    Data Type: 64-bit int  InDom: 164.103426 0x29019402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3493,7 +3493,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric186.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3514,7 +3514,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric187.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.104450 0x16019802
+    Data Type: 64-bit int  InDom: 164.104450 0x29019802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3529,43 +3529,43 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric187.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     value 2
 
-opentelemetry.simplemetric1164.metric1 [I am a Counter]
+opentelemetry.simplemetric188.metric1 [I am a Counter]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Counter
     value 5
 
-opentelemetry.simplemetric1164.metric2 [I am a Gauge]
+opentelemetry.simplemetric188.metric2 [I am a Gauge]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: instant  Units: none
 Help:
 I am a Gauge
     value 10
 
-opentelemetry.simplemetric1164.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.105474 0x16019c02
+opentelemetry.simplemetric188.metric3 [I am a Histogram]
+    Data Type: 64-bit int  InDom: 164.105474 0x29019c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     inst [0 or "le=1"] value 1
     inst [1 or "le=inf"] value 1
 
-opentelemetry.simplemetric1164.metric3_count [I am a Histogram]
+opentelemetry.simplemetric188.metric3_count [I am a Histogram]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     value 2
 
-opentelemetry.simplemetric1164.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.simplemetric188.metric3_sum [I am a Histogram]
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3586,7 +3586,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric189.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.106498 0x1601a002
+    Data Type: 64-bit int  InDom: 164.106498 0x2901a002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3601,7 +3601,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric189.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3622,7 +3622,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric19.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.107522 0x1601a402
+    Data Type: 64-bit int  InDom: 164.107522 0x2901a402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3637,7 +3637,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric19.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3658,7 +3658,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric190.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.108546 0x1601a802
+    Data Type: 64-bit int  InDom: 164.108546 0x2901a802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3673,7 +3673,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric190.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3694,7 +3694,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric191.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.109570 0x1601ac02
+    Data Type: 64-bit int  InDom: 164.109570 0x2901ac02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3709,7 +3709,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric191.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3730,7 +3730,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric192.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.110594 0x1601b002
+    Data Type: 64-bit int  InDom: 164.110594 0x2901b002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3745,7 +3745,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric192.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3766,7 +3766,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric193.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.111618 0x1601b402
+    Data Type: 64-bit int  InDom: 164.111618 0x2901b402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3781,7 +3781,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric193.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3802,7 +3802,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric194.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.112642 0x1601b802
+    Data Type: 64-bit int  InDom: 164.112642 0x2901b802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3817,7 +3817,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric194.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3838,7 +3838,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric195.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.113666 0x1601bc02
+    Data Type: 64-bit int  InDom: 164.113666 0x2901bc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3853,7 +3853,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric195.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3874,7 +3874,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric196.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.114690 0x1601c002
+    Data Type: 64-bit int  InDom: 164.114690 0x2901c002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3889,7 +3889,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric196.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3910,7 +3910,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric197.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.115714 0x1601c402
+    Data Type: 64-bit int  InDom: 164.115714 0x2901c402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3925,7 +3925,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric197.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3946,7 +3946,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric198.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.116738 0x1601c802
+    Data Type: 64-bit int  InDom: 164.116738 0x2901c802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3961,7 +3961,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric198.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3982,7 +3982,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric199.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.117762 0x1601cc02
+    Data Type: 64-bit int  InDom: 164.117762 0x2901cc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -3997,7 +3997,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric199.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4018,7 +4018,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric2.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.118786 0x1601d002
+    Data Type: 64-bit int  InDom: 164.118786 0x2901d002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4033,7 +4033,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric2.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4054,7 +4054,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric20.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.119810 0x1601d402
+    Data Type: 64-bit int  InDom: 164.119810 0x2901d402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4069,7 +4069,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric20.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4090,7 +4090,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric200.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.120834 0x1601d802
+    Data Type: 64-bit int  InDom: 164.120834 0x2901d802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4105,7 +4105,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric200.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4126,7 +4126,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric201.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.121858 0x1601dc02
+    Data Type: 64-bit int  InDom: 164.121858 0x2901dc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4141,7 +4141,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric201.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4162,7 +4162,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric202.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.1221642 0x1601e002
+    Data Type: 64-bit int  InDom: 164.122882 0x2901e002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4177,7 +4177,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric202.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4198,7 +4198,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric203.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.123906 0x1601e402
+    Data Type: 64-bit int  InDom: 164.123906 0x2901e402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4213,7 +4213,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric203.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4234,7 +4234,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric204.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.124930 0x1601e802
+    Data Type: 64-bit int  InDom: 164.124930 0x2901e802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4249,7 +4249,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric204.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4270,7 +4270,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric205.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.125954 0x1601ec02
+    Data Type: 64-bit int  InDom: 164.125954 0x2901ec02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4285,7 +4285,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric205.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4306,7 +4306,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric206.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.126978 0x1601f002
+    Data Type: 64-bit int  InDom: 164.126978 0x2901f002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4321,7 +4321,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric206.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4342,7 +4342,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric207.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.128002 0x1601f402
+    Data Type: 64-bit int  InDom: 164.128002 0x2901f402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4357,7 +4357,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric207.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4378,7 +4378,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric208.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.129026 0x1601f802
+    Data Type: 64-bit int  InDom: 164.129026 0x2901f802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4393,7 +4393,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric208.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4414,7 +4414,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric209.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.130050 0x1601fc02
+    Data Type: 64-bit int  InDom: 164.130050 0x2901fc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4429,7 +4429,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric209.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4450,7 +4450,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric21.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.131074 0x16020002
+    Data Type: 64-bit int  InDom: 164.131074 0x29020002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4465,7 +4465,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric21.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4486,7 +4486,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric210.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.132098 0x16020402
+    Data Type: 64-bit int  InDom: 164.132098 0x29020402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4501,7 +4501,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric210.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4522,7 +4522,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric211.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.133122 0x16020802
+    Data Type: 64-bit int  InDom: 164.133122 0x29020802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4537,7 +4537,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric211.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4558,7 +4558,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric212.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.134146 0x16020c02
+    Data Type: 64-bit int  InDom: 164.134146 0x29020c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4573,7 +4573,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric212.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4594,7 +4594,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric213.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.135170 0x16021002
+    Data Type: 64-bit int  InDom: 164.135170 0x29021002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4609,7 +4609,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric213.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4630,7 +4630,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric214.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.136194 0x16021402
+    Data Type: 64-bit int  InDom: 164.136194 0x29021402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4645,7 +4645,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric214.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4666,7 +4666,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric215.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.137218 0x16021802
+    Data Type: 64-bit int  InDom: 164.137218 0x29021802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4681,7 +4681,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric215.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4702,7 +4702,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric216.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.138242 0x16021c02
+    Data Type: 64-bit int  InDom: 164.138242 0x29021c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4717,7 +4717,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric216.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4738,7 +4738,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric217.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.139266 0x16022002
+    Data Type: 64-bit int  InDom: 164.139266 0x29022002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4753,7 +4753,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric217.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4774,7 +4774,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric218.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.140290 0x16022402
+    Data Type: 64-bit int  InDom: 164.140290 0x29022402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4789,7 +4789,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric218.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4810,7 +4810,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric219.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.141314 0x16022802
+    Data Type: 64-bit int  InDom: 164.141314 0x29022802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4825,7 +4825,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric219.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4846,7 +4846,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric22.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.142338 0x16022c02
+    Data Type: 64-bit int  InDom: 164.142338 0x29022c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4861,7 +4861,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric22.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4882,7 +4882,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric220.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.143362 0x16023002
+    Data Type: 64-bit int  InDom: 164.143362 0x29023002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4897,7 +4897,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric220.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4918,7 +4918,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric221.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.144386 0x16023402
+    Data Type: 64-bit int  InDom: 164.144386 0x29023402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4933,7 +4933,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric221.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4954,7 +4954,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric222.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.145410 0x16023802
+    Data Type: 64-bit int  InDom: 164.145410 0x29023802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4969,7 +4969,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric222.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -4990,7 +4990,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric223.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.146434 0x16023c02
+    Data Type: 64-bit int  InDom: 164.146434 0x29023c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5005,7 +5005,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric223.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5026,7 +5026,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric224.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.147458 0x16024002
+    Data Type: 64-bit int  InDom: 164.147458 0x29024002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5041,7 +5041,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric224.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5062,7 +5062,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric225.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.148482 0x16024402
+    Data Type: 64-bit int  InDom: 164.148482 0x29024402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5077,7 +5077,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric225.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5098,7 +5098,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric226.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.149506 0x16024802
+    Data Type: 64-bit int  InDom: 164.149506 0x29024802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5113,7 +5113,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric226.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5134,7 +5134,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric227.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.150530 0x16024c02
+    Data Type: 64-bit int  InDom: 164.150530 0x29024c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5149,7 +5149,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric227.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5170,7 +5170,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric228.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.151554 0x16025002
+    Data Type: 64-bit int  InDom: 164.151554 0x29025002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5185,7 +5185,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric228.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5206,7 +5206,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric229.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.152578 0x16025402
+    Data Type: 64-bit int  InDom: 164.152578 0x29025402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5221,7 +5221,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric229.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5242,7 +5242,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric23.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.153602 0x16025802
+    Data Type: 64-bit int  InDom: 164.153602 0x29025802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5257,7 +5257,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric23.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5278,7 +5278,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric230.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.154626 0x16025c02
+    Data Type: 64-bit int  InDom: 164.154626 0x29025c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5293,7 +5293,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric230.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5314,7 +5314,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric231.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.155650 0x16026002
+    Data Type: 64-bit int  InDom: 164.155650 0x29026002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5329,7 +5329,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric231.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5350,7 +5350,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric232.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.156674 0x16026402
+    Data Type: 64-bit int  InDom: 164.156674 0x29026402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5365,7 +5365,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric232.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5386,7 +5386,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric233.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.157698 0x16026802
+    Data Type: 64-bit int  InDom: 164.157698 0x29026802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5401,7 +5401,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric233.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5422,7 +5422,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric234.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.158722 0x16026c02
+    Data Type: 64-bit int  InDom: 164.158722 0x29026c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5437,7 +5437,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric234.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5458,7 +5458,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric235.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.159746 0x16027002
+    Data Type: 64-bit int  InDom: 164.159746 0x29027002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5473,7 +5473,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric235.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5494,7 +5494,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric236.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.160770 0x16027402
+    Data Type: 64-bit int  InDom: 164.160770 0x29027402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5509,7 +5509,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric236.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5530,7 +5530,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric237.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.161794 0x16027802
+    Data Type: 64-bit int  InDom: 164.161794 0x29027802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5545,7 +5545,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric237.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5566,7 +5566,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric238.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.162818 0x16027c02
+    Data Type: 64-bit int  InDom: 164.162818 0x29027c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5581,7 +5581,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric238.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5602,7 +5602,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric239.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.163842 0x16028002
+    Data Type: 64-bit int  InDom: 164.163842 0x29028002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5617,7 +5617,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric239.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5638,7 +5638,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric24.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.164866 0x16028402
+    Data Type: 64-bit int  InDom: 164.164866 0x29028402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5653,7 +5653,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric24.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5674,7 +5674,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric240.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.165890 0x160216402
+    Data Type: 64-bit int  InDom: 164.165890 0x29028802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5689,7 +5689,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric240.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5710,7 +5710,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric241.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.166914 0x16028c02
+    Data Type: 64-bit int  InDom: 164.166914 0x29028c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5725,7 +5725,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric241.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5746,7 +5746,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric242.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.167938 0x16029002
+    Data Type: 64-bit int  InDom: 164.167938 0x29029002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5761,7 +5761,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric242.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5782,7 +5782,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric243.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.168962 0x16029402
+    Data Type: 64-bit int  InDom: 164.168962 0x29029402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5797,7 +5797,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric243.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5818,7 +5818,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric244.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.169986 0x16029802
+    Data Type: 64-bit int  InDom: 164.169986 0x29029802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5833,7 +5833,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric244.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5854,7 +5854,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric245.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.171010 0x16029c02
+    Data Type: 64-bit int  InDom: 164.171010 0x29029c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5869,7 +5869,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric245.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5890,7 +5890,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric246.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.172034 0x1602a002
+    Data Type: 64-bit int  InDom: 164.172034 0x2902a002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5905,7 +5905,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric246.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5926,7 +5926,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric247.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.173058 0x1602a402
+    Data Type: 64-bit int  InDom: 164.173058 0x2902a402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5941,7 +5941,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric247.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5962,7 +5962,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric248.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.174082 0x1602a802
+    Data Type: 64-bit int  InDom: 164.174082 0x2902a802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5977,7 +5977,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric248.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -5998,7 +5998,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric249.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.175106 0x1602ac02
+    Data Type: 64-bit int  InDom: 164.175106 0x2902ac02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6013,7 +6013,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric249.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6034,7 +6034,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric25.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.176130 0x1602b002
+    Data Type: 64-bit int  InDom: 164.176130 0x2902b002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6049,7 +6049,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric25.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6070,7 +6070,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric250.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.177154 0x1602b402
+    Data Type: 64-bit int  InDom: 164.177154 0x2902b402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6085,7 +6085,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric250.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6106,7 +6106,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric251.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.178178 0x1602b802
+    Data Type: 64-bit int  InDom: 164.178178 0x2902b802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6121,7 +6121,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric251.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6142,7 +6142,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric252.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.179202 0x1602bc02
+    Data Type: 64-bit int  InDom: 164.179202 0x2902bc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6157,7 +6157,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric252.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6178,7 +6178,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric253.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.180226 0x1602c002
+    Data Type: 64-bit int  InDom: 164.180226 0x2902c002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6193,7 +6193,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric253.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6214,7 +6214,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric254.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.181250 0x1602c402
+    Data Type: 64-bit int  InDom: 164.181250 0x2902c402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6229,7 +6229,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric254.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6250,7 +6250,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric255.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.182274 0x1602c802
+    Data Type: 64-bit int  InDom: 164.182274 0x2902c802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6265,7 +6265,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric255.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6286,7 +6286,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric256.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.183298 0x1602cc02
+    Data Type: 64-bit int  InDom: 164.183298 0x2902cc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6301,7 +6301,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric256.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6322,7 +6322,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric257.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.184322 0x1602d002
+    Data Type: 64-bit int  InDom: 164.184322 0x2902d002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6337,7 +6337,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric257.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6358,7 +6358,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric258.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.185346 0x1602d402
+    Data Type: 64-bit int  InDom: 164.185346 0x2902d402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6373,7 +6373,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric258.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6394,7 +6394,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric259.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.186370 0x1602d802
+    Data Type: 64-bit int  InDom: 164.186370 0x2902d802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6409,7 +6409,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric259.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6430,7 +6430,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric26.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.187394 0x1602dc02
+    Data Type: 64-bit int  InDom: 164.187394 0x2902dc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6445,7 +6445,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric26.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6466,7 +6466,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric260.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.1164418 0x1602e002
+    Data Type: 64-bit int  InDom: 164.188418 0x2902e002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6481,7 +6481,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric260.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6502,7 +6502,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric261.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.189442 0x1602e402
+    Data Type: 64-bit int  InDom: 164.189442 0x2902e402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6517,7 +6517,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric261.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6538,7 +6538,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric262.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.190466 0x1602e802
+    Data Type: 64-bit int  InDom: 164.190466 0x2902e802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6553,7 +6553,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric262.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6574,7 +6574,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric263.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.191490 0x1602ec02
+    Data Type: 64-bit int  InDom: 164.191490 0x2902ec02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6589,7 +6589,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric263.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6610,7 +6610,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric264.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.192514 0x1602f002
+    Data Type: 64-bit int  InDom: 164.192514 0x2902f002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6625,7 +6625,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric264.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6646,7 +6646,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric265.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.193538 0x1602f402
+    Data Type: 64-bit int  InDom: 164.193538 0x2902f402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6661,7 +6661,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric265.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6682,7 +6682,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric266.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.194562 0x1602f802
+    Data Type: 64-bit int  InDom: 164.194562 0x2902f802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6697,7 +6697,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric266.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6718,7 +6718,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric267.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.195586 0x1602fc02
+    Data Type: 64-bit int  InDom: 164.195586 0x2902fc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6733,7 +6733,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric267.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6754,7 +6754,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric268.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.196610 0x16030002
+    Data Type: 64-bit int  InDom: 164.196610 0x29030002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6769,7 +6769,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric268.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6790,7 +6790,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric269.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.197634 0x16030402
+    Data Type: 64-bit int  InDom: 164.197634 0x29030402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6805,7 +6805,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric269.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6826,7 +6826,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric27.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.198658 0x16030802
+    Data Type: 64-bit int  InDom: 164.198658 0x29030802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6841,7 +6841,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric27.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6862,7 +6862,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric270.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.199682 0x16030c02
+    Data Type: 64-bit int  InDom: 164.199682 0x29030c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6877,7 +6877,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric270.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6898,7 +6898,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric271.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.200706 0x16031002
+    Data Type: 64-bit int  InDom: 164.200706 0x29031002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6913,7 +6913,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric271.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6934,7 +6934,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric272.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.201730 0x16031402
+    Data Type: 64-bit int  InDom: 164.201730 0x29031402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6949,7 +6949,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric272.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6970,7 +6970,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric273.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.202754 0x16031802
+    Data Type: 64-bit int  InDom: 164.202754 0x29031802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -6985,7 +6985,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric273.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7006,7 +7006,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric274.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.203778 0x16031c02
+    Data Type: 64-bit int  InDom: 164.203778 0x29031c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7021,7 +7021,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric274.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7042,7 +7042,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric275.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.204802 0x16032002
+    Data Type: 64-bit int  InDom: 164.204802 0x29032002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7057,7 +7057,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric275.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7078,7 +7078,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric276.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.205826 0x16032402
+    Data Type: 64-bit int  InDom: 164.205826 0x29032402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7093,7 +7093,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric276.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7114,7 +7114,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric277.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.206850 0x16032802
+    Data Type: 64-bit int  InDom: 164.206850 0x29032802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7129,7 +7129,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric277.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7150,7 +7150,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric278.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.207874 0x16032c02
+    Data Type: 64-bit int  InDom: 164.207874 0x29032c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7165,7 +7165,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric278.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7186,7 +7186,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric279.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.2016498 0x16033002
+    Data Type: 64-bit int  InDom: 164.208898 0x29033002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7201,7 +7201,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric279.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7222,7 +7222,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric28.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.209922 0x16033402
+    Data Type: 64-bit int  InDom: 164.209922 0x29033402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7237,7 +7237,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric28.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7258,7 +7258,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric280.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.210946 0x16033802
+    Data Type: 64-bit int  InDom: 164.210946 0x29033802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7273,7 +7273,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric280.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7294,7 +7294,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric281.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.211970 0x16033c02
+    Data Type: 64-bit int  InDom: 164.211970 0x29033c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7309,7 +7309,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric281.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7330,7 +7330,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric282.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.212994 0x16034002
+    Data Type: 64-bit int  InDom: 164.212994 0x29034002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7345,7 +7345,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric282.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7366,7 +7366,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric283.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.214018 0x16034402
+    Data Type: 64-bit int  InDom: 164.214018 0x29034402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7381,7 +7381,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric283.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7402,7 +7402,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric284.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.215042 0x16034802
+    Data Type: 64-bit int  InDom: 164.215042 0x29034802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7417,7 +7417,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric284.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7438,7 +7438,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric285.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.216066 0x16034c02
+    Data Type: 64-bit int  InDom: 164.216066 0x29034c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7453,7 +7453,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric285.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7474,7 +7474,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric286.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.217090 0x16035002
+    Data Type: 64-bit int  InDom: 164.217090 0x29035002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7489,7 +7489,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric286.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7510,7 +7510,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric287.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.218114 0x16035402
+    Data Type: 64-bit int  InDom: 164.218114 0x29035402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7525,43 +7525,43 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric287.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     value 2
 
-opentelemetry.simplemetric2164.metric1 [I am a Counter]
+opentelemetry.simplemetric288.metric1 [I am a Counter]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Counter
     value 5
 
-opentelemetry.simplemetric2164.metric2 [I am a Gauge]
+opentelemetry.simplemetric288.metric2 [I am a Gauge]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: instant  Units: none
 Help:
 I am a Gauge
     value 10
 
-opentelemetry.simplemetric2164.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.219138 0x16035802
+opentelemetry.simplemetric288.metric3 [I am a Histogram]
+    Data Type: 64-bit int  InDom: 164.219138 0x29035802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     inst [0 or "le=1"] value 1
     inst [1 or "le=inf"] value 1
 
-opentelemetry.simplemetric2164.metric3_count [I am a Histogram]
+opentelemetry.simplemetric288.metric3_count [I am a Histogram]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     value 2
 
-opentelemetry.simplemetric2164.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.simplemetric288.metric3_sum [I am a Histogram]
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7582,7 +7582,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric289.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.220162 0x16035c02
+    Data Type: 64-bit int  InDom: 164.220162 0x29035c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7597,7 +7597,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric289.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7618,7 +7618,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric29.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.221186 0x16036002
+    Data Type: 64-bit int  InDom: 164.221186 0x29036002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7633,7 +7633,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric29.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7654,7 +7654,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric290.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.222210 0x16036402
+    Data Type: 64-bit int  InDom: 164.222210 0x29036402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7669,7 +7669,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric290.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7690,7 +7690,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric291.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.223234 0x16036802
+    Data Type: 64-bit int  InDom: 164.223234 0x29036802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7705,7 +7705,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric291.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7726,7 +7726,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric292.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.224258 0x16036c02
+    Data Type: 64-bit int  InDom: 164.224258 0x29036c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7741,7 +7741,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric292.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7762,7 +7762,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric293.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.225282 0x16037002
+    Data Type: 64-bit int  InDom: 164.225282 0x29037002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7777,7 +7777,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric293.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7798,7 +7798,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric294.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.226306 0x16037402
+    Data Type: 64-bit int  InDom: 164.226306 0x29037402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7813,7 +7813,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric294.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7834,7 +7834,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric295.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.227330 0x16037802
+    Data Type: 64-bit int  InDom: 164.227330 0x29037802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7849,7 +7849,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric295.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7870,7 +7870,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric296.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.228354 0x16037c02
+    Data Type: 64-bit int  InDom: 164.228354 0x29037c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7885,7 +7885,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric296.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7906,7 +7906,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric297.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.229378 0x16038002
+    Data Type: 64-bit int  InDom: 164.229378 0x29038002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7921,7 +7921,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric297.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7942,7 +7942,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric298.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.230402 0x16038402
+    Data Type: 64-bit int  InDom: 164.230402 0x29038402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7957,7 +7957,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric298.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7978,7 +7978,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric299.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.231426 0x160316402
+    Data Type: 64-bit int  InDom: 164.231426 0x29038802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -7993,7 +7993,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric299.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8014,7 +8014,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric3.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.232450 0x16038c02
+    Data Type: 64-bit int  InDom: 164.232450 0x29038c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8029,7 +8029,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric3.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8050,7 +8050,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric30.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.233474 0x16039002
+    Data Type: 64-bit int  InDom: 164.233474 0x29039002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8065,7 +8065,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric30.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8086,7 +8086,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric300.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.234498 0x16039402
+    Data Type: 64-bit int  InDom: 164.234498 0x29039402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8101,7 +8101,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric300.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8122,7 +8122,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric301.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.235522 0x16039802
+    Data Type: 64-bit int  InDom: 164.235522 0x29039802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8137,7 +8137,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric301.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8158,7 +8158,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric302.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.236546 0x16039c02
+    Data Type: 64-bit int  InDom: 164.236546 0x29039c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8173,7 +8173,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric302.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8194,7 +8194,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric303.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.237570 0x1603a002
+    Data Type: 64-bit int  InDom: 164.237570 0x2903a002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8209,7 +8209,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric303.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8230,7 +8230,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric304.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.238594 0x1603a402
+    Data Type: 64-bit int  InDom: 164.238594 0x2903a402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8245,7 +8245,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric304.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8266,7 +8266,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric305.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.239618 0x1603a802
+    Data Type: 64-bit int  InDom: 164.239618 0x2903a802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8281,7 +8281,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric305.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8302,7 +8302,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric306.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.240642 0x1603ac02
+    Data Type: 64-bit int  InDom: 164.240642 0x2903ac02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8317,7 +8317,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric306.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8338,7 +8338,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric307.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.241666 0x1603b002
+    Data Type: 64-bit int  InDom: 164.241666 0x2903b002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8353,7 +8353,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric307.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8374,7 +8374,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric308.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.242690 0x1603b402
+    Data Type: 64-bit int  InDom: 164.242690 0x2903b402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8389,7 +8389,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric308.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8410,7 +8410,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric309.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.243714 0x1603b802
+    Data Type: 64-bit int  InDom: 164.243714 0x2903b802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8425,7 +8425,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric309.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8446,7 +8446,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric31.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.244738 0x1603bc02
+    Data Type: 64-bit int  InDom: 164.244738 0x2903bc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8461,7 +8461,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric31.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8482,7 +8482,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric310.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.245762 0x1603c002
+    Data Type: 64-bit int  InDom: 164.245762 0x2903c002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8497,7 +8497,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric310.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8518,7 +8518,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric311.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.246786 0x1603c402
+    Data Type: 64-bit int  InDom: 164.246786 0x2903c402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8533,7 +8533,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric311.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8554,7 +8554,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric312.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.247810 0x1603c802
+    Data Type: 64-bit int  InDom: 164.247810 0x2903c802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8569,7 +8569,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric312.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8590,7 +8590,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric313.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.2416434 0x1603cc02
+    Data Type: 64-bit int  InDom: 164.248834 0x2903cc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8605,7 +8605,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric313.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8626,7 +8626,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric314.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.249858 0x1603d002
+    Data Type: 64-bit int  InDom: 164.249858 0x2903d002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8641,7 +8641,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric314.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8662,7 +8662,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric315.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.2501642 0x1603d402
+    Data Type: 64-bit int  InDom: 164.250882 0x2903d402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8677,7 +8677,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric315.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8698,7 +8698,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric316.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.251906 0x1603d802
+    Data Type: 64-bit int  InDom: 164.251906 0x2903d802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8713,7 +8713,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric316.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8734,7 +8734,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric317.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.252930 0x1603dc02
+    Data Type: 64-bit int  InDom: 164.252930 0x2903dc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8749,7 +8749,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric317.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8770,7 +8770,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric318.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.253954 0x1603e002
+    Data Type: 64-bit int  InDom: 164.253954 0x2903e002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8785,7 +8785,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric318.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8806,7 +8806,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric319.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.254978 0x1603e402
+    Data Type: 64-bit int  InDom: 164.254978 0x2903e402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8821,7 +8821,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric319.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8842,7 +8842,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric32.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.256002 0x1603e802
+    Data Type: 64-bit int  InDom: 164.256002 0x2903e802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8857,7 +8857,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric32.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8878,7 +8878,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric320.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.257026 0x1603ec02
+    Data Type: 64-bit int  InDom: 164.257026 0x2903ec02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8893,7 +8893,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric320.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8914,7 +8914,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric321.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.258050 0x1603f002
+    Data Type: 64-bit int  InDom: 164.258050 0x2903f002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8929,7 +8929,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric321.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8950,7 +8950,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric322.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.259074 0x1603f402
+    Data Type: 64-bit int  InDom: 164.259074 0x2903f402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8965,7 +8965,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric322.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -8986,7 +8986,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric323.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.260098 0x1603f802
+    Data Type: 64-bit int  InDom: 164.260098 0x2903f802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9001,7 +9001,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric323.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9022,7 +9022,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric324.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.261122 0x1603fc02
+    Data Type: 64-bit int  InDom: 164.261122 0x2903fc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9037,7 +9037,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric324.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9058,7 +9058,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric325.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.262146 0x16040002
+    Data Type: 64-bit int  InDom: 164.262146 0x29040002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9073,7 +9073,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric325.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9094,7 +9094,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric326.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.263170 0x16040402
+    Data Type: 64-bit int  InDom: 164.263170 0x29040402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9109,7 +9109,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric326.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9130,7 +9130,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric327.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.264194 0x16040802
+    Data Type: 64-bit int  InDom: 164.264194 0x29040802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9145,7 +9145,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric327.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9166,7 +9166,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric328.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.265218 0x16040c02
+    Data Type: 64-bit int  InDom: 164.265218 0x29040c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9181,7 +9181,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric328.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9202,7 +9202,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric329.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.266242 0x16041002
+    Data Type: 64-bit int  InDom: 164.266242 0x29041002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9217,7 +9217,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric329.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9238,7 +9238,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric33.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.267266 0x16041402
+    Data Type: 64-bit int  InDom: 164.267266 0x29041402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9253,7 +9253,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric33.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9274,7 +9274,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric330.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.268290 0x16041802
+    Data Type: 64-bit int  InDom: 164.268290 0x29041802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9289,7 +9289,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric330.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9310,7 +9310,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric331.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.269314 0x16041c02
+    Data Type: 64-bit int  InDom: 164.269314 0x29041c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9325,7 +9325,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric331.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9346,7 +9346,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric332.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.270338 0x16042002
+    Data Type: 64-bit int  InDom: 164.270338 0x29042002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9361,7 +9361,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric332.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9382,7 +9382,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric333.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.271362 0x16042402
+    Data Type: 64-bit int  InDom: 164.271362 0x29042402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9397,7 +9397,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric333.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9418,7 +9418,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric334.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.272386 0x16042802
+    Data Type: 64-bit int  InDom: 164.272386 0x29042802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9433,7 +9433,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric334.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9454,7 +9454,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric335.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.273410 0x16042c02
+    Data Type: 64-bit int  InDom: 164.273410 0x29042c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9469,7 +9469,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric335.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9490,7 +9490,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric336.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.274434 0x16043002
+    Data Type: 64-bit int  InDom: 164.274434 0x29043002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9505,7 +9505,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric336.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9526,7 +9526,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric337.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.275458 0x16043402
+    Data Type: 64-bit int  InDom: 164.275458 0x29043402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9541,7 +9541,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric337.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9562,7 +9562,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric338.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.276482 0x16043802
+    Data Type: 64-bit int  InDom: 164.276482 0x29043802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9577,7 +9577,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric338.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9598,7 +9598,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric339.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.277506 0x16043c02
+    Data Type: 64-bit int  InDom: 164.277506 0x29043c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9613,7 +9613,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric339.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9634,7 +9634,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric34.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.278530 0x16044002
+    Data Type: 64-bit int  InDom: 164.278530 0x29044002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9649,7 +9649,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric34.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9670,7 +9670,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric340.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.279554 0x16044402
+    Data Type: 64-bit int  InDom: 164.279554 0x29044402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9685,7 +9685,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric340.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9706,7 +9706,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric341.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.280578 0x16044802
+    Data Type: 64-bit int  InDom: 164.280578 0x29044802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9721,7 +9721,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric341.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9742,7 +9742,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric342.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.281602 0x16044c02
+    Data Type: 64-bit int  InDom: 164.281602 0x29044c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9757,7 +9757,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric342.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9778,7 +9778,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric343.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.282626 0x16045002
+    Data Type: 64-bit int  InDom: 164.282626 0x29045002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9793,7 +9793,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric343.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9814,7 +9814,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric344.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.283650 0x16045402
+    Data Type: 64-bit int  InDom: 164.283650 0x29045402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9829,7 +9829,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric344.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9850,7 +9850,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric345.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.284674 0x16045802
+    Data Type: 64-bit int  InDom: 164.284674 0x29045802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9865,7 +9865,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric345.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9886,7 +9886,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric346.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.285698 0x16045c02
+    Data Type: 64-bit int  InDom: 164.285698 0x29045c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9901,7 +9901,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric346.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9922,7 +9922,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric347.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.286722 0x16046002
+    Data Type: 64-bit int  InDom: 164.286722 0x29046002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9937,7 +9937,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric347.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9958,7 +9958,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric348.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.287746 0x16046402
+    Data Type: 64-bit int  InDom: 164.287746 0x29046402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9973,7 +9973,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric348.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -9994,7 +9994,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric349.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.2164770 0x16046802
+    Data Type: 64-bit int  InDom: 164.288770 0x29046802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10009,7 +10009,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric349.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10030,7 +10030,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric35.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.289794 0x16046c02
+    Data Type: 64-bit int  InDom: 164.289794 0x29046c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10045,7 +10045,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric35.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10066,7 +10066,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric350.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.290818 0x16047002
+    Data Type: 64-bit int  InDom: 164.290818 0x29047002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10081,7 +10081,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric350.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10102,7 +10102,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric351.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.291842 0x16047402
+    Data Type: 64-bit int  InDom: 164.291842 0x29047402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10117,7 +10117,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric351.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10138,7 +10138,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric352.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.292866 0x16047802
+    Data Type: 64-bit int  InDom: 164.292866 0x29047802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10153,7 +10153,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric352.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10174,7 +10174,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric353.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.293890 0x16047c02
+    Data Type: 64-bit int  InDom: 164.293890 0x29047c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10189,7 +10189,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric353.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10210,7 +10210,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric354.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.294914 0x16048002
+    Data Type: 64-bit int  InDom: 164.294914 0x29048002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10225,7 +10225,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric354.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10246,7 +10246,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric355.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.295938 0x16048402
+    Data Type: 64-bit int  InDom: 164.295938 0x29048402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10261,7 +10261,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric355.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10282,7 +10282,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric356.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.296962 0x160416402
+    Data Type: 64-bit int  InDom: 164.296962 0x29048802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10297,7 +10297,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric356.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10318,7 +10318,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric357.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.297986 0x16048c02
+    Data Type: 64-bit int  InDom: 164.297986 0x29048c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10333,7 +10333,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric357.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10354,7 +10354,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric358.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.299010 0x16049002
+    Data Type: 64-bit int  InDom: 164.299010 0x29049002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10369,7 +10369,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric358.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10390,7 +10390,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric359.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.300034 0x16049402
+    Data Type: 64-bit int  InDom: 164.300034 0x29049402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10405,7 +10405,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric359.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10426,7 +10426,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric36.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.301058 0x16049802
+    Data Type: 64-bit int  InDom: 164.301058 0x29049802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10441,7 +10441,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric36.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10462,7 +10462,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric360.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.302082 0x16049c02
+    Data Type: 64-bit int  InDom: 164.302082 0x29049c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10477,7 +10477,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric360.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10498,7 +10498,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric361.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.303106 0x1604a002
+    Data Type: 64-bit int  InDom: 164.303106 0x2904a002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10513,7 +10513,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric361.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10534,7 +10534,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric362.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.304130 0x1604a402
+    Data Type: 64-bit int  InDom: 164.304130 0x2904a402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10549,7 +10549,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric362.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10570,7 +10570,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric363.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.305154 0x1604a802
+    Data Type: 64-bit int  InDom: 164.305154 0x2904a802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10585,7 +10585,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric363.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10606,7 +10606,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric364.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.306178 0x1604ac02
+    Data Type: 64-bit int  InDom: 164.306178 0x2904ac02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10621,7 +10621,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric364.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10642,7 +10642,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric365.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.307202 0x1604b002
+    Data Type: 64-bit int  InDom: 164.307202 0x2904b002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10657,7 +10657,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric365.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10678,7 +10678,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric366.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.308226 0x1604b402
+    Data Type: 64-bit int  InDom: 164.308226 0x2904b402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10693,7 +10693,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric366.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10714,7 +10714,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric367.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.309250 0x1604b802
+    Data Type: 64-bit int  InDom: 164.309250 0x2904b802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10729,7 +10729,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric367.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10750,7 +10750,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric368.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.310274 0x1604bc02
+    Data Type: 64-bit int  InDom: 164.310274 0x2904bc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10765,7 +10765,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric368.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10786,7 +10786,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric369.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.311298 0x1604c002
+    Data Type: 64-bit int  InDom: 164.311298 0x2904c002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10801,7 +10801,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric369.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10822,7 +10822,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric37.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.312322 0x1604c402
+    Data Type: 64-bit int  InDom: 164.312322 0x2904c402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10837,7 +10837,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric37.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10858,7 +10858,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric370.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.313346 0x1604c802
+    Data Type: 64-bit int  InDom: 164.313346 0x2904c802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10873,7 +10873,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric370.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10894,7 +10894,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric371.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.314370 0x1604cc02
+    Data Type: 64-bit int  InDom: 164.314370 0x2904cc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10909,7 +10909,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric371.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10930,7 +10930,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric372.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.315394 0x1604d002
+    Data Type: 64-bit int  InDom: 164.315394 0x2904d002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10945,7 +10945,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric372.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10966,7 +10966,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric373.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.316418 0x1604d402
+    Data Type: 64-bit int  InDom: 164.316418 0x2904d402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -10981,7 +10981,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric373.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11002,7 +11002,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric374.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.317442 0x1604d802
+    Data Type: 64-bit int  InDom: 164.317442 0x2904d802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11017,7 +11017,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric374.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11038,7 +11038,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric375.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.318466 0x1604dc02
+    Data Type: 64-bit int  InDom: 164.318466 0x2904dc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11053,7 +11053,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric375.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11074,7 +11074,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric376.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.319490 0x1604e002
+    Data Type: 64-bit int  InDom: 164.319490 0x2904e002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11089,7 +11089,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric376.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11110,7 +11110,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric377.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.320514 0x1604e402
+    Data Type: 64-bit int  InDom: 164.320514 0x2904e402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11125,7 +11125,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric377.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11146,7 +11146,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric378.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.321538 0x1604e802
+    Data Type: 64-bit int  InDom: 164.321538 0x2904e802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11161,7 +11161,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric378.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11182,7 +11182,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric379.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.322562 0x1604ec02
+    Data Type: 64-bit int  InDom: 164.322562 0x2904ec02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11197,7 +11197,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric379.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11218,7 +11218,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric38.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.323586 0x1604f002
+    Data Type: 64-bit int  InDom: 164.323586 0x2904f002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11233,7 +11233,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric38.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11254,7 +11254,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric380.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.324610 0x1604f402
+    Data Type: 64-bit int  InDom: 164.324610 0x2904f402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11269,7 +11269,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric380.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11290,7 +11290,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric381.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.325634 0x1604f802
+    Data Type: 64-bit int  InDom: 164.325634 0x2904f802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11305,7 +11305,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric381.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11326,7 +11326,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric382.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.326658 0x1604fc02
+    Data Type: 64-bit int  InDom: 164.326658 0x2904fc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11341,7 +11341,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric382.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11362,7 +11362,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric383.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.327682 0x16050002
+    Data Type: 64-bit int  InDom: 164.327682 0x29050002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11377,7 +11377,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric383.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11398,7 +11398,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric384.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.328706 0x16050402
+    Data Type: 64-bit int  InDom: 164.328706 0x29050402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11413,7 +11413,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric384.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11434,7 +11434,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric385.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.329730 0x16050802
+    Data Type: 64-bit int  InDom: 164.329730 0x29050802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11449,7 +11449,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric385.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11470,7 +11470,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric386.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.330754 0x16050c02
+    Data Type: 64-bit int  InDom: 164.330754 0x29050c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11485,7 +11485,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric386.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11506,7 +11506,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric387.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.331778 0x16051002
+    Data Type: 64-bit int  InDom: 164.331778 0x29051002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11521,43 +11521,43 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric387.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     value 2
 
-opentelemetry.simplemetric3164.metric1 [I am a Counter]
+opentelemetry.simplemetric388.metric1 [I am a Counter]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Counter
     value 5
 
-opentelemetry.simplemetric3164.metric2 [I am a Gauge]
+opentelemetry.simplemetric388.metric2 [I am a Gauge]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: instant  Units: none
 Help:
 I am a Gauge
     value 10
 
-opentelemetry.simplemetric3164.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.332802 0x16051402
+opentelemetry.simplemetric388.metric3 [I am a Histogram]
+    Data Type: 64-bit int  InDom: 164.332802 0x29051402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     inst [0 or "le=1"] value 1
     inst [1 or "le=inf"] value 1
 
-opentelemetry.simplemetric3164.metric3_count [I am a Histogram]
+opentelemetry.simplemetric388.metric3_count [I am a Histogram]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     value 2
 
-opentelemetry.simplemetric3164.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.simplemetric388.metric3_sum [I am a Histogram]
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11578,7 +11578,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric389.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.333826 0x16051802
+    Data Type: 64-bit int  InDom: 164.333826 0x29051802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11593,7 +11593,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric389.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11614,7 +11614,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric39.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.334850 0x16051c02
+    Data Type: 64-bit int  InDom: 164.334850 0x29051c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11629,7 +11629,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric39.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11650,7 +11650,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric390.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.335874 0x16052002
+    Data Type: 64-bit int  InDom: 164.335874 0x29052002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11665,7 +11665,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric390.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11686,7 +11686,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric391.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.336898 0x16052402
+    Data Type: 64-bit int  InDom: 164.336898 0x29052402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11701,7 +11701,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric391.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11722,7 +11722,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric392.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.337922 0x16052802
+    Data Type: 64-bit int  InDom: 164.337922 0x29052802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11737,7 +11737,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric392.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11758,7 +11758,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric393.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.338946 0x16052c02
+    Data Type: 64-bit int  InDom: 164.338946 0x29052c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11773,7 +11773,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric393.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11794,7 +11794,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric394.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.339970 0x16053002
+    Data Type: 64-bit int  InDom: 164.339970 0x29053002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11809,7 +11809,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric394.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11830,7 +11830,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric395.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.340994 0x16053402
+    Data Type: 64-bit int  InDom: 164.340994 0x29053402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11845,7 +11845,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric395.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11866,7 +11866,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric396.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.342018 0x16053802
+    Data Type: 64-bit int  InDom: 164.342018 0x29053802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11881,7 +11881,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric396.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11902,7 +11902,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric397.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.343042 0x16053c02
+    Data Type: 64-bit int  InDom: 164.343042 0x29053c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11917,7 +11917,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric397.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11938,7 +11938,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric398.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.344066 0x16054002
+    Data Type: 64-bit int  InDom: 164.344066 0x29054002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11953,7 +11953,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric398.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11974,7 +11974,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric399.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.345090 0x16054402
+    Data Type: 64-bit int  InDom: 164.345090 0x29054402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -11989,7 +11989,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric399.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12010,7 +12010,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric4.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.346114 0x16054802
+    Data Type: 64-bit int  InDom: 164.346114 0x29054802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12025,7 +12025,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric4.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12046,7 +12046,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric40.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.347138 0x16054c02
+    Data Type: 64-bit int  InDom: 164.347138 0x29054c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12061,7 +12061,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric40.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12082,7 +12082,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric400.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.348162 0x16055002
+    Data Type: 64-bit int  InDom: 164.348162 0x29055002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12097,7 +12097,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric400.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12118,7 +12118,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric401.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.349186 0x16055402
+    Data Type: 64-bit int  InDom: 164.349186 0x29055402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12133,7 +12133,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric401.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12154,7 +12154,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric402.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.350210 0x16055802
+    Data Type: 64-bit int  InDom: 164.350210 0x29055802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12169,7 +12169,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric402.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12190,7 +12190,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric403.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.351234 0x16055c02
+    Data Type: 64-bit int  InDom: 164.351234 0x29055c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12205,7 +12205,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric403.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12226,7 +12226,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric404.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.352258 0x16056002
+    Data Type: 64-bit int  InDom: 164.352258 0x29056002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12241,7 +12241,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric404.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12262,7 +12262,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric405.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.353282 0x16056402
+    Data Type: 64-bit int  InDom: 164.353282 0x29056402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12277,7 +12277,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric405.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12298,7 +12298,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric406.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.354306 0x16056802
+    Data Type: 64-bit int  InDom: 164.354306 0x29056802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12313,7 +12313,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric406.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12334,7 +12334,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric407.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.355330 0x16056c02
+    Data Type: 64-bit int  InDom: 164.355330 0x29056c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12349,7 +12349,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric407.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12370,7 +12370,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric408.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.356354 0x16057002
+    Data Type: 64-bit int  InDom: 164.356354 0x29057002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12385,7 +12385,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric408.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12406,7 +12406,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric409.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.357378 0x16057402
+    Data Type: 64-bit int  InDom: 164.357378 0x29057402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12421,7 +12421,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric409.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12442,7 +12442,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric41.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.358402 0x16057802
+    Data Type: 64-bit int  InDom: 164.358402 0x29057802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12457,7 +12457,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric41.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12478,7 +12478,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric410.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.359426 0x16057c02
+    Data Type: 64-bit int  InDom: 164.359426 0x29057c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12493,7 +12493,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric410.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12514,7 +12514,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric411.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.360450 0x16058002
+    Data Type: 64-bit int  InDom: 164.360450 0x29058002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12529,7 +12529,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric411.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12550,7 +12550,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric412.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.361474 0x16058402
+    Data Type: 64-bit int  InDom: 164.361474 0x29058402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12565,7 +12565,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric412.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12586,7 +12586,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric413.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.362498 0x160516402
+    Data Type: 64-bit int  InDom: 164.362498 0x29058802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12601,7 +12601,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric413.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12622,7 +12622,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric414.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.363522 0x16058c02
+    Data Type: 64-bit int  InDom: 164.363522 0x29058c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12637,7 +12637,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric414.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12658,7 +12658,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric415.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.364546 0x16059002
+    Data Type: 64-bit int  InDom: 164.364546 0x29059002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12673,7 +12673,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric415.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12694,7 +12694,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric416.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.365570 0x16059402
+    Data Type: 64-bit int  InDom: 164.365570 0x29059402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12709,7 +12709,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric416.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12730,7 +12730,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric417.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.366594 0x16059802
+    Data Type: 64-bit int  InDom: 164.366594 0x29059802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12745,7 +12745,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric417.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12766,7 +12766,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric418.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.367618 0x16059c02
+    Data Type: 64-bit int  InDom: 164.367618 0x29059c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12781,7 +12781,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric418.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12802,7 +12802,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric419.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.368642 0x1605a002
+    Data Type: 64-bit int  InDom: 164.368642 0x2905a002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12817,7 +12817,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric419.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12838,7 +12838,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric42.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.369666 0x1605a402
+    Data Type: 64-bit int  InDom: 164.369666 0x2905a402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12853,7 +12853,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric42.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12874,7 +12874,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric420.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.370690 0x1605a802
+    Data Type: 64-bit int  InDom: 164.370690 0x2905a802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12889,7 +12889,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric420.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12910,7 +12910,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric421.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.371714 0x1605ac02
+    Data Type: 64-bit int  InDom: 164.371714 0x2905ac02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12925,7 +12925,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric421.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12946,7 +12946,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric422.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.372738 0x1605b002
+    Data Type: 64-bit int  InDom: 164.372738 0x2905b002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12961,7 +12961,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric422.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12982,7 +12982,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric423.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.373762 0x1605b402
+    Data Type: 64-bit int  InDom: 164.373762 0x2905b402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -12997,7 +12997,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric423.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13018,7 +13018,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric424.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.374786 0x1605b802
+    Data Type: 64-bit int  InDom: 164.374786 0x2905b802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13033,7 +13033,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric424.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13054,7 +13054,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric425.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.375810 0x1605bc02
+    Data Type: 64-bit int  InDom: 164.375810 0x2905bc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13069,7 +13069,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric425.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13090,7 +13090,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric426.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.376834 0x1605c002
+    Data Type: 64-bit int  InDom: 164.376834 0x2905c002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13105,7 +13105,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric426.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13126,7 +13126,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric427.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.377858 0x1605c402
+    Data Type: 64-bit int  InDom: 164.377858 0x2905c402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13141,7 +13141,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric427.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13162,7 +13162,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric428.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.3716482 0x1605c802
+    Data Type: 64-bit int  InDom: 164.378882 0x2905c802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13177,7 +13177,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric428.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13198,7 +13198,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric429.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.379906 0x1605cc02
+    Data Type: 64-bit int  InDom: 164.379906 0x2905cc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13213,7 +13213,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric429.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13234,7 +13234,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric43.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.380930 0x1605d002
+    Data Type: 64-bit int  InDom: 164.380930 0x2905d002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13249,7 +13249,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric43.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13270,7 +13270,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric430.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.381954 0x1605d402
+    Data Type: 64-bit int  InDom: 164.381954 0x2905d402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13285,7 +13285,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric430.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13306,7 +13306,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric431.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.382978 0x1605d802
+    Data Type: 64-bit int  InDom: 164.382978 0x2905d802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13321,7 +13321,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric431.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13342,7 +13342,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric432.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.384002 0x1605dc02
+    Data Type: 64-bit int  InDom: 164.384002 0x2905dc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13357,7 +13357,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric432.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13378,7 +13378,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric433.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.385026 0x1605e002
+    Data Type: 64-bit int  InDom: 164.385026 0x2905e002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13393,7 +13393,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric433.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13414,7 +13414,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric434.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.386050 0x1605e402
+    Data Type: 64-bit int  InDom: 164.386050 0x2905e402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13429,7 +13429,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric434.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13450,7 +13450,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric435.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.387074 0x1605e802
+    Data Type: 64-bit int  InDom: 164.387074 0x2905e802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13465,7 +13465,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric435.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13486,7 +13486,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric436.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.3164098 0x1605ec02
+    Data Type: 64-bit int  InDom: 164.388098 0x2905ec02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13501,7 +13501,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric436.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13522,7 +13522,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric437.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.389122 0x1605f002
+    Data Type: 64-bit int  InDom: 164.389122 0x2905f002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13537,7 +13537,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric437.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13558,7 +13558,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric438.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.390146 0x1605f402
+    Data Type: 64-bit int  InDom: 164.390146 0x2905f402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13573,7 +13573,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric438.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13594,7 +13594,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric439.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.391170 0x1605f802
+    Data Type: 64-bit int  InDom: 164.391170 0x2905f802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13609,7 +13609,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric439.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13630,7 +13630,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric44.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.392194 0x1605fc02
+    Data Type: 64-bit int  InDom: 164.392194 0x2905fc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13645,7 +13645,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric44.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13666,7 +13666,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric440.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.393218 0x16060002
+    Data Type: 64-bit int  InDom: 164.393218 0x29060002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13681,7 +13681,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric440.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13702,7 +13702,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric441.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.394242 0x16060402
+    Data Type: 64-bit int  InDom: 164.394242 0x29060402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13717,7 +13717,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric441.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13738,7 +13738,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric442.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.395266 0x16060802
+    Data Type: 64-bit int  InDom: 164.395266 0x29060802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13753,7 +13753,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric442.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13774,7 +13774,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric443.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.396290 0x16060c02
+    Data Type: 64-bit int  InDom: 164.396290 0x29060c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13789,7 +13789,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric443.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13810,7 +13810,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric444.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.397314 0x16061002
+    Data Type: 64-bit int  InDom: 164.397314 0x29061002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13825,7 +13825,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric444.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13846,7 +13846,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric445.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.398338 0x16061402
+    Data Type: 64-bit int  InDom: 164.398338 0x29061402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13861,7 +13861,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric445.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13882,7 +13882,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric446.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.399362 0x16061802
+    Data Type: 64-bit int  InDom: 164.399362 0x29061802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13897,7 +13897,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric446.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13918,7 +13918,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric447.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.400386 0x16061c02
+    Data Type: 64-bit int  InDom: 164.400386 0x29061c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13933,7 +13933,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric447.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13954,7 +13954,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric448.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.401410 0x16062002
+    Data Type: 64-bit int  InDom: 164.401410 0x29062002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13969,7 +13969,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric448.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -13990,7 +13990,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric449.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.402434 0x16062402
+    Data Type: 64-bit int  InDom: 164.402434 0x29062402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14005,7 +14005,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric449.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14026,7 +14026,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric45.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.403458 0x16062802
+    Data Type: 64-bit int  InDom: 164.403458 0x29062802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14041,7 +14041,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric45.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14062,7 +14062,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric450.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.404482 0x16062c02
+    Data Type: 64-bit int  InDom: 164.404482 0x29062c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14077,7 +14077,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric450.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14098,7 +14098,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric451.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.405506 0x16063002
+    Data Type: 64-bit int  InDom: 164.405506 0x29063002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14113,7 +14113,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric451.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14134,7 +14134,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric452.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.406530 0x16063402
+    Data Type: 64-bit int  InDom: 164.406530 0x29063402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14149,7 +14149,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric452.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14170,7 +14170,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric453.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.407554 0x16063802
+    Data Type: 64-bit int  InDom: 164.407554 0x29063802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14185,7 +14185,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric453.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14206,7 +14206,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric454.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.408578 0x16063c02
+    Data Type: 64-bit int  InDom: 164.408578 0x29063c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14221,7 +14221,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric454.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14242,7 +14242,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric455.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.409602 0x16064002
+    Data Type: 64-bit int  InDom: 164.409602 0x29064002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14257,7 +14257,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric455.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14278,7 +14278,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric456.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.410626 0x16064402
+    Data Type: 64-bit int  InDom: 164.410626 0x29064402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14293,7 +14293,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric456.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14314,7 +14314,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric457.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.411650 0x16064802
+    Data Type: 64-bit int  InDom: 164.411650 0x29064802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14329,7 +14329,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric457.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14350,7 +14350,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric458.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.412674 0x16064c02
+    Data Type: 64-bit int  InDom: 164.412674 0x29064c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14365,7 +14365,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric458.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14386,7 +14386,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric459.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.413698 0x16065002
+    Data Type: 64-bit int  InDom: 164.413698 0x29065002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14401,7 +14401,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric459.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14422,7 +14422,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric46.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.414722 0x16065402
+    Data Type: 64-bit int  InDom: 164.414722 0x29065402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14437,7 +14437,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric46.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14458,7 +14458,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric460.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.415746 0x16065802
+    Data Type: 64-bit int  InDom: 164.415746 0x29065802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14473,7 +14473,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric460.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14494,7 +14494,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric461.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.416770 0x16065c02
+    Data Type: 64-bit int  InDom: 164.416770 0x29065c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14509,7 +14509,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric461.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14530,7 +14530,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric462.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.417794 0x16066002
+    Data Type: 64-bit int  InDom: 164.417794 0x29066002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14545,7 +14545,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric462.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14566,7 +14566,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric463.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.4116418 0x16066402
+    Data Type: 64-bit int  InDom: 164.418818 0x29066402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14581,7 +14581,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric463.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14602,7 +14602,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric464.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.419842 0x16066802
+    Data Type: 64-bit int  InDom: 164.419842 0x29066802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14617,7 +14617,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric464.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14638,7 +14638,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric465.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.420866 0x16066c02
+    Data Type: 64-bit int  InDom: 164.420866 0x29066c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14653,7 +14653,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric465.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14674,7 +14674,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric466.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.421890 0x16067002
+    Data Type: 64-bit int  InDom: 164.421890 0x29067002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14689,7 +14689,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric466.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14710,7 +14710,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric467.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.422914 0x16067402
+    Data Type: 64-bit int  InDom: 164.422914 0x29067402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14725,7 +14725,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric467.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14746,7 +14746,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric468.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.423938 0x16067802
+    Data Type: 64-bit int  InDom: 164.423938 0x29067802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14761,7 +14761,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric468.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14782,7 +14782,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric469.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.424962 0x16067c02
+    Data Type: 64-bit int  InDom: 164.424962 0x29067c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14797,7 +14797,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric469.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14818,7 +14818,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric47.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.425986 0x16068002
+    Data Type: 64-bit int  InDom: 164.425986 0x29068002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14833,7 +14833,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric47.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14854,7 +14854,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric470.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.427010 0x16068402
+    Data Type: 64-bit int  InDom: 164.427010 0x29068402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14869,7 +14869,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric470.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14890,7 +14890,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric471.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.428034 0x160616402
+    Data Type: 64-bit int  InDom: 164.428034 0x29068802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14905,7 +14905,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric471.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14926,7 +14926,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric472.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.429058 0x16068c02
+    Data Type: 64-bit int  InDom: 164.429058 0x29068c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14941,7 +14941,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric472.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14962,7 +14962,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric473.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.430082 0x16069002
+    Data Type: 64-bit int  InDom: 164.430082 0x29069002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14977,7 +14977,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric473.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -14998,7 +14998,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric474.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.431106 0x16069402
+    Data Type: 64-bit int  InDom: 164.431106 0x29069402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15013,7 +15013,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric474.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15034,7 +15034,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric475.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.432130 0x16069802
+    Data Type: 64-bit int  InDom: 164.432130 0x29069802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15049,7 +15049,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric475.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15070,7 +15070,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric476.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.433154 0x16069c02
+    Data Type: 64-bit int  InDom: 164.433154 0x29069c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15085,7 +15085,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric476.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15106,7 +15106,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric477.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.434178 0x1606a002
+    Data Type: 64-bit int  InDom: 164.434178 0x2906a002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15121,7 +15121,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric477.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15142,7 +15142,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric478.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.435202 0x1606a402
+    Data Type: 64-bit int  InDom: 164.435202 0x2906a402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15157,7 +15157,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric478.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15178,7 +15178,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric479.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.436226 0x1606a802
+    Data Type: 64-bit int  InDom: 164.436226 0x2906a802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15193,7 +15193,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric479.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15214,7 +15214,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric48.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.437250 0x1606ac02
+    Data Type: 64-bit int  InDom: 164.437250 0x2906ac02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15229,7 +15229,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric48.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15250,7 +15250,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric480.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.438274 0x1606b002
+    Data Type: 64-bit int  InDom: 164.438274 0x2906b002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15265,7 +15265,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric480.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15286,7 +15286,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric481.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.439298 0x1606b402
+    Data Type: 64-bit int  InDom: 164.439298 0x2906b402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15301,7 +15301,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric481.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15322,7 +15322,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric482.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.440322 0x1606b802
+    Data Type: 64-bit int  InDom: 164.440322 0x2906b802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15337,7 +15337,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric482.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15358,7 +15358,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric483.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.441346 0x1606bc02
+    Data Type: 64-bit int  InDom: 164.441346 0x2906bc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15373,7 +15373,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric483.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15394,7 +15394,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric484.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.442370 0x1606c002
+    Data Type: 64-bit int  InDom: 164.442370 0x2906c002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15409,7 +15409,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric484.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15430,7 +15430,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric485.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.443394 0x1606c402
+    Data Type: 64-bit int  InDom: 164.443394 0x2906c402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15445,7 +15445,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric485.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15466,7 +15466,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric486.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.444418 0x1606c802
+    Data Type: 64-bit int  InDom: 164.444418 0x2906c802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15481,7 +15481,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric486.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15502,7 +15502,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric487.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.445442 0x1606cc02
+    Data Type: 64-bit int  InDom: 164.445442 0x2906cc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15517,43 +15517,43 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric487.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     value 2
 
-opentelemetry.simplemetric4164.metric1 [I am a Counter]
+opentelemetry.simplemetric488.metric1 [I am a Counter]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Counter
     value 5
 
-opentelemetry.simplemetric4164.metric2 [I am a Gauge]
+opentelemetry.simplemetric488.metric2 [I am a Gauge]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: instant  Units: none
 Help:
 I am a Gauge
     value 10
 
-opentelemetry.simplemetric4164.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.446466 0x1606d002
+opentelemetry.simplemetric488.metric3 [I am a Histogram]
+    Data Type: 64-bit int  InDom: 164.446466 0x2906d002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     inst [0 or "le=1"] value 1
     inst [1 or "le=inf"] value 1
 
-opentelemetry.simplemetric4164.metric3_count [I am a Histogram]
+opentelemetry.simplemetric488.metric3_count [I am a Histogram]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     value 2
 
-opentelemetry.simplemetric4164.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.simplemetric488.metric3_sum [I am a Histogram]
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15574,7 +15574,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric489.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.447490 0x1606d402
+    Data Type: 64-bit int  InDom: 164.447490 0x2906d402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15589,7 +15589,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric489.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15610,7 +15610,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric49.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.448514 0x1606d802
+    Data Type: 64-bit int  InDom: 164.448514 0x2906d802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15625,7 +15625,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric49.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15646,7 +15646,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric490.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.449538 0x1606dc02
+    Data Type: 64-bit int  InDom: 164.449538 0x2906dc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15661,7 +15661,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric490.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15682,7 +15682,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric491.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.450562 0x1606e002
+    Data Type: 64-bit int  InDom: 164.450562 0x2906e002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15697,7 +15697,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric491.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15718,7 +15718,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric492.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.451586 0x1606e402
+    Data Type: 64-bit int  InDom: 164.451586 0x2906e402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15733,7 +15733,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric492.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15754,7 +15754,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric493.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.452610 0x1606e802
+    Data Type: 64-bit int  InDom: 164.452610 0x2906e802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15769,7 +15769,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric493.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15790,7 +15790,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric494.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.453634 0x1606ec02
+    Data Type: 64-bit int  InDom: 164.453634 0x2906ec02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15805,7 +15805,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric494.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15826,7 +15826,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric495.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.454658 0x1606f002
+    Data Type: 64-bit int  InDom: 164.454658 0x2906f002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15841,7 +15841,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric495.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15862,7 +15862,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric496.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.455682 0x1606f402
+    Data Type: 64-bit int  InDom: 164.455682 0x2906f402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15877,7 +15877,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric496.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15898,7 +15898,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric497.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.456706 0x1606f802
+    Data Type: 64-bit int  InDom: 164.456706 0x2906f802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15913,7 +15913,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric497.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15934,7 +15934,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric498.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.457730 0x1606fc02
+    Data Type: 64-bit int  InDom: 164.457730 0x2906fc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15949,7 +15949,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric498.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15970,7 +15970,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric499.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.458754 0x16070002
+    Data Type: 64-bit int  InDom: 164.458754 0x29070002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -15985,7 +15985,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric499.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16006,7 +16006,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric5.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.459778 0x16070402
+    Data Type: 64-bit int  InDom: 164.459778 0x29070402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16021,7 +16021,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric5.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16042,7 +16042,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric50.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.460802 0x16070802
+    Data Type: 64-bit int  InDom: 164.460802 0x29070802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16057,7 +16057,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric50.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16078,7 +16078,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric500.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.461826 0x16070c02
+    Data Type: 64-bit int  InDom: 164.461826 0x29070c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16093,7 +16093,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric500.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16114,7 +16114,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric51.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.462850 0x16071002
+    Data Type: 64-bit int  InDom: 164.462850 0x29071002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16129,7 +16129,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric51.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16150,7 +16150,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric52.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.463874 0x16071402
+    Data Type: 64-bit int  InDom: 164.463874 0x29071402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16165,7 +16165,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric52.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16186,7 +16186,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric53.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.464898 0x16071802
+    Data Type: 64-bit int  InDom: 164.464898 0x29071802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16201,7 +16201,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric53.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16222,7 +16222,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric54.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.465922 0x16071c02
+    Data Type: 64-bit int  InDom: 164.465922 0x29071c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16237,7 +16237,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric54.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16258,7 +16258,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric55.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.466946 0x16072002
+    Data Type: 64-bit int  InDom: 164.466946 0x29072002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16273,7 +16273,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric55.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16294,7 +16294,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric56.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.467970 0x16072402
+    Data Type: 64-bit int  InDom: 164.467970 0x29072402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16309,7 +16309,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric56.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16330,7 +16330,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric57.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.468994 0x16072802
+    Data Type: 64-bit int  InDom: 164.468994 0x29072802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16345,7 +16345,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric57.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16366,7 +16366,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric58.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.470018 0x16072c02
+    Data Type: 64-bit int  InDom: 164.470018 0x29072c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16381,7 +16381,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric58.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16402,7 +16402,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric59.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.471042 0x16073002
+    Data Type: 64-bit int  InDom: 164.471042 0x29073002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16417,7 +16417,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric59.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16438,7 +16438,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric6.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.472066 0x16073402
+    Data Type: 64-bit int  InDom: 164.472066 0x29073402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16453,7 +16453,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric6.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16474,7 +16474,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric60.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.473090 0x16073802
+    Data Type: 64-bit int  InDom: 164.473090 0x29073802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16489,7 +16489,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric60.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16510,7 +16510,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric61.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.474114 0x16073c02
+    Data Type: 64-bit int  InDom: 164.474114 0x29073c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16525,7 +16525,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric61.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16546,7 +16546,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric62.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.475138 0x16074002
+    Data Type: 64-bit int  InDom: 164.475138 0x29074002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16561,7 +16561,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric62.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16582,7 +16582,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric63.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.476162 0x16074402
+    Data Type: 64-bit int  InDom: 164.476162 0x29074402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16597,7 +16597,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric63.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16618,7 +16618,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric64.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.477186 0x16074802
+    Data Type: 64-bit int  InDom: 164.477186 0x29074802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16633,7 +16633,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric64.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16654,7 +16654,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric65.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.478210 0x16074c02
+    Data Type: 64-bit int  InDom: 164.478210 0x29074c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16669,7 +16669,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric65.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16690,7 +16690,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric66.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.479234 0x16075002
+    Data Type: 64-bit int  InDom: 164.479234 0x29075002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16705,7 +16705,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric66.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16726,7 +16726,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric67.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.480258 0x16075402
+    Data Type: 64-bit int  InDom: 164.480258 0x29075402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16741,7 +16741,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric67.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16762,7 +16762,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric68.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.481282 0x16075802
+    Data Type: 64-bit int  InDom: 164.481282 0x29075802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16777,7 +16777,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric68.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16798,7 +16798,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric69.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.482306 0x16075c02
+    Data Type: 64-bit int  InDom: 164.482306 0x29075c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16813,7 +16813,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric69.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16834,7 +16834,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric7.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.483330 0x16076002
+    Data Type: 64-bit int  InDom: 164.483330 0x29076002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16849,7 +16849,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric7.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16870,7 +16870,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric70.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.484354 0x16076402
+    Data Type: 64-bit int  InDom: 164.484354 0x29076402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16885,7 +16885,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric70.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16906,7 +16906,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric71.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.485378 0x16076802
+    Data Type: 64-bit int  InDom: 164.485378 0x29076802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16921,7 +16921,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric71.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16942,7 +16942,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric72.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.486402 0x16076c02
+    Data Type: 64-bit int  InDom: 164.486402 0x29076c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16957,7 +16957,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric72.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16978,7 +16978,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric73.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.487426 0x16077002
+    Data Type: 64-bit int  InDom: 164.487426 0x29077002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -16993,7 +16993,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric73.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17014,7 +17014,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric74.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.4164450 0x16077402
+    Data Type: 64-bit int  InDom: 164.488450 0x29077402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17029,7 +17029,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric74.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17050,7 +17050,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric75.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.489474 0x16077802
+    Data Type: 64-bit int  InDom: 164.489474 0x29077802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17065,7 +17065,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric75.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17086,7 +17086,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric76.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.490498 0x16077c02
+    Data Type: 64-bit int  InDom: 164.490498 0x29077c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17101,7 +17101,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric76.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17122,7 +17122,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric77.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.491522 0x16078002
+    Data Type: 64-bit int  InDom: 164.491522 0x29078002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17137,7 +17137,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric77.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17158,7 +17158,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric78.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.492546 0x16078402
+    Data Type: 64-bit int  InDom: 164.492546 0x29078402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17173,7 +17173,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric78.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17194,7 +17194,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric79.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.493570 0x160716402
+    Data Type: 64-bit int  InDom: 164.493570 0x29078802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17209,7 +17209,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric79.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17230,7 +17230,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric8.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.494594 0x16078c02
+    Data Type: 64-bit int  InDom: 164.494594 0x29078c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17245,7 +17245,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric8.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17266,7 +17266,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric80.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.495618 0x16079002
+    Data Type: 64-bit int  InDom: 164.495618 0x29079002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17281,7 +17281,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric80.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17302,7 +17302,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric81.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.496642 0x16079402
+    Data Type: 64-bit int  InDom: 164.496642 0x29079402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17317,7 +17317,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric81.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17338,7 +17338,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric82.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.497666 0x16079802
+    Data Type: 64-bit int  InDom: 164.497666 0x29079802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17353,7 +17353,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric82.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17374,7 +17374,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric83.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.498690 0x16079c02
+    Data Type: 64-bit int  InDom: 164.498690 0x29079c02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17389,7 +17389,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric83.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17410,7 +17410,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric84.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.499714 0x1607a002
+    Data Type: 64-bit int  InDom: 164.499714 0x2907a002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17425,7 +17425,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric84.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17446,7 +17446,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric85.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.500738 0x1607a402
+    Data Type: 64-bit int  InDom: 164.500738 0x2907a402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17461,7 +17461,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric85.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17482,7 +17482,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric86.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.501762 0x1607a802
+    Data Type: 64-bit int  InDom: 164.501762 0x2907a802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17497,7 +17497,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric86.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17518,7 +17518,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric87.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.502786 0x1607ac02
+    Data Type: 64-bit int  InDom: 164.502786 0x2907ac02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17533,43 +17533,43 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric87.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     value 2
 
-opentelemetry.simplemetric164.metric1 [I am a Counter]
+opentelemetry.simplemetric88.metric1 [I am a Counter]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Counter
     value 5
 
-opentelemetry.simplemetric164.metric2 [I am a Gauge]
+opentelemetry.simplemetric88.metric2 [I am a Gauge]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: instant  Units: none
 Help:
 I am a Gauge
     value 10
 
-opentelemetry.simplemetric164.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.503810 0x1607b002
+opentelemetry.simplemetric88.metric3 [I am a Histogram]
+    Data Type: 64-bit int  InDom: 164.503810 0x2907b002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     inst [0 or "le=1"] value 1
     inst [1 or "le=inf"] value 1
 
-opentelemetry.simplemetric164.metric3_count [I am a Histogram]
+opentelemetry.simplemetric88.metric3_count [I am a Histogram]
     Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
     value 2
 
-opentelemetry.simplemetric164.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+opentelemetry.simplemetric88.metric3_sum [I am a Histogram]
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17590,7 +17590,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric89.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.504834 0x1607b402
+    Data Type: 64-bit int  InDom: 164.504834 0x2907b402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17605,7 +17605,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric89.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17626,7 +17626,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric9.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.505858 0x1607b802
+    Data Type: 64-bit int  InDom: 164.505858 0x2907b802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17641,7 +17641,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric9.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17662,7 +17662,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric90.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.5061642 0x1607bc02
+    Data Type: 64-bit int  InDom: 164.506882 0x2907bc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17677,7 +17677,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric90.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17698,7 +17698,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric91.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.507906 0x1607c002
+    Data Type: 64-bit int  InDom: 164.507906 0x2907c002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17713,7 +17713,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric91.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17734,7 +17734,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric92.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.508930 0x1607c402
+    Data Type: 64-bit int  InDom: 164.508930 0x2907c402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17749,7 +17749,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric92.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17770,7 +17770,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric93.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.509954 0x1607c802
+    Data Type: 64-bit int  InDom: 164.509954 0x2907c802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17785,7 +17785,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric93.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17806,7 +17806,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric94.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.510978 0x1607cc02
+    Data Type: 64-bit int  InDom: 164.510978 0x2907cc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17821,7 +17821,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric94.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17842,7 +17842,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric95.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.512002 0x1607d002
+    Data Type: 64-bit int  InDom: 164.512002 0x2907d002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17857,7 +17857,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric95.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17878,7 +17878,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric96.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.513026 0x1607d402
+    Data Type: 64-bit int  InDom: 164.513026 0x2907d402
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17893,7 +17893,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric96.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17914,7 +17914,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric97.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.514050 0x1607d802
+    Data Type: 64-bit int  InDom: 164.514050 0x2907d802
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17929,7 +17929,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric97.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17950,7 +17950,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric98.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.515074 0x1607dc02
+    Data Type: 64-bit int  InDom: 164.515074 0x2907dc02
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17965,7 +17965,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric98.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -17986,7 +17986,7 @@ I am a Gauge
     value 10
 
 opentelemetry.simplemetric99.metric3 [I am a Histogram]
-    Data Type: 64-bit int  InDom: 164.516098 0x1607e002
+    Data Type: 64-bit int  InDom: 164.516098 0x2907e002
     Semantics: counter  Units: none
 Help:
 I am a Histogram
@@ -18001,7 +18001,7 @@ I am a Histogram
     value 2
 
 opentelemetry.simplemetric99.metric3_sum [I am a Histogram]
-    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
     Semantics: counter  Units: none
 Help:
 I am a Histogram

--- a/qa/1948
+++ b/qa/1948
@@ -17,8 +17,6 @@ echo "QA output created by $seq"
 
 _pmdaopentelemetry_check || _notrun "opentelemetry pmda and/or load generator not installed"
 
-_notrun "currently failing, needs analysis and updates"
-
 status=1        # failure is the default!
 $sudo rm -rf $tmp $tmp.* $seq.full
 totalendpoints=5 #total queue to work through
@@ -55,7 +53,6 @@ _stop_auto_restart pmcd
 
 _pmdaopentelemetry_save_config
 _pmdaopentelemetry_install
-
 port=`_find_free_port 10000`
 echo "port=$port" >>$here/$seq.full
 

--- a/qa/1948.out
+++ b/qa/1948.out
@@ -3,8 +3,8 @@ QA output created by 1948
 === opentelemetry agent installation ===
 Fetch and desc opentelemetry metrics: success
 
-opentelemetry.source1.sample_counter0001 []
-    Data Type: double  InDom: 88.6145 0x16001801
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
+    Data Type: double  InDom: 164.6145 0x29001801
     Semantics: counter  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 510616182
@@ -407,8 +407,8 @@ opentelemetry.source1.sample_counter0001 []
     inst [398 or "398 inst-398"] value 203225240000
     inst [399 or "399 inst-399"] value 203735857000
 
-opentelemetry.source1.sample_gauge0000 []
-    Data Type: double  InDom: 88.6144 0x16001800
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
+    Data Type: double  InDom: 164.6144 0x29001800
     Semantics: instant  Units: none
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 24.2
@@ -811,9 +811,9 @@ opentelemetry.source1.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 9631.6
     inst [399 or "399 inst-399"] value 9655.799999999999
 
-opentelemetry.source1.sample_summary0002 []
-    Data Type: double  InDom: 88.6146 0x16001802
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
+    Data Type: double  InDom: 164.6146 0x29001802
+    Semantics: counter  Units: none
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0006384920000000001
     inst [2 or "quantile: 0.5"] value 0.001276984
@@ -1215,17 +1215,17 @@ opentelemetry.source1.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.254119816
     inst [399 or "quantile: 99.75"] value 0.254758308
 
-opentelemetry.source1.sample_summary0002_count []
-    Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
+    Data Type: 64-bit int  InDom: PM_INDOM_NULL 0xffffffff
+    Semantics: counter  Units: none
     value 7272
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     Data Type: double  InDom: PM_INDOM_NULL 0xffffffff
-    Semantics: instant  Units: none
+    Semantics: counter  Units: none
     value 5.564827
 
-opentelemetry.source0.sample_counter0001 []
+opentelemetry.source0.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 170205394
     inst [2 or "2 inst-2"] value 340410788
@@ -1627,7 +1627,7 @@ opentelemetry.source0.sample_counter0001 []
     inst [398 or "398 inst-398"] value 67741746800
     inst [399 or "399 inst-399"] value 67911952200
 
-opentelemetry.source0.sample_gauge0000 []
+opentelemetry.source0.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 0
     inst [2 or "2 inst-2"] value 0
@@ -2029,7 +2029,7 @@ opentelemetry.source0.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 0
     inst [399 or "399 inst-399"] value 0
 
-opentelemetry.source0.sample_summary0002 []
+opentelemetry.source0.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.000319246
     inst [2 or "quantile: 0.5"] value 0.0006384920000000001
@@ -2431,13 +2431,13 @@ opentelemetry.source0.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.127059908
     inst [399 or "quantile: 99.75"] value 0.127379154
 
-opentelemetry.source0.sample_summary0002_count []
+opentelemetry.source0.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 3636
 
-opentelemetry.source0.sample_summary0002_sum []
+opentelemetry.source0.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 2.782414
 
-opentelemetry.source0.sample_counter0001 []
+opentelemetry.source0.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 170205394
     inst [2 or "2 inst-2"] value 340410788
@@ -2839,7 +2839,7 @@ opentelemetry.source0.sample_counter0001 []
     inst [398 or "398 inst-398"] value 67741746800
     inst [399 or "399 inst-399"] value 67911952200
 
-opentelemetry.source0.sample_gauge0000 []
+opentelemetry.source0.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 0
     inst [2 or "2 inst-2"] value 0
@@ -3241,7 +3241,7 @@ opentelemetry.source0.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 0
     inst [399 or "399 inst-399"] value 0
 
-opentelemetry.source0.sample_summary0002 []
+opentelemetry.source0.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.000319246
     inst [2 or "quantile: 0.5"] value 0.0006384920000000001
@@ -3643,13 +3643,13 @@ opentelemetry.source0.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.127059908
     inst [399 or "quantile: 99.75"] value 0.127379154
 
-opentelemetry.source0.sample_summary0002_count []
+opentelemetry.source0.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 3636
 
-opentelemetry.source0.sample_summary0002_sum []
+opentelemetry.source0.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 2.782414
 
-opentelemetry.source0.sample_counter0001 []
+opentelemetry.source0.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 170205394
     inst [2 or "2 inst-2"] value 340410788
@@ -4051,7 +4051,7 @@ opentelemetry.source0.sample_counter0001 []
     inst [398 or "398 inst-398"] value 67741746800
     inst [399 or "399 inst-399"] value 67911952200
 
-opentelemetry.source0.sample_gauge0000 []
+opentelemetry.source0.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 0
     inst [2 or "2 inst-2"] value 0
@@ -4453,7 +4453,7 @@ opentelemetry.source0.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 0
     inst [399 or "399 inst-399"] value 0
 
-opentelemetry.source0.sample_summary0002 []
+opentelemetry.source0.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.000319246
     inst [2 or "quantile: 0.5"] value 0.0006384920000000001
@@ -4855,28 +4855,28 @@ opentelemetry.source0.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.127059908
     inst [399 or "quantile: 99.75"] value 0.127379154
 
-opentelemetry.source0.sample_summary0002_count []
+opentelemetry.source0.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 3636
 
-opentelemetry.source0.sample_summary0002_sum []
+opentelemetry.source0.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 2.782414
 
-opentelemetry.source0.sample_counter0001 []
+opentelemetry.source0.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_gauge0000 []
+opentelemetry.source0.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0002 []
+opentelemetry.source0.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0002_count []
+opentelemetry.source0.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source0.sample_summary0002_sum []
+opentelemetry.source0.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0001 []
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 680821576
     inst [2 or "2 inst-2"] value 1361643150
@@ -5278,7 +5278,7 @@ opentelemetry.source1.sample_counter0001 []
     inst [398 or "398 inst-398"] value 270966987000
     inst [399 or "399 inst-399"] value 271647809000
 
-opentelemetry.source1.sample_gauge0000 []
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 36.3
     inst [2 or "2 inst-2"] value 72.59999999999999
@@ -5680,7 +5680,7 @@ opentelemetry.source1.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 14447.4
     inst [399 or "399 inst-399"] value 14483.7
 
-opentelemetry.source1.sample_summary0002 []
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0007981150000000001
     inst [2 or "quantile: 0.5"] value 0.00159623
@@ -6082,13 +6082,13 @@ opentelemetry.source1.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.3176497700000001
     inst [399 or "quantile: 99.75"] value 0.318447885
 
-opentelemetry.source1.sample_summary0002_count []
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 9090
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 6.956034
 
-opentelemetry.source1.sample_counter0001 []
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 851026970
     inst [2 or "2 inst-2"] value 1702053940
@@ -6490,7 +6490,7 @@ opentelemetry.source1.sample_counter0001 []
     inst [398 or "398 inst-398"] value 338708734000
     inst [399 or "399 inst-399"] value 339559761000
 
-opentelemetry.source1.sample_gauge0000 []
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 48.4
     inst [2 or "2 inst-2"] value 96.8
@@ -6892,7 +6892,7 @@ opentelemetry.source1.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 19263.2
     inst [399 or "399 inst-399"] value 19311.6
 
-opentelemetry.source1.sample_summary0002 []
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0009577380000000001
     inst [2 or "quantile: 0.5"] value 0.001915476
@@ -7294,43 +7294,43 @@ opentelemetry.source1.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.3811797240000001
     inst [399 or "quantile: 99.75"] value 0.382137462
 
-opentelemetry.source1.sample_summary0002_count []
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 10908
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 8.347241
 
-opentelemetry.source1.sample_counter0001 []
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0000 []
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0002 []
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0002_count []
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_counter0001 []
+opentelemetry.source1.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_gauge0000 []
+opentelemetry.source1.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0002 []
+opentelemetry.source1.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0002_count []
+opentelemetry.source1.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source1.sample_summary0002_sum []
+opentelemetry.source1.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source2.sample_counter0001 []
+opentelemetry.source2.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 851026970
     inst [2 or "2 inst-2"] value 1702053940
@@ -7732,7 +7732,7 @@ opentelemetry.source2.sample_counter0001 []
     inst [398 or "398 inst-398"] value 338708734000
     inst [399 or "399 inst-399"] value 339559761000
 
-opentelemetry.source2.sample_gauge0000 []
+opentelemetry.source2.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 48.4
     inst [2 or "2 inst-2"] value 96.8
@@ -8134,7 +8134,7 @@ opentelemetry.source2.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 19263.2
     inst [399 or "399 inst-399"] value 19311.6
 
-opentelemetry.source2.sample_summary0002 []
+opentelemetry.source2.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.0009577380000000001
     inst [2 or "quantile: 0.5"] value 0.001915476
@@ -8536,13 +8536,13 @@ opentelemetry.source2.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.3811797240000001
     inst [399 or "quantile: 99.75"] value 0.382137462
 
-opentelemetry.source2.sample_summary0002_count []
+opentelemetry.source2.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 10908
 
-opentelemetry.source2.sample_summary0002_sum []
+opentelemetry.source2.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 8.347241
 
-opentelemetry.source2.sample_counter0001 []
+opentelemetry.source2.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1191437760
     inst [2 or "2 inst-2"] value 2382875520
@@ -8944,7 +8944,7 @@ opentelemetry.source2.sample_counter0001 []
     inst [398 or "398 inst-398"] value 474192228000
     inst [399 or "399 inst-399"] value 475383665000
 
-opentelemetry.source2.sample_gauge0000 []
+opentelemetry.source2.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 72.59999999999999
     inst [2 or "2 inst-2"] value 145.2
@@ -9346,7 +9346,7 @@ opentelemetry.source2.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 28894.8
     inst [399 or "399 inst-399"] value 28967.4
 
-opentelemetry.source2.sample_summary0002 []
+opentelemetry.source2.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001276984
     inst [2 or "quantile: 0.5"] value 0.002553968
@@ -9748,13 +9748,13 @@ opentelemetry.source2.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.508239632
     inst [399 or "quantile: 99.75"] value 0.5095166160000001
 
-opentelemetry.source2.sample_summary0002_count []
+opentelemetry.source2.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 14544
 
-opentelemetry.source2.sample_summary0002_sum []
+opentelemetry.source2.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 11.129654
 
-opentelemetry.source2.sample_counter0001 []
+opentelemetry.source2.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1531848550
     inst [2 or "2 inst-2"] value 3063697090
@@ -10156,7 +10156,7 @@ opentelemetry.source2.sample_counter0001 []
     inst [398 or "398 inst-398"] value 609675721000
     inst [399 or "399 inst-399"] value 611207570000
 
-opentelemetry.source2.sample_gauge0000 []
+opentelemetry.source2.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 96.8
     inst [2 or "2 inst-2"] value 193.6
@@ -10558,7 +10558,7 @@ opentelemetry.source2.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 38526.4
     inst [399 or "399 inst-399"] value 38623.2
 
-opentelemetry.source2.sample_summary0002 []
+opentelemetry.source2.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00159623
     inst [2 or "quantile: 0.5"] value 0.00319246
@@ -10960,28 +10960,28 @@ opentelemetry.source2.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.6352995400000001
     inst [399 or "quantile: 99.75"] value 0.6368957700000001
 
-opentelemetry.source2.sample_summary0002_count []
+opentelemetry.source2.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 18180
 
-opentelemetry.source2.sample_summary0002_sum []
+opentelemetry.source2.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 13.912068
 
-opentelemetry.source2.sample_counter0001 []
+opentelemetry.source2.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source2.sample_gauge0000 []
+opentelemetry.source2.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source2.sample_summary0002 []
+opentelemetry.source2.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source2.sample_summary0002_count []
+opentelemetry.source2.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source2.sample_summary0002_sum []
+opentelemetry.source2.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source3.sample_counter0001 []
+opentelemetry.source3.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1191437760
     inst [2 or "2 inst-2"] value 2382875520
@@ -11383,7 +11383,7 @@ opentelemetry.source3.sample_counter0001 []
     inst [398 or "398 inst-398"] value 474192228000
     inst [399 or "399 inst-399"] value 475383665000
 
-opentelemetry.source3.sample_gauge0000 []
+opentelemetry.source3.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 72.59999999999999
     inst [2 or "2 inst-2"] value 145.2
@@ -11785,7 +11785,7 @@ opentelemetry.source3.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 28894.8
     inst [399 or "399 inst-399"] value 28967.4
 
-opentelemetry.source3.sample_summary0002 []
+opentelemetry.source3.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001276984
     inst [2 or "quantile: 0.5"] value 0.002553968
@@ -12187,13 +12187,13 @@ opentelemetry.source3.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.508239632
     inst [399 or "quantile: 99.75"] value 0.5095166160000001
 
-opentelemetry.source3.sample_summary0002_count []
+opentelemetry.source3.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 14544
 
-opentelemetry.source3.sample_summary0002_sum []
+opentelemetry.source3.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 11.129654
 
-opentelemetry.source3.sample_counter0001 []
+opentelemetry.source3.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1702053940
     inst [2 or "2 inst-2"] value 3404107880
@@ -12595,7 +12595,7 @@ opentelemetry.source3.sample_counter0001 []
     inst [398 or "398 inst-398"] value 677417468000
     inst [399 or "399 inst-399"] value 679119522000
 
-opentelemetry.source3.sample_gauge0000 []
+opentelemetry.source3.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 108.9
     inst [2 or "2 inst-2"] value 217.8
@@ -12997,7 +12997,7 @@ opentelemetry.source3.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 43342.2
     inst [399 or "399 inst-399"] value 43451.1
 
-opentelemetry.source3.sample_summary0002 []
+opentelemetry.source3.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.001755853
     inst [2 or "quantile: 0.5"] value 0.003511706
@@ -13399,13 +13399,13 @@ opentelemetry.source3.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.6988294940000001
     inst [399 or "quantile: 99.75"] value 0.7005853470000001
 
-opentelemetry.source3.sample_summary0002_count []
+opentelemetry.source3.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 19998
 
-opentelemetry.source3.sample_summary0002_sum []
+opentelemetry.source3.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 15.303274
 
-opentelemetry.source3.sample_counter0001 []
+opentelemetry.source3.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -13807,7 +13807,7 @@ opentelemetry.source3.sample_counter0001 []
     inst [398 or "398 inst-398"] value 880642709000
     inst [399 or "399 inst-399"] value 882855379000
 
-opentelemetry.source3.sample_gauge0000 []
+opentelemetry.source3.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -14209,7 +14209,7 @@ opentelemetry.source3.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 57789.6
     inst [399 or "399 inst-399"] value 57934.8
 
-opentelemetry.source3.sample_summary0002 []
+opentelemetry.source3.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -14611,28 +14611,28 @@ opentelemetry.source3.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.8894193560000001
     inst [399 or "quantile: 99.75"] value 0.8916540780000001
 
-opentelemetry.source3.sample_summary0002_count []
+opentelemetry.source3.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source3.sample_summary0002_sum []
+opentelemetry.source3.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source3.sample_counter0001 []
+opentelemetry.source3.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source3.sample_gauge0000 []
+opentelemetry.source3.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source3.sample_summary0002 []
+opentelemetry.source3.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source3.sample_summary0002_count []
+opentelemetry.source3.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source3.sample_summary0002_sum []
+opentelemetry.source3.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source4.sample_counter0001 []
+opentelemetry.source4.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 1531848550
     inst [2 or "2 inst-2"] value 3063697090
@@ -15034,7 +15034,7 @@ opentelemetry.source4.sample_counter0001 []
     inst [398 or "398 inst-398"] value 609675721000
     inst [399 or "399 inst-399"] value 611207570000
 
-opentelemetry.source4.sample_gauge0000 []
+opentelemetry.source4.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 96.8
     inst [2 or "2 inst-2"] value 193.6
@@ -15436,7 +15436,7 @@ opentelemetry.source4.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 38526.4
     inst [399 or "399 inst-399"] value 38623.2
 
-opentelemetry.source4.sample_summary0002 []
+opentelemetry.source4.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.00159623
     inst [2 or "quantile: 0.5"] value 0.00319246
@@ -15838,13 +15838,13 @@ opentelemetry.source4.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.6352995400000001
     inst [399 or "quantile: 99.75"] value 0.6368957700000001
 
-opentelemetry.source4.sample_summary0002_count []
+opentelemetry.source4.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 18180
 
-opentelemetry.source4.sample_summary0002_sum []
+opentelemetry.source4.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 13.912068
 
-opentelemetry.source4.sample_counter0001 []
+opentelemetry.source4.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2212670120
     inst [2 or "2 inst-2"] value 4425340240
@@ -16246,7 +16246,7 @@ opentelemetry.source4.sample_counter0001 []
     inst [398 or "398 inst-398"] value 880642709000
     inst [399 or "399 inst-399"] value 882855379000
 
-opentelemetry.source4.sample_gauge0000 []
+opentelemetry.source4.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 145.2
     inst [2 or "2 inst-2"] value 290.4
@@ -16648,7 +16648,7 @@ opentelemetry.source4.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 57789.6
     inst [399 or "399 inst-399"] value 57934.8
 
-opentelemetry.source4.sample_summary0002 []
+opentelemetry.source4.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002234722
     inst [2 or "quantile: 0.5"] value 0.004469444
@@ -17050,13 +17050,13 @@ opentelemetry.source4.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 0.8894193560000001
     inst [399 or "quantile: 99.75"] value 0.8916540780000001
 
-opentelemetry.source4.sample_summary0002_count []
+opentelemetry.source4.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 25452
 
-opentelemetry.source4.sample_summary0002_sum []
+opentelemetry.source4.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 19.476895
 
-opentelemetry.source4.sample_counter0001 []
+opentelemetry.source4.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 2893491700
     inst [2 or "2 inst-2"] value 5786983400
@@ -17458,7 +17458,7 @@ opentelemetry.source4.sample_counter0001 []
     inst [398 or "398 inst-398"] value 1151609700000
     inst [399 or "399 inst-399"] value 1154503190000
 
-opentelemetry.source4.sample_gauge0000 []
+opentelemetry.source4.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
     inst [0 or "0 inst-0"] value 0
     inst [1 or "1 inst-1"] value 193.6
     inst [2 or "2 inst-2"] value 387.2
@@ -17860,7 +17860,7 @@ opentelemetry.source4.sample_gauge0000 []
     inst [398 or "398 inst-398"] value 77052.8
     inst [399 or "399 inst-399"] value 77246.39999999999
 
-opentelemetry.source4.sample_summary0002 []
+opentelemetry.source4.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     inst [0 or "quantile: 0.0"] value 0
     inst [1 or "quantile: 0.25"] value 0.002873214
     inst [2 or "quantile: 0.5"] value 0.005746428
@@ -18262,25 +18262,25 @@ opentelemetry.source4.sample_summary0002 []
     inst [398 or "quantile: 99.5"] value 1.143539172
     inst [399 or "quantile: 99.75"] value 1.146412386
 
-opentelemetry.source4.sample_summary0002_count []
+opentelemetry.source4.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 32724
 
-opentelemetry.source4.sample_summary0002_sum []
+opentelemetry.source4.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
     value 25.041722
 
-opentelemetry.source4.sample_counter0001 []
+opentelemetry.source4.sample_counter0001 [sample_counter0001 instance scale 0.7 value scale 170205394.0]
 Error: Try again. Information not currently available
 
-opentelemetry.source4.sample_gauge0000 []
+opentelemetry.source4.sample_gauge0000 [sample_gauge0000 instance scale 1, value scale 12.1]
 Error: Try again. Information not currently available
 
-opentelemetry.source4.sample_summary0002 []
+opentelemetry.source4.sample_summary0002 [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source4.sample_summary0002_count []
+opentelemetry.source4.sample_summary0002_count [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
-opentelemetry.source4.sample_summary0002_sum []
+opentelemetry.source4.sample_summary0002_sum [sample_summary0002 instance scale 0.25 value scale 0.000159623]
 Error: Try again. Information not currently available
 
 === remove opentelemetry agent ===

--- a/qa/common.opentelemetry
+++ b/qa/common.opentelemetry
@@ -63,7 +63,7 @@ _pmdaopentelemetry_save_config()
     $sudo mv $CONFIG_DIR $CONFIG_DIR.$seq
     $sudo mkdir -p $CONFIG_DIR
     $sudo chmod 777 $CONFIG_DIR
-    for __f in $PCP_VAR_DIR/config/pmda/88.*.py; do
+    for __f in $PCP_VAR_DIR/config/pmda/164.*.py; do
         [ -f "$__f" ] && $sudo mv -f $__f $__f.$seq
     done
     # turn off all pmloggers when running open telemetry tests
@@ -78,8 +78,8 @@ _pmdaopentelemetry_restore_config()
         $sudo mv $CONFIG_DIR.$seq $CONFIG_DIR
         $sudo chmod 755 $CONFIG_DIR
     fi
-    $sudo rm -f $PCP_VAR_DIR/config/pmda/88.*.py
-    for __f in $PCP_VAR_DIR/config/pmda/88.*.py.$seq; do
+    $sudo rm -f $PCP_VAR_DIR/config/pmda/164.*.py
+    for __f in $PCP_VAR_DIR/config/pmda/164.*.py.$seq; do
         [ -f "$__f" ] && $sudo mv -f $__f `echo $__f | sed -e "s/\.$seq//"`
     done
 }

--- a/qa/opentelemetry/opentelemetry_endpoint.python
+++ b/qa/opentelemetry/opentelemetry_endpoint.python
@@ -40,22 +40,21 @@ class FakeEndpoint(BaseHTTPServer.BaseHTTPRequestHandler):
         instance_count = 0
         format_name = 'sample_gauge{:04d}'.format(endpointNum)
         format_desc = 'sample_gauge{:04d} instance scale {}, value scale {}'.format(endpointNum, instance_scale, gauge_value)
-        gauge_string = {'resourceMetrics': [{'resource': {'attributes': [{'key': 'service.name', 'value': {'stringValue': 'my.service'}}]}, 'scopeMetrics': [{'scope': {'name': 'my.library', 'version': '1.0.0', 'attributes': [{'key': 'my.scope.attribute', 'value': {'stringValue': 'some.scope.attribute'}}]}, 'metrics': [{'name': 'sample_gauge', 'unit': '1', 'description': 'description', 'gauge': {'aggregationTemporality': 2, 'isMonotonic': True, 'dataPoints': [{'asDoube': 5, 'startTimeUnixNano': '1544712660300000000', 'timeUnixNano': '1544712660300000000', 'attributes': [{'key': 'labels', 'value': {'stringValue': 'some.interesting.labels'}}]}]}}]}]}]}
-        helper_str = gauge_string['resourceMetrics'][0]['scopeMetrics'][0]['metrics'][0]
-        points = helper_str['gauge']['dataPoints'][0]
-        helper_str['name'] = format_name
-        helper_str['description'] = format_desc
+        gauge_string = {'name': 'sample_gauge', 'unit': '1', 'description': 'description', 'gauge': {'aggregationTemporality': '2', 'isMonotonic': 'True', 'dataPoints': [{'asDouble': '5', 'timeUnixNano': '1544712660300000000', 'attributes': [{'key': 'labels', 'value': {'stringValue': 'some.interesting.labels'}}]}]}}
+        points = gauge_string['gauge']['dataPoints'][0]
+        gauge_string['name'] = format_name
+        gauge_string['description'] = format_desc
         data = []
         for i in range(instances):
             copy = deepcopy(points)
             format_instname = "{{bar=\'{:.1f}\'}}".format(i * instance_scale)
             format_value = "{:.1f}".format((int(iteration) * instance_count * gauge_value))
+            inst_dict = {'key': 'instance', 'value': {'stringValue': format_instname}}
             copy['asDouble'] = format_value
-            copy['attributes'][0]['instname'] = format_instname
+            copy['attributes'].append(inst_dict)
             data.append(copy)
             instance_count += 1
-        helper_str['gauge']['dataPoints'] = data
-        gauge_string = json.dumps(gauge_string, sort_keys=False, indent=4, separators=(',', ': '))
+        gauge_string['gauge']['dataPoints'] = data
         return gauge_string
 
     def sample_counter_data(self, iteration=None, instances=None, metrics=None, endpointNum=None):
@@ -64,22 +63,21 @@ class FakeEndpoint(BaseHTTPServer.BaseHTTPRequestHandler):
         instance_count = 0
         format_name = 'sample_counter{:04d}'.format(endpointNum)
         format_desc = 'sample_counter{:04d} instance scale {} value scale {}'.format(endpointNum, instance_scale, counter_value)
-        counter_string = {'resourceMetrics': [{'resource': {'attributes': [{'key': 'service.name', 'value': {'stringValue': 'my.service'}}]}, 'scopeMetrics': [{'scope': {'name': 'my.library', 'version': '1.0.0', 'attributes': [{'key': 'my.scope.attribute', 'value': {'stringValue': 'some.scope.attribute'}}]}, 'metrics': [{'name': 'sample_counter', 'unit': '1', 'description': 'description', 'sum': {'aggregationTemporality': 2, 'isMonotonic': True, 'dataPoints': [{'value': 5, 'startTimeUnixNano': '1544712660300000000', 'timeUnixNano': '1544712660300000000', 'attributes': [{'label5': 'some interesting label'}]},{'asDouble': 10, 'startTimeUnixNano': '1544712660300000000', 'timeUnixNano': '1544712660300000000', 'attributes': [{'key': 'labels', 'value': {'stringValue': 'some.interesting.labels'}}]}]}}]}]}]}
-        helper_str = counter_string['resourceMetrics'][0]['scopeMetrics'][0]['metrics'][0]
-        points = helper_str['sum']['dataPoints'][0]
-        helper_str['name'] = format_name
-        helper_str['description'] = format_desc
+        counter_string = {'name': 'sample_counter', 'unit': '1', 'description': 'description', 'sum': {'aggregationTemporality': '2', 'isMonotonic': 'True', 'dataPoints': [{'asDouble': 10, 'timeUnixNano': '1544712660300000000', 'attributes': [{'key': 'labels', 'value': {'stringValue': 'some.interesting.labels'}}]}]}}
+        points = counter_string['sum']['dataPoints'][0]
+        counter_string['name'] = format_name
+        counter_string['description'] = format_desc
         data = []
         for i in range(instances):
             copy = deepcopy(points)
             format_instname = "{{baz=\'{:.1f}\'}}".format(i * instance_scale)
             format_value = "{:.8e}".format((int(iteration) * instance_count * counter_value))
+            inst_dict = {'key': 'instance', 'value': {'stringValue': format_instname}}
             copy['asDouble'] = format_value
-            copy['attributes'][0]['instname'] = format_instname
+            copy['attributes'].append(inst_dict)
             data.append(copy)
             instance_count += 1
-        helper_str['sum']['dataPoints'] = data
-        counter_string = json.dumps(counter_string, sort_keys=False, indent=4, separators=(',', ': '))
+        counter_string['sum']['dataPoints'] = data
         return counter_string
 
     def sample_summary_data(self, iteration=None, instances=None, metrics=None, endpointNum=None):
@@ -92,17 +90,15 @@ class FakeEndpoint(BaseHTTPServer.BaseHTTPRequestHandler):
         format_desc = 'sample_summary{:04d} instance scale {} value scale {}'.format(endpointNum, instance_scale, summary_value_q0)
         format_count = '{:d}'.format((int(iteration) * int(summary_value_count)))
         format_sum = '{:16f}'.format((int(iteration) * float(summary_value_sum)))
-        summary_string = {'resourceMetrics': [{'resource': {'attributes': [{'key': 'service.name', 'value': {'stringValue': 'my.service'}}], 'schema_url': ''}, 'scopeMetrics': [{'scope': {'name': 'getting-started', 'version': '0.1.2', 'schema_url': '', 'attributes': [{}]}, 'metrics': [{'name': 'my.summary', 'description': '', 'unit': '', 'summary': {'dataPoints': [{'attributes': [{'key': 'labels', 'value': {'stringValue': 'some.interesting.labels'}}], 'startTimeUnixNano': 1741190626268422106, 'timeUnixNano': 1741190626268846852, 'count': 1, 'sum': 99.9, 'quantileValues': []}]}}], 'schema_url': ''}], 'schema_url': ''}]}
-        helper_str = summary_string['resourceMetrics'][0]['scopeMetrics'][0]['metrics'][0]
-        points = helper_str['summary']['dataPoints'][0]
-        helper_str['name'] = format_name
-        helper_str['description'] = format_desc
+        summary_string = {'name': 'my.summary', 'description': '', 'unit': '', 'summary': {'dataPoints': [{'attributes': [{'key': 'labels', 'value': {'stringValue': 'some.interesting.labels'}}], 'timeUnixNano': 1741190626268846852, 'count': 1, 'sum': 99.9, 'quantileValues': []}]}}
+        points = summary_string['summary']['dataPoints'][0]
+        summary_string['name'] = format_name
+        summary_string['description'] = format_desc
         points["count"] = format_count
         points["sum"] = format_sum
         for i in range(instances):
             points["quantileValues"].append({'quantile': (i * instance_scale), 'value': (int(iteration) * instance_count * float(summary_value_q0))})
             instance_count += 1
-        summary_string = json.dumps(summary_string, sort_keys=False, indent=4, separators=(',', ': '))
         return summary_string
 
     def sample_histogram_data(self, iteration=None, instances=None, metrics=None, endpointNum=None):
@@ -115,11 +111,10 @@ class FakeEndpoint(BaseHTTPServer.BaseHTTPRequestHandler):
         format_desc = 'sample_histogram{:04d} instance scale {} value scale {} (sample histogram has instances)'.format(endpointNum, instance_scale, histogram_value_l1)
         format_count = "{:d}".format((int(instances) * int(histogram_value_count)))
         format_sum = "{:d}".format((int(instances) * int(histogram_value_sum)))
-        histogram_string = {'resourceMetrics': [{'resource': {'attributes': [{'key': 'service.name', 'value': {'stringValue': 'my.service'}}], 'schema_url': ''}, 'scopeMetrics': [{'scope': {'name': 'getting-started', 'version': '0.1.2', 'schema_url': '', 'attributes': [{}]}, 'metrics': [{'name': 'my.histogram', 'description': '', 'unit': '', 'histogram': {'dataPoints': [{'attributes': [{}], 'startTimeUnixNano': 1741190626268422106, 'timeUnixNano': 1741190626268846852, 'count': 1, 'sum': 99.9, 'bucketCounts': [], 'explicitBounds': [], 'min': 99.9, 'max': 99.9, 'exemplars': []}], 'aggregationTemporality': 2}}], 'schema_url': ''}], 'schema_url': ''}]}
-        helper_str = histogram_string['resourceMetrics'][0]['scopeMetrics'][0]['metrics'][0]
-        points = helper_str['histogram']['dataPoints'][0]
-        helper_str['name'] = format_name
-        helper_str['description'] = format_desc
+        histogram_string = {'name': 'my.histogram', 'description': '', 'unit': '', 'histogram': {'dataPoints': [{'attributes': [{}], 'timeUnixNano': 1741190626268846852, 'count': 1, 'sum': 99.9, 'bucketCounts': [], 'explicitBounds': [], 'min': 99.9, 'max': 99.9, 'exemplars': []}], 'aggregationTemporality': 2}}
+        points = histogram_string['histogram']['dataPoints'][0]
+        histogram_string['name'] = format_name
+        histogram_string['description'] = format_desc
         points["count"] = format_count
         points["sum"] = format_sum
         for i in range(instances):
@@ -127,37 +122,42 @@ class FakeEndpoint(BaseHTTPServer.BaseHTTPRequestHandler):
             points["explicitBounds"].append((i * instance_scale))
             instance_count += 1
         points["bucketCounts"].append(0)
-        histogram_string = json.dumps(histogram_string, sort_keys=False, indent=4, separators=(',', ': '))
         return histogram_string
+ 
+    def start_string(self):
+        start = {'resourceMetrics': [{'resource': {'attributes': [{'key': 'service.name', 'value': {'stringValue': 'my.service'}}]}, 'scopeMetrics': [{'scope': {'name': 'my.library', 'version': '1.0.0', 'attributes': [{'key': 'my.scope.attribute', 'value': {'stringValue': 'some.scope.attribute'}}]}, 'metrics': []}]}]}
+        return start
 
     def format_opentelemetry_output(self, metrics=None, iteration=None, instances=None, error=None, endpointNum=None):
         metrics_remaining = metrics
-        endpoint_string = ""
+        endpoint_string = self.start_string()
+        helper = endpoint_string['resourceMetrics'][0]['scopeMetrics'][0]['metrics']
+
         while metrics_remaining >= 0:
-            endpoint_string += self.sample_gauge_data(iteration, instances, metrics_remaining, (metrics-metrics_remaining))
+            helper.append(self.sample_gauge_data(iteration, instances, metrics_remaining, (metrics-metrics_remaining)))
             metrics_remaining -= 1
             iteration += 1
             if metrics_remaining <= 0:
                 break
-            endpoint_string += self.sample_counter_data(iteration, instances, metrics_remaining, (metrics-metrics_remaining))
+            helper.append(self.sample_counter_data(iteration, instances, metrics_remaining, (metrics-metrics_remaining)))
             metrics_remaining -= 1
             iteration += 1
             if metrics_remaining <= 0:
                 break
-            endpoint_string += self.sample_summary_data(iteration, instances, metrics_remaining, (metrics-metrics_remaining))
+            helper.append(self.sample_summary_data(iteration, instances, metrics_remaining, (metrics-metrics_remaining)))
 #            metrics_remaining -= 4
             metrics_remaining -= instances
             iteration += 1
             if metrics_remaining <= 0:
                 break
-            endpoint_string += self.sample_histogram_data(iteration, instances, metrics_remaining, (metrics-metrics_remaining))
+            helper.append(self.sample_histogram_data(iteration, instances, metrics_remaining, (metrics-metrics_remaining)))
 #            metrics_remaining -= 5
             metrics_remaining -= instances
             iteration += 1
+        endpoint_string = json.dumps(endpoint_string, sort_keys=False, indent=4, separators=(',', ': '))
         if error is not None:
             return endpoint_string[:int(len(endpoint_string)/int(error))]
         else:
-            print("ENDPOINT STRING", endpoint_string, "END")
             return endpoint_string
 
     def do_GET(self):

--- a/qa/opentelemetry/samples/labelfiltering.txt
+++ b/qa/opentelemetry/samples/labelfiltering.txt
@@ -32,11 +32,10 @@
               "description": "I am a Counter Metric to test the labels",
               "sum": {
                 "aggregationTemporality": 1,
-                "isMonotonic": true,
+                "isMonotonic": "true",
                 "dataPoints": [
                   {
-                    "asDouble": 5,
-                    "startTimeUnixNano": "1544712660300000000",
+                    "asInt": "5",
                     "timeUnixNano": "1544712660300000000",
                     "attributes": [
                       {

--- a/qa/opentelemetry/samples/simplemetric.txt
+++ b/qa/opentelemetry/samples/simplemetric.txt
@@ -35,8 +35,7 @@
                 "isMonotonic": true,
                 "dataPoints": [
                   {
-                    "asDouble": 5,
-                    "startTimeUnixNano": "1544712660300000000",
+                    "asInt": 5,
                     "timeUnixNano": "1544712660300000000",
                     "attributes": [
                       {
@@ -57,7 +56,7 @@
               "gauge": {
                 "dataPoints": [
                   {
-                    "asDouble": 10,
+                    "asInt": 10,
                     "timeUnixNano": "1544712660300000000",
                     "attributes": [
                       {
@@ -79,7 +78,6 @@
                 "aggregationTemporality": 1,
                 "dataPoints": [
                   {
-                    "startTimeUnixNano": "1544712660300000000",
                     "timeUnixNano": "1544712660300000000",
                     "count": 2,
                     "sum": 2,

--- a/qa/opentelemetry/scripts/GNUmakefile
+++ b/qa/opentelemetry/scripts/GNUmakefile
@@ -1,0 +1,20 @@
+TOPDIR = ../../..
+include $(TOPDIR)/src/include/builddefs
+
+TESTDIR = $(PCP_VAR_DIR)/testsuite/opentelemetry/scripts
+SCRIPTS = $(shell ls -1 | sed -e '/^GNU.*/d' -e '/^curl$$/d' -e '/not_exec/d' -e '/.*.txt$$/d')
+#NONEXEC = $(shell echo *not_exec* *.txt)
+SUBDIRS = curl
+
+default setup default_pcp:	$(SCRIPTS) $(SUBDIRS)
+	$(SUBDIRS_MAKERULE)
+
+install install_pcp:	$(SUBDIRS)
+	$(INSTALL) -m 755 -d $(TESTDIR)
+	$(INSTALL) -m 755 -f $(SCRIPTS) $(TESTDIR)
+	#$(INSTALL) -m 644 -f $(NONEXEC) $(TESTDIR)
+	$(INSTALL) -m 644 -f GNUmakefile.install $(TESTDIR)/GNUmakefile
+	$(SUBDIRS_MAKERULE)
+
+include $(BUILDRULES)
+

--- a/qa/opentelemetry/scripts/GNUmakefile.install
+++ b/qa/opentelemetry/scripts/GNUmakefile.install
@@ -1,0 +1,1 @@
+default setup install clean check:

--- a/qa/opentelemetry/scripts/curl/GNUmakefile
+++ b/qa/opentelemetry/scripts/curl/GNUmakefile
@@ -1,0 +1,15 @@
+TOPDIR = ../../../..
+include $(TOPDIR)/src/include/builddefs
+
+TESTDIR = $(PCP_VAR_DIR)/testsuite/opentelemetry/scripts/curl
+SCRIPTS = $(shell ls -1 | sed -e '/^GNU.*/d')
+
+default setup default_pcp:	$(SCRIPTS)
+
+install install_pcp:	$(SCRIPTS)
+	$(INSTALL) -m 755 -d $(TESTDIR)
+	$(INSTALL) -m 755 -f $(SCRIPTS) $(TESTDIR)/$(SCRIPTS)
+	$(INSTALL) -m 644 -f GNUmakefile.install $(TESTDIR)/GNUmakefile
+
+include $(BUILDRULES)
+

--- a/qa/opentelemetry/scripts/curl/GNUmakefile.install
+++ b/qa/opentelemetry/scripts/curl/GNUmakefile.install
@@ -1,0 +1,1 @@
+default setup install clean:

--- a/qa/opentelemetry/scripts/curl/script.sh
+++ b/qa/opentelemetry/scripts/curl/script.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+. /etc/pcp.conf
+curl -Gqs file://$PCP_PMDAS_DIR/opentelemetry/config.d/some_metric.txt

--- a/qa/opentelemetry/scripts/curl_scripted.sh
+++ b/qa/opentelemetry/scripts/curl_scripted.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+. /etc/pcp.conf
+curl -Gqs file://$PCP_PMDAS_DIR/opentelemetry/config.d/some_script_metric.txt

--- a/qa/opentelemetry/scripts/python_scripted.python
+++ b/qa/opentelemetry/scripts/python_scripted.python
@@ -1,4 +1,6 @@
-{
+#!/usr/bin/env pmpython
+
+data = {
   "resourceMetrics": [
     {
       "resource": {
@@ -14,7 +16,7 @@
       "scopeMetrics": [
         {
           "scope": {
-            "name": "my.library",
+            "name": "my.scope",
             "version": "1.0.0",
             "attributes": [
               {
@@ -27,19 +29,19 @@
           },
           "metrics": [
             {
-              "name": "somemetric",
+              "name": "some_python_scripted_metric",
               "unit": "1",
-              "description": "metric to test duplicate labels",
+              "description": "I am a Counter",
               "sum": {
                 "aggregationTemporality": 1,
-                "isMonotonic": "true",
+                "isMonotonic": true,
                 "dataPoints": [
                   {
-                    "asDouble": "5",
+                    "asInt": 10,
                     "timeUnixNano": "1544712660300000000",
                     "attributes": [
                       {
-                        "key": "my.sum.attribute",
+                        "key": "my.counter.attr",
                         "value": {
                           "stringValue": "someValue"
                         }
@@ -55,3 +57,6 @@
     }
   ]
 }
+
+print(json.dumps(data, indent=4, sort_keys=False))
+exit(0)

--- a/qa/opentelemetry/scripts/some_script_metric.txt
+++ b/qa/opentelemetry/scripts/some_script_metric.txt
@@ -14,7 +14,7 @@
       "scopeMetrics": [
         {
           "scope": {
-            "name": "my.library",
+            "name": "my.scope",
             "version": "1.0.0",
             "attributes": [
               {
@@ -27,19 +27,19 @@
           },
           "metrics": [
             {
-              "name": "somemetric",
+              "name": "some_metric",
               "unit": "1",
-              "description": "metric to test duplicate labels",
+              "description": "I am a Counter",
               "sum": {
                 "aggregationTemporality": 1,
-                "isMonotonic": "true",
+                "isMonotonic": true,
                 "dataPoints": [
                   {
-                    "asDouble": "5",
+                    "asInt": 10,
                     "timeUnixNano": "1544712660300000000",
                     "attributes": [
                       {
-                        "key": "my.sum.attribute",
+                        "key": "my.counter.attr",
                         "value": {
                           "stringValue": "someValue"
                         }

--- a/src/pmdas/opentelemetry/pmdaopentelemetry.1
+++ b/src/pmdas/opentelemetry/pmdaopentelemetry.1
@@ -433,18 +433,16 @@ Metric data returned by URL or scripted configuration files may contain
 metadata that can be used by the
 .B opentelemetry
 PMDA to specify the semantics, data type, scaling and units of dynamically created metrics.
-This metadata is prefixed with
-.B "# PCP5"
-or
-.B "# PCP"
-in the ingested metric data.
+This metadata is found for each metric under the
+.B "metric"
+list header in the opentelemetry json data structure.
 For additional information about PCP metadata, see
 .BR pmLookupDesc (3)
 and
 .BR pmParseUnitsStr (3)
 and examples in shipped configuration files.
 .PP
-In-line "PCP5" metadata must be supplied by the metrics source end-point (URL or script).
+Metadata must be supplied in the json data by the opentelemetry source end-point (URL or script)
 An alternative is to specify this in the URL configuration file directly, which has the advantage
 of not having to modify the source/end-point if the metadata is incorrect or missing.
 Metadata specified in the URL configuration file over-rides any in-line metadata.

--- a/src/pmdas/opentelemetry/pmdaopentelemetry.python
+++ b/src/pmdas/opentelemetry/pmdaopentelemetry.python
@@ -19,8 +19,9 @@
 # pylint: disable=too-many-nested-blocks, too-many-return-statements
 # pylint: disable=broad-except, bare-except, missing-docstring
 # pylint: disable=expression-not-assigned, too-many-arguments
-# pylint: disable=too-many-positional-arguments
-# pylint: disable=consider-using-f-string
+# pylint: disable=too-many-positional-arguments, multiple-statements
+# pylint: disable=consider-using-f-string, consider-using-enumerate
+# pylint: disable=unused-variable
 
 import os
 import re
@@ -83,14 +84,15 @@ typestrD = {'double': c_api.PM_TYPE_DOUBLE,
 
 class Metric(object):
     ''' Metric information class '''
-    def __init__(self, source, name, metricnum, metric_dict, included_labels, optional_labels):
+    def __init__(self, source, name, metricnum, metric_dict, included_labels, optional_labels, conf_metadata):
         self.source = source
         self.name = name
         self.helpline = metric_dict["description"]
         self.metricnum = metricnum # seen during fetch callbacks
         self.pmid = source.pmda.pmid(source.cluster, metricnum) # add domain/cluster#
         self.indom_number = MAX_CLUSTER+1 + (source.cluster * (MAX_METRIC+1)) + metricnum
-        self.units = metric_dict["unit"].lower()
+        self.multiplier = 1 # pmParseUnits returns a tuple of (pmUnits, multiplier)
+        self.units = metric_dict["unit"]
         self.munits = pmUnits(0, 0, 0, 0, 0, 0)
         self.monotonic = metric_dict["isMonotonic"]
         self.values = {} # instance-vector-to-value
@@ -99,9 +101,24 @@ class Metric(object):
         self.optional_labels = optional_labels # optional labels
         self.inst_labels = {} # dict of instid:labels (where labels is a dict)
 
-        self.assign_metadata(metric_dict["values"][0], metric_dict["semantic"], metric_dict["type"], self.units)
-        self.singular = metric_dict["is_singular"]
+        if conf_metadata:
+            # assign config provided metadata
+            if self.source.pmda.dbg:
+                self.source.pmda.debug("conf_metadata: %s" % conf_metadata)
+            split_metadata = conf_metadata.split(' ')
+            self.mname = 'opentelemetry.' + self.source.name + '.' + split_metadata[1]
+            self.mtype = self.decodeTypeStr(split_metadata[2])
+            self.munits, self.multiplier = self.parse_pcp_units(' '.join(split_metadata[5:]))
+            if split_metadata[4] == 'instant':
+                self.msem = c_api.PM_SEM_INSTANT
+            elif split_metadata[4] == 'counter':
+                self.msem = c_api.PM_SEM_COUNTER
+            elif split_metadata[4] == 'discrete':
+                self.msem = c_api.PM_SEM_DISCRETE
+        else:
+            self.assign_metadata(metric_dict["semantic"], metric_dict["data_type"], self.units)
 
+        self.singular = metric_dict["is_singular"]
         if self.singular:
             self.mindom = c_api.PM_INDOM_NULL
             self.indom_table = None
@@ -127,7 +144,30 @@ class Metric(object):
                 self.source.pmda.debug("created metric %#x (%s) labels='%s' optional_labels='%s'" %
                     (self.pmid, self.mname, self.labels, self.optional_labels))
 
-    def assign_metadata(self, value, semantics, mtype, units):
+    def decodeTypeStr(self, typestr):
+        try:
+            ret = typestrD[typestr]
+        except:
+            ret = c_api.PM_TYPE_DOUBLE
+
+        return ret
+
+    def parse_pcp_units(self, s):
+        ''' parse a PCP units string '''
+        mult = 1
+        units = pmUnits(0, 0, 0, 0, 0, 0)
+        if s != 'none':
+            try:
+                units, mult = pmContext.pmParseUnitsStr(s)
+            except Exception as e:
+                self.source.pmda.err('parse_pcp_units "%s" Error: %s' % (s, e))
+
+        self.source.pmda.debug('parse_pcp_units "%s": units=%s mult=%f' %
+            (s, str(units), mult)) if self.source.pmda.dbg else None
+
+        return units, mult
+
+    def assign_metadata(self, semantics, data_type, units):
         ''' Compute metric metadata self.{mtype, mname, msem, munits}
         '''
         #
@@ -137,83 +177,83 @@ class Metric(object):
         self.msem = c_api.PM_SEM_INSTANT # aka guage
         self.mname = 'opentelemetry.' + self.source.name + '.' + self.name.replace(":", ".")
 
-        # Space unit prefixes
-        def UCUM_space_prefix(prefix):  # pylint: disable=unused-variable (TODO)
-            if prefix == "": # base bytes
-                return c_api.PM_SPACE_BYTE
-            elif prefix == "Ki": # Kibibyte
-                return c_api.PM_SPACE_KBYTE
-            elif prefix == "Mi": # Mebibyte
-                return c_api.PM_SPACE_MBYTE
-            elif prefix == "Gi": # Gibibyte
-                return c_api.PM_SPACE_GBYTE
-            elif prefix == "Ti": # Tebibyte
-                return c_api.PM_SPACE_TBYTE
-            elif prefix == "Pi": # Pebibyte
-                return c_api.PM_SPACE_PBYTE
-            elif prefix == "Ei": # Exbibyte
-                return c_api.PM_SPACE_EBYTE
-            elif prefix == "Zi": # Zebibyte
-                return c_api.PM_SPACE_ZBYTE
-            elif prefix == "Yi": # Yobibyte
-                return c_api.PM_SPACE_YBYTE
-            return None
+        # space unit prefixes
+        def UCUM_space_prefix(prefix):
+            if prefix == "By":
+                return 0 # base bytes
+            elif prefix == "KiBy":
+                return 1 # Kibibyte
+            elif prefix == "MiBy":
+                return 2 # Mebibyte
+            elif prefix == "GiBy":
+                return 3 # Gibibyte
+            elif prefix == "TiBy":
+                return 4 # Tebibyte
+            elif prefix == "PiBy":
+                return 5 # Pebibyte
+            elif prefix == "EiBy":
+                return 6 # Exbibyte
+            elif prefix == "ZiBi":
+                return 7 # Zebibyte
+            elif prefix == "YiBi":
+                return 8 # obibyte
+            else:
+                return -1
 
-        # Time unit prefixes
-        def UCUM_time_prefix(prefix):  # pylint: disable=unused-variable (TODO)
-            if prefix == "ns": # nano
-                return c_api.PM_TIME_NSEC
-            elif prefix == "us": # micro
-                return c_api.PM_TIME_USEC
-            elif prefix == "ms": # milli
-                return c_api.PM_TIME_MSEC
-            elif prefix == "s": # base second
-                return c_api.PM_TIME_SEC
-            elif prefix == "min": # minute
-                return c_api.PM_TIME_MIN
-            elif prefix == "h": # hour
-                return c_api.PM_TIME_HOUR
-            return None
+        # time unit prefixes
+        def UCUM_time_prefix(prefix):
+            if prefix == "ns":
+                return 0 # nano
+            elif prefix == "us":
+                return 1 # micro
+            elif prefix == "ms":
+                return 2 # milli
+            elif prefix == "s":
+                return 3 # base second
+            elif prefix == "min":
+                return 4 # minute
+            elif prefix == "h":
+                return 5 # hour
+            else:
+                return -1
 
-        # Count unit prefixes (powers of 10)
-        def UCUM_count_prefix(prefix):  # pylint: disable=unused-variable (TODO)
-            if prefix == "y":
-                return -24 # yocto
-            elif prefix == "z":
-                return -21 # zepto
-            elif prefix == "a":
-                return -18 # atto
-            elif prefix == "f":
-                return -15 # femto
-            elif prefix == "p":
-                return -12 # pico
-            elif prefix == "n":
-                return -9 # nano
-            elif prefix == "u":
-                return -6 # micro
-            elif prefix == "m":
-                return -3 # milli
-            elif prefix == "":
-                return 0 # no prefix (PM_COUNT_ONE)
-            elif prefix == "k":
-                return 3 # kilo
-            elif prefix == "M":
-                return 6 # mega
-            elif prefix == "G":
-                return 9 # giga
-            elif prefix == "T":
-                return 12 # tera
-            elif prefix == "P":
-                return 15 # peta
-            elif prefix == "E":
-                return 18 # exa
-            elif prefix == "Z":
-                return 21 # zetta
-            elif prefix == "y":
-                return 24 # yotta
-            return None
+        def parse_single_units(unit_string, unit_dict):
+            if "**" in unit_string:
+                power = unit_string.split("**")[1]
+            else:
+                power = 1
+            if unit_string.startswith('{') and unit_string.endswith('}'):
+                unit_dict["dimcount"] = power
+            elif 'By' in unit_string:
+                unit_dict["dimspace"] = power
+                unit_dict["scalespace"] = UCUM_space_prefix(unit_string)
+                if unit_dict["scalespace"] == -1:
+                    unit_dict["dimspace"] = 0
+                    unit_dict["scalespace"] = 0
+            else:
+                unit_dict["dimtime"] = power
+                unit_dict["scaletime"]  = UCUM_time_prefix(unit_string)
+                if unit_dict["scaletime"] == -1:
+                    unit_dict["dimtime"] = 0
+                    unit_dict["scaletime"] = 0
 
-        self.munits = pmUnits(0, 0, 0, 0, 0, 0) # ignore for now, need UCUM converter
+        def parse_units(units):
+            # parse metric units:
+            unit_dict = {"dimspace": 0, "dimtime": 0, "dimcount": 0, "scalespace": 0, "scaletime": 0, "scalecount": 0}
+            if units == "1":
+                return unit_dict
+            units = units.lower()
+
+            if '/' in units:
+                split = units.split('/')
+                parse_single_units(split[0], unit_dict)
+                parse_single_units(split[1], unit_dict)
+            else:
+                parse_single_units(units, unit_dict)
+            return unit_dict
+
+        unit_dict = parse_units(units)
+        self.munits = pmUnits(unit_dict["dimspace"], unit_dict["dimtime"], unit_dict["dimcount"], unit_dict["scalespace"], unit_dict["scaletime"], unit_dict["scalecount"])
 
         # assign semantics
         if semantics == "counter":
@@ -222,46 +262,61 @@ class Metric(object):
             self.msem = c_api.PM_SEM_INSTANT
 
         # assign datatype
-        if type == "asDouble":
+        if data_type == "double":
             self.mtype = c_api.PM_TYPE_DOUBLE
-        elif type == "asInt":
+        elif data_type == "int":
             self.mtype = c_api.PM_TYPE_64
-        elif type == "asString":
+        elif data_type == "string":
             self.mtype = c_api.PM_TYPE_STRING
         else:
             self.mtype = c_api.PM_TYPE_DOUBLE
 
         if self.source.pmda.dbg:
-            self.source.pmda.debug('assign_metadata: mname="%s" type="%s" msem="%s" munits="%s"' %
+            self.source.pmda.debug('assign_metadata: mname="%s" data_type="%s" msem="%s" munits="%s"' %
                 (self.mname, self.mtype, self.msem, self.munits))
 
     def clear_values(self):
         ''' Erase all stored instance/value pairs, in anticipation of a new set. '''
         self.values.clear()
 
-    def store_inst(self, labels, value, num):
-        ''' Store given new instance/value pair. '''
-
-        # assert (labels is None) == (self.indom_table is None) # no metric indom flipflop
-        if self.singular:
-            inst = c_api.PM_IN_NULL
-            instname = "PM_IN_NULL"
-            self.source.pmda.debug('store_inst mname="%s" singular=True value="%s" labels=%s' % (self.mname, value, labels))
-        else:
-            instname = None
-            # NB: no quoting/transforms - preserve incoming value verbatim
-            if labels:
-                instname = labels[num]
-            if instname is None:
-                self.indom_table.prefix_mode = True # Mark for instance# prefixed names
-                instname = "inst-%s" % num
-            inst = self.indom_table.intern_lookup_value(instname)
+    def store_singular_inst(self, labels, value):
+        ''' Store singular instance/value pair '''
+        inst = c_api.PM_IN_NULL
+        instname = "PM_IN_NULL"
+        self.source.pmda.debug('store_inst mname="%s" singular=True value="%s" labels=%s' % (self.mname, value, labels))
 
         self.values[inst] = value
         self.inst_labels[inst] = labels
         if self.source.pmda.dbg:
             self.source.pmda.debug('store_inst mname=%s inst=%d instname="%s" value="%s"' % (self.mname, inst, instname, value))
             self.source.pmda.debug('store_inst mname=%s inst_labels[%d]=%s' % (self.mname, inst, labels))
+
+    def store_multiple_insts(self, metric_type, instances, labels, values):
+        ''' Store instance/value pair of metric with > 1 instances '''
+        # keep track of if the number of instances in the inst name list matches the num of inst values ?
+        if len(instances) != len(values):
+            self.source.pmda.err("error num instances doesn't match num values")
+        if instances[0] == "inst-0":
+            self.indom_table.prefix_mode = True # Mark for instance# prefixed names
+
+        if metric_type in ("histogram", "summary"):
+            for idx in range (len(instances)):
+                included_labels, optional_labels = self.source.filter_labelset(labels)
+                inst = self.indom_table.intern_lookup_value(instances[idx])
+                self.values[inst] = values[idx]
+                self.inst_labels[inst] = included_labels
+                if self.source.pmda.dbg:
+                    self.source.pmda.debug('store_inst mname=%s inst=%d instname="%s" value="%s"' % (self.mname, inst, instances[idx], values[idx]))
+                    self.source.pmda.debug('store_inst mname=%s inst_labels[%d]=%s' % (self.mname, inst, included_labels))
+        else:
+            for idx in range (len(instances)):
+                included_labels, optional_labels = self.source.filter_labelset(labels[idx][idx])
+                inst = self.indom_table.intern_lookup_value(instances[idx])
+                self.values[inst] = values[idx]
+                self.inst_labels[inst] = included_labels
+                if self.source.pmda.dbg:
+                    self.source.pmda.debug('store_inst mname=%s inst=%d instname="%s" value="%s"' % (self.mname, inst, instances[idx], values[idx]))
+                    self.source.pmda.debug('store_inst mname=%s inst_labels[%d]=%s' % (self.mname, inst, included_labels))
 
     def save(self):
         if self.indom_table is not None:
@@ -293,7 +348,6 @@ class Metric(object):
 
         self.source.pmda.debug('fetch_inst returning %s' % ret)
         return ret
-
 
 class PersistentNameTable(object):
     '''Persistent name table.  Answers name-to-number queries by assigning
@@ -472,8 +526,8 @@ class Source(object):
                 included_labels[lname] = optional_labels[lname] = lval
         if included_labels == {}:
             return None, None # no labels => singular indom
-        if optional_labels == {}:
-            optional_labels = None
+        #if optional_labels == {}:
+            #optional_labels = None
         return included_labels, optional_labels
 
     def valid_metric_name(self, name):
@@ -494,16 +548,21 @@ class Source(object):
             unescaped = helpline.replace('\\\\', '\\').replace('\\n', '\n')
             split = unescaped.split('\n')
             help_oneline = split[0] # must have at least one entry
-            help_text = '\n'.join(split[1:]) # may have other entries
+            help_text = helpline # may have other entries
         else:
             help_oneline = ''
             help_text = ''
-        return help_text, help_oneline
+        return help_oneline, help_text
+
+    def format_name(self, name):
+        return name.replace(".", "_")
 
     def collect_attributes(self, attribute_list):
         labels = {}
         for item in attribute_list:
-            key = item["key"]
+            if not item:
+                continue
+            key = self.format_name(item["key"])
             value = item["value"]["stringValue"]
             labels[key] = value
         return labels
@@ -512,9 +571,15 @@ class Source(object):
         try:
             mname = metric["name"]
             fullname = ("opentelemetry.%s.%s") % (self.name, mname)
-            included_labels, optional_labels = self.filter_labelset(metric["labels"])
-            naming_labels = metric["instances"]
-            self.pmda.debug("naming labels --> %s" % naming_labels) if self.pmda.dbg else None
+            if metric["type"] == "histogram" or metric["type"] == "summary":
+                included_labels, optional_labels = self.filter_labelset(metric["labels"])
+            elif len(metric["labels"]) == 0:
+                included_labels, optional_labels = self.filter_labelset(metric["labels"][0])
+            else:
+                all_labels = {}
+                for idx in range (len(metric["labels"])):
+                    all_labels.update(metric["labels"][idx][idx])
+                included_labels, optional_labels = self.filter_labelset(all_labels)
             self.pmda.debug("included_labels '%s'" % (included_labels)) if self.pmda.dbg else None
             self.pmda.debug("optional_labels '%s'" % (optional_labels)) if self.pmda.dbg else None
             if mname in self.metrics_by_name:
@@ -531,13 +596,12 @@ class Source(object):
                     except Exception as e:
                         self.pmda.debug("can't re-add metric: %s, see error: %s" % (fullname, e)) if self.pmda.dbg else None
                 m = self.metrics_by_name[mname]
-                assert self.metrics_by_name[mname]
+                assert self.metrics_by_num[m.metricnum] == m
                 if m.singular:
                     # singular metrics have no naming labels
-                    m.store_inst(included_labels, metric["values"][0], 0)
+                    m.store_singular_inst(included_labels, metric["values"][0])
                 else:
-                    for x in range(0, len(metric["values"])):
-                        m.store_inst(naming_labels, metric["values"][x], x)
+                    m.store_multiple_insts(metric["type"], metric["instances"], metric["labels"], metric["values"])
             # new metric
             else:
                 # check metric is not excluded by filters
@@ -551,16 +615,23 @@ class Source(object):
                         raise ValueError('invalid metric name: ' + mname)
                     # new metric
                     metricnum = self.pmids_table.intern_lookup_value(mname)
-                    name = metric["name"]
-                    m = Metric(self, name, metricnum, metric, included_labels, optional_labels)
+                    # check if the config specifies metadata for this metric
+                    conf_metadata = None
+                    if self.metadatalist:
+                        for metadata in self.metadatalist:
+                            rx = self.pmda.lookup_regex(metadata[0])
+                            if rx.match(mname):
+                                # config metadata overrides parsed metadata
+                                conf_metadata = "METADATA %s %s" % (mname, ' '.join(metadata[1:])) # to EOL
+                                break
+                    m = Metric(self, mname, metricnum, metric, included_labels, optional_labels, conf_metadata)
                     self.metrics_by_name[mname] = m
                     self.metrics_by_num[metricnum] = m # not pmid!
                     if m.singular:
                         # singular metrics have no naming labels
-                        m.store_inst(included_labels, metric["values"][0], 0)
+                        m.store_singular_inst(included_labels, metric["values"][0])
                     else:
-                        for x in range(0, len(metric["values"])):
-                            m.store_inst(naming_labels, metric["values"][x], x)
+                        m.store_multiple_insts(metric["type"], metric["instances"], metric["labels"], metric["values"])
                     self.pmda.set_notify_change()
         except ValueError as e:
             if not self.parse_error:
@@ -577,6 +648,7 @@ class Source(object):
     def parse_metric(self, resource_name, scope_name, metric_dictionary):
         num_metrics = 0
         metric = {}
+        metric["prefix_name"] = "%s.%s" % (resource_name, scope_name)
         metric["name"] = metric_dictionary["name"]
         metric["unit"] = metric_dictionary["unit"]
         metric["description"] = metric_dictionary["description"]
@@ -584,50 +656,63 @@ class Source(object):
         # determine metric type
         if "sum" in metric_dictionary:  # sum or counter
             metric["semantic"] = "counter"
-            mtype = "sum"
+            metric["type"] = "sum"
         elif "gauge" in metric_dictionary:  # gauge
             metric["semantic"] = "gauge"
-            mtype = "gauge"
+            metric["type"] = "gauge"
         elif "histogram" in metric_dictionary:  # histogram
             metric["semantic"] = "counter"
-            mtype = "histogram"
+            metric["type"] = "histogram"
         elif "summary" in metric_dictionary:    # sum
             metric["semantic"] = "counter"
-            mtype = "summary"
+            metric["type"] = "summary"
         else:
             # what to do in this case? set to gauge or throw an exception?
             self.pmda.debug("error") if self.pmda.dbg else None
 
-        if "aggregationTemporality" in metric_dictionary[mtype]:
-            metric["a_temp"] = metric_dictionary[mtype]["aggregationTemporality"]
+        if "aggregationTemporality" in metric_dictionary[metric["type"]]:
+            metric["a_temp"] = metric_dictionary[metric["type"]]["aggregationTemporality"]
 
-        if "isMonotonic" in metric_dictionary[mtype]:
-            metric["isMonotonic"] = metric_dictionary[mtype]["isMonotonic"]
+        if "isMonotonic" in metric_dictionary[metric["type"]]:
+            metric["isMonotonic"] = metric_dictionary[metric["type"]]["isMonotonic"]
         else:
             metric["isMonotonic"] = False
 
         # determine if metric is singular
-        if len(metric_dictionary[mtype]["dataPoints"]) == 1 and type != "histogram" and type != "summary":
+        if len(metric_dictionary[metric["type"]]["dataPoints"]) == 1 and metric["type"] != "histogram" and metric["type"] != "summary":
             metric["is_singular"] = True
         else:
             metric["is_singular"] = False
 
         metric["values"] = []
         metric["instances"] = []
-        data_points = metric_dictionary[mtype]["dataPoints"]
-        if mtype in ["sum", "gauge"]:
+        metric["labels"] = []
+        data_points = metric_dictionary[metric["type"]]["dataPoints"]
+        if metric["type"] == "sum" or metric["type"] == "gauge":
+            inst_num = 0
             for instance in data_points:
                 metric["time"] = instance["timeUnixNano"]
-                metric["labels"] = self.collect_attributes(instance["attributes"])
-                # throw out metric if instances do not match type?
+                labels = self.collect_attributes(instance["attributes"])
+                metric["labels"].append({inst_num: labels})
+
+                if "instance" in metric["labels"][inst_num]:
+                    metric["instances"].append(metric["labels"][inst_num]["instance"])
+                    inst_num += 1
+                elif "instname" in metric["labels"]:
+                    metric["instances"].append(metric["labels"][inst_num]["instname"])
+                    inst_num += 1
+                else:
+                    metric["instances"].append("inst-%s" % inst_num)
+                    inst_num += 1
+
                 if "asDouble" in instance:
-                    metric["type"] = "double"
+                    metric["data_type"] = "double"
                     metric["values"].append(instance["asDouble"])
                 elif "asInt" in instance:
-                    metric["type"] = "int"
+                    metric["data_type"] = "int"
                     metric["values"].append(instance["asInt"])
                 elif "asString" in instance:
-                    metric["type"] = "string"
+                    metric["data_type"] = "string"
                     metric["values"].append(instance["asString"])
                 else:
                     self.pmda.debug("error2") if self.pmda.dbg else None
@@ -635,12 +720,12 @@ class Source(object):
                 num_metrics += 1
         else: # histogram or sum
             for instance in data_points:
-                count = instance["count"]
-                msum = instance["sum"]
+                count_attr = instance["count"]
+                sum_attr = instance["sum"]
                 metric["time"] = instance["timeUnixNano"]
-                metric["type"] = "int"
+                metric["data_type"] = "int"
                 metric["labels"] = self.collect_attributes(instance["attributes"])
-                if mtype == "histogram":
+                if metric["type"] == "histogram":
                     self.pmda.debug("instance: %s" % instance) if self.pmda.dbg else None
                     metric["values"] = instance["bucketCounts"]
                     for item in instance["explicitBounds"]:
@@ -648,8 +733,9 @@ class Source(object):
                     metric["instances"].append("le=inf")
                 else: # summary
                     quantiles = instance["quantileValues"]
+                    metric["data_type"] = "double"
                     for item in quantiles:
-                        metric["instances"].append(item["quantile"])
+                        metric["instances"].append("quantile: %s" % item["quantile"])
                         metric["values"].append(item["value"])
 
                 if self.add_metric(metric):
@@ -660,18 +746,17 @@ class Source(object):
                 metric_sum_name = metric["name"] + "_sum"
 
                 metric["name"] = metric_count_name
-                metric["value"] = count
+                metric["values"].clear(); metric["values"].append(count_attr)
+                metric["is_singular"] = True
+                metric["data_type"] = "int"
                 if self.add_metric(metric):
                     num_metrics += 1
 
                 metric["name"] = metric_sum_name
-                metric["value"] = msum
-                metric["type"] = "double"
+                metric["values"].clear(); metric["values"].append(sum_attr)
+                metric["data_type"] = "double"
                 if self.add_metric(metric):
                     num_metrics += 1
-
-        self.pmda.debug("metric dictionary: %s" % metric) if self.pmda.dbg else None
-
         return num_metrics
 
     def parse_lines(self, text):
@@ -680,7 +765,7 @@ class Source(object):
 
         for resource in data:
             resource_attributes = self.collect_attributes(resource["resource"]["attributes"])
-            resource_name = resource_attributes["service.name"]
+            resource_name = resource_attributes["service_name"]
             scope_metrics = resource["scopeMetrics"]
             for scope in scope_metrics:
                 scope_name = scope["scope"]["name"]


### PR DESCRIPTION
addition of new pmda causing several
qa test failures. QA tests 1632, 1678,
1726, 1787, 1888, 1890, 1942, and 1948
are updated and working. Changes made to
label, storing instances, and unit parsing
code. Rework of QA opentelemetry endpoint
file and addition of otel QA script.