### PR TITLE
pmdadm: Add support for collecting dm-multipath metrics

### DIFF
--- a/qa/657
+++ b/qa/657
@@ -27,6 +27,7 @@ export DM_SETUP_THINPOOL="cat $root/dmthin-pool"
 export DM_SETUP_THIN="cat $root/dmthin-thin"
 export DM_SETUP_CRYPT="cat $root/dmsetup-crypt"
 export DM_SETUP_CRYPTSETUP="cat $root/cryptsetup-status"
+export DM_SETUP_MULTIPATH="cat $root/multipathd"
 
 # don't want Install to possibly restart pmcd via systemctl, as this
 # will clobber the environment, ...
@@ -132,6 +133,31 @@ echo '/dev/mapper/luks-4456fe89-d09e-416f-8721-bedb66abda85 is disabled and is n
   size:    996853760 [512-byte units] (510389125120 [bytes])
   mode:    read/write
   flags:   discards' > $root/cryptsetup-status
+
+cat << 'MULTIPATHD_OUTPUT' > $root/multipathd
+mpatha (3600c0ff000123456789012345000000) dm-1 HITACHI,DF400F
+size=500G features='1 queue_if_no_path' hwhandler='0' wp=rw
+|-+- policy='round-robin 0' prio=50 status=active
+| |- 1:0:0:1 sda 8:0   active ready running
+| |- 2:0:0:1 sdc 8:32  active ready running
+| |- 3:0:0:1 sde 8:64  active ready running
+| `- 4:0:0:1 sdg 8:96  active ready running
+`-+- policy='round-robin 0' prio=10 status=enabled
+  |- 1:0:1:1 sdb 8:16  active ready running
+  |- 2:0:1:1 sdd 8:48  active ready running
+  |- 3:0:1:1 sdf 8:80  active ready running
+  `- 4:0:1:1 sdh 8:112 active ready running
+
+mpathb (36005076303ffc56200000000000010aa) dm-4 Pure Storage,FlashArray
+size=1.5T features='3 queue_if_no_path pg_init_retries 50' hwhandler='1 alua' wp=rw
+|-+- policy='service-time 0' prio=100 status=active
+| |- 5:0:0:1 sdi 8:128 active ready running
+| `- 6:0:0:1 sdk 8:160 active ready running
+`-+- policy='service-time 0' prio=10 status=enabled
+  |- 5:0:1:1 sdj 8:144 failed faulty detached
+  `- 6:0:1:1 sdl 8:176 active ready running"
+MULTIPATHD_OUTPUT
+
 cd $here
 
 echo
@@ -154,6 +180,10 @@ pminfo -dfmtT dmthin.vol
 echo
 echo "=== Check dm-crypt metrics for crypt metrics ==="
 pminfo -dfmtT dmcrypt
+
+echo
+echo "=== Check dm-multipath metrics ==="
+pminfo -dfmtT dmmultipath
 
 # cleanup
 _remove_pmda

--- a/qa/657.out
+++ b/qa/657.out
@@ -11,6 +11,7 @@ Check dmcache metrics have appeared ... 16 metrics and X values
 Check dmthin metrics have appeared ... 13 metrics and X values
 Check dmstats metrics have appeared ... 15 metrics and X values
 Check dmcrypt metrics have appeared ... 13 metrics and X values
+Check dmmultipath metrics have appeared ... 18 metrics and X values
 
 === Check dm-cache metrics ===
 
@@ -322,3 +323,215 @@ dmcrypt.flags PMID: 129.6.12 [Flags for the crypt device]
 Help:
 Flags for the crypt device
     inst [0 or "luks-4456fe89-d09e-416f-8721-bedb66abda85"] value "discards"
