### PR TITLE
pmdaopenmetrics: fix benchmark performance bug

### DIFF
--- a/src/pmdas/openmetrics/pmdaopenmetrics.python
+++ b/src/pmdas/openmetrics/pmdaopenmetrics.python
@@ -565,6 +565,7 @@ class Source(object):
         self.document = None
 
         self.refresh_time = 0 # "never"
+
         if not is_scripted:
             # source is a URL.  Create a session for it and initialize a few things
             self.requests = self.pmda.requests # allow persistent connections etc.
@@ -601,7 +602,7 @@ class Source(object):
         '''
         now = time.time()
         last_try_age = now - self.refresh_time
-        return len(self.metrics_by_name) == 0 or last_try_age > self.pmda.refresh_timeout
+        return last_try_age > self.pmda.refresh_timeout
 
     def check_filter(self, name, entrytype):
         '''


### PR DESCRIPTION
Resolves RHEL-124769. Clusters were being refreshed hundreds of times / second because the configuration directory was populated with sources that were not connected to the PMDA. This caused the length of the metric dictionary to always equal 0 and the conditional in the function old_enough_for_refresh to always return true. The solution now checks if the source metric dict is equal to 0 AND if its the first time connecting to the source. Otherwise call for refresh every timeout seconds.