### PR TITLE
build: extend man page linting to check for runtime errors

### DIFF
--- a/man/man1/dkvis.1
+++ b/man/man1/dkvis.1
@@ -41,7 +41,7 @@ The height of the bars is proportional to the activity.
 The user can specify a list of disks as \f2diskid\f1 arguments
 using the disk naming scheme reported by
 .sp 0.5v
-.ft CW
+.ft CR
 .ti 1i
 $ pminfo -f disk.dev.total
 .sp 0.5v

--- a/man/man1/mpvis.1
+++ b/man/man1/mpvis.1
@@ -70,7 +70,7 @@ than one row of CPUs).
 The user can specify a list of CPUs as \f2cpuid\f1 arguments
 using the naming scheme reported by
 .sp 0.5v
-.ft CW
+.ft CR
 .ti 1i
 $ pminfo -f kernel.percpu.cpu.user
 .sp 0.5v

--- a/man/man1/pcpintro.1
+++ b/man/man1/pcpintro.1
@@ -152,6 +152,7 @@ There is a set of common command line arguments that are used consistently
 by most PCP tools.
 .TP
 \fB\-a\fR \fIarchive\fR, \fB\-\-archive\fR=\fIarchive\fR
+.RS
 Performance metric information is retrospectively retrieved
 from the set of Performance Co-Pilot (PCP) archives identified by
 .IR archive
@@ -162,7 +163,6 @@ See
 and
 .BR LOGARCHIVE (5)
 for archive creation interfaces and format documentation.
-.RS
 .PP
 .I archive
 is a comma-separated list of names, each
@@ -205,6 +205,7 @@ etc.
 .RE
 .TP
 \fB\-h\fR \fIhost\fR, \fB\-\-host\fR=\fIhost\fR
+.RS
 Unless directed to another host by the
 .B \-h
 (or
@@ -247,8 +248,10 @@ is 0 or
 is not specified, the application
 will sample and report continuously (in real time mode) or until the end
 of the set of PCP archives (in archive mode).
+.RE
 .TP
 \fB\-z\fR, \fB\-\-hostzone\fR
+.RS
 Change the reporting timezone to the local timezone at the
 host that is the source of the performance metrics, as identified via
 either the
@@ -260,8 +263,10 @@ or
 (or
 .BR \-\-archive )
 options.
+.RE
 .TP
 \fB\-Z\fR \fItimezone\fR, \fB\-\-timezone\fR=\fItimezone\fR
+.RS
 By default, applications
 report the time of day according to the local timezone on the
 system where
@@ -276,8 +281,10 @@ in the format of the environment variable
 .B TZ
 as described in
 .BR environ (7).
+.RE
 .TP
 \fB\-D\fR \fIdebugspec\fR, \fB\-\-debug\fR=\fIdebugspec\fR
+.RS
 Sets the PCP debugging options to
 .I debugspec
 to enable diagnostics and tracing that is most helpful for developers or
@@ -304,6 +311,7 @@ option, but a typical invocation in this mode would be
 .B "\-O today"
 or
 .BR "\-\-origin yesterday" .
+.RE
 .SH INTERVAL SPECIFICATION AND ALIGNMENT
 Most PCP tools operate with periodic sampling or
 reporting, and the
@@ -1181,8 +1189,7 @@ is a directory then recursive descent is used to enumerate all
 files below that directory and these are added to the list.
 .RS
 .PP
-Each file in the resulting list is assumed to
-contain
+Each file in the resulting list is assumed to contain
 definitions of derived metrics as per the syntax described in
 .BR pmLoadDerivedConfig (3),
 and these are loaded in order.
@@ -1276,7 +1283,6 @@ If
 .B PCP_STDERR
 is set to any other value, the value is assumed to
 be a filename, and all messages will be written there.
-.RE
 .TP
 .B PMCD_CONNECT_TIMEOUT
 When attempting to connect to a remote

--- a/man/man1/pmdapipe.1
+++ b/man/man1/pmdapipe.1
@@ -332,11 +332,17 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	event processing and generation, interactions with \fBpmcd\fP(1), client context handling, command execution
+appl0	T{
+event processing and generation, interactions with \fBpmcd\fP(1),
+client context handling, command execution
+T}
 _
 appl1	access controls, user and group diagnostics
 _
-appl2	\fIconfigfile\fP handling, bad command argument diagnostics, \fBselect\fP(2) handling
+appl2	T{
+\fIconfigfile\fP handling, bad command argument diagnostics,
+\fBselect\fP(2) handling
+T}
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmdapipe.1
+++ b/man/man1/pmdapipe.1
@@ -332,22 +332,11 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-event processing and generation, interactions with \fBpmcd\fP(1),
-client context handling, command execution
-T}
+appl0	event processing and generation, interactions with \fBpmcd\fP(1), client context handling, command execution
 _
-appl1	T{
-.ad l
-access controls, user and group diagnostics
-T}
+appl1	access controls, user and group diagnostics
 _
-appl2	T{
-.ad l
-.I configfile
-handling, bad command argument diagnostics, \fBselect\fP(2) handling
-T}
+appl2	\fIconfigfile\fP handling, bad command argument diagnostics, \fBselect\fP(2) handling
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmdashping.1
+++ b/man/man1/pmdashping.1
@@ -237,7 +237,9 @@ appl0	exit handling
 _
 appl1	\fIconfigfile\fP parsing, timeouts, refresh cycle
 _
-appl2	append commands and arguments to \fIshping.out\fP as they are executed
+appl2	T{
+append commands and arguments to \fIshping.out\fP as they are executed
+T}
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmdashping.1
+++ b/man/man1/pmdashping.1
@@ -233,22 +233,11 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-exit handling
-T}
+appl0	exit handling
 _
-appl1	T{
-.ad l
-\fIconfigfile\fP parsing, timeouts, refresh cycle
-T}
+appl1	\fIconfigfile\fP parsing, timeouts, refresh cycle
 _
-appl2	T{
-.ad l
-append commands and arguments to
-.I shping.out
-as they are executed
-T}
+appl2	append commands and arguments to \fIshping.out\fP as they are executed
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmdaweblog.1
+++ b/man/man1/pmdaweblog.1
@@ -592,22 +592,11 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-initialization,
-.I configfile
-parsing and log file processing
-T}
+appl0	initialization, \fIconfigfile\fP parsing and log file processing
 _
-appl1	T{
-.ad l
-timer operations, log file probing
-T}
+appl1	timer operations, log file probing
 _
-appl2	T{
-.ad l
-IPC with worker processes, log lines processed
-T}
+appl2	IPC with worker processes, log lines processed
 .TE
 .SH SEE ALSO
 .BR pmcd (1),

--- a/man/man1/pmhostname.1
+++ b/man/man1/pmhostname.1
@@ -89,12 +89,7 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-detailed diagnostics, e.g. result from calling
-.BR gethostname (2)
-and PMAPI routines
-T}
+appl0	detailed diagnostics, e.g. result from calling \fBgethostname\fP(2) and PMAPI routines
 .TE
 .SH SEE ALSO
 .BR nslookup (1),

--- a/man/man1/pmhostname.1
+++ b/man/man1/pmhostname.1
@@ -89,7 +89,10 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	detailed diagnostics, e.g. result from calling \fBgethostname\fP(2) and PMAPI routines
+appl0	T{
+detailed diagnostics, e.g. result from calling \fBgethostname\fP(2)
+and PMAPI routines
+T}
 .TE
 .SH SEE ALSO
 .BR nslookup (1),

--- a/man/man1/pmie.1
+++ b/man/man1/pmie.1
@@ -1507,9 +1507,13 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	lexical scanning during parsing of the configuration file
+appl0	T{
+lexical scanning during parsing of the configuration file
+T}
 _
-appl1	configuration file parsing and expression tree construction
+appl1	T{
+configuration file parsing and expression tree construction
+T}
 _
 appl2	expression evaluation
 _

