### PR TITLE
Graceful fail when pmdahdb fails to connect

### DIFF
--- a/src/pmdas/hdb/pmdahdb.python
+++ b/src/pmdas/hdb/pmdahdb.python
@@ -3529,7 +3529,7 @@ def _main():
             conf.hdb_config.node_timeout,
             conf.hdb_config.comm_timeout,
         )
-    except RuntimeError as ex:
+    except (RuntimeError, dbapi.Error) as ex:
         print(ex, file=sys.stderr)
         sys.exit(1)
     # Default domain number is PMDA(88)


### PR DESCRIPTION
Do not throw whole exception back-trace to user when connection from pmda-hdb to SAP-HANA instance fails.