### PR TITLE
Fix nowebgroup.c: remove return from void function

### DIFF
--- a/src/libpcp_web/src/nowebgroup.c
+++ b/src/libpcp_web/src/nowebgroup.c
@@ -108,5 +108,4 @@ void
 pmWebGroupDestroy(pmWebGroupSettings *settings, sds id, void *arg)
 {
     (void)settings; (void)id; (void)arg;
-    return -EOPNOTSUPP;
 }


### PR DESCRIPTION
Fixes compilation error on macOS without libuv where pmWebGroupDestroy 
(declared void) incorrectly returns -EOPNOTSUPP.

## Issue
Commit 590343053c added pmWebGroupDestroy stub to nowebgroup.c but 
included `return -EOPNOTSUPP;` in a void function, causing:
```
nowebgroup.c:111:5: error: void function 'pmWebGroupDestroy' 
should not return a value [-Wreturn-mismatch]
```

## Why CI Passes But Local Builds Fail
GitHub macOS runners have Node.js pre-installed, which depends on 
libuv as a Homebrew dependency. This means CI builds use webgroup.c 
(real implementation) instead of nowebgroup.c (stub), masking this bug.

Local macOS builds without libuv installed hit this error with modern 
Clang's strict -Wreturn-mismatch enforcement.

## Solution
Remove the return statement from the void stub function, matching the 
pattern of other stubs in the same file (pmWebGroupDerive, 
pmWebGroupFetch, etc).

## Testing
Verified clean build on macOS 25.2.0 (arm64) without libuv using:
```
./Makepkgs --verbose
```

Build completes successfully (exit code 0) after this fix.