### PR TITLE
pmlogcompress: increase default xz compression level from 0 to 3

### DIFF
--- a/src/pmlogcompress/pmlogcompress
+++ b/src/pmlogcompress/pmlogcompress
@@ -74,18 +74,19 @@ _xz_setup()
 {
     if [ -z "${xz_args+onetrip}" ]
     then
-	if xz -3 --block-size=10MiB </dev/null >/dev/null 2>&1
+	if xz -2 --block-size=10MiB </dev/null >/dev/null 2>&1
 	then
-	    # want minimal overheads, -0 is the same as --fast ...
+	    # want minimal overheads, -2 where we found better compression ratio
+		# with least overhead
 	    # these options were selected after extensive analysis
 	    # for original settings in pmlogger_daily
 	    #
-	    xz_args="-3 --block-size=10MiB"
-	elif xz -3 </dev/null >/dev/null 2>&1
+	    xz_args="-2 --block-size=10MiB"
+	elif xz -2 </dev/null >/dev/null 2>&1
 	then
 	    # no --block-size in older versions of xz
 	    #
-	    xz_args="-3"
+	    xz_args="-2"
 	else
 	    xz_args=''
 	fi


### PR DESCRIPTION
Raise the default xz compression level from 0 to 3 for improved compression efficiency. For smaller archives with xz -0 level
533M total --> 26M total in 16.4695 sec
For smaller archives with xz -3 level
533M total --> 13M total in 24.1473 sec

For larger archives with xz -0 level
15G total -->695M   total in 815.4636 sec
For larger archives with xz -3 level
15G total -->428M   total in 1016.3921 sec
[xz_benchmark_small_archive.log](https://github.com/user-attachments/files/23671080/xz_benchmark_small_archive.log)
[xz_benchmark_big_archive.log](https://github.com/user-attachments/files/23671081/xz_benchmark_big_archive.log)
