### PR TITLE
build: macOS build additions and improvements

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -16,17 +16,27 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-      - name: Install and verify setuptools
-        id: install-setuptools
+      - name: Install python venv
+        id: install-python-venv
         run: |
           python3 --version
           pip3 --version
-          pip3 install --upgrade pip setuptools wheel
+          pip3 install --upgrade pip
+          python3 -m venv build
+          source build/bin/activate
+      - name: Install and verify python setuptools
+        id: install-python-venv
+        run: |
+          pip3 install setuptools wheel
           python3 -c "import setuptools; print(setuptools.__version__)"
+      - name: Install python module deps
+        id: install-python-modules
+        run: |
+          python3 -m pip install lxml openpyxl OrderedDict psycopg2-binary prometheus_client pyarrow pyodbc requests six
       - name: Install Homebrew deps
         id: install-deps
         run: |
-          brew install gnu-tar pkg-config autoconf
+          brew install autoconf gnu-tar pkg-config libuv ncurses openssl ragel readline unixodbc xz zstd
       - name: Build on macOS
         id: Build
         run: |

--- a/configure
+++ b/configure
@@ -8587,7 +8587,7 @@ fi
 
   test -n "$PYLINT" && break
 done
-test -n "$PYLINT" || PYLINT="/bin/true"
+test -n "$PYLINT" || PYLINT="/usr/bin/true"
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1014,7 +1014,7 @@ AC_OUTPUT
 AC_CHECK_PROGS(GIT, git)
 AC_SUBST(GIT)
 
-AC_CHECK_PROGS(PYLINT, pylint, /bin/true)
+AC_CHECK_PROGS(PYLINT, pylint, /usr/bin/true)
 AC_SUBST(PYLINT)
 
 dnl check if python3 available for the build and runtime

--- a/qa/admin/check-manifest
+++ b/qa/admin/check-manifest
@@ -1021,7 +1021,7 @@ in
 	;;
 
     brew)
-	echo >&2 "TODO: no list all packages method for brew"
+	brew list --formulae -1
 	;;
 
     *)

--- a/qa/admin/old-list-packages
+++ b/qa/admin/old-list-packages
@@ -650,7 +650,7 @@ in
     Darwin)
 	mytype=brew
 	installcmd="brew install"
-	echo >&2 "TODO: no list all packages method for brew"
+	brew list --formulae -1 >$tmp.installed
 	;;
 
 esac

--- a/qa/admin/package-lists/Darwin+24.6.0+arm64
+++ b/qa/admin/package-lists/Darwin+24.6.0+arm64
@@ -1,0 +1,59 @@
+# PCP required package list for Darwin 24.6.0 arm64
+# created by nathans on Sun 21 Sep 2025 08:59:13 AEST
+#
+HdrHistogram_c
+JSON cpan
+Pillow-PIL pip3
+RediSearch
+Spreadsheet::Read cpan
+Spreadsheet::ReadSXC cpan
+Spreadsheet::WriteExcel cpan
+Spreadsheet::XLSX cpan
+Text::CSV_XS cpan
+XML::TokeParser cpan
+YAML::LibYAML cpan
+YAML::XS cpan
+autoconf
+bash
+bc
+bcc pip3
+bison
+cppcheck
+docker
+ed
+elasticsearch pip3
+flex
+gawk
+gdb
+grep
+httpd
+icu4c
+libuv
+libvirt
+libvirt-python pip3
+lxml pip3
+make
+mandoc
+mariadb
+memcached
+ncurses
+nmap
+openpyxl pip3
+pkg-config
+postgresql
+prometheus_client pip3
+psycopg2 pip3
+python
+qt
+readline
+requests pip3
+sed
+setuptools pip3
+six pip3
+smartmontools
+socat
+sqlite
+unbound
+valkey
+xz
+zstd


### PR DESCRIPTION
Update several more QA-related locations with current brew recipe. Install pylint for checking, fix configure.ac defaults is missing (no /bin/true on macOS, only /usr/bin/true).

Additional build dependency packages added to enable more of PCP for macOS (agents, tools).