### PR TITLE
pmdadm: Add support for collecting dmcrypt metrics

### DIFF
--- a/qa/657
+++ b/qa/657
@@ -25,6 +25,8 @@ root=$tmp.root
 export DM_SETUP_CACHE="cat $root/dmcache-caches"
 export DM_SETUP_THINPOOL="cat $root/dmthin-pool"
 export DM_SETUP_THIN="cat $root/dmthin-thin"
+export DM_SETUP_CRYPT="cat $root/dmsetup-crypt"
+export DM_SETUP_CRYPTSETUP="cat $root/cryptsetup-status"
 
 # don't want Install to possibly restart pmcd via systemctl, as this
 # will clobber the environment, ...
@@ -118,6 +120,18 @@ echo 'zz_cache: 0 1677721600 cache 8 10162/262144 128 39839/3276800 1087840 8217
 echo 'yy_pool: 0 409600 thin-pool 0 13/65536 0/3200 - rw no_discard_passdown queue_if_no_space' > $root/dmthin-pool
 echo 'vg_1-lv3: 0 8388608 thin 7000704 8388607
 vg_1-lv2: 0 8388608 thin 6832768 8388607' > $root/dmthin-thin
+echo 'luks-4456fe89-d09e-416f-8721-bedb66abda85: 0 996853760 crypt' > $root/dmsetup-crypt
+echo '/dev/mapper/luks-4456fe89-d09e-416f-8721-bedb66abda85 is disabled and is not in use.
+  type:    LUKS2
+  cipher:  aes-xts-plain64
+  keysize: 512 [bits]
+  key location: keyring
+  device:  /dev/nvme0n1p3
+  sector size:  512 [bytes]
+  offset:  32768 [512-byte units] (16777216 [bytes])
+  size:    996853760 [512-byte units] (510389125120 [bytes])
+  mode:    read/write
+  flags:   discards' > $root/cryptsetup-status
 cd $here
 
 echo
@@ -136,6 +150,10 @@ pminfo -dfmtT dmthin.pool
 echo
 echo "=== Check dm-thin metrics for thin vol metrics ==="
 pminfo -dfmtT dmthin.vol
+
+echo
+echo "=== Check dm-crypt metrics for crypt metrics ==="
+pminfo -dfmtT dmcrypt
 
 # cleanup
 _remove_pmda

--- a/qa/657.out
+++ b/qa/657.out
@@ -10,6 +10,7 @@ Updating the PMCD control file, and notifying PMCD ...
 Check dmcache metrics have appeared ... 16 metrics and X values
 Check dmthin metrics have appeared ... 13 metrics and X values
 Check dmstats metrics have appeared ... 15 metrics and X values
+Check dmcrypt metrics have appeared ... 13 metrics and X values
 
 === Check dm-cache metrics ===
 
@@ -228,3 +229,96 @@ Help:
 The highest mapped sector of the thin volume.
     inst [0 or "vg_1-lv3"] value 8388607
     inst [1 or "vg_1-lv2"] value 8388607
+
+=== Check dm-crypt metrics for crypt metrics ===
+
+dmcrypt.active PMID: 129.6.0 [Whether the crypt device is active]
+    Data Type: 32-bit unsigned int  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+Whether the crypt device is active
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value 0
+
+dmcrypt.type PMID: 129.6.1 [Crypt device type]
+    Data Type: string  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+Crypt device type
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value "LUKS2"
+
+dmcrypt.cipher PMID: 129.6.2 [Cipher used for the crypt device]
+    Data Type: string  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+Cipher used for the crypt device
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value "aes-xts-plain64"
+
+dmcrypt.keysize PMID: 129.6.3 [Keysize for the crypt device]
+    Data Type: 32-bit unsigned int  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+Keysize for the crypt device
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value 512
+
+dmcrypt.key_location PMID: 129.6.4 [Decryption key location for the crypt device]
+    Data Type: string  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+Decryption key location for the crypt device
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value "keyring"
+
+dmcrypt.device PMID: 129.6.5 [The crypt device]
+    Data Type: string  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+The crypt device
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value "/dev/nvme0n1p3"
+
+dmcrypt.sector_size PMID: 129.6.6 [Sector size for the crypt device]
+    Data Type: 32-bit unsigned int  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+Sector size for the crypt device
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value 512
+
+dmcrypt.offset PMID: 129.6.7 [Offset for the crypt device]
+    Data Type: 64-bit unsigned int  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+Offset for the crypt device
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value 32768
+
+dmcrypt.offset_bytes PMID: 129.6.8 [Offset in bytes for the crypt device]
+    Data Type: 64-bit unsigned int  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+Offset in bytes for the crypt device
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value 16777216
+
+dmcrypt.size PMID: 129.6.9 [Crypt device size]
+    Data Type: 64-bit unsigned int  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+Crypt device size
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value 996853760
+
+dmcrypt.size_bytes PMID: 129.6.10 [Crypt device size in bytes]
+    Data Type: 64-bit unsigned int  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+Crypt device size in bytes
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value 510389125120
+
+dmcrypt.mode PMID: 129.6.11 [Current mode for the crypt device]
+    Data Type: string  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+Current mode for the crypt device
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value "read/write"
+
+dmcrypt.flags PMID: 129.6.12 [Flags for the crypt device]
+    Data Type: string  InDom: 129.6 0x20400006
+    Semantics: instant  Units: none
+Help:
+Flags for the crypt device
+    inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value "discards"

