### PR TITLE
cisco PMDA: Make the code less likely to overflow

### DIFF
--- a/src/pmdas/cisco/telnet.c
+++ b/src/pmdas/cisco/telnet.c
@@ -385,8 +385,7 @@ get_fr_bw(cisco_t *cp, char *interface)
 
 	    case BW:
 		sscanf(w, "%d", &bandwidth);
-		bandwidth *= 1000;		/* Kbit -> bytes/sec */
-		bandwidth /= 8;
+		bandwidth *= (1000/8);		/* Kbit -> bytes/sec */
 		state = IN_REPORT;
 		break;
 
@@ -664,8 +663,7 @@ grab_cisco(intf_t *ip)
 
 	    case BW:
 		sscanf(w, "%d", &tmp.bandwidth);
-		tmp.bandwidth *= 1000;		/* Kbit -> bytes/sec */
-		tmp.bandwidth /= 8;
+		tmp.bandwidth *= (1000/8);	/* Kbit -> bytes/sec */
 		nval++;
 		state = IN_REPORT;
 		break;


### PR DESCRIPTION
There were a couple places in the code where the Kbit/sec was being converted to bytes/sec and this was being done with a multiply by 1000 immediately followed by a divide by 8.  It is cleaner to simply multiply by the constant (1000/8) to eliminate some of the possible overflows.

Resolves CID 426725