### PR TITLE
pmlogger selinux fix for observed denials

### DIFF
--- a/src/selinux/pcp.te
+++ b/src/selinux/pcp.te
@@ -307,6 +307,7 @@ allow pcp_pmlogger_t self:unix_dgram_socket create_socket_perms;
 
 allow pcp_pmlogger_t pcp_pmlogger_exec_t:file execute_no_trans;
 allow pcp_pmlogger_t ldconfig_exec_t:file { execute execute_no_trans };
+allow pcp_pmlogger_t pcp_pmie_exec_t:file execute;
 
 dontaudit pcp_pmlogger_t self:cap_userns { sys_ptrace };
 


### PR DESCRIPTION
This PR adds a rule to pcp.te to fix an observed AVC denied message while testing.