+
+=== Check dm-multipath metrics ===
+
+dmmultipath.name PMID: 129.7.0 [The map name (alias - user friendly name)]
+    Data Type: string  InDom: 129.7 0x20400007
+    Semantics: instant  Units: none
+Help:
+The map name (alias - user friendly name)
+    inst [0 or "dm-1"] value "mpatha"
+    inst [1 or "dm-4"] value "mpathb"
+
+dmmultipath.wwid PMID: 129.7.1 [The map World Wide Identifier (WWID)]
+    Data Type: string  InDom: 129.7 0x20400007
+    Semantics: instant  Units: none
+Help:
+The map World Wide Identifier (WWID)
+    inst [0 or "dm-1"] value "3600c0ff000123456789012345000000"
+    inst [1 or "dm-4"] value "36005076303ffc56200000000000010aa"
+
+dmmultipath.device PMID: 129.7.2 [The device node name of the map device in device mapper]
+    Data Type: string  InDom: 129.7 0x20400007
+    Semantics: instant  Units: none
+Help:
+The device node name of the map device in device mapper
+    inst [0 or "dm-1"] value "dm-1"
+    inst [1 or "dm-4"] value "dm-4"
+
+dmmultipath.vendor PMID: 129.7.3 [The vendor name]
+    Data Type: string  InDom: 129.7 0x20400007
+    Semantics: instant  Units: none
+Help:
+The vendor name
+    inst [0 or "dm-1"] value "HITACHI"
+    inst [1 or "dm-4"] value "Pure Storage"
+
+dmmultipath.product_name PMID: 129.7.4 [The product name]
+    Data Type: string  InDom: 129.7 0x20400007
+    Semantics: instant  Units: none
+Help:
+The product name
+    inst [0 or "dm-1"] value "DF400F"
+    inst [1 or "dm-4"] value "FlashArray"
+
+dmmultipath.size PMID: 129.7.5 [The total size of the device]
+    Data Type: string  InDom: 129.7 0x20400007
+    Semantics: instant  Units: none
+Help:
+The total size of the device
+    inst [0 or "dm-1"] value "500G"
+    inst [1 or "dm-4"] value "1.5T"
+
+dmmultipath.features PMID: 129.7.6 [Device features]
+    Data Type: string  InDom: 129.7 0x20400007
+    Semantics: instant  Units: none
+Help:
+Device features
+    inst [0 or "dm-1"] value "1 queue_if_no_path"
+    inst [1 or "dm-4"] value "3 queue_if_no_path pg_init_retries 50"
+
+dmmultipath.hardware_handler PMID: 129.7.7 [The hardware handler used]
+    Data Type: string  InDom: 129.7 0x20400007
+    Semantics: instant  Units: none
+Help:
+The hardware handler used
+    inst [0 or "dm-1"] value "0"
+    inst [1 or "dm-4"] value "1 alua"
+
+dmmultipath.permissions PMID: 129.7.8 [Write premissions]
+    Data Type: string  InDom: 129.7 0x20400007
+    Semantics: instant  Units: none
+Help:
+Write premissions
+    inst [0 or "dm-1"] value "rw"
+    inst [1 or "dm-4"] value "rw"
+
+dmmultipath.path.selector_algorithm PMID: 129.8.0 [The I/O load balancing policy]
+    Data Type: string  InDom: 129.8 0x20400008
+    Semantics: instant  Units: none
+Help:
+The I/O load balancing policy
+    inst [0 or "dm-1:path_0"] value "round-robin 0"
+    inst [1 or "dm-1:path_1"] value "round-robin 0"
+    inst [2 or "dm-4:path_0"] value "service-time 0"
+    inst [3 or "dm-4:path_1"] value "service-time 0"
+
+dmmultipath.path.priority PMID: 129.8.1 [The priority of the path group]
+    Data Type: 64-bit unsigned int  InDom: 129.8 0x20400008
+    Semantics: instant  Units: none
+Help:
+The priority of the path group
+    inst [0 or "dm-1:path_0"] value 50
+    inst [1 or "dm-1:path_1"] value 10
+    inst [2 or "dm-4:path_0"] value 100
+    inst [3 or "dm-4:path_1"] value 10
+
+dmmultipath.path.status PMID: 129.8.2 [The status of the path group]
+    Data Type: string  InDom: 129.8 0x20400008
+    Semantics: instant  Units: none
+Help:
+The status of the path group
+    inst [0 or "dm-1:path_0"] value "active"
+    inst [1 or "dm-1:path_1"] value "enabled"
+    inst [2 or "dm-4:path_0"] value "active"
+    inst [3 or "dm-4:path_1"] value "enabled"
+
+dmmultipath.path.device.bus_id PMID: 129.9.0 [The SCSI Host:Channel:Target:LUN identifier]
+    Data Type: string  InDom: 129.9 0x20400009
+    Semantics: instant  Units: none
+Help:
+The SCSI Host:Channel:Target:LUN identifier
+    inst [0 or "dm-1:path_0:sda"] value "1:0:0:1"
+    inst [1 or "dm-1:path_0:sdc"] value "2:0:0:1"
+    inst [2 or "dm-1:path_0:sde"] value "3:0:0:1"
+    inst [3 or "dm-1:path_0:sdg"] value "4:0:0:1"
+    inst [4 or "dm-1:path_1:sdb"] value "1:0:1:1"
+    inst [5 or "dm-1:path_1:sdd"] value "2:0:1:1"
+    inst [6 or "dm-1:path_1:sdf"] value "3:0:1:1"
+    inst [7 or "dm-1:path_1:sdh"] value "4:0:1:1"
+    inst [8 or "dm-4:path_0:sdi"] value "5:0:0:1"
+    inst [9 or "dm-4:path_0:sdk"] value "6:0:0:1"
+    inst [10 or "dm-4:path_1:sdj"] value "5:0:1:1"
+    inst [11 or "dm-4:path_1:sdl"] value "6:0:1:1"
+
+dmmultipath.path.device.dev_name PMID: 129.9.1 [The kernel standard device node name]
+    Data Type: string  InDom: 129.9 0x20400009
+    Semantics: instant  Units: none
+Help:
+The kernel standard device node name
+    inst [0 or "dm-1:path_0:sda"] value "sda"
+    inst [1 or "dm-1:path_0:sdc"] value "sdc"
+    inst [2 or "dm-1:path_0:sde"] value "sde"
+    inst [3 or "dm-1:path_0:sdg"] value "sdg"
+    inst [4 or "dm-1:path_1:sdb"] value "sdb"
+    inst [5 or "dm-1:path_1:sdd"] value "sdd"
+    inst [6 or "dm-1:path_1:sdf"] value "sdf"
+    inst [7 or "dm-1:path_1:sdh"] value "sdh"
+    inst [8 or "dm-4:path_0:sdi"] value "sdi"
+    inst [9 or "dm-4:path_0:sdk"] value "sdk"
+    inst [10 or "dm-4:path_1:sdj"] value "sdj"
+    inst [11 or "dm-4:path_1:sdl"] value "sdl"
+
+dmmultipath.path.device.dev_id PMID: 129.9.2 [The Major/Minor device numbers]
+    Data Type: string  InDom: 129.9 0x20400009
+    Semantics: instant  Units: none
+Help:
+The Major/Minor device numbers
+    inst [0 or "dm-1:path_0:sda"] value "8:0"
+    inst [1 or "dm-1:path_0:sdc"] value "8:32"
+    inst [2 or "dm-1:path_0:sde"] value "8:64"
+    inst [3 or "dm-1:path_0:sdg"] value "8:96"
+    inst [4 or "dm-1:path_1:sdb"] value "8:16"
+    inst [5 or "dm-1:path_1:sdd"] value "8:48"
+    inst [6 or "dm-1:path_1:sdf"] value "8:80"
+    inst [7 or "dm-1:path_1:sdh"] value "8:112"
+    inst [8 or "dm-4:path_0:sdi"] value "8:128"
+    inst [9 or "dm-4:path_0:sdk"] value "8:160"
+    inst [10 or "dm-4:path_1:sdj"] value "8:144"
+    inst [11 or "dm-4:path_1:sdl"] value "8:176"
+
+dmmultipath.path.device.device_status PMID: 129.9.3 [The Device Mapper (DM) Status]
+    Data Type: string  InDom: 129.9 0x20400009
+    Semantics: instant  Units: none
+Help:
+The Device Mapper (DM) Status
+    inst [0 or "dm-1:path_0:sda"] value "active"
+    inst [1 or "dm-1:path_0:sdc"] value "active"
+    inst [2 or "dm-1:path_0:sde"] value "active"
+    inst [3 or "dm-1:path_0:sdg"] value "active"
+    inst [4 or "dm-1:path_1:sdb"] value "active"
+    inst [5 or "dm-1:path_1:sdd"] value "active"
+    inst [6 or "dm-1:path_1:sdf"] value "active"
+    inst [7 or "dm-1:path_1:sdh"] value "active"
+    inst [8 or "dm-4:path_0:sdi"] value "active"
+    inst [9 or "dm-4:path_0:sdk"] value "active"
+    inst [10 or "dm-4:path_1:sdj"] value "failed"
+    inst [11 or "dm-4:path_1:sdl"] value "active"
+
+dmmultipath.path.device.path_status PMID: 129.9.4 [The Path Status (from the path checker)]
+    Data Type: string  InDom: 129.9 0x20400009
+    Semantics: instant  Units: none
+Help:
+The Path Status (from the path checker)
+    inst [0 or "dm-1:path_0:sda"] value "ready"
+    inst [1 or "dm-1:path_0:sdc"] value "ready"
+    inst [2 or "dm-1:path_0:sde"] value "ready"
+    inst [3 or "dm-1:path_0:sdg"] value "ready"
+    inst [4 or "dm-1:path_1:sdb"] value "ready"
+    inst [5 or "dm-1:path_1:sdd"] value "ready"
+    inst [6 or "dm-1:path_1:sdf"] value "ready"
+    inst [7 or "dm-1:path_1:sdh"] value "ready"
+    inst [8 or "dm-4:path_0:sdi"] value "ready"
+    inst [9 or "dm-4:path_0:sdk"] value "ready"
+    inst [10 or "dm-4:path_1:sdj"] value "faulty"
+    inst [11 or "dm-4:path_1:sdl"] value "ready"
+
+dmmultipath.path.device.kernel_status PMID: 129.9.5 [The state of the path device in the kernel]
+    Data Type: string  InDom: 129.9 0x20400009
+    Semantics: instant  Units: none
+Help:
+The state of the path device in the kernel
+    inst [0 or "dm-1:path_0:sda"] value "running"
+    inst [1 or "dm-1:path_0:sdc"] value "running"
+    inst [2 or "dm-1:path_0:sde"] value "running"
+    inst [3 or "dm-1:path_0:sdg"] value "running"
+    inst [4 or "dm-1:path_1:sdb"] value "running"
+    inst [5 or "dm-1:path_1:sdd"] value "running"
+    inst [6 or "dm-1:path_1:sdf"] value "running"
+    inst [7 or "dm-1:path_1:sdh"] value "running"
+    inst [8 or "dm-4:path_0:sdi"] value "running"
+    inst [9 or "dm-4:path_0:sdk"] value "running"
+    inst [10 or "dm-4:path_1:sdj"] value "detached"
+    inst [11 or "dm-4:path_1:sdl"] value "running""