--- a/man/man1/pmie.1
+++ b/man/man1/pmie.1
@@ -733,38 +733,26 @@ lf(CB) | l | l.
 Operators	Type	Explanation
 _
 T{
-.ad l
 some_inst
-.br
 some_host
-.br
 some_sample
 T}	Existential	T{
-.ad l
 True if at least one set member is true in the associated dimension
 T}
 _
 T{
-.ad l
 all_inst
-.br
 all_host
-.br
 all_sample
 T}	Universal	T{
-.ad l
 True if all set members are true in the associated dimension
 T}
 _
 T{
-.ad l
 \f(CIN\f(CB%_inst
-.br
 \f(CIN\f(CB%_host
-.br
 \f(CIN\f(CB%_sample\fR
 T}	Percentile	T{
-.ad l
 True if at least \fIN\fP percent of set members are true in the associated dimension
 T}
 .TE
@@ -787,19 +775,11 @@ lf(CB) | l.
 Operators	Explanation
 _
 match_inst	T{
-.ad l
-For each value of the logical expression that is ``true'', the
-result is ``true'' if the associated instance name matches the
-regular expression.
-Otherwise the result is ``false''.
+For each value of the logical expression that is ``true'', the result is ``true'' if the associated instance name matches the regular expression.  Otherwise the result is ``false''.
 T}
 _
 nomatch_inst	T{
-.ad l
-For each value of the logical expression that is ``true'', the
-result is ``true'' if the associated instance name does
-\fBnot\fP match the
-regular expression.  Otherwise the result is ``false''.
+For each value of the logical expression that is ``true'', the result is ``true'' if the associated instance name does \fBnot\fP match the regular expression.  Otherwise the result is ``false''.
 T}
 .TE
 .PP
@@ -824,50 +804,34 @@ lf(CB) | l | l.
 Operators	Type	Explanation
 _
 T{
-.ad l
 min_inst
-.br
 min_host
-.br
 min_sample
 T}	Extrema	T{
-.ad l
 Minimum value across all set members in the associated dimension
 T}
 _
 T{
-.ad l
 max_inst
-.br
 max_host
-.br
 max_sample
 T}	Extrema	T{
-.ad l
 Maximum value across all set members in the associated dimension
 T}
 _
 T{
-.ad l
 sum_inst
-.br
 sum_host
-.br
 sum_sample
 T}	Aggregate	T{
-.ad l
 Sum of values across all set members in the associated dimension
 T}
 _
 T{
-.ad l
 avg_inst
-.br
 avg_host
-.br
 avg_sample
 T}	Aggregate	T{
-.ad l
 Average value across all set members in the associated dimension
 T}
 .TE
@@ -1543,25 +1507,13 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-lexical scanning during parsing of the configuration file
-T}
+appl0	lexical scanning during parsing of the configuration file
 _
-appl1	T{
-.ad l
-configuration file parsing and expression tree construction
-T}
+appl1	configuration file parsing and expression tree construction
 _
-appl2	T{
-.ad l
-expression evaluation
-T}
+appl2	expression evaluation
 _
-appl3	T{
-.ad l
-status file operations
-T}
+appl3	status file operations
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pminfo.1
+++ b/man/man1/pminfo.1
@@ -335,7 +335,9 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl4	report batch downsizing if \fIbatchsize\fP would exceed maximum PDU size
+appl4	T{
+report batch downsizing if \fIbatchsize\fP would exceed maximum PDU size
+T}
 _
 appl5	dump PDU stats at end if context is a host
 .TE

--- a/man/man1/pminfo.1
+++ b/man/man1/pminfo.1
@@ -335,17 +335,9 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl4	T{
-.ad l
-report batch downsizing if
-.I batchsize
-would exceed maximum PDU size
-T}
+appl4	report batch downsizing if \fIbatchsize\fP would exceed maximum PDU size
 _
-appl5	T{
-.ad l
-dump PDU stats at end if context is a host
-T}
+appl5	dump PDU stats at end if context is a host
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmlogbasename.1
+++ b/man/man1/pmlogbasename.1
@@ -102,20 +102,9 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-report the name of each file that exists and potentially matches
-.I name
-T}
+appl0	report the name of each file that exists and potentially matches \fIname\fP
 _
-appl1	T{
-.ad l
-report the name of each file that does
-.B not
-exist but was probed looking
-for matches with
-.I name
-T}
+appl1	report the name of each file that does \fBnot\fP exist but was probed looking for matches with \fIname\fP
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1)

--- a/man/man1/pmlogbasename.1
+++ b/man/man1/pmlogbasename.1
@@ -102,9 +102,14 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	report the name of each file that exists and potentially matches \fIname\fP
+appl0	T{
+report the name of each file that exists and potentially matches \fIname\fP
+T}
 _
-appl1	report the name of each file that does \fBnot\fP exist but was probed looking for matches with \fIname\fP
+appl1	T{
+report the name of each file that does \fBnot\fP exist but was probed
+looking for matches with \fIname\fP
+T}
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1)

--- a/man/man1/pmlogcheck.1
+++ b/man/man1/pmlogcheck.1
@@ -274,27 +274,14 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-dump each
-.B pmResult
-processed
+appl0	dump each \fBpmResult\fP processed
 T}
 _
-appl1	T{
-.ad l
-report each time a new metric-instance pair is seen
-T}
+appl1	report each time a new metric-instance pair is seen
 _
-appl2	T{
-.ad l
-report counter values as part of wrap detection
-T}
+appl2	report counter values as part of wrap detection
 _
-appl3	T{
-.ad l
-report elapsed and cpu time for each pass
-T}
+appl3	report elapsed and cpu time for each pass
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmlogextract.1
+++ b/man/man1/pmlogextract.1
@@ -706,41 +706,17 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-parser diagnostics for
-.I configfile
-if
-.B \-c
-specified
-T}
+appl0	parser diagnostics for \fIconfigfile\fP if \fB\-c\fP specified
 _
-appl1	T{
-.ad l
-memory allocations and
-.B reclist
-operations
-T}
+appl1	memory allocations and \fBreclist\fP operations
 _
-appl2	T{
-.ad l
-time window and end-of-file tests
-T}
+appl2	time window and end-of-file tests
 _
-appl3	T{
-.ad l
-input and output archive version decisions
-T}
+appl3	input and output archive version decisions
 _
-appl4	T{
-.ad l
-instance domain juggling
-T}
+appl4	instance domain juggling
 _
-appl5	T{
-.ad l
-output volume switching
-T}
+appl5	output volume switching
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmlogger.1
+++ b/man/man1/pmlogger.1
@@ -1331,65 +1331,24 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-control request PDUs to and from
-.BR pmlc (1)
+appl0	control request PDUs to and from \fBpmlc\fP(1)
+_
+appl1	credentials exchange
+_
+appl2	alarm (timing) loop diagnostics, callback work and record control mode messages
+_
+appl3	signal callbacks and exit logging
+_
+appl4	record timestamps in \fIlogfile\fP as milestones are reached
+_
+appl5	PDU stats after \fIconffile\fP file processed
+_
+appl6	building the metadata cache from \fIconffile\fP to boost start-up performance, \fIpass0\fP() work
 T}
 _
-appl1	T{
-.ad l
-credentials exchange
-T}
+appl7	suppress building of the metadata cache, \fIpass0\fP() becomes a no-op
 _
-appl2	T{
-.ad l
-alarm (timing) loop diagnostics, callback work and record control
-mode messages
-T}
-_
-appl3	T{
-.ad l
-signal callbacks and exit logging
-T}
-_
-appl4	T{
-.ad l
-record timestamps in
-.I logfile
-as milestones are reached
-T}
-_
-appl5	T{
-.ad l
-PDU stats after
-.I conffile
-file processed
-T}
-_
-appl6	T{
-.ad l
-building the metadata cache from
-.I conffile
-to boost start-up performance,
-.IR pass0 ()
-work
-T}
-_
-appl7	T{
-.ad l
-suppress building of the metadata cache,
-.IR pass0 ()
-becomes a no-op
-T}
-_
-appl8	T{
-.ad l
-hist_hash updates and queries to support
-.B query
-command from
-.BR pmlc (1)
-T}
+appl8	hist_hash updates and queries to support \fBquery\fP command from \fBpmlc\fP(1)
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmlogger.1
+++ b/man/man1/pmlogger.1
@@ -1335,7 +1335,10 @@ appl0	control request PDUs to and from \fBpmlc\fP(1)
 _
 appl1	credentials exchange
 _
-appl2	alarm (timing) loop diagnostics, callback work and record control mode messages
+appl2	T{
+alarm (timing) loop diagnostics, callback work and record
+control mode messages
+T}
 _
 appl3	signal callbacks and exit logging
 _
@@ -1343,12 +1346,17 @@ appl4	record timestamps in \fIlogfile\fP as milestones are reached
 _
 appl5	PDU stats after \fIconffile\fP file processed
 _
-appl6	building the metadata cache from \fIconffile\fP to boost start-up performance, \fIpass0\fP() work
+appl6	T{
+building the metadata cache from \fIconffile\fP to boost start-up performance, \fIpass0\fP() work
 T}
 _
-appl7	suppress building of the metadata cache, \fIpass0\fP() becomes a no-op
+appl7	T{
+suppress building of the metadata cache, \fIpass0\fP() becomes a no-op
+T}
 _
-appl8	hist_hash updates and queries to support \fBquery\fP command from \fBpmlc\fP(1)
+appl8	T{
+hist_hash updates and queries to support \fBquery\fP command from \fBpmlc\fP(1)
+T}
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmlogrewrite.1
+++ b/man/man1/pmlogrewrite.1
@@ -1715,15 +1715,23 @@ Option	Description
 _
 appl0	archive reads and writes for data and metadata volumes
 _
-appl1	metadata changes (metric descriptors, instance domains, help text, metric labels)
+appl1	T{
+metadata changes (metric descriptors, instance domains, help text,
+metric labels)
+T}
 _
 appl2	metric value (\fBpmResult\fP) changes
 _
-appl3	\fB\-q\fR handling and explanation of required changes that are the reason for not taking a quick exit
+appl3	T{
+\fB\-q\fR handling and explanation of required changes that are the
+reason for not taking a quick exit
+T}
 _
 appl4	\fIconfig\fR file parser diagnostics
 _
-appl5	\fBRregex\fR(7) matching for metric value changes and instance name changes
+appl5	T{
+\fBRregex\fR(7) matching for metric value changes and instance name changes
+T}
 _
 appl6	lexical scanner called from \fIconfig\fR file parser
 .TE

--- a/man/man1/pmlogrewrite.1
+++ b/man/man1/pmlogrewrite.1
@@ -1713,48 +1713,19 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-archive reads and writes for data and metadata volumes
-T}
+appl0	archive reads and writes for data and metadata volumes
 _
-appl1	T{
-.ad l
-metadata changes (metric descriptors, instance domains,
-help text, metric labels)
-T}
+appl1	metadata changes (metric descriptors, instance domains, help text, metric labels)
 _
-appl2	T{
-.ad l
-metric value (\fBpmResult\fP) changes
-T}
+appl2	metric value (\fBpmResult\fP) changes
 _
-appl3	T{
-.ad l
-.B \-q
-handling
-and explanation of required changes that are the reason for
-not taking a quick exit
-T}
+appl3	\fB\-q\fR handling and explanation of required changes that are the reason for not taking a quick exit
 _
-appl4	T{
-.ad l
-.I config
-file parser diagnostics
-T}
+appl4	\fIconfig\fR file parser diagnostics
 _
-appl5	T{
-.ad l
-.BR regex (7)
-matching for metric value changes and instance name changes
-T}
+appl5	\fBRregex\fR(7) matching for metric value changes and instance name changes
 _
-appl6	T{
-.ad l
-lexical scanner called from
-.I config
-file parser
-T}
+appl6	lexical scanner called from \fIconfig\fR file parser
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmproxy.1
+++ b/man/man1/pmproxy.1
@@ -563,30 +563,11 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-client connections and disconnections
-T}
+appl0	client connections and disconnections
 _
-appl1	T{
-.ad l
-desperate logging mode, where a period followed by the PID of
-.B pmproxy
-is inserted in the name of
-.IR logfile
-before the last period, so for example pmproxy.log
-becomes pmproxy.<pid>.log
-T}
+appl1	desperate logging mode, where a period followed by the PID of \fBpmproxy\fR is inserted in the name of \fIRlogfile\fP before the last period, so for example pmproxy.log becomes pmproxy.<pid>.log
 _
-appl2	T{
-.ad l
-log incoming HTTP URLs (this is also enabled by the
-.B http
-debugging option, but the latter has broader scope because it
-turns on debugging in the libraries that
-.B pmproxy
-uses)
-T}
+appl2	log incoming HTTP URLs (this is also enabled by the \fBhttp\fR debugging option, but the latter has broader scope because it turns on debugging in the libraries that \fBpmproxy\fR uses)
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmproxy.1
+++ b/man/man1/pmproxy.1
@@ -565,9 +565,17 @@ Option	Description
 _
 appl0	client connections and disconnections
 _
