### PR TITLE
rocestat PMDA: fix invalid path on RHEL8

### DIFF
--- a/src/pmdas/rocestat/pmdarocestat.python
+++ b/src/pmdas/rocestat/pmdarocestat.python
@@ -135,7 +135,7 @@ class NICSTATS:
 
     def get_up_interfaces(self):
         """Get the names of all interfaces that are in the Up state."""
-        result = subprocess.Popen(['/usr/bin/ibdev2netdev'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        result = subprocess.Popen(['ibdev2netdev'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         output, _ = result.communicate()
 
         if result.returncode != 0:


### PR DESCRIPTION
ibdev2netdev can be installed in multiple locations. 
For example, ibdev2netdev is installed either in /usr/sbin or /usr/bin on RHEL8.

```
$ sudo yum provides ibdev2netdev
mlnx-ofa_kernel-24.10-OFED.24.10.3.2.5.1.rhel8u6.x86_64 : Infiniband HCA Driver
Repo        : @System
Matched from:
Filename    : /usr/sbin/ibdev2netdev

rdma-core-37.2-1.el8.x86_64 : RDMA core userspace libraries and daemons
Repo        : rocky86-baseos
Matched from:
Filename    : /usr/bin/ibdev2netdev
```

We avoid hard-coding an absolute path and
simply invoke it by name so that PATH resolution can handle it.