--- a/src/pmdas/dm/GNUmakefile
+++ b/src/pmdas/dm/GNUmakefile
@@ -17,7 +17,7 @@ include	$(TOPDIR)/src/include/builddefs
 
 IAM		= dm
 DOMAIN		= DM
-PMNSFILES	= pmns.dmcache pmns.dmthin pmns.dmstats pmns.vdo pmns.dmcrypt
+PMNSFILES	= pmns.dmcache pmns.dmthin pmns.dmstats pmns.vdo pmns.dmcrypt pmns.dmmultipath
 CMDTARGET	= pmda$(IAM)
 LIBTARGET	= pmda_$(IAM).$(DSOSUFFIX)
 PMDAINIT	= $(IAM)_init
@@ -26,8 +26,8 @@ PMDAADMDIR	= $(PCP_PMDASADM_DIR)/$(IAM)
 PMIEDIR		= $(PCP_SYSCONF_DIR)/pmieconf/$(IAM)
 PMIEVARDIR	= $(PCP_VAR_DIR)/config/pmieconf/$(IAM)
 
-CFILES		= pmda.c dmthin.c dmcache.c vdo.c dmcrypt.c
-HFILES		= indom.h dmthin.h dmcache.h dmstats.h vdo.h dmcrypt.h
+CFILES		= pmda.c dmthin.c dmcache.c vdo.c dmcrypt.c dmmultipath.c
+HFILES		= indom.h dmthin.h dmcache.h dmstats.h vdo.h dmcrypt.h dmmultipath.h
 LLDLIBS		= $(PCP_PMDALIB)
 LCFLAGS		= $(INVISIBILITY)
 