-appl1	desperate logging mode, where a period followed by the PID of \fBpmproxy\fR is inserted in the name of \fIRlogfile\fP before the last period, so for example pmproxy.log becomes pmproxy.<pid>.log
+appl1	T{
+desperate logging mode, where a period followed by the PID of
+\fBpmproxy\fR is inserted in the name of \fIRlogfile\fP before the last
+period, so for example pmproxy.log becomes pmproxy.<pid>.log
+T}
 _
-appl2	log incoming HTTP URLs (this is also enabled by the \fBhttp\fR debugging option, but the latter has broader scope because it turns on debugging in the libraries that \fBpmproxy\fR uses)
+appl2	T{
+log incoming HTTP URLs (this is also enabled by the \fBhttp\fR debugging
+option, but the latter has broader scope because it turns on debugging
+in the libraries that \fBpmproxy\fR uses)
+T}
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmtime.1
+++ b/man/man1/pmtime.1
@@ -106,13 +106,7 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-enable internal diagnostics that report all
-.B pmtime
-events, e.g. setting timezone, state changes, interval changes,
-timescale changes, etc.
-T}
+appl0	enable internal diagnostics that report all \fBpmtime\fP events, e.g. setting timezone, state changes, interval changes, timescale changes, etc.
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmtime.1
+++ b/man/man1/pmtime.1
@@ -106,7 +106,11 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	enable internal diagnostics that report all \fBpmtime\fP events, e.g. setting timezone, state changes, interval changes, timescale changes, etc.
+appl0	T{
+enable internal diagnostics that report all \fBpmtime\fP events,
+e.g. setting timezone, state changes, interval changes, timescale
+changes, etc.
+T}
 .TE
 .SH SEE ALSO
 .BR PCPIntro (1),

--- a/man/man1/pmview.1
+++ b/man/man1/pmview.1
@@ -581,46 +581,21 @@ lf(B) | lf(B)
 lf(B) | lxf(R) .
 Option	Description
 _
-appl0	T{
-.ad l
-scene construction
-T}
+appl0	scene construction
 _
-appl1	T{
-.ad l
-object selection, deselection and launch
-T}
+appl1	object selection, deselection and launch
 _
-appl2	T{
-.ad l
-fetching and object modulation
-T}
+appl2	fetching and object modulation
 _
-appl3	T{
-.ad l
-object refreshing
-T}
+appl3	object refreshing
 _
-appl4	T{
-.ad l
-UI objects (other than the Inventor window)
-T}
+appl4	UI objects (other than the Inventor window)
 _
-pmc	T{
-.ad l
-metrics class operations (\fIlibpcp_qmc\fP)
-T}
+pmc	metrics class operations (\fIlibpcp_qmc\fP)
 _
-timecontrol	T{
-.ad l
-.BR pmtime (1)
-interactions
-T}
+timecontrol	\fBpmtime\fP(1) interactions
 _
-qed	T{
-.ad l
-\fIlibpcp_qed\fP methods
-T}
+qed	\fIlibpcp_qed\fP methods
 .TE
 .SH SEE ALSO
 .BR dkvis (1),

--- a/man/man3/pmgetoptions.3
+++ b/man/man3/pmgetoptions.3
@@ -447,18 +447,17 @@ $PCP_ARCHIVE	\-a	--archive	T{
 metrics source is a PCP archive
 T}
 _