--- a/src/pmdas/dm/GNUmakefile
+++ b/src/pmdas/dm/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015-2021 Red Hat.
+# Copyright (c) 2015-2025 Red Hat.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -17,7 +17,7 @@ include	$(TOPDIR)/src/include/builddefs
 
 IAM		= dm
 DOMAIN		= DM
-PMNSFILES	= pmns.dmcache pmns.dmthin pmns.dmstats pmns.vdo
+PMNSFILES	= pmns.dmcache pmns.dmthin pmns.dmstats pmns.vdo pmns.dmcrypt
 CMDTARGET	= pmda$(IAM)
 LIBTARGET	= pmda_$(IAM).$(DSOSUFFIX)
 PMDAINIT	= $(IAM)_init
@@ -26,8 +26,8 @@ PMDAADMDIR	= $(PCP_PMDASADM_DIR)/$(IAM)
 PMIEDIR		= $(PCP_SYSCONF_DIR)/pmieconf/$(IAM)
 PMIEVARDIR	= $(PCP_VAR_DIR)/config/pmieconf/$(IAM)
 
-CFILES		= pmda.c dmthin.c dmcache.c vdo.c
-HFILES		= indom.h dmthin.h dmcache.h dmstats.h vdo.h
+CFILES		= pmda.c dmthin.c dmcache.c vdo.c dmcrypt.c
+HFILES		= indom.h dmthin.h dmcache.h dmstats.h vdo.h dmcrypt.h
 LLDLIBS		= $(PCP_PMDALIB)
 LCFLAGS		= $(INVISIBILITY)
 
@@ -79,11 +79,12 @@ domain.h: ../../pmns/stdpmid
 	$(DOMAIN_MAKERULE)
 
 $(OBJECTS): domain.h
-pmda.o dmcache.o dmthin.o dm.o vdo.o: indom.h
+pmda.o dmcache.o dmthin.o dm.o vdo.o dmcrypt.o: indom.h
 pmda.o dmcache.o: dmcache.h
 pmda.o dmthin.o: dmthin.h
 ifeq "$(HAVE_DEVMAPPER)" "true"
 pmda.o dmstats.o: dmstats.h
+pmda.o dmcrypt.o: dmcrypt.h
 endif
 pmda.o vdo.o: vdo.h
 

--- a/src/pmdas/dm/Install
+++ b/src/pmdas/dm/Install
@@ -19,7 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=dm
-pmns_name="dmcache dmthin dmstats vdo"
+pmns_name="dmcache dmthin dmstats vdo dmcrypt"
 
 which dmsetup >/dev/null 2>&1
 if [ $? -ne 0 ]

--- a/src/pmdas/dm/Remove
+++ b/src/pmdas/dm/Remove
@@ -19,7 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=dm
-pmns_name="dmcache dmthin dmstats vdo"
+pmns_name="dmcache dmthin dmstats vdo dmcrypt"
 pmdaSetup
 pmdaRemove
 exit

