### PR TITLE
Fixes hugepagesize metric value from bytes to KB as per proc/meminfo

### DIFF
--- a/src/pmdas/linux/help
+++ b/src/pmdas/linux/help
@@ -1745,7 +1745,7 @@ of the number of fragments by combining them as they are received.
 @ hinv.pagesize Memory page size
 The memory page size of the running kernel in bytes.
 @ hinv.hugepagesize Huge page size from /proc/meminfo
-The memory huge page size of the running kernel in bytes.
+The memory huge page size of the running kernel in kilobytes.
 @ hinv.ncpu number of CPUs in the system
 @ hinv.ndisk number of disks in the system
 @ hinv.nfilesys number of (local) file systems currently mounted

--- a/src/pmdas/linux/pmda.c
+++ b/src/pmdas/linux/pmda.c
@@ -8835,10 +8835,10 @@ linux_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
 		return 0; /* no values available */
 	   atom->ull = proc_meminfo.MemAvailable;
 	   break;
-	case 59: /* hinv.hugepagesize (in bytes) */
+	case 59: /* hinv.hugepagesize (in kbytes) */
 	    if (!MEMINFO_VALID_VALUE(proc_meminfo.Hugepagesize))
 	    	return 0; /* no values available */
-	    atom->ul = (proc_meminfo.Hugepagesize << 10);
+	    atom->ul = proc_meminfo.Hugepagesize;
 	    break;
 	case 60: /* mem.util.hugepagesTotalBytes (in bytes) */
 	   if (!MEMINFO_VALID_VALUE(proc_meminfo.HugepagesTotal))


### PR DESCRIPTION
Before:
[localhost@vbox ~]$ pcp meminfo | grep Hugepagesize ; cat /proc/meminfo | grep Hugepagesize
Hugepagesize      : 2097152 kB
Hugepagesize:       2048 kB

After:
[local@localhost ~]$ pcp meminfo | grep Hugepagesize ; cat /proc/meminfo | grep Hugepagesize
Hugepagesize      : 2048 kB
Hugepagesize:       2048 kB