-$PCP_ARCHIVE_LIST		--archive-list	T{
+$PCP_ARCHIVE_LIST		--archive list	T{
 .hy 0
-comma-separated list of metric source archives
+a comma-separated list of metric source archives
 T}
 _
 $PCP_FOLIO		--archive-folio	T{
 .hy 0
-metric source is a \fBmkaf\fP(1) archives folio
+the metric source is a \fBmkaf\fP(1) archives folio
 T}
 _
 $PCP_DEBUG	\-D	--debug	T{
-.hy 0
 a comma-separated list of \fBpmSetDebug\fP(3) debugging options
 T}
 _
@@ -474,13 +473,12 @@ T}
 _
 $PCP_HOST_LIST		--host-list	T{
 .hy 0
-comma-separated list of metric source hosts
+a comma-separated list of metric source hosts
 T}
 _
 $PCP_SPECLOCAL	\-K	--spec-local	T{
 .hy 0
-.ad l
-optional additional DSO PMDA specification for local connection, see \fBpmSpecLocalPMDA\fP(3)
+optional extra local context PMDA DSO information
 T}
 _
 T{
@@ -492,7 +490,7 @@ T}
 _
 $PCP_NAMESPACE	\-n	--namespace	T{
 .hy 0
-use an alternative Performance Metrics Name Space (PMNS)
+use alternative PMNS (Perform-ance Metrics Name Space)
 T}
 _
 $PCP_UNIQNAMES	\-N	--uniqnames	T{
@@ -509,7 +507,7 @@ T}
 _
 $PCP_GUIPORT	\-p	--guiport	T{
 .hy 0
-port for connection to an existing \fBpmtime\fP(1) time control
+port of existing \fBpmtime\fP(1) time control
 T}
 _
 $PCP_START_TIME	\-S	--start	T{
@@ -529,7 +527,7 @@ T}
 _
 $PCP_INTERVAL	\-t	--interval	T{
 .hy 0
-sampling interval
+sample interval
 T}
 _
 $PCP_TIMEZONE	\-Z	--timezone	T{

--- a/man/man3/pmgetoptions.3
+++ b/man/man3/pmgetoptions.3
@@ -439,147 +439,106 @@ Environment	Short	Long	Meaning
 _
 $PCP_ALIGN_TIME	\-A	--align	T{
 .hy 0
-.ad l
 align sample times on natural boundaries
 T}
 _
 $PCP_ARCHIVE	\-a	--archive	T{
 .hy 0
-.ad l
 metrics source is a PCP archive
 T}
 _
 $PCP_ARCHIVE_LIST		--archive-list	T{
 .hy 0
-.ad l
 comma-separated list of metric source archives
 T}
 _
 $PCP_FOLIO		--archive-folio	T{
 .hy 0
-.ad l
-metric source is a
-.BR mkaf (1)
-archives folio
+metric source is a \fBmkaf\fP(1) archives folio
 T}
 _
 $PCP_DEBUG	\-D	--debug	T{
 .hy 0
-.ad l
-a comma-separated list of
-.BR pmSetDebug (3)
-debugging options
+a comma-separated list of \fBpmSetDebug\fP(3) debugging options
 T}
 _
 $PCP_GUIMODE	\-g	--guimode	T{
 .hy 0
-.ad l
-start in GUI mode with new
-.BR pmtime (1)
-time control
+start in GUI mode with new \fBpmtime\fP(1) time control
 T}
 _
 $PCP_HOST	\-h	--host	T{
 .hy 0
-.ad l
-metrics source is
-.BR pmcd (1)
-on a host
+metrics source is \fBpmcd\fP(1) on a host
 T}
 _
 $PCP_HOST_LIST		--host-list	T{
 .hy 0
-.ad l
 comma-separated list of metric source hosts
 T}
 _
 $PCP_SPECLOCAL	\-K	--spec-local	T{
 .hy 0
 .ad l
-optional additional DSO PMDA specification for local connection,
-see
-.BR pmSpecLocalPMDA (3)
+optional additional DSO PMDA specification for local connection, see \fBpmSpecLocalPMDA\fP(3)
 T}
 _
 T{
-.hy 0
-.ad l
-$PCP_LOCALPMDA
-\fRor\fP
-$PCP_LOCALMODE
+$PCP_LOCALPMDA or $PCP_LOCALMODE
 T}	\-L	--local-PMDA	T{
 .hy 0
-.ad l
 metrics source is local connection to a DSO PMDA
 T}
 _
 $PCP_NAMESPACE	\-n	--namespace	T{
 .hy 0
-.ad l
 use an alternative Performance Metrics Name Space (PMNS)
 T}
 _
 $PCP_UNIQNAMES	\-N	--uniqnames	T{
 .hy 0
-.ad l
-like
-.B \-n
-but only one name allowed for each metric in the PMNS
+like \fB\-n\fP but only one name allowed for each metric in the PMNS
 T}
 _
 T{
-.hy 0
-.ad l
-$PCP_ORIGIN
-\fRor\fP
-$PCP_ORIGIN_TIME
+$PCP_ORIGIN or $PCP_ORIGIN_TIME
 T}	\-O	--origin	T{
 .hy 0
-.ad l
 initial sample time within the time window
 T}
 _
 $PCP_GUIPORT	\-p	--guiport	T{
 .hy 0
-.ad l
-port for connection to an existing
-.BR pmtime (1)
-time control
+port for connection to an existing \fBpmtime\fP(1) time control
 T}
 _
 $PCP_START_TIME	\-S	--start	T{
 .hy 0
-.ad l
 start of the time window
 T}
 _
 $PCP_SAMPLES	\-s	--samples	T{
 .hy 0
-.ad l
 terminate after this many samples
 T}
 _
 $PCP_FINISH_TIME	\-T	--finish	T{
 .hy 0
-.ad l
 end of the time window
 T}
 _
 $PCP_INTERVAL	\-t	--interval	T{
 .hy 0
-.ad l
 sampling interval
 T}
 _
 $PCP_TIMEZONE	\-Z	--timezone	T{
 .hy 0
-.ad l
 set reporting timezone
 T}
 _
 $PCP_HOSTZONE	\-z	--hostzone	T{
 .hy 0
-.ad l
 set reporting timezone to local time of metrics source
 T}
 .TE

--- a/man/man3/pmmergelabels.3
+++ b/man/man3/pmmergelabels.3
@@ -34,7 +34,8 @@ int pmMergeLabelSets(pmLabelSet **\fIsets\fP,
 int\ \fInsets\fP,
 char\ *\fIbuffer\fP,
 int\ \fIlength\fP,
-int\ (*\fIfilter\fP)(const\ pmLabel\ *,\ const\ char\ *,\ void\ *),
+int\ (*\fIfilter\fP)
+(const\ pmLabel\ *,\ const\ char\ *,\ void\ *),
 void\ *\fIarg\fP);
 .in
 .sp

--- a/man/man3/pmregisterderived.3
+++ b/man/man3/pmregisterderived.3
@@ -904,17 +904,26 @@ Derived Metric	Starting PMID	Description
 _
 global	511.0.1	T{
 .hy 0
-Metrics are assigned \fIascending\fP PMIDs as they are registered via \fBpmRegisterDerived\fP, \fBpmRegisterDerivedMetric\fP or \fBpmLoadDerivedConfig\fP(3).
+Metrics are assigned \fIascending\fP PMIDs as they are registered
+via \fBpmRegisterDerived\fP or \fBpmRegister-DerivedMetric\fP, or
+\fBpmLoad-DerivedConfig\fP(3).
 T}
 _
 per-context	511.2047.1023	T{
 .hy 0
-Metrics are assigned \fIdescending\fP PMIDs as they are registered via \fBpmAddDerived\fP(3) or \fBpmAddDerivedMetric\fP(3).
+Metrics are assigned \fIdescending\fP PMIDs as they are registered via
+\fBpmAddDerived\fP(3) or \fBpmAddDerivedMetric\fP(3).
 T}
 _
 remapped	511.c.i	T{
 .hy 0
-When a derived metric is recorded in a PCP archive by \fBpmlogger\fP(1) or one of the related archive creation tools, the PMID of the derived metric is remapped in the archive so that \fIc\fP is the cluster of derived metric plus 2048, and i is the item of the derived metric.  For example, a derived metric with PMID 511.0.13 will have the remapped PMID 511.2048.13 in an archive.  See \fBpmlogger\fP(1) for a discussion about adding derived metrics to a PCP archive.
+When a derived metric is recorded in a PCP archive by \fBpmlogger\fP(1)
+or one of the related archive creation tools, the PMID of the derived
+metric is remapped in the archive so that \fIc\fP is the cluster of
+derived metric plus 2048, and i is the item of the derived metric.
+For example, a derived metric with PMID 511.0.13 will have the remapped
+PMID 511.2048.13 in an archive.  See \fBpmlogger\fP(1) for a discussion
+about adding derived metrics to a PCP archive.
 T}
 .TE
 .PP

--- a/man/man3/pmregisterderived.3
+++ b/man/man3/pmregisterderived.3
@@ -432,29 +432,19 @@ lf(CR) | lf(R)x.
 tag	value
 _
 type	T{
-one of the numeric metric types from <pcp/pmapi.h>, stripped of the
-PM_TYPE_
-prefix, so
-\f(CR32\fP, \f(CRU32\fP, \f(CR64\fP, \f(CRU64\fP, \f(CRFLOAT\fP or
-\f(CRDOUBLE\fP.
+one of the numeric metric types from <pcp/pmapi.h>, stripped of the PM_TYPE_ prefix, so \f(CR32\fP, \f(CRU32\fP, \f(CR64\fP, \f(CRU64\fP, \f(CRFLOAT\fP or \f(CRDOUBLE\fP.
 T}
 _
 semantics	T{
-one of the semantic types from <pcp/pmapi.h>, stripped of the
-PM_SEM_
-prefix, so
-\f(CRCOUNTER\fP, \f(CRINSTANT\fP or \f(CRDISCRETE\fP.
+one of the semantic types from <pcp/pmapi.h>, stripped of the PM_SEM_ prefix, so \f(CRCOUNTER\fP, \f(CRINSTANT\fP or \f(CRDISCRETE\fP.
 T}
 _
 units	T{
-a specification of dimension and scale (together forming the units),
-in the syntax accepted by
-.BR pmParseUnitsStr (3).
+a specification of dimension and scale (together forming the units), in the syntax accepted by \fBpmParseUnitsStr\fP(3).
 T}
 _
 meta	T{
-a metric name and that metric provides the base metadata that may be
-modified by other parameters
+a metric name and that metric provides the base metadata that may be modified by other parameters
 T}
 .TE
 .RS 2n
@@ -527,25 +517,11 @@ A singular instance being the average value across all instances for the metric 
 T}
 _
 count(x)	T{
-A singular instance being the count of the number of instances for the metric x.
-As a special case, if fetching the metric x returns an error, then
-\f(CRcount(x)\fP will be 0.
+A singular instance being the count of the number of instances for the metric x.  As a special case, if fetching the metric x returns an error, then \f(CRcount(x)\fP will be 0.
 T}
 _
 defined(x)	T{
-A boolean value that is true (``1'') if the metric
-.ft CR
-x
-.ft R
-is defined in the PMNS, else false (``0'').
-The function is evaluated when a new PMAPI context
-is created with
-.BR pmNewContext (3)
-or re-established with
-.BR pmReconnectContext (3).
-So any subsequent changes to the PMNS after the PMAPI
-context has been established will not change the value
-of this function in the expression evaluation.
+A boolean value that is true (``1'') if the metric x is defined in the PMNS, else false (``0'').  The function is evaluated when a new PMAPI context is created with \fBpmNewContext\fP(3) or re-established with \fBpmReconnectContext\fP(3).  So any subsequent changes to the PMNS after the PMAPI context has been established will not change the value of this function in the expression evaluation.
 T}
 _
 max(x)	T{
@@ -561,9 +537,7 @@ A singular instance being the sum of the values across all instances for the met
 T}
 .TE
 .IP \(bu 2n
-The following unary function returns the instantaneous value of an
-expression, not the rate-converted value that is the default
-for expressions with the semantics of PM_SEM_COUNTER.
+The following unary function returns the instantaneous value of an expression, not the rate-converted value that is the default for expressions with the semantics of PM_SEM_COUNTER.
 .TS
 box,center;
 cf(R) | cf(R)
@@ -571,29 +545,15 @@ lf(CR) | lf(R)x.
 Function	Value
 _
 instant(expr)	T{
-Returns the current value of the expression, even it has
-the semantics of a counter, i.e. PM_SEM_COUNTER.
-The semantics of the derived metric are based on the semantics of the
-expression \f(CRexpr\fR; if \f(CRexpr\fR has semantics PM_SEM_COUNTER, the semantics of
-\f(CRinstant(expr)\fR is PM_SEM_INSTANT, otherwise the semantics of the derived metric
+Returns the current value of the expression, even it has the semantics of a counter, i.e. PM_SEM_COUNTER.  The semantics of the derived metric are based on the semantics of the expression \f(CRexpr\fR; if \f(CRexpr\fR has semantics PM_SEM_COUNTER, the semantics of \f(CRinstant(expr)\fR is PM_SEM_INSTANT, otherwise the semantics of the derived metric
 is the same as the semantics of \f(CRexpr\fR.
 T}
 .TE
 .IP \(bu 2n
-The following unary functions return values computed from
-the value of an expression on consecutive samples, or
-.BR pmFetch (3)
-calls.
-The expression (\f(CRexpr\fR below) may involve one or more metrics
-but must have an arithmetic value
-(integer of various sizes and signedness, float or double) for all
-instances.
+The following unary functions return values computed from the value of an expression on consecutive samples, or \fBpmFetch\fP(3) calls.  The expression (\f(CRexpr\fR below) may involve one or more metrics but must have an arithmetic value (integer of various sizes and signedness, float or double) for all instances.
 .RS 2n
 .PP
-If \f(CRexpr\fP is a set-valued expression then only those instances
-that appear in
-.B both
-samples will appear in the result.
+If \f(CRexpr\fP is a set-valued expression then only those instances that appear in \fBboth\fP samples will appear in the result.
 .TS
 box,center;
 cf(R) | cf(R)
@@ -601,45 +561,12 @@ lf(CR) | lf(R)x.
 Function	Value
 _
 delta(expr)	T{
-Returns the difference in values for the expression between
-one call to
-.BR pmFetch (3)
-and the next. There is one value in the result
-for each instance that appears in both the current and the previous
-sample.
-If the expression is unsigned, then the type of the result is
-converted to ensure as much precision as possible can be retained,
-so if the expression has type PM_TYPE_U32 then the result is of type PM_TYPE_64, else
-if the expression has type PM_TYPE_U64 then the result is of type PM_TYPE_DOUBLE.
-Otherwise the type of the result is the same as the type of the
-expression.
+Returns the difference in values for the expression between one call to \fBpmFetch\fP(3) and the next. There is one value in the result for each instance that appears in both the current and the previous sample.  If the expression is unsigned, then the type of the result is converted to ensure as much precision as possible can be retained, so if the expression has type PM_TYPE_U32 then the result is of type PM_TYPE_64, else if the expression has type PM_TYPE_U64 then the result is of type PM_TYPE_DOUBLE.  Otherwise the type of the result is the same as the type of the expression.
 T}
 _
 rate(expr)	T{
-Returns the difference in values for the expression between
-one call to
-.BR pmFetch (3)
-and the next divided by the elapsed time between the calls to
-.BR pmFetch (3).
-The semantics of the derived metric are based on the semantics of the
-expression with the dimension in the
-.B time
-domain decreased by one and scaling if required in the time utilization case
-where the operand is in units of time, and the derived metric is unitless.
-There is one value in the result
-for each instance that appears in both the current and the previous
-sample, except in the case where the expression has
-the semantics of a counter, i.e. PM_SEM_COUNTER, and
-current value of an instance is smaller than the previous value
-of the same instance then no value is
-returned for this instance (this corresponds to a ``counter wrap'' or a ``counter reset'').
-These rules
-mimic the rate conversion applied to counter metrics by tools
-such as
-.BR pmval (1),
-.BR pmie (1)
-and
-.BR pmchart (1).
+Returns the difference in values for the expression between one call to
+\fBpmFetch\fP(3) and the next divided by the elapsed time between the calls to \fBpmFetch\fP(3).  The semantics of the derived metric are based on the semantics of the expression with the dimension in the \fBtime\fP domain decreased by one and scaling if required in the time utilization case where the operand is in units of time, and the derived metric is unitless.  There is one value in the result for each instance that appears in both the current and the previous sample, except in the case where the expression has the semantics of a counter, i.e. PM_SEM_COUNTER, and current value of an instance is smaller than the previous value of the same instance then no value is returned for this instance (this corresponds to a ``counter wrap'' or a ``counter reset'').  These rules mimic the rate conversion applied to counter metrics by tools such as \fBpmval\fP(1), \fBpmie\fP(1) and \fBpmchart\fP(1).
 T}
 .TE
 .RE
@@ -976,41 +903,18 @@ lf(R) | lf(R) | lf(R)x.
 Derived Metric	Starting PMID	Description
 _
 global	511.0.1	T{
-.ad l
 .hy 0
-Metrics are assigned
-.I ascending
-PMIDs as they are registered via
-.BR pmRegisterDerived ,
-.BR pmRegisterDerivedMetric
-or
-.BR pmLoadDerivedConfig (3).
+Metrics are assigned \fIascending\fP PMIDs as they are registered via \fBpmRegisterDerived\fP, \fBpmRegisterDerivedMetric\fP or \fBpmLoadDerivedConfig\fP(3).
 T}
 _
 per-context	511.2047.1023	T{
-.ad l
 .hy 0
-Metrics are assigned
-.I descending
-PMIDs as they are registered via
-.BR pmAddDerived (3)
-or
-.BR pmAddDerivedMetric (3).
+Metrics are assigned \fIdescending\fP PMIDs as they are registered via \fBpmAddDerived\fP(3) or \fBpmAddDerivedMetric\fP(3).
 T}
 _
 remapped	511.c.i	T{
-.ad l
 .hy 0
-When a derived metric is recorded in a PCP archive by
-.BR pmlogger (1)
-or one of the related archive creation tools, the PMID of the
-derived metric is remapped in the archive so that \fIc\fP is the cluster of
-derived metric plus 2048, and i is the item of the derived metric.
-For example, a derived metric with PMID 511.0.13 will have the
-remapped PMID 511.2048.13 in an archive.
-See
-.BR pmlogger (1)
-for a discussion about adding derived metrics to a PCP archive.
+When a derived metric is recorded in a PCP archive by \fBpmlogger\fP(1) or one of the related archive creation tools, the PMID of the derived metric is remapped in the archive so that \fIc\fP is the cluster of derived metric plus 2048, and i is the item of the derived metric.  For example, a derived metric with PMID 511.0.13 will have the remapped PMID 511.2048.13 in an archive.  See \fBpmlogger\fP(1) for a discussion about adding derived metrics to a PCP archive.
 T}
 .TE
 .PP
@@ -1033,7 +937,6 @@ _
 	remapped	per-context	global	
 _
 no	no	no	no	T{
-.ad l
 .hy 0
 none; the metric is undefined
 T}
@@ -1061,10 +964,8 @@ _
 yes	no	yes	yes	base metric
 _
 yes	yes	-	-	T{
-.ad l
 .hy 0
-cannot happen; for any name there can be at most one of a base metric or
-a remapped metric
+cannot happen; for any name there can be at most one of a base metric or a remapped metric
 T}
 .TE
 .PP

--- a/man/man3/pmwebapi.3
+++ b/man/man3/pmwebapi.3
@@ -236,7 +236,6 @@ REST API clients can optionally submit an URL-encoded query string
 in the body of the HTTP request unless otherwise noted.
 In this case the POST method must be used instead of the GET method.
 .SS GET \fI/series/ping\fR
-.PP
 Simple liveness test for clients to check whether the server is up
 and supports the \fI/series\fR API.
 .SS GET \fI/series/query\fR \- \fBpmSeriesQuery\fR(3)
@@ -1283,11 +1282,9 @@ The value passed in the request will be sent back in the
 response \- all responses are in JSON object form and will
 include an additional top level "client" field.
 .SS GET \fI/logger/ping\fR
-.P
 Basic liveness test for clients to check whether the server is up
 and supports the \fI/logger\fR API.
 .SS POST \fI/logger/label\fR
-.P
 The body of this API is the machine-agnostic binary (on-disk)
 representation of a PCP archive label as described in
 .BR LOGARCHIVE (5).
@@ -1301,15 +1298,12 @@ ensures correct content is written for each.
 This API returns a numeric token (LOGID) that must be used in all
 subsequent API interactions for this archive as described below.
 .SS POST \fI/logger/meta/LOGID\fR
-.P
 The request body contains metadata file records as described in
 .BR LOGARCHIVE .
 .SS POST \fI/logger/index/LOGID\fR
-.P
 The request body contains temporal index records as described in
 .BR LOGARCHIVE .
 .SS POST \fI/logger/volume/VOLID/LOGID\fR
-.P
 The request body contains timestamped metric value samples, as
 described in
 .BR LOGARCHIVE .

--- a/man/man3/pmwebapi.3
+++ b/man/man3/pmwebapi.3
@@ -102,12 +102,22 @@ c | c | cw(2.4i)
 lf(CR) | l | l.
 Parameters	Type	Explanation
 _
-names	string	Comma-separated list of metric names
-filter	string	Comma-separated list of excluded metric names
-match	string	Pattern matching style (exact, glob or regex)
-times	boolean	Append sample times (milliseconds since epoch)
+names	string	T{
+Comma-separated list of metric names
+T}
+filter	string	T{
+Comma-separated list of excluded metric names
+T}
+match	string	T{
+Pattern matching style (exact, glob or regex)
+T}
+times	boolean	T{
+Append sample times (milliseconds since epoch)
+T}
 _
-hostspec	string	Host specification as described in \f(CBPCPIntro\fR(1)
+hostspec	string	T{
+Host specification as described in \f(CBPCPIntro\fR(1)
+T}
 .TE
 .P
 Fetches current values and metadata for all metrics, or only
@@ -799,9 +809,15 @@ c | c | cw(2.4i)
 lf(CR) | l | l.
 Parameters	Type	Explanation
 _
-hostspec	string	Host specification as described in \f(CBPCPIntro\fR(1)
-polltimeout	number	Seconds of inactivity before closing context
-client	string	Request identifier sent back with response
+hostspec	string	T{
+Host specification as described in \f(CBPCPIntro\fR(1)
+T}
+polltimeout	number	T{
+Seconds of inactivity before closing context
+T}
+client	string	T{
+Request identifier sent back with response
+T}
 .TE
 .P
 To create a context for live sampling, a web client can access any
@@ -855,16 +871,34 @@ c | c | cw(2.4i)
 lf(CR) | l | l.
 Parameters	Type	Explanation
 _
-name	string	An individual metric name
-names	string	Comma-separated list of metric names
-pmid	pmID	Numeric or \f(CBpmIDStr\fR(3) metric identifier
-pmids	string	Comma-separated numeric or \f(CBpmIDStr\fR(3) pmIDs
-prefix	string	Metric namespace component as in \f(CBPMNS\fR(5)
+name	string	T{
+An individual metric name
+T}
+names	string	T{
+Comma-separated list of metric names
+T}
+pmid	pmID	T{
+Numeric or \f(CBpmIDStr\fR(3) metric identifier
+T}
+pmids	string	T{
+Comma-separated numeric or \f(CBpmIDStr\fR(3) pmIDs
+T}
+prefix	string	T{
+Metric namespace component as in \f(CBPMNS\fR(5)
+T}
 _
-hostspec	string	Host specification as described in \f(CBPCPIntro\fR(1)
-context	number	Web context number (optional like hostspec)
-polltimeout	number	Seconds of inactivity before context closed
-client	string	Request identifier sent back with response
+hostspec	string	T{
+Host specification as described in \f(CBPCPIntro\fR(1)
+T}
+context	number	T{
+Web context number (optional like hostspec)
+T}
+polltimeout	number	T{
+Seconds of inactivity before context closed
+T}
+client	string	T{
+Request identifier sent back with response
+T}
 .TE
 .P
 The
@@ -951,16 +985,34 @@ c | c | cw(2.4i)
 lf(CR) | l | l.
 Parameters	Type	Explanation
 _
-delta	string	Sampling interval in \f(CBpmParseInterval\fR(3) form
-name	string	An individual metric name
-names	string	Comma-separated list of metric names
-pmid	pmID	Numeric or \f(CBpmIDStr\fR(3) metric identifier
-pmids	string	Comma-separated numeric or \f(CBpmIDStr\fR(3) pmIDs
+delta	string	T{
+Sampling interval in \f(CBpmParseInterval\fR(3) form
+T}
+name	string	T{
+An individual metric name
+T}
+names	string	T{
+Comma-separated list of metric names
+T}
+pmid	pmID	T{
+Numeric or \f(CBpmIDStr\fR(3) metric identifier
+T}
+pmids	string	T{
+Comma-separated numeric or \f(CBpmIDStr\fR(3) pmIDs
+T}
 _
-hostspec	string	Host specification as described in \f(CBPCPIntro\fR(1)
-context	number	Web context number (optional like hostspec)
-polltimeout	number	Seconds of inactivity before context closed
-client	string	Request identifier sent back with response
+hostspec	string	T{
+Host specification as described in \f(CBPCPIntro\fR(1)
+T}
+context	number	T{
+Web context number (optional like hostspec)
+T}
+polltimeout	number	T{
+Seconds of inactivity before context closed
+T}
+client	string	T{
+Request identifier sent back with response
+T}
 .TE
 .P
 This request fetches (samples) current values for given metrics.
@@ -1013,12 +1065,22 @@ c | c | cw(2.4i)
 lf(CR) | l | l.
 Parameters	Type	Explanation
 _
-prefix	string	Metric namespace component as in \f(CBPMNS\fR(5)
+prefix	string	T{
+Metric namespace component as in \f(CBPMNS\fR(5)
+T}
 _
-hostspec	string	Host specification as described in \f(CBPCPIntro\fR(1)
-context	number	Web context number (optional like hostspec)
-polltimeout	number	Seconds of inactivity before context closed
-client	string	Request identifier sent back with response
+hostspec	string	T{
+Host specification as described in \f(CBPCPIntro\fR(1)
+T}
+context	number	T{
+Web context number (optional like hostspec)
+T}
+polltimeout	number	T{
+Seconds of inactivity before context closed
+T}
+client	string	T{
+Request identifier sent back with response
+T}
 .TE
 .P
 The
@@ -1062,16 +1124,34 @@ c | c | cw(2.4i)
 lf(CR) | l | l.
 Parameters	Type	Explanation
 _
-iname	string	Comma-separated list of instance names
-indom	pmInDom	Numeric or \f(CBpmInDomStr\fR(3) instance domain
-instance	number	Comma-separated list of instance numbers
-match	string	Pattern matching style (exact, glob or regex)
-name	string	An individual metric name
+iname	string	T{
+Comma-separated list of instance names
+T}
+indom	pmInDom	T{
+Numeric or \f(CBpmInDomStr\fR(3) instance domain
+T}
+instance	number	T{
+Comma-separated list of instance numbers
+T}
+match	string	T{
+Pattern matching style (exact, glob or regex)
+T}
+name	string	T{
+An individual metric name
+T}
 _
-hostspec	string	Host specification as described in \f(CBPCPIntro\fR(1)
-context	number	Web context number (optional like hostspec)
-polltimeout	number	Seconds of inactivity before context closed
-client	string	Request identifier sent back with response
+hostspec	string	T{
+Host specification as described in \f(CBPCPIntro\fR(1)
+T}
+context	number	T{
+Web context number (optional like hostspec)
+T}
+polltimeout	number	T{
+Seconds of inactivity before context closed
+T}
+client	string	T{
+Request identifier sent back with response
+T}
 .TE
 .P
 This request lists the current instances of an instance domain.
@@ -1132,16 +1212,34 @@ c | c | cw(2.4i)
 lf(CR) | l | l.
 Parameters	Type	Explanation
 _
-iname	string	Comma-separated list of instance names
-indom	pmInDom	Numeric or \f(CBpmInDomStr\fR(3) instance domain
-instance	number	Comma-separated list of instance numbers
-expr	string	One of "add" or "del" (mandatory).
-match	string	Pattern matching style (exact, glob or regex)
+iname	string	T{
+Comma-separated list of instance names
+T}
+indom	pmInDom	T{
+Numeric or \f(CBpmInDomStr\fR(3) instance domain
+T}
+instance	number	T{
+Comma-separated list of instance numbers
+T}
+expr	string	T{
+One of "add" or "del" (mandatory).
+T}
+match	string	T{
+Pattern matching style (exact, glob or regex)
+T}
 _
-hostspec	string	Host specification as described in \f(CBPCPIntro\fR(1)
-context	number	Web context number (optional like hostspec)
-polltimeout	number	Seconds of inactivity before context closed
-client	string	Request identifier sent back with response
+hostspec	string	T{
+Host specification as described in \f(CBPCPIntro\fR(1)
+T}
+context	number	T{
+Web context number (optional like hostspec)
+T}
+polltimeout	number	T{
+Seconds of inactivity before context closed
+T}
+client	string	T{
+Request identifier sent back with response
+T}
 .TE
 .P
 Some PMAPI operations can be performed with an active instance
@@ -1164,10 +1262,18 @@ instance	number	Comma-separated list of instance numbers
 name	string	An individual metric name
 value	(any)	New value for the given metric instance(s)
 _
-hostspec	string	Host specification as described in \f(CBPCPIntro\fR(1)
-context	number	Web context number (optional like hostspec)
-polltimeout	number	Seconds of inactivity before context closed
-client	string	Request identifier sent back with response
+hostspec	string	T{
+Host specification as described in \f(CBPCPIntro\fR(1)
+T}
+context	number	T{
+Web context number (optional like hostspec)
+T}
+polltimeout	number	T{
+Seconds of inactivity before context closed
+T}
+client	string	T{
+Request identifier sent back with response
+T}
 .TE
 .P
 Some performance metrics allow their value to be modified,
@@ -1202,10 +1308,18 @@ _
 expr	string	Derived metric expression
 name	string	New derived metric name
 _
-hostspec	string	Host specification as described in \f(CBPCPIntro\fR(1)
-context	number	Web context number (optional like hostspec)
-polltimeout	number	Seconds of inactivity before context closed
-client	string	Request identifier sent back with response
+hostspec	string	T{
+Host specification as described in \f(CBPCPIntro\fR(1)
+T}
+context	number	T{
+Web context number (optional like hostspec)
+T}
+polltimeout	number	T{
+Seconds of inactivity before context closed
+T}
+client	string	T{
+Request identifier sent back with response
+T}
 .TE
 .P
 Create a new derived metric, as defined by the
@@ -1251,13 +1365,25 @@ c | c | cw(2.4i)
 lf(CR) | l | l.
 Parameters	Type	Explanation
 _
-names	string	Comma-separated list of metric names
-times	boolean	Append sample times (milliseconds since epoch)
+names	string	T{
+Comma-separated list of metric names
+T}
+times	boolean	T{
+Append sample times (milliseconds since epoch)
+T}
 _
-context	number	Web context number (optional like hostspec)
-hostspec	string	Host specification as described in \f(CBPCPIntro\fR(1)
-polltimeout	number	Seconds of inactivity before context closed
-client	string	Request identifier sent back with response
+context	number	T{
+Web context number (optional like hostspec)
+T}
+hostspec	string	T{
+Host specification as described in \f(CBPCPIntro\fR(1)
+T}
+polltimeout	number	T{
+Seconds of inactivity before context closed
+T}
+client	string	T{
+Request identifier sent back with response
+T}
 .TE
 .P
 This request is a subset of the style described in the

--- a/man/man3i/__pmaf.3
+++ b/man/man3i/__pmaf.3
@@ -111,7 +111,8 @@ routines to modify the state of the heap.
 Refer to the
 .I "Pointer to a Function"
 Section of the POSIX.1-2013 document at
-http://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html
+.I https://pubs.opengroup.org
+.I /onlinepubs/9699919799/functions/V2_chap02.html
 for a fuller description.
 .P
 The safest and simplest class of

--- a/man/man3i/__pmaf.3
+++ b/man/man3i/__pmaf.3
@@ -111,9 +111,10 @@ routines to modify the state of the heap.
 Refer to the
 .I "Pointer to a Function"
 Section of the POSIX.1-2013 document at
-.I https://pubs.opengroup.org
-.I /onlinepubs/9699919799/functions/V2_chap02.html
-for a fuller description.
+.I https://pubs.opengroup.org/
+.br
+.I onlinepubs/9699919799/functions/V2_chap02.html
+for a more complete description.
 .P
 The safest and simplest class of
 .I func

--- a/man/man5/LOGARCHIVE.5
+++ b/man/man5/LOGARCHIVE.5
@@ -562,10 +562,18 @@ Version 2
 _
 Offset	Length	Name
 _
-0	4	tag, TYPE_LABEL_V2=3
-4	4	timestamp, seconds part (past UNIX epoch)
-8	4	timestamp, microseconds part
-12	4	label type (PM_LABEL_* type macros.)
+0	4	T{
+tag, TYPE_LABEL_V2=3
+T}
+4	4	T{
+timestamp, seconds part (past UNIX epoch)
+T}
+8	4	T{
+timestamp, microseconds part
+T}
+12	4	T{
+label type (PM_LABEL_* type macros.)
+T}
 16	4	T{
 .TW
 numeric identifier - domain, PMID, etc or PM_IN_NULL=-1 for context labels
@@ -574,12 +582,20 @@ T}
 .TW
 N: number of label sets in this record, usually 1 except in the case of instances
 T}
-24	4	offset to the start of the JSONB labels string
-28	L1	first labelset array entry (see below)
+24	4	T{
+offset to the start of the JSONB labels string
+T}
+28	L1	first T{
+labelset array entry (see below)
+T}
 \&...	...	...
-28+L1	LN	N-th labelset array entry (see below)
+28+L1	LN	N-th T{
+labelset array entry (see below)
+T}
 \&...	...	...
-28+L1+...LN	M	concatenated JSONB strings for all labelsets
+28+L1+...LN	M	T{
+concatenated JSONB strings for all labelsets
+T}
 .TE
 
 .TS
@@ -591,10 +607,18 @@ Version 3
 _
 Offset	Length	Name
 _
-0	4	tag, TYPE_LABEL=7
-4	8	timestamp, seconds part (past UNIX epoch)
-12	4	timestamp, nanoseconds part
-16	4	label type (PM_LABEL_* type macros.)
+0	4	T{
+tag, TYPE_LABEL=7
+T}
+4	8	T{
+timestamp, seconds part (past UNIX epoch)
+T}
+12	4	T{
+timestamp, nanoseconds part
+T}
+16	4	T{
+label type (PM_LABEL_* type macros.)
+T}
 20	4	T{
 .TW
 numeric identifier - domain, PMID, etc or PM_IN_NULL=-1 for context labels
@@ -603,12 +627,20 @@ T}
 .TW
 N: number of label sets in this record, usually 1 except in the case of instances
 T}
-28	4	offset to the start of the JSONB labels string
-32	L1	first labelset array entry (see below)
+28	4	T{
+offset to the start of the JSONB labels string
+T}
+32	L1	T{
+first labelset array entry (see below)
+T}
 \&...	...	...
-32+L1	LN	N-th labelset array entry (see below)
+32+L1	LN	T{
+N-th labelset array entry (see below)
+T}
 \&...	...	...
-32+L1+...LN	M	concatenated JSONB strings for all labelsets
+32+L1+...LN	M	T{
+concatenated JSONB strings for all labelsets
+T}
 .TE
 
 .PP

--- a/man/man5/mmv.5
+++ b/man/man5/mmv.5
@@ -259,13 +259,21 @@ c | c | c
 n | n | l.
 Offset	Length	Value
 _
-0	4	Flags (PM_LABEL_[CLUSTER|ITEM|INDOM|INSTANCES]|OPTIONAL)
+0	4	T{
+Flags - PM_LABEL_ CLUSTER, ITEM, INDOM, INSTANCES and OPTIONAL
+T}
 _
-4	4	Identifier for given type (indom, cluster or item)
+4	4	T{
+Identifier for given type (indom, cluster or item)
+T}
 _
-8	4	Internal Instance or PM_IN_NULL
+8	4	T{
+Internal Instance or PM_IN_NULL
+T}
 _
-12	244	Payload (Name and Value JSONB String)
+12	244	T{
+Payload (Name and Value JSONB String)
+T}
 .TE
 .PP
 Each entry in the payload is a 244 byte (maximum) character array,

--- a/scripts/man-lint
+++ b/scripts/man-lint
@@ -96,4 +96,16 @@ state == 1	{ for (i = 1; i <= NF; i++) {
     fi
 done
 
+# sanity check that man(1) can read each file without producing errors
+for manpage in "$@"
+do
+    man ./$manpage 2>$tmp/err | cat >/dev/null
+    if [ -s $tmp/err ]
+    then
+	echo "Error: man ./$manpage produces the following stderr diagnostics:"
+	cat $tmp/err
+	sts=1
+    fi
+done
+
 exit

--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -227,7 +227,7 @@ MKINSTALLP = @mkinstallp@
 DLLTOOL = @dlltool@
 RPMBUILD= @rpmbuild@
 RPM	= @rpm@
-POD2MAN = @pod2man@
+POD2MAN = @pod2man@ --fixed=CR
 DPKG	= @dpkg@
 MAKEPKG	= @makepkg@
 GENPMDA	= $(TOPDIR)/src/genpmda/genpmda

--- a/src/pmdas/hdb/pmdahdb.1
+++ b/src/pmdas/hdb/pmdahdb.1
@@ -18,24 +18,31 @@
 .SH NAME
 \f3pmdahdb\f1 \- SAP HANA PMDA
 .SH DESCRIPTION
-\f3pmdahdb\f1 is a Performance Metrics Domain Agent (PMDA) which exports metric
-values about an SAP HANA (\fBH\fRigh-performance \fBAN\fRalytic \fBA\fRppliance) database,
-a multi-model database that stores data in its memory instead of keeping it on a disk.
+\f3pmdahdb\f1 is a Performance Metrics Domain Agent (PMDA) which exports
+metric values about an SAP HANA (\fBH\fRigh-performance \fBAN\fRalytic
+\fBA\fRppliance) database, a multi-model database that stores data in
+its memory instead of keeping it on a disk.
 .PP
 This PMDA can be used in scale-out scenarios.
 All metrics are Host and Port aware.
 Host and Port are included in the instance names (<host>.<port>.<instance>).
 .PP
-\f3pmdahdb\f1 currently does not support Multitenant Database Container (MDC) systems.
-The agent can only target a single database container at the moment (this container can
-be a tenant database).
+\f3pmdahdb\f1 currently does not support Multitenant Database Container
+(MDC) systems.
+The agent can only target a single database container at the moment
+(this container can be a tenant database).
 .SH INSTALLATION
 The hdb configuration is maintained with
 .IR hdb.conf.
-Currently there is only one hdb section that contains the SAP HANA connection parameters.
+Currently there is only one hdb section that contains the SAP HANA
+connection parameters.
 Quoted passwords are supported.
 For more information about quoted passwords, see:
-https://help.sap.com/docs/SAP_HANA_ONE/102d9916bf77407ea3942fef93a47da8/61662e3032ad4f8dbdb5063a21a7d706.html#password-layout
+.I https://help.sap.com/docs/SAP_HANA_ONE/
+.br
+.I 102d9916bf77407ea3942fef93a47da8/
+.br
+.IR 61662e3032ad4f8dbdb5063a21a7d706.html#password-layout .
 .PP
 Install the hdb PMDA by using the Install script as root:
 .sp 1
@@ -75,8 +82,10 @@ default log file for error messages from \fBpmdahdb\fR
 .SH PCP ENVIRONMENT
 Environment variables with the prefix \fBPCP_\fR are used to parameterize
 the file and directory names used by \fBPCP\fR.
-On each installation, the file \fB/etc/pcp.conf\fR contains the local values for these variables.
-The \fB$PCP_CONF\fR variable may be used to specify an alternative configuration file, as described in \fIpcp.conf\fR(5).
+On each installation, the file \fB/etc/pcp.conf\fR contains the local
+values for these variables.
+The \fB$PCP_CONF\fR variable may be used to specify an alternative
+configuration file, as described in \fIpcp.conf\fR(5).
 .SH SEE ALSO
 .BR PCPIntro (1),
 .BR pmcd (1),

--- a/src/pmdas/opentelemetry/pmdaopentelemetry.1
+++ b/src/pmdas/opentelemetry/pmdaopentelemetry.1
@@ -29,9 +29,10 @@
 [\f3\-t\f1 \f2timeout\f1]
 [\f3\-u\f1 \f2user\f1]
 .SH DESCRIPTION
-\fBpmdaopentelemetry\fR is a Performance Metrics Domain Agent (PMDA) which
-dynamically creates PCP metrics from configured OpenTelemetry endpoints,
-which provide HTTP based access to application metrics.
+.B pmdaopentelemetry
+is a Performance Metrics Domain Agent (PMDA) which dynamically
+creates PCP metrics from configured OpenTelemetry endpoints that
+provide HTTP based access to application metrics.
 .P
 The default \f2config\fP directory is
 .BR $PCP_PMDAS_DIR/opentelemetry/config.d/ ,
@@ -41,13 +42,15 @@ The default \f2user\fP, if not specified with the \f3\-u\fP option,
 is the "pcp" user.
 If the
 .B \-n
-option is given, the list of configuration files will not be sorted prior to processing.
-This list is sorted by default but that can be expensive if there are a large number of
-configuration files (URLs and/or scripts).
+option is given, the list of configuration files will not be sorted
+prior to processing.
+This list is sorted by default but that can be expensive if there
+are a large number of configuration files (URLs and/or scripts).
 .PP
 If the
 .B \-D
-option is given, additional diagnostic messages will be written to the PMDA log file,
+option is given, additional diagnostic messages will be written to
+the PMDA log file,
 which is
 .B $PCP_LOG_DIR/pmcd/opentelemetry.log
 by default (see also
@@ -68,8 +71,9 @@ is either
 or
 .BR 0
 (to disable verbose log messages).
-This is particularly useful for examining the http headers passed to each fetch request,
-filter settings and other processing details that are logged when the debugging flag is enabled.
+This is particularly useful for examining the http headers passed
+to each fetch request, filter settings and other processing details
+that are logged when the debugging flag is enabled.
 .PP
 The
 .B \-d
@@ -111,7 +115,8 @@ stream for the parent process,
 .BR pmcd (1),
 which may itself have redirected
 .BR stderr .
-This redirection is normally most useful in a containerized environment, or when using
+This redirection is normally most useful in a containerized
+environment, or when using
 .BR dbpmda (1).
 .PP
 The
@@ -144,22 +149,23 @@ option), looking for source URL files (\c
 and executable scripts or binaries.
 Any files that do not have the
 .B .url
-suffix or are not executable, are ignored \- this allows documentation files
-such as "README" and non-executable "common" script function definitions to
-be present without being considered as config files.
+suffix or are not executable, are ignored \- this allows documentation
+files such as "README" and non-executable "common" script function
+definitions to be present without being considered as config files.
 .PP
-A remote server does not have to be up or stay running \- the PMDA tolerates
-remote URLs that may come and go over time.
+A remote server does not have to be up or stay running \- the PMDA
+tolerates remote URLs that may come and go over time.
 The PMDA will relay data and metadata when/if they are available,
 and will return errors when/if they are down.
 PCP metric IDs, internal and external instance domain identifiers are
 persisted and will be restored when individual metric sources become
 available and/or when the PMDA is restarted.
-In addition, the PMDA checks directory modification times and will rescan
-for new or changed configuration files dynamically.
+In addition, the PMDA checks directory modification times and will
+rescan for new or changed configuration files dynamically.
 It is
 .I not
-necessary to restart the PMDA when adding, removing or changing configuration files.
+necessary to restart the PMDA when adding, removing or changing
+configuration files.
 .SH "URL SOURCES"
 Each file with the
 .I .url
@@ -171,7 +177,7 @@ Local file access is also supported with a conventional
 .I file:///somepath/somefile
 URL, in which case
 .I somepath/somefile
-should contain opentelemetry formatted metric data.
+should contain OpenTelemetry formatted metric data.
 .PP
 The first line of a
 .I .url
@@ -234,8 +240,8 @@ or
 Dynamically created metric names that match
 .I regex
 will be either included or excluded in the name space, as specified.
-Note that only the PMNS leaf component of the metric name (as ingested from the URL source)
-is compared with the
+Note that only the PMNS leaf component of the metric name (as
+ingested from the URL source) is compared with the
 .I regex
 pattern.
 The simple rule is that the \fIfirst matching\fP filter regex
@@ -247,13 +253,15 @@ This is backward compatible with older versions of the configuration
 file that did not support filters.
 Multiple
 .B FILTER:
-lines would normally be used, e.g. to include some metrics but exclude all others, use
+lines would normally be used, e.g. to include some metrics but
+exclude all others, use
 .B "FILTER: EXCLUDE METRIC .*"
 as the last of several filters that include the desired metrics.
 Conversely, to exclude some metrics but include all others, use
 .B "FILTER: EXCLUDE METRIC"
 .IR regex .
-In this case it's not necessary (though doesn't hurt) to specify the final
+In this case it's not necessary (though doesn't hurt) to specify
+the final
 .B "FILTER: INCLUDE METRIC .*"
 because, as stated above, any metric that does not match
 any filter regex will be included by default.
@@ -265,7 +273,8 @@ syntax and semantics as metric filtering.
 will delete all labels with label name matching
 .I regex
 from all metrics defined by the configuration file.
-The same rules as for metric filters apply for label filters too - an implicit rule:
+The same rules as for metric filters apply for label filters too \-
+an implicit rule:
 .BI "FILTER: INCLUDE LABEL .*"
 applies to all labels that do not match any earlier label filter rule.
 .BI "FILTER: OPTIONAL LABEL" " regex"
@@ -297,34 +306,44 @@ labels are used to construct the PCP instance name.
 By excluding some labels (or changing them to optional),
 the instance names will change.
 By excluding some labels, different instances returned by the URL
-or scripted configuration entry for the same metric may become duplicates.
-When such duplicates occur, the last duplicate instance returned by the end-point
-URL or script prevails over any earlier instances.
-For these reasons, it is recommended that label filtering rules be configured when the configuration file
-is first defined, and not changed thereafter.
-If a label filtering change is required, the configuration file should be renamed, which effectively
-defines a new metric (or set of peer metrics as returned by the URL or script), with the new (or changed) instance naming.
+or scripted configuration entry for the same metric may become
+duplicates.
+When such duplicates occur, the last duplicate instance returned by
+the end-point URL or script prevails over any earlier instances.
+For these reasons, it is recommended that label filtering rules be
+configured when the configuration file is first defined, and not
+changed thereafter.
+If a label filtering change is required, the configuration file
+should be renamed, which effectively defines a new metric (or set
+of peer metrics as returned by the URL or script), with the new (or
+changed) instance naming.
 .P
-Unrecognized keywords in configuration files are reported in the PMDA log file but otherwise ignored.
+Unrecognized keywords in configuration files are reported in the PMDA
+log file but otherwise ignored.
 .SH "SCRIPTED SOURCES"
 Executable scripts present in the
 .I $PCP_PMDAS_DIR/opentelemetry/config.d
 directory or sub-directories will be executed and the
 .B stdout
-stream containing opentelemetry formatted metric data will be parsed as though it had come from a URL or file.
+stream containing OpenTelemetry formatted metric data will be parsed as
+though it had come from a URL or file.
 The
 .B stderr
-stream from a script will be sent to the PMDA log file, which by default can be found in
+stream from a script will be sent to the PMDA log file, which by default
+can be found in
 .BR $(PCP_LOG_DIR)/pmcd/opentelemetry.log .
 .PP
-Note that scripted sources do not support label or metric filtering (as described above for URL sources) - they can
-simply do their own filtering in the script itself with
+Note that scripted sources do not support label or metric filtering
+(as described above for URL sources) - they can simply do their own
+filtering in the script itself with
 .BR sed (1),
 .BR awk (1),
 or whatever tool is desired.
 .PP
-For full details of the opentelemetry sexposition formats, see
-.IR https://github.com/open-telemetry/opentelemetry-proto/blob/v1.5.0/opentelemetry/proto/metrics/v1/metrics.proto .
+For full details of the OpenTelemetry exposition formats see
+.I https://github.com/open-telemetry/opentelemetry-proto/
+.br
+.IR blob/main/opentelemetry/proto/metrics/v1/metrics.proto .
 .SH "SELinux CONSIDERATIONS"
 Scripted config files are executed by the
 .B pmdaopentelemetry
@@ -432,7 +451,8 @@ log mandatory on 2 second {
 Metric data returned by URL or scripted configuration files may contain
 metadata that can be used by the
 .B opentelemetry
-PMDA to specify the semantics, data type, scaling and units of dynamically created metrics.
+PMDA to specify the semantics, data type, scaling and units of
+dynamically created metrics.
 This metadata is found for each metric under the
 .B "metric"
 list header in the opentelemetry json data structure.
@@ -442,10 +462,13 @@ and
 .BR pmParseUnitsStr (3)
 and examples in shipped configuration files.
 .PP
-Metadata must be supplied in the json data by the opentelemetry source end-point (URL or script)
-An alternative is to specify this in the URL configuration file directly, which has the advantage
-of not having to modify the source/end-point if the metadata is incorrect or missing.
-Metadata specified in the URL configuration file over-rides any in-line metadata.
+Metadata must be supplied in the json data by the opentelemetry
+source end-point (URL or script).
+An alternative is to specify this in the URL configuration file
+directly, which has the advantage of not having to modify the
+source/end-point if the metadata is incorrect or missing.
+Metadata specified in the URL configuration file over-rides any
+in-line metadata.
 .PP
 The configuration file syntax for specifying metadata is:
 .br
@@ -455,20 +478,24 @@ Where:
 .br
 \f3METADATA:\fP is literal
 .br
-\f2regex\fP is an extended regular expression to match one or more metric names returned by the URL,
+\f2regex\fP is an extended regular expression to match one or more
+metric names returned by the URL,
 .br
-\f2type\fP is one of the PCP numeric types (\f332\fP, \f3u32\fP, \f364\fP, \f3u64\fP, \f3float\fP or \f3double\fP),
+\f2type\fP is one of the PCP numeric types (\f332\fP, \f3u32\fP,
+\f364\fP, \f3u64\fP, \f3float\fP or \f3double\fP),
 .br
 \f2indom\fP is an arbitrary instance domain name, or \f3PM_INDOM_NULL\fP,
 .br
-\f2semantics\fP is either \f3counter\fP, \f3instant\fP or \f3discrete\fP and
+\f2semantics\fP is either \f3counter\fP, \f3instant\fP or \f3discrete\fP
+and
 .br
-\f2units\fP is either \f3none\fP or a string extending to end of line that is parsable by
+\f2units\fP is either \f3none\fP or a string extending to end of
+line that is parsable by
 .BR pmParseUnitsStr(3),
 i.e. the units, dimensions and scaling to be used for matching metrics.
 .PP
-An example configuration file that ingests metrics from the Grafana /metrics end-point on localhost,
-filters out all metrics returned by that URL
+An example configuration file that ingests metrics from the Grafana
+/metrics end-point on localhost, filters out all metrics returned by that URL
 .I except
 for
 .B grafana_api_response_status_total
@@ -507,9 +534,11 @@ All of these metrics have integer values with counter semantics, except
 which has a string value.
 It is important to note that fetching any of the
 .B opentelemetry.control
-metrics will only update the counters and status values if the corresponding URL is actually fetched.
-If the source URL is not fetched, the control metric values do not trigger a refresh and the control
-values reported represent the most recent fetch of each corresponding source.
+metrics will only update the counters and status values if the
+corresponding URL is actually fetched.
+If the source URL is not fetched, the control metric values do not
+trigger a refresh and the control values reported represent the
+most recent fetch of each corresponding source.
 .PP
 The instance domain for the
 .B opentelemetry.control
@@ -521,8 +550,9 @@ A string representing the status of the last fetch of the corresponding source.
 This will generally be
 .B success
 for an http response code of 200.
-This metric can be used for service availability monitoring - provided, as stated above,
-the corresponding source URL is fetched too.
+This metric can be used for service availability monitoring -
+provided, as stated above, the corresponding source URL is fetched
+too.
 .IP \fBopentelemetry.control.status_code\fP
 This metric is similar to
 .B opentelemetry.control.status
@@ -530,27 +560,35 @@ except that it is the integer response code of the last fetch.
 A value of
 .B 200
 usually signifies success and any other value failure.
-This metric can also be used for service availability monitoring, with the same caveats as
+This metric can also be used for service availability monitoring,
+with the same caveats as
 .BR opentelemetry.control.status .
 .IP \fBopentelemetry.control.calls\fP
-total number of times each configured metric source has been fetched (if it's a URL)
-or executed (if it's a script), since the PMDA started.
-This metric has counter semantics and would normally be converted to a rate/second by client tools.
+total number of times each configured metric source has been fetched
+(if it is a URL) or executed (if it's a script), since the PMDA
+started.
+This metric has counter semantics and would normally be converted
+to a rate/second by client tools.
 .IP \fBopentelemetry.control.fetch_time\fP
-Total time in milliseconds that each configured metric source has taken to return a document,
-excluding the time to parse the document.
-This metric has counter semantics and would normally be rate converted by client tools
-but is also useful in raw form as the accumulated parse time since the PMDA was started.
+Total time in milliseconds that each configured metric source has
+taken to return a document, excluding the time to parse the document.
+This metric has counter semantics and would normally be rate converted
+by client tools but is also useful in raw form as the accumulated
+parse time since the PMDA was started.
 .IP \fBopentelemetry.control.parse_time\fP
-Total time in milliseconds that each configured metric source has taken to parse each document,
-excluding the time to fetch the document.
-This metric has counter semantics and would normally be rate converted by client tools but
-is also useful in raw form as the accumulated parse time since the PMDA was started.
+Total time in milliseconds that each configured metric source has
+taken to parse each document, excluding the time to fetch the
+document.
+This metric has counter semantics and would normally be rate converted
+by client tools but is also useful in raw form as the accumulated
+parse time since the PMDA was started.
 .PP
-When converted to a rate, the \fBcalls\fP metric represents the average fetch rate of each source
-over the sampling interval (time delta between samples).
-The \fBfetch_time\fP and \fBparse_time\fP counters, when converted to a rate, represent the
-average fetch and parsing latency (respectfully), during the sampling interval.
+When converted to a rate, the \fBcalls\fP metric represents the
+average fetch rate of each source over the sampling interval (time
+delta between samples).
+The \fBfetch_time\fP and \fBparse_time\fP counters, when converted
+to a rate, represent the average fetch and parsing latency
+(respectfully), during the sampling interval.
 .PP
 The
 .BR opentelemetry.control.debug
@@ -563,8 +601,9 @@ additional debug messages will be written to the PMDA log file.
 .B pmdaopentelemetry
 and
 .B libpcp
-internals impose some numerical constraints about the number of sources (4095),
-metrics (1024) within each source, and instances for each metric (4194304).
+internals impose some numerical constraints about the number of
+sources (4095), metrics (1024) within each source, and instances
+for each metric (4194304).
 .SH INSTALLATION
 Install the OpenTelemetry PMDA by using the Install script as root:
 .sp 1
@@ -607,11 +646,13 @@ installation script for the \fBpmdaopentelemetry\fR agent
 .IP "\fB$PCP_PMDAS_DIR/opentelemetry/Remove\fR" 4
 undo installation script for the \fBpmdaopentelemetry\fR agent
 .IP "\fB$PCP_PMDAS_DIR/opentelemetry/config.d/\fR" 4
-contains URLs and scripts used by the \fBpmdaopentelemetry\fR agent as sources of opentelemetry metric data.
+contains URLs and scripts used by the \fBpmdaopentelemetry\fR agent
+as sources of opentelemetry metric data.
 .IP "\fB$PCP_LOG_DIR/pmcd/opentelemetry.log\fR" 4
 default log file for error messages from \fBpmdaopentelemetry\fR
 .IP "\fB$PCP_VAR_DIR/config/164.*\fR" 4
-files containing internal tables for metric and instance ID number persistence (domain 164).
+files containing internal tables for metric and instance ID number
+persistence (domain 164).
 .SH PCP ENVIRONMENT
 Environment variables with the prefix \fBPCP_\fR are used to
 parameterize the file and directory names used by \fBPCP\fR.
@@ -636,10 +677,8 @@ configuration file, as described in
 
 .\" control lines for scripts/man-spell
 .\" +ok+ grafana_api_response_status_total exposition_formats
-.\" +ok+ OpenObservability
-.\" +ok+ OpenMetrics status_code parse_time headername fetch_time prometheus
+.\" +ok+ status_code parse_time headername fetch_time
 .\" +ok+ labelsets scriptlet semodule somefile somehost somepath
 .\" +ok+ mypolicy mysource SELinux loadavg Grafana ABCDEF github Config
 .\" +ok+ stat IDs EOL AVC url RC rc {from /etc/pcp/pmcd/rc.local}
-.\" +ok+ md {from https://github.com/OpenObservability/OpenMetrics/blob/master/specification/OpenMetrics.md}
 .\" +ok+ pp {from mypolicy.pp}


### PR DESCRIPTION
On macOS there are several man pages producing warnings that can be seen when man(1) is run for these installed pages.

This adds a CI checking for these warnings.  Fixes to follow.