@@ -85,6 +85,7 @@ pmda.o dmthin.o: dmthin.h
 ifeq "$(HAVE_DEVMAPPER)" "true"
 pmda.o dmstats.o: dmstats.h
 pmda.o dmcrypt.o: dmcrypt.h
+pmda.o dmmultipath.0: dmmultipath.h
 endif
 pmda.o vdo.o: vdo.h
 

--- a/src/pmdas/dm/Install
+++ b/src/pmdas/dm/Install
@@ -19,7 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=dm
-pmns_name="dmcache dmthin dmstats vdo dmcrypt"
+pmns_name="dmcache dmthin dmstats vdo dmcrypt dmmultipath"
 
 which dmsetup >/dev/null 2>&1
 if [ $? -ne 0 ]

--- a/src/pmdas/dm/Remove
+++ b/src/pmdas/dm/Remove
@@ -19,7 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=dm
-pmns_name="dmcache dmthin dmstats vdo dmcrypt"
+pmns_name="dmcache dmthin dmstats vdo dmcrypt dmmultipath"
 pmdaSetup
 pmdaRemove
 exit

--- a/src/pmdas/dm/dmmultipath.c
+++ b/src/pmdas/dm/dmmultipath.c
@@ -1,0 +1,323 @@
+/*
+ * Device Mapper PMDA - Multipath (dm-multipath) Stats
+ *
+ * Copyright (c) 2025 Red Hat.
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#include "pmapi.h"
+#include "libpcp.h"
+#include "pmda.h"
+
+#include "indom.h"
+#include "dmmultipath.h"
+
+#include <inttypes.h>
+#include <ctype.h>
+
+static char *dm_setup_dmmultipathd;
+
+/* multipathd command output is padded with a leading tab layout,
+ * trim this out from the output to make comparisons easier.
+ */
+char 
+*trim_whitespace(char* str)
+{
+    /* trim leading space */
+    while (isspace((unsigned char)*str))
+	str++;
+    return str;
+}
+
+int
+dm_multipath_info_fetch(int item, struct multipath_info *info, pmAtomValue *atom)
+{
+    if (item < 0 || item >= NUM_MULTIPATH_STATS)
+	return PM_ERR_PMID;
+
+    switch (item) {
+        case MULTIPATH_NAME:
+            atom->cp = info->name;
+            break;
+
+        case MULTIPATH_WWID:
+            atom->cp = info->wwid;
+            break;
+
+        case MULTIPATH_DEVICE:
+            atom->cp = info->device;
+            break;
+
+        case MULTIPATH_VENDOR:
+            atom->cp = info->vendor;
+            break;
+
+        case MULTIPATH_PRODUCT_NAME:
+            atom->cp = info->product_name;
+            break;
+
+        case MULTIPATH_SIZE:
+            atom->cp = info->size;
+            break;
+
+        case MULTIPATH_FEATURES:
+            atom->cp = info->features;
+            break;
+
+        case MULTIPATH_HARDWARE_HANDLER:
+            atom->cp = info->hardware_handler;
+            break;
+
+        case MULTIPATH_PERMISSIONS:
+            atom->cp = info->permissions;
+            break;
+    }
+    return PMDA_FETCH_STATIC;
+}
+
+int
+dm_multipath_path_fetch(int item, struct multipath_path *path, pmAtomValue *atom)
+{
+    if (item < 0 || item >= NUM_MULTIPATH_PATH_STATS)
+	return PM_ERR_PMID;
+
+    switch (item) {
+        case MULTIPATH_PATH_SELECTOR_ALGORITHM:
+            atom->cp = path->selector_algorithm;
+            break;
+
+        case MULTIPATH_PATH_PRIORITY:
+            atom->ull = path->priority;
+            break;
+
+        case MULTIPATH_PATH_STATUS:
+            atom->cp = path->status;
+            break;
+    }
+    return PMDA_FETCH_STATIC;
+}
+
+int
+dm_multipath_device_fetch(int item, struct multipath_device *dev, pmAtomValue *atom)
+{
+    if (item < 0 || item >= NUM_MULTIPATH_DEVICE_STATS)
+	return PM_ERR_PMID;
+
+    switch (item) {
+        case MULTIPATH_DEVICE_BUS_ID:
+            atom->cp = dev->bus_id;
+            break;
+
+        case MULTIPATH_DEVICE_DEV_NAME:
+            atom->cp = dev->dev_name;
+            break;
+
+        case MULTIPATH_DEVICE_DEV_ID:
+            atom->cp = dev->dev_id;
+            break;
+
+        case MULTIPATH_DEVICE_DEVICE_STATUS:
+            atom->cp = dev->device_status;
+            break;
+
+        case MULTIPATH_DEVICE_PATH_STATUS:
+            atom->cp = dev->path_status;
+            break;
+
+        case MULTIPATH_DEVICE_KERNEL_STATUS:
+            atom->cp = dev->kernel_status;
+            break;
+
+    }
+    return PMDA_FETCH_STATIC;
+}
+
+int
+dm_multipath_instance_refresh(void)
+{
+    char info_name[128], path_name[128], dev_name[128];
+    char device[128];
+    char buffer[BUFSIZ];
+    FILE *fp;
+    
+    int sts;
+    __pmExecCtl_t *argp = NULL;
+    
+    pmInDom info_indom = dm_indom(DM_MULTI_INFO_INDOM);
+    pmInDom path_indom = dm_indom(DM_MULTI_PATH_INDOM);
+    pmInDom dev_indom = dm_indom(DM_MULTI_DEV_INDOM);
+    
+    pmdaCacheOp(info_indom, PMDA_CACHE_INACTIVE);
+    pmdaCacheOp(path_indom, PMDA_CACHE_INACTIVE);
+    pmdaCacheOp(dev_indom, PMDA_CACHE_INACTIVE);
+
+    if ((sts = __pmProcessUnpickArgs(&argp, dm_setup_dmmultipathd)) < 0)
+	return sts;
+    if ((sts = __pmProcessPipe(&argp, "r", PM_EXEC_TOSS_NONE, &fp)) < 0)
+	return sts;
+
+    int path_count = 0;
+
+    while (fgets(buffer, sizeof(buffer) -1, fp)) {
+        char *trimmed = trim_whitespace(buffer);
+
+        struct multipath_info *info;
+
+        // No entries found
+        if (strstr(buffer, "multipath.conf does not exist"))
+            break;
+
+        if (trimmed[0] == '\0')
+            // Skip empty lines
+            continue;
+
+        if (trimmed[0] != '`' && trimmed[0] != '|') {
+
+            if (!strstr(trimmed, "size=")) { 
+                // We are starting a new map this line should start with the
+                // map alias and not include size/feature info
+                path_count = 0;
+
+                sscanf(trimmed, "%*s %*s %s", info_name);
+
+                sts = pmdaCacheLookupName(info_indom, info_name, NULL, (void **)&info);
+                if (sts == PM_ERR_INST || (sts >=0 && info == NULL )) {
+                    info = calloc(1, sizeof(struct multipath_info));
+                    if (info == NULL) {
+                        __pmProcessPipeClose(fp);
+                        return PM_ERR_AGAIN;
+                    }
+                }
+                else if (sts < 0)
+	            continue;
+
+                sscanf(trimmed, "%s %s %s %255[^,],%s",
+                    info->name,
+                    info->wwid,
+                    info->device,
+                    info->vendor,
+                    info->product_name);
+
+                // Remove intial and trailing parenthesis from WWID entry
+                memmove(info->wwid, info->wwid+1, strlen(info->wwid));
+                info->wwid[strlen(info->wwid) - 1] = '\0';
+            } else {
+                // Second information line of current map, can collect and save
+                // info indom
+
+                if (!info)
+                    continue; // Something has gone wrong with part 1 of map allocation
+
+                sscanf(trimmed, "size=%s features='%255[^']' hwhandler='%127[^']' wp=%s",
+                    info->size,
+                    info->features,
+                    info->hardware_handler,
+                    info->permissions);
+
+                pmdaCacheStore(info_indom, PMDA_CACHE_ADD, info_name, (void *)info);
+            }
+        }
+
+        if (strstr(trimmed, "policy=")) {
+            // We are on a new path group on the current map, can collect and
+            // save path indom
+            pmsprintf(path_name, sizeof(path_name), "%s:path_%d", info_name, path_count);
+
+            struct multipath_path *path;
+
+            sts = pmdaCacheLookupName(path_indom, path_name, NULL, (void **)&path);
+            if (sts == PM_ERR_INST || (sts >=0 && path == NULL )) {
+                path = calloc(1, sizeof(struct multipath_path));
+                if (path == NULL) {
+                    __pmProcessPipeClose(fp);
+                    return PM_ERR_AGAIN;
+                }
+            }
+            else if (sts < 0)
+	        continue;
+
+            sscanf(trimmed, "%*s policy='%[^']' prio=%"SCNu64" status=%s",
+                path->selector_algorithm,
+                &path->priority,
+                path->status);
+
+            pmdaCacheStore(path_indom, PMDA_CACHE_ADD, path_name, (void *)path);
+
+            //increment path each time until it is reset by a new map.
+            path_count++;
+        }
+        
+        if (trimmed[0] == '|' || trimmed[0] == '`') {
+            // We are on a new device on the current path for the map, can
+            // collect and save device indom
+
+            if(strstr(trimmed, "policy="))
+                continue; // We don't want path line information, that's above
+
+            char *data_start = buffer + 4; // Skip leading ASCII art characters
+            sscanf(data_start, "%*s %s", device);
+
+            pmsprintf(dev_name, sizeof(dev_name), "%s:%s", path_name, device);
+
+            struct multipath_device *dev;
+
+            sts = pmdaCacheLookupName(dev_indom, dev_name, NULL, (void **)&dev);
+            if (sts == PM_ERR_INST || (sts >=0 && dev == NULL )) {
+                dev = calloc(1, sizeof(struct multipath_device));
+                if (dev == NULL) {
+                    __pmProcessPipeClose(fp);
+                    return PM_ERR_AGAIN;
+                }
+            }
+            else if (sts < 0)
+	        continue;
+
+            sscanf(data_start, "%s %s %s %s %s %s",
+                dev->bus_id,
+                dev->dev_name,
+                dev->dev_id,
+                dev->device_status,
+                dev->path_status,
+                dev->kernel_status);
+
+            pmdaCacheStore(dev_indom, PMDA_CACHE_ADD, dev_name, (void *)dev);
+        }
+    }
+    
+    sts = __pmProcessPipeClose(fp);
+    if (sts <= 0)
+        return sts;
+    if (sts == 2000)
+	pmNotifyErr(LOG_ERR, "%s: pipe (%s) terminated with unknown error\n",
+			__FUNCTION__, dm_setup_dmmultipathd);
+    else if (sts > 1000)
+	pmNotifyErr(LOG_ERR, "%s: pipe (%s) terminated with signal %d\n",
+			__FUNCTION__, dm_setup_dmmultipathd, sts - 1000);
+    else
+	pmNotifyErr(LOG_ERR, "%s: pipe (%s) terminated with exit status %d\n",
+			__FUNCTION__, dm_setup_dmmultipathd, sts);
+
+    return PM_ERR_GENERIC;   
+}
+
+void
+dm_multipath_setup(void)
+{
+    static char multipathd_command[] = "multipathd show topology";
+    char *env_command;
+
+    /* allow override at startup for QA testing */
+    if ((env_command = getenv("DM_SETUP_MULTIPATH")) != NULL)
+        dm_setup_dmmultipathd = env_command;
+    else
+        dm_setup_dmmultipathd = multipathd_command;
+}

