### PR TITLE
pmdadocker: fix QA 924

### DIFF
--- a/qa/924
+++ b/qa/924
@@ -32,7 +32,7 @@ username=`id -un`
 trap "cd $here; $sudo rm -rf $tmp $tmp.*; exit \$status" 0 1 2 3 15
 
 # real QA test starts here
-valgrind --tool=helgrind $PCP_PMDAS_DIR/docker/pmdadocker -C -U $username 2>&1 \
+sudo valgrind --tool=helgrind $PCP_PMDAS_DIR/docker/pmdadocker -C -U $username 2>&1 \
 | _filter_helgrind \
 | _filter
 


### PR DESCRIPTION
QA 924 was unintentionally skipped because it was executed as a user without sufficient permissions to /var/lib/docker. Therefore, modified the test to run with sudo.

When I ran the tests with sudo, several errors occurred, which I also fixed.
  - coredump
    - reason: http_client is not initialized
  - a stack overflow warning
    - reason: indomtab is not initialized, which caused cache conflicts.