### PR TITLE
src/pmieconf/pmieconf.c: Eliminate minor memory leaks [Coverity]

### DIFF
--- a/src/pmieconf/rules.c
+++ b/src/pmieconf/rules.c
@@ -1189,8 +1189,11 @@ read_rule(FILE *f, rule_t **r, char *name)
 	if ((sts = read_next_attribute(f, &attr, &value)) < 0)
 	    return errmsg;
 	else if (sts == 0) {	/* end of attribute list */
-	    if ((*r = alloc_rule(rule)) == NULL)
+	    if ((*r = alloc_rule(rule)) == NULL) {
+		free(rule.predicate);
+		free(rule.enumerate);
 		return errmsg;
+	    }
 	    break;
 	}
 	else {


### PR DESCRIPTION
There are minor memory leaks in read_rule() if the duplicate rule names are encountered. Make sure the allocated memory is freed if this is encountered.

Fixes CID 454664
Fixes CID 454667