--- a/src/pmdas/dm/dmmultipath.h
+++ b/src/pmdas/dm/dmmultipath.h
@@ -1,0 +1,86 @@
+/*
+ * Device Mapper PMDA - Multipath (dm-multipath) Stats
+ *
+ * Copyright (c) 2025 Red Hat.
+ * 
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef DMMULTIPATH_H
+#define DMMULTIPATH_H
+
+enum {
+    MULTIPATH_NAME = 0,
+    MULTIPATH_WWID,
+    MULTIPATH_DEVICE,
+    MULTIPATH_VENDOR,
+    MULTIPATH_PRODUCT_NAME,
+    MULTIPATH_SIZE,
+    MULTIPATH_FEATURES,
+    MULTIPATH_HARDWARE_HANDLER,
+    MULTIPATH_PERMISSIONS,
+    NUM_MULTIPATH_STATS
+};
+
+enum {
+    MULTIPATH_PATH_SELECTOR_ALGORITHM = 0,
+    MULTIPATH_PATH_PRIORITY,
+    MULTIPATH_PATH_STATUS,
+    NUM_MULTIPATH_PATH_STATS
+};
+
+enum {
+    MULTIPATH_DEVICE_BUS_ID = 0,
+    MULTIPATH_DEVICE_DEV_NAME,
+    MULTIPATH_DEVICE_DEV_ID,
+    MULTIPATH_DEVICE_DEVICE_STATUS,
+    MULTIPATH_DEVICE_PATH_STATUS,
+    MULTIPATH_DEVICE_KERNEL_STATUS,
+    NUM_MULTIPATH_DEVICE_STATS
+};
+
+struct multipath_info {
+    char name[256];
+    char wwid[37];
+    char device[11];
+    char vendor[256];
+    char product_name[256];
+    char size[128];
+    char features[256];
+    char hardware_handler[128];
+    char permissions [8];
+};
+
+struct multipath_path {
+    char selector_algorithm[128];
+    uint64_t priority;
+    char status[10];
+};
+
+struct multipath_device {
+    char bus_id[256];
+    char dev_name[256];
+    char dev_id[12];
+    char device_status[7];
+    char path_status[12];
+    char kernel_status[10];
+
+};
+
+extern int dm_multipath_info_fetch(int, struct multipath_info *, pmAtomValue *);
+extern int dm_multipath_path_fetch(int, struct multipath_path *, pmAtomValue *);
+extern int dm_multipath_device_fetch(int, struct multipath_device *, pmAtomValue *);
+
+extern int dm_multipath_instance_refresh(void);
+
+extern void dm_multipath_setup(void);
+
+#endif /* DMMULTIPATH_H */

