### PR TITLE
Fix locale-dependent behavior

### DIFF
--- a/qa/admin/list-packages
+++ b/qa/admin/list-packages
@@ -3,6 +3,7 @@
 # Replacement for check-vm using (almost) explicit package lists for
 # each distro-version-architecture combination
 #
+LANG=C.UTF-8
 
 _usage()
 {


### PR DESCRIPTION
When retrieving the list of packages,
the output of commands like yum sometimes assumes the English only. 
Therefore, set the LANG Environment.

Fixes: #2338