### PR TITLE
build: resolve CI failure on macOS with latest toolchain

### DIFF
--- a/src/include/pcp/platform_defs.h.in
+++ b/src/include/pcp/platform_defs.h.in
@@ -72,12 +72,12 @@ extern "C" {
 #include <ws2tcpip.h>
 #endif
 
-#if defined(HAVE_ENDIAN_H)
-#include <endian.h>
+#if defined(HAVE_MACHINE_ENDIAN_H)
+#include <machine/endian.h>
 #elif defined(HAVE_SYS_ENDIAN_H)
 #include <sys/endian.h>
-#elif defined(HAVE_MACHINE_ENDIAN_H)
-#include <machine/endian.h>
+#elif defined(HAVE_ENDIAN_H)
+#include <endian.h>
 #endif
 #if defined(HAVE_ENDIAN_H) || defined(HAVE_SYS_ENDIAN_H) || defined(HAVE_MACHINE_ENDIAN_H)
 #if defined(BYTE_ORDER) && BYTE_ORDER == BIG_ENDIAN

--- a/src/libpcp3/src/util.c
+++ b/src/libpcp3/src/util.c
@@ -2385,17 +2385,6 @@ alphasort(const_dirent **p, const_dirent **q)
  * is preserved.
  * ====================================================
  */
-
-#ifdef HAVE_ENDIAN_H
-#include <endian.h>
-#else
-#ifdef HAVE_SYS_ENDIAN_H
-#include <sys/endian.h>
-#else
-bozo!
-#endif
-#endif
-
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #define __HI(x) *(1+(int*)&x)
 #define __LO(x) *(int*)&x


### PR DESCRIPTION
Through some quirk of system headers and macros we are now seeing HAVE_SYS_ENDIAN_H defined even when configure didn't detect it on macOS.  Rearrange the order of includes so the right thing happens on macOS.

Also remove superflous re-#include of endian headers in the libpcp util.c source file.