--- a/src/pmdas/dm/help
+++ b/src/pmdas/dm/help
@@ -33,6 +33,9 @@
 @ DM.4 Device mapper latency histogram bins
 @ DM.5 Virtual Data Optimization devices
 @ DM.6 Device mapper encrypted block devices
+@ DM.7 Device mapper multipath map information
+@ DM.8 Device mapper multipath map paths
+@ DM.9 Device mapper multipath map devices
 
 @ dmcache.size Size of each cache device
 The total size of each cache device in Kbytes.
@@ -367,3 +370,22 @@ added a new entry.
 @dmcrypt.size_bytes Crypt device size in bytes
 @dmcrypt.mode Current mode for the crypt device
 @dmcrypt.flags Flags for the crypt device
+
+@dmmultipath.name The map name (alias - user friendly name)
+@dmmultipath.wwid The map World Wide Identifier (WWID)
+@dmmultipath.device The device node name of the map device in device mapper
+@dmmultipath.vendor The vendor name
+@dmmultipath.product_name The product name
+@dmmultipath.size The total size of the device
+@dmmultipath.features Device features
+@dmmultipath.hardware_handler The hardware handler used
+@dmmultipath.permissions Write premissions
+@dmmultipath.path.selector_algorithm The I/O load balancing policy
+@dmmultipath.path.priority The priority of the path group
+@dmmultipath.path.status The status of the path group
+@dmmultipath.path.device.bus_id The SCSI Host:Channel:Target:LUN identifier
+@dmmultipath.path.device.dev_name The kernel standard device node name
+@dmmultipath.path.device.dev_id The Major/Minor device numbers
+@dmmultipath.path.device.device_status The Device Mapper (DM) Status
+@dmmultipath.path.device.path_status The Path Status (from the path checker)
+@dmmultipath.path.device.kernel_status The state of the path device in the kernel

