### PR TITLE
Improvements of hdb pmda

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -463,6 +463,9 @@ Summary: Performance Co-Pilot (PCP) metrics for SAP HANA databases
 URL: https://pcp.io
 Requires: pcp = @package_version@ pcp-libs = @package_version@
 Requires: python3-pcp
+%if 0%{?rhel} > 8 || 0%{?fedora} > 0
+Requires: python3-packaging
+%endif
 %description pmda-hdb
 This package provides a PMDA to export metric values about a SAP HANA
 database (https://www.sap.com/products/data-cloud/hana.html).

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -1513,6 +1513,9 @@ Summary: Performance Co-Pilot (PCP) metrics for SAP HANA databases
 URL: https://pcp.io
 Requires: pcp = %{version}-%{release} pcp-libs = %{version}-%{release}
 Requires: python3-pcp
+%if 0%{?rhel} > 8 || 0%{?fedora} > 0
+Requires: python3-packaging
+%endif
 %description pmda-hdb
 This package provides a PMDA to export metric values about a SAP HANA
 database (https://www.sap.com/products/data-cloud/hana.html).

--- a/src/pmdas/hdb/hdb.conf
+++ b/src/pmdas/hdb/hdb.conf
@@ -3,10 +3,23 @@
 #
 
 [hdb]
-host=localhost
-port=39017
+# IP address or DNS name of the SAP HANA service
+#host=localhost
+
+# TCP Port the SAP HANA service listens on
+#port=39017
+
+# SAP HANA user used for authentication
 user=user
+
+# Password of the SAP HANA user
 password=password
-connect_timeout=60000
-node_connect_timeout=10000
-communication_timeout=2000
+
+# Connection timeout in miliSeconds
+#connect_timeout=60000
+
+# Node connection timeout in miliSeconds
+#node_connect_timeout=10000
+
+# Communication timeout in miliSeconds
+#communication_timeout=2000

--- a/src/pmdas/hdb/pmdahdb.python
+++ b/src/pmdas/hdb/pmdahdb.python
@@ -52,11 +52,15 @@ from cpmapi import (
 from pcp.pmapi import pmContext, pmUnits
 from pcp.pmda import PMDA, pmdaIndom, pmdaInstid, pmdaMetric
 try:
+    from packaging.version import parse as Version
+except: # pylint: disable=bare-except
+    from distutils.version import LooseVersion as Version # pylint: disable=deprecated-module
+
+try:
     from hdbcli import dbapi
-    from looseversion import LooseVersion
     from pyhdbcli import OperationalError, ResultRow
 except:
-    raise ImportError("Failed to import hdbcli, pyhdbcli, and/or looseversion. Please make sure these modules are " \
+    raise ImportError("Failed to import hdbcli, and/or pyhdbcli. Please make sure these modules are " \
     "installed.")
 
 
@@ -163,9 +167,9 @@ def _hana_revision_included(
     """
     if revision is None:
         raise ValueError("version must not be None")
-    v_revision = LooseVersion(revision)
-    v_min = LooseVersion(min_revision) if min_revision else None
-    v_max = LooseVersion(max_revision) if max_revision else None
+    v_revision = Version(revision)
+    v_min = Version(min_revision) if min_revision else None
+    v_max = Version(max_revision) if max_revision else None
 
     if v_min is not None and v_max is not None:
         if v_max < v_min:
@@ -3483,14 +3487,15 @@ def _parse_config(filename: str) -> _Config:
 
     # hana config parsing
     try:
+        section = parser[_Config.HDBConfig.SECTION]
         hdb_config = _Config.HDBConfig(
-            host=parser.get(_Config.HDBConfig.SECTION, "host"),
-            port=parser.getint(_Config.HDBConfig.SECTION, "port"),
-            user=parser.get(_Config.HDBConfig.SECTION, "user"),
-            password=parser.get(_Config.HDBConfig.SECTION, "password"),
-            connect_timeout=parser.get(_Config.HDBConfig.SECTION, "connect_timeout"),
-            node_timeout=parser.get(_Config.HDBConfig.SECTION, "node_connect_timeout"),
-            comm_timeout=parser.get(_Config.HDBConfig.SECTION, "communication_timeout"),
+            host=section.get("host", 'localhost'),
+            port=section.getint("port", 39017),
+            user=section.get("user"),
+            password=section.get("password"),
+            connect_timeout=section.get("connect_timeout", '60000'),
+            node_timeout=section.get("node_connect_timeout", '10000'),
+            comm_timeout=section.get("communication_timeout", '2000'),
         )
     except configparser.Error as parse_err:
         raise RuntimeError(


### PR DESCRIPTION
Make config parameters in hdb.conf optional, with exception of username and password.

Replace LooseVersion module with packaging.version module as the LooseVersion is not available in RHEL and is considered as obsolete.