--- a/src/pmdas/dm/dmcrypt.c
+++ b/src/pmdas/dm/dmcrypt.c
@@ -1,0 +1,271 @@
+/*
+ * Device Mapper PMDA - Crypt (dm-crypt) Stats
+ *
+ * Copyright (c) 2025 Red Hat.
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+ 
+#include "pmapi.h"
+#include "libpcp.h"
+#include "pmda.h"
+
+#include "indom.h"
+#include "dmcrypt.h"
+
+#include <inttypes.h>
+#include <ctype.h>
+
+static char *dm_setup_dmsetup;
+static char *dm_setup_cryptsetup;
+
+/* cryptsetup command output is padded with a leading tab layout,
+ * trim this out from the output to make comparisons easier.
+ */
+char 
+*strtrim(char* str) {
+    // Check for empty String
+    if(*str == 0)  // All spaces
+        return str;
+
+    // Trim leading space
+    while(isspace((unsigned char)*str)) str++;
+
+    return str;
+}
+
+int
+dm_crypt_fetch(int item, struct crypt_stats *crypt_stats, pmAtomValue *atom)
+{
+    if (item < 0 || item >= NUM_CRYPT_STATS)
+	return PM_ERR_PMID;
+
+    switch(item) {
+        case CRYPT_ACTIVE:
+            atom->ul = crypt_stats->active;
+            break;
+
+        case CRYPT_TYPE:
+            atom->cp = crypt_stats->type;
+            break;
+
+        case CRYPT_CIPHER:
+            atom->cp = crypt_stats->cipher;
+            break;
+
+        case CRYPT_KEYSIZE:
+            atom->ul = crypt_stats->keysize;
+            break;
+
+        case CRYPT_KEY_LOCATION:
+            atom->cp = crypt_stats->key_location;
+            break;
+
+        case CRYPT_DEVICE:
+            atom->cp = crypt_stats->device;
+            break;
+
+        case CRYPT_SECTOR_SIZE:
+            atom->ul = crypt_stats->sector_size;
+            break;
+
+        case CRYPT_OFFSET:
+            atom->ull = crypt_stats->offset;
+            break;
+
+        case CRYPT_OFFSET_BYTES:
+            atom->ull = crypt_stats->offset_bytes;
+            break;
+
+        case CRYPT_SIZE:
+            atom->ull = crypt_stats->size;
+            break;
+
+        case CRYPT_SIZE_BYTES:
+            atom->ull = crypt_stats->size_bytes;
+            break;
+
+        case CRYPT_MODE:
+            atom->cp = crypt_stats->mode;
+            break;
+
+        case CRYPT_FLAGS:
+            atom->cp = crypt_stats->flags;
+            break;
+    }
+    return PMDA_FETCH_STATIC;
+}
+
+/*
+ * Grab output from cryptsetup status (or read in from cat when under QA),
+ * Match the data to the crypt vol which we wish to update the metrics and
+ * assign the values to crypt_stats.
+ */
+int
+dm_refresh_crypt(const char *name, struct crypt_stats *crypt_stats)
+{
+    char buffer[BUFSIZ];
+    FILE *fp;
+    int sts;
+    __pmExecCtl_t *argp = NULL;
+
+    pmsprintf(buffer, sizeof(buffer), "%s %s", dm_setup_cryptsetup, name);
+
+    if ((sts = __pmProcessUnpickArgs(&argp, buffer)) < 0)
+	return sts;
+    if ((sts = __pmProcessPipe(&argp, "r", PM_EXEC_TOSS_NONE, &fp)) < 0)
+	return sts;
+
+    while (fgets(buffer, sizeof(buffer) -1, fp)) {
+        if (strstr(buffer, name)) {
+            if (strstr(buffer, "active") != NULL) {
+                crypt_stats->active = 1;
+            } else {
+                crypt_stats->active = 0;
+            }
+        }
+        
+        char *trimmed = strtrim(buffer);
+
+        if (strncmp(trimmed, "type:", 5) == 0)
+            sscanf(buffer, "%*s %s", crypt_stats->type);
+
+        if (strncmp(trimmed, "cipher:", 7) == 0)
+            sscanf(buffer, "%*s %s", crypt_stats->cipher);
+
+        if (strncmp(trimmed, "keysize:", 8) == 0)
+            sscanf(buffer, "%*s %"SCNu32"", &crypt_stats->keysize);
+
+        if (strncmp(trimmed, "key location:", 13) == 0)
+            sscanf(buffer, "%*s %*s %s", crypt_stats->key_location);
+
+        if (strncmp(trimmed, "device:", 7) == 0)
+            sscanf(buffer, "%*s %s", crypt_stats->device);
+
+        if (strncmp(trimmed, "sector size:", 12) == 0)
+            sscanf(buffer, "%*s %*s %"SCNu32"", &crypt_stats->sector_size);
+
+        if (strncmp(trimmed, "offset:", 7) == 0)
+            sscanf(buffer, "%*s %"SCNu64"", &crypt_stats->offset);
+
+        if (strncmp(trimmed, "size:", 5) == 0)
+            sscanf(buffer, "%*s %"SCNu64"", &crypt_stats->size);
+
+        if (strncmp(trimmed, "mode:", 5) == 0)
+            sscanf(buffer, "%*s %s", crypt_stats->mode);
+    
+        if (strncmp(trimmed, "flags:", 6) == 0)
+            sscanf(buffer, "%*s %s", crypt_stats->flags);
+            
+        if ((crypt_stats->size != 0) && (crypt_stats->sector_size !=0))
+            crypt_stats->size_bytes = crypt_stats->size * crypt_stats->sector_size;
+
+        if ((crypt_stats->offset != 0) && (crypt_stats->sector_size !=0))
+            crypt_stats->offset_bytes = crypt_stats->offset * crypt_stats->sector_size;
+
+    }
+
+    sts = __pmProcessPipeClose(fp);
+    if (sts <= 0)
+        return sts;
+    if (sts == 2000)
+	pmNotifyErr(LOG_ERR, "dm_refresh_crypt: pipe (%s %s) terminated with unknown error\n", dm_setup_cryptsetup, name);
+    else if (sts > 1000)
+	pmNotifyErr(LOG_ERR, "dm_refresh_crypt: pipe (%s %s) terminated with signal %d\n", dm_setup_cryptsetup, name, sts - 1000);
+    else
+	pmNotifyErr(LOG_ERR, "dm_refresh_crypt: pipe (%s %s) terminated with exit status %d\n", dm_setup_cryptsetup, name, sts);
+
+    return PM_ERR_GENERIC;
+}
+
+/*
+ * Update the dm crypt instance domain. This will change as volumes are created, 
+ * activated and removed.
+ *
+ * Using the pmdaCache interfaces simplifies things and provides us
+ * with guarantees around consistent instance numbering in all of
+ * those interesting corner cases.
+ */
+int
+dm_crypt_instance_refresh(void)
+{
+    int sts;
+    FILE *fp;
+    char buffer[BUFSIZ];
+    struct crypt_stats *crypt;
+    pmInDom indom = dm_indom(DM_CRYPT_INDOM);
+    __pmExecCtl_t *argp = NULL;
+
+    pmdaCacheOp(indom, PMDA_CACHE_INACTIVE);
+
+    /*
+     * update indom cache based off of thin pools listed by dmsetup
+     */
+    if ((sts = __pmProcessUnpickArgs(&argp, dm_setup_dmsetup)) < 0)
+	return sts;
+    if ((sts = __pmProcessPipe(&argp, "r", PM_EXEC_TOSS_NONE, &fp)) < 0)
+	return sts;
+
+    while (fgets(buffer, sizeof(buffer) -1, fp)) {
+        if (strstr(buffer, "crypt")) {
+            strtok(buffer, ":");
+
+            /*
+             * at this point buffer contains our crypt device lvm names
+             * this will be used to map stats to file-system instances
+             */
+	    sts = pmdaCacheLookupName(indom, buffer, NULL, (void **)&crypt);
+	    if (sts == PM_ERR_INST || (sts >= 0 && crypt == NULL)){
+	        crypt = calloc(1, sizeof(*crypt));
+                if (crypt == NULL) {
+		    __pmProcessPipeClose(fp);
+                    return PM_ERR_AGAIN;
+                }
+            }
+	    else if (sts < 0)
+	        continue;
+
+	    /* (re)activate this entry for the current query */
+	    pmdaCacheStore(indom, PMDA_CACHE_ADD, buffer, (void *)crypt);
+        }
+    }
+
+    sts = __pmProcessPipeClose(fp);
+    if (sts <= 0)
+        return sts;
+    if (sts == 2000)
+	pmNotifyErr(LOG_ERR, "dm_crypt_instance_refresh: pipe (%s) terminated with unknown error\n", dm_setup_dmsetup);
+    else if (sts > 1000)
+	pmNotifyErr(LOG_ERR, "dm_crypt_instance_refresh: pipe (%s) terminated with signal %d\n", dm_setup_dmsetup, sts - 1000);
+    else
+	pmNotifyErr(LOG_ERR, "dm_crypt_instance_refresh: pipe (%s) terminated with exit status %d\n", dm_setup_dmsetup, sts);
+
+    return PM_ERR_GENERIC;            
+}
+
+void
+dm_crypt_setup(void)
+{
+    static char dmsetup_command[] = "dmsetup status --target crypt";
+    static char cryptsetup_command[] = "cryptsetup status ";
+    char *env_command;
+
+    /* allow override at startup for QA testing */
+    if ((env_command = getenv("DM_SETUP_CRYPT")) != NULL)
+        dm_setup_dmsetup = env_command;
+    else
+        dm_setup_dmsetup = dmsetup_command;
+
+    if ((env_command = getenv("DM_SETUP_CRYPTSETUP")) != NULL)
+        dm_setup_cryptsetup = env_command;
+    else
+        dm_setup_cryptsetup = cryptsetup_command;
+}

