### PR TITLE
pmlogctl: fix intermittent qa/1483 failure relating to a diagnostic

### DIFF
--- a/src/pmlogctl/pmlogctl.sh
+++ b/src/pmlogctl/pmlogctl.sh
@@ -734,15 +734,17 @@ _diagnose()
 
 # check ${IAM} really started
 #
-# $1 = dir as it appears on the $PCP_TMP_DIR/${IAM} files (so a real path,
+# $1 = host
+# $2 = dir as it appears on the $PCP_TMP_DIR/${IAM} files (so a real path,
 #      not a possibly sybolic path from a control file)
-# $2 = args from control file
+# $3 = args from control file
 #
 _check_started()
 {
     $SHOWME && return 0
-    dir="$1"
-    args="$2"
+    host="$1"
+    dir="$2"
+    args="$3"
     max=600		# 1/10 of a second, so 1 minute max
     i=0
     $VERY_VERBOSE && $PCP_ECHO_PROG >&2 $PCP_ECHO_N "Started? dir=$dir args=$args ""$PCP_ECHO_C"
@@ -1521,7 +1523,7 @@ $1 == "'"$host"'"	{ printf "%s",$5
 			  for (i = 6; i <= NF; i++) printf " %s",$i
 			  print ""
 			}'`
-	_check_started "$dir_args" "$args" || sts=1
+	_check_started "$host" "$dir_args" "$args" || sts=1
     done
 
     return $sts
@@ -1673,7 +1675,7 @@ $1 == "'"$host"'"	{ printf "%s",$5
 		      for (i = 6; i <= NF; i++) printf " %s",$i
 		      print ""
 		    }'`
-	    _check_started "$dir_args" "$args" || sts=1
+	    _check_started "$host" "$dir_args" "$args" || sts=1
 	fi
     done
 
@@ -1806,7 +1808,7 @@ $1 == "'"#!#$__host"'" && ($4 == "'"$__dir"'" || $4 == "'"$__alt_dir"'")	{ sub(/
 	fi
 	$RUNASPCP "$CHECKCMD $CHECKARGS -c \"$__control\""
 
-	_check_started "$__args_dir" "$__args" || __sts=1
+	_check_started "$__host" "$__args_dir" "$__args" || __sts=1
     done
 
     return $__sts


### PR DESCRIPTION
Test qa/1483 sometimes fails with:

> output mismatch (see 1483.out.bad)
> 25a26
> > Oct 21 20:22:28 8b9db31fb831 pmlogctl[1464231]: Warning: pmlogger failed to start for host  and directory /var/log/pcp/pmlogger/1210-no.such.host.pcp.io

Note the lack of a hostname between "host  and".  Digging into it, this relates to use of a variable that is not set in pmlogctl.sh - this fixes that and from there existing filtering should now work.