### PR TITLE
Fix for code scanning alert no. 376: Unsigned difference expression compared to zero

### DIFF
--- a/qa/src/chk_memleak.c
+++ b/qa/src/chk_memleak.c
@@ -118,7 +118,7 @@ main(int argc, char **argv)
 	}
 	else {
 	    __pmProcessDataSize(&memusage);
-	    if (memusage - first_memusage > 0) {
+	    if (memusage > first_memusage) {
 		if (i > 1)
 		    printf("iteration %d: leaked %lu bytes\n", i,
 			   memusage - last_memusage);


### PR DESCRIPTION
Fix for [https://github.com/performancecopilot/pcp/security/code-scanning/376](https://github.com/performancecopilot/pcp/security/code-scanning/376)

To fix the problem, we must ensure the subtraction occurs in a signed type context, or (preferably) change the logic to a direct unsigned comparison without subtraction. Instead of comparing `(memusage - first_memusage) > 0`, compare simply `memusage > first_memusage`, which is safer and avoids underflow. This change does not alter functionality, since `'a - b > 0'` is equivalent to `'a > b'` in unsigned arithmetic (except when underflowed), but is clearer and would not trigger static analysis warnings.

Edit the block in qa/src/chk_memleak.c at line 121:
- Replace `if (memusage - first_memusage > 0) {` with `if (memusage > first_memusage) {`

No imports or additional changes needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