--- a/src/pmdas/dm/dmcrypt.h
+++ b/src/pmdas/dm/dmcrypt.h
@@ -1,0 +1,58 @@
+/*
+ * Device Mapper PMDA - Crypt (dm-crypt) Stats
+ *
+ * Copyright (c) 2025 Red Hat.
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef DMCRYPT_H
+#define DMCRYPT_H
+
+enum {
+    CRYPT_ACTIVE = 0,
+    CRYPT_TYPE,
+    CRYPT_CIPHER,
+    CRYPT_KEYSIZE,
+    CRYPT_KEY_LOCATION,
+    CRYPT_DEVICE,
+    CRYPT_SECTOR_SIZE,
+    CRYPT_OFFSET,
+    CRYPT_OFFSET_BYTES,
+    CRYPT_SIZE,
+    CRYPT_SIZE_BYTES,
+    CRYPT_MODE,
+    CRYPT_FLAGS,
+    NUM_CRYPT_STATS
+};
+
+struct crypt_stats {
+    __uint32_t active;
+    char type[128];
+    char cipher[256];
+    __uint32_t keysize;
+    char key_location[128];
+    char device[PATH_MAX];
+    __uint32_t sector_size;
+    __uint64_t offset;
+    __uint64_t offset_bytes;
+    __uint64_t size;
+    __uint64_t size_bytes;
+    char mode[12];
+    char flags[256];
+};
+
+extern int dm_crypt_fetch(int, struct crypt_stats *, pmAtomValue *);
+extern int dm_refresh_crypt(const char *, struct crypt_stats *);
+extern int dm_crypt_instance_refresh(void);
+extern void dm_crypt_setup(void);
+
+#endif /* DMCRYPT_H */

