### PR TITLE
pmdahacluster:  Support "cibadmin --local" deprecation for pacemaker …

### DIFF
--- a/src/pmdas/hacluster/pacemaker.c
+++ b/src/pmdas/hacluster/pacemaker.c
@@ -794,7 +794,7 @@ hacluster_refresh_pacemaker_resources(const char *instance_name, struct resource
 void
 pacemaker_stats_setup(void)
 {
-	static char pacemaker_command_cibadmin[] = "cibadmin --query --local";
+	static char pacemaker_command_cibadmin[] = "cibadmin --query";
 	static char pacemaker_command_crm_mon[] = "crm_mon -X --inactive";
 	char *env_command;
 

--- a/src/pmdas/hacluster/pmda.c
+++ b/src/pmdas/hacluster/pmda.c
@@ -1627,7 +1627,7 @@ hacluster_labelCallBack(pmInDom indom, unsigned int inst, pmLabelSet **lp)
 void
 hacluster_inst_setup(void)
 {
-	static char pacemaker_command_cibadmin[] = "cibadmin --query --local";
+	static char pacemaker_command_cibadmin[] = "cibadmin --query";
 	static char pacemaker_command_crm_mon[] = "crm_mon -X --inactive";
 	static char corosync_command_quorumtool[] = "corosync-quorumtool -p";
 	static char corosync_command_cfgtool[] = "corosync-cfgtool -s";


### PR DESCRIPTION
…metrics

"cibadmin --local" switch has been depreciated as of pacemaker 3.0.

Update the collection of pacemaker metrics to not make use the switch when collecting metrics.