--- a/src/pmdas/dm/indom.h
+++ b/src/pmdas/dm/indom.h
@@ -25,6 +25,9 @@ enum {
     DM_HISTOGRAM_INDOM = 4,	/* Dmstats latency histogram */
     DM_VDODEV_INDOM = 5,	/* VDO devices */
     DM_CRYPT_INDOM = 6,		/* Dmcrypt*/
+    DM_MULTI_INFO_INDOM = 7,	/* Dm-multipath info */
+    DM_MULTI_PATH_INDOM = 8,	/* Dm-multipath per path */
+    DM_MULTI_DEV_INDOM = 9,	/* Dm-multipath per device*/
     NUM_INDOMS
 };
 

--- a/src/pmdas/dm/pmda.c
+++ b/src/pmdas/dm/pmda.c
@@ -24,17 +24,21 @@
 #include "dmstats.h"
 #include "vdo.h"
 #include "dmcrypt.h"
+#include "dmmultipath.h"
 
 static int		_isDSO = 1; /* for local contexts */
 
 enum {
-    CLUSTER_CACHE = 0,		/* DM-Cache Caches */
-    CLUSTER_POOL = 1,		/* DM-Thin Pools */
-    CLUSTER_VOL = 2,		/* DM-Thin Volumes */
-    CLUSTER_DM_COUNTER = 3,	/* Dmstats basic counter */
-    CLUSTER_DM_HISTOGRAM = 4,	/* Dmstats latency histogram */
-    CLUSTER_VDODEV = 5,		/* VDO per-device statistics */
-    CLUSTER_DM_CRYPT = 6, 	/* DM-Crypt Targets */
+    CLUSTER_CACHE = 0,			/* DM-Cache Caches */
+    CLUSTER_POOL = 1,			/* DM-Thin Pools */
+    CLUSTER_VOL = 2,			/* DM-Thin Volumes */
+    CLUSTER_DM_COUNTER = 3,		/* Dmstats basic counter */
+    CLUSTER_DM_HISTOGRAM = 4,		/* Dmstats latency histogram */
+    CLUSTER_VDODEV = 5,			/* VDO per-device statistics */
+    CLUSTER_DM_CRYPT = 6, 		/* DM-Crypt Targets */
+    CLUSTER_DM_MULTIPATH_INFO = 7,	/* DM-Multipath Info */
+    CLUSTER_DM_MULTIPATH_PATH = 8,	/* DM-Multipath Path */
+    CLUSTER_DM_MULTIPATH_DEVICE = 9,	/* DM-Mulitpath Device */
     NUM_CLUSTERS
 };
 
@@ -1092,6 +1096,79 @@ static pmdaMetric metrictable[] = {
         PMDA_PMID(CLUSTER_DM_CRYPT, CRYPT_FLAGS),
         PM_TYPE_STRING, DM_CRYPT_INDOM, PM_SEM_INSTANT,
         PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    /* DM Multipath stats */
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_INFO, MULTIPATH_NAME),
+        PM_TYPE_STRING, DM_MULTI_INFO_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_INFO, MULTIPATH_WWID),
+        PM_TYPE_STRING, DM_MULTI_INFO_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_INFO, MULTIPATH_DEVICE),
+        PM_TYPE_STRING, DM_MULTI_INFO_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_INFO, MULTIPATH_VENDOR),
+        PM_TYPE_STRING, DM_MULTI_INFO_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_INFO, MULTIPATH_PRODUCT_NAME),
+        PM_TYPE_STRING, DM_MULTI_INFO_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_INFO, MULTIPATH_SIZE),
+        PM_TYPE_STRING, DM_MULTI_INFO_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_INFO, MULTIPATH_FEATURES),
+        PM_TYPE_STRING, DM_MULTI_INFO_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_INFO, MULTIPATH_HARDWARE_HANDLER),
+        PM_TYPE_STRING, DM_MULTI_INFO_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_INFO, MULTIPATH_PERMISSIONS),
+        PM_TYPE_STRING, DM_MULTI_INFO_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_PATH, MULTIPATH_PATH_SELECTOR_ALGORITHM),
+        PM_TYPE_STRING, DM_MULTI_PATH_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_PATH, MULTIPATH_PATH_PRIORITY),
+        PM_TYPE_U64, DM_MULTI_PATH_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_PATH, MULTIPATH_PATH_STATUS),
+        PM_TYPE_STRING, DM_MULTI_PATH_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_DEVICE, MULTIPATH_DEVICE_BUS_ID),
+        PM_TYPE_STRING, DM_MULTI_DEV_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_DEVICE, MULTIPATH_DEVICE_DEV_NAME),
+        PM_TYPE_STRING, DM_MULTI_DEV_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_DEVICE, MULTIPATH_DEVICE_DEV_ID),
+        PM_TYPE_STRING, DM_MULTI_DEV_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_DEVICE, MULTIPATH_DEVICE_DEVICE_STATUS),
+        PM_TYPE_STRING, DM_MULTI_DEV_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_DEVICE, MULTIPATH_DEVICE_PATH_STATUS),
+        PM_TYPE_STRING, DM_MULTI_DEV_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
+    { .m_desc = {
+        PMDA_PMID(CLUSTER_DM_MULTIPATH_DEVICE, MULTIPATH_DEVICE_KERNEL_STATUS),
+        PM_TYPE_STRING, DM_MULTI_DEV_INDOM, PM_SEM_INSTANT,
+        PMDA_PMUNITS(0,0,0,0,0,0) }, },
 };
 
 static pmdaIndom indomtable[] = {
@@ -1102,6 +1179,9 @@ static pmdaIndom indomtable[] = {
     { .it_indom = DM_HISTOGRAM_INDOM },
     { .it_indom = DM_VDODEV_INDOM },
     { .it_indom = DM_CRYPT_INDOM },
+    { .it_indom = DM_MULTI_INFO_INDOM },
+    { .it_indom = DM_MULTI_PATH_INDOM },
+    { .it_indom = DM_MULTI_DEV_INDOM },
 };
 
 pmInDom
@@ -1123,6 +1203,7 @@ dm_instance(pmInDom indom, int inst, char *name, pmInResult **result, pmdaExt *p
 	dm_thin_pool_instance_refresh();
 	dm_thin_vol_instance_refresh();
 	dm_crypt_instance_refresh();
+	dm_multipath_instance_refresh();
     }
 
     (void)pm_dm_stats_instance_refresh();
@@ -1255,6 +1336,12 @@ dm_fetch_refresh(pmdaExt *pmda, int *need_refresh)
                 dm_refresh_crypt(name, crypt);
         }
     }
