### PR TITLE
docs: Fix typos in man/man1/pcp-kube-pods.1

### DIFF
--- a/man/man1/pcp-kube-pods.1
+++ b/man/man1/pcp-kube-pods.1
@@ -24,7 +24,7 @@
 uses
 .BR kubectl (1)
 to provide a list of IP addresses for PODs running in a local
-Kubenetes cluster, that may be running PCP services like
+Kubernetes cluster, that may be running PCP services like
 .BR pmcd (1)
 and
 .BR pmproxy (1).
@@ -91,4 +91,4 @@ and
 .BR pcp.env (5).
 
 .\" control lines for scripts/man-spell
-.\" +ok+ Kubenetes PCP_KUBE_PODS PODs kubectl podIP
+.\" +ok+ Kubernetes PCP_KUBE_PODS PODs kubectl podIP


### PR DESCRIPTION
docs: Fix typos in man/man1/pcp-kube-pods.1