### PR TITLE
src/libpcp_pmda/src/callback.c: Explicit type cast to quiet Coverity

### DIFF
--- a/src/libpcp_pmda/src/callback.c
+++ b/src/libpcp_pmda/src/callback.c
@@ -903,7 +903,7 @@ pmdaLabel(int ident, int type, pmLabelSet **lpp, pmdaExt *pmda)
 	    }
 	    if ((lp->nlabels = sts) > 0)
 		pmdaAddLabelFlags(lp, type);
-	    lp->inst = inst;
+	    lp->inst = (unsigned int)inst;
 	    count++;
 	    lp++;
 


### PR DESCRIPTION
Coverity complains about a overflow storing a negative value in an unsigned in pmdaLabel().  Making it an explicit type cast to make clear this is intentional and to quiet Coverity.

Resolves CID 426733