+    
+    if ((need_refresh[CLUSTER_DM_MULTIPATH_INFO] ||
+         need_refresh[CLUSTER_DM_MULTIPATH_PATH] ||
+         need_refresh[CLUSTER_DM_MULTIPATH_DEVICE]) && privilege) {
+         dm_multipath_instance_refresh();
+    }
 
     return 0;
 }
@@ -1287,7 +1374,10 @@ dm_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
     struct pool_stats *pool;
     struct vol_stats *vol;
     struct pm_wrap *pw;
-    struct crypt_stats * crypt;
+    struct crypt_stats *crypt;
+    struct multipath_info *info;
+    struct multipath_path *path;
+    struct multipath_device *dev;
     char *device;
     int sts;
 
@@ -1334,6 +1424,24 @@ dm_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
 	        return sts;
 	    return dm_crypt_fetch(item, crypt, atom);
 
+        case CLUSTER_DM_MULTIPATH_INFO:
+	    sts = pmdaCacheLookup(dm_indom(DM_MULTI_INFO_INDOM), inst, NULL, (void **)&info);
+	    if (sts < 0)
+	        return sts;
+	    return dm_multipath_info_fetch(item, info, atom);
+
+        case CLUSTER_DM_MULTIPATH_PATH:
+	    sts = pmdaCacheLookup(dm_indom(DM_MULTI_PATH_INDOM), inst, NULL, (void **)&path);
+	    if (sts < 0)
+	        return sts;
+	    return dm_multipath_path_fetch(item, path, atom);
+
+        case CLUSTER_DM_MULTIPATH_DEVICE:
+	    sts = pmdaCacheLookup(dm_indom(DM_MULTI_DEV_INDOM), inst, NULL, (void **)&dev);
+	    if (sts < 0)
+	        return sts;
+	    return dm_multipath_device_fetch(item, dev, atom);
+
         default: /* unknown cluster */
 	    return PM_ERR_PMID;
     }
@@ -1367,6 +1475,7 @@ dm_init(pmdaInterface *dp)
     dm_thin_setup();
     dm_vdo_setup();
     dm_crypt_setup();
+    dm_multipath_setup();
 
     int	nindoms = sizeof(indomtable)/sizeof(indomtable[0]);
     int	nmetrics = sizeof(metrictable)/sizeof(metrictable[0]);

--- a/src/pmdas/dm/pmns.dmmultipath
+++ b/src/pmdas/dm/pmns.dmmultipath
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+ 
+dmmultipath {
+    name				DM:7:0
+    wwid				DM:7:1
+    device				DM:7:2
+    vendor				DM:7:3
+    product_name		DM:7:4
+    size				DM:7:5
+    features			DM:7:6
+    hardware_handler	DM:7:7
+    permissions			DM:7:8
+    path
+}
+ 
+dmmultipath.path {
+    selector_algorithm	DM:8:0
+    priority			DM:8:1
+    status				DM:8:2
+    device
+}
+
+dmmultipath.path.device {
+    bus_id				DM:9:0
+    dev_name			DM:9:1
+    dev_id				DM:9:2
+    device_status		DM:9:3
+    path_status			DM:9:4
+    kernel_status		DM:9:5
+}

--- a/src/pmdas/dm/root
+++ b/src/pmdas/dm/root
@@ -14,6 +14,7 @@ root {
     dmstats
     vdo
     dmcrypt
+    dmmultipath
 }
 
 #include "pmns.dmcache"
@@ -21,3 +22,4 @@ root {
 #include "pmns.dmstats"
 #include "pmns.vdo"
 #include "pmns.dmcrypt"
+#include "pmns.dmmultipath"


### PR DESCRIPTION
Add support for collecting information about local multipath I/O configuration for block devices through dm-multipath.

Update QA/657 to reflect these new additions.