--- a/src/pmdas/dm/help
+++ b/src/pmdas/dm/help
@@ -352,3 +352,17 @@ updated an existing entry.
 @ vdo.dev.index.updates_not_found Update calls where entry not found
 The number of update calls since context statistics were last reset that
 added a new entry.
+
+@dmcrypt.active Whether the crypt device is active
+@dmcrypt.type Crypt device type
+@dmcrypt.cipher Cipher used for the crypt device
+@dmcrypt.keysize Keysize for the crypt device
+@dmcrypt.key_location Decryption key location for the crypt device
+@dmcrypt.device The crypt device
+@dmcrypt.sector_size Sector size for the crypt device
+@dmcrypt.offset Offset for the crypt device
+@dmcrypt.offset_bytes Offset in bytes for the crypt device
+@dmcrypt.size Crypt device size
+@dmcrypt.size_bytes Crypt device size in bytes
+@dmcrypt.mode Current mode for the crypt device
+@dmcrypt.flags Flags for the crypt device

--- a/src/pmdas/dm/indom.h
+++ b/src/pmdas/dm/indom.h
@@ -24,6 +24,7 @@ enum {
     DM_STATS_INDOM = 3,		/* Dmstats basic counter */
     DM_HISTOGRAM_INDOM = 4,	/* Dmstats latency histogram */
     DM_VDODEV_INDOM = 5,	/* VDO devices */
+    DM_CRYPT_INDOM = 6,		/* Dmcrypt*/
     NUM_INDOMS
 };
 

--- a/src/pmdas/dm/pmns.dmcrypt
+++ b/src/pmdas/dm/pmns.dmcrypt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+ 
+ dmcrypt {
+ 	active              DM:6:0
+ 	type                DM:6:1
+ 	cipher              DM:6:2
+ 	keysize             DM:6:3
+ 	key_location        DM:6:4
+ 	device              DM:6:5
+ 	sector_size         DM:6:6
+ 	offset              DM:6:7
+ 	offset_bytes        DM:6:8
+ 	size                DM:6:9
+ 	size_bytes          DM:6:10
+ 	mode                DM:6:11
+ 	flags               DM:6:12
+}

--- a/src/pmdas/dm/root
+++ b/src/pmdas/dm/root
@@ -13,9 +13,11 @@ root {
     dmthin
     dmstats
     vdo
+    dmcrypt
 }
 
 #include "pmns.dmcache"
 #include "pmns.dmthin"
 #include "pmns.dmstats"
 #include "pmns.vdo"
+#include "pmns.dmcrypt"


### PR DESCRIPTION
Add support for collecting information about local dmcrypt device mapper targets.

Update QA/657 to reflect these new additions.