### PR TITLE
build: shell script portability fixes (TMPDIR, ar path, shellcheck warnings)

### DIFF
--- a/configure
+++ b/configure
@@ -5947,7 +5947,7 @@ fi
 
   test -n "$AR" && break
 done
-test -n "$AR" || AR="/usr/bin/ar"
+test -n "$AR" || AR="ar"
 
 fi
 if test ! -x "$AR"; then

--- a/src/bashrc/getargs
+++ b/src/bashrc/getargs
@@ -5,7 +5,7 @@
 #
 
 verbose=false
-if [ $# -gt 1 -a X"$1" = X-v ]
+if [ $# -gt 1 ] && [ "$1" = -v ]
 then
 verbose=true
 shift
@@ -17,9 +17,9 @@ echo "Usage: $0 source-file ..."
 exit 1
 fi
 
-tmp=/var/tmp/bashrc-getargs-$$
+tmp=${TMPDIR:-/tmp}/bashrc-getargs-$$
 status=1
-trap "rm -f $tmp.*; exit \$status" 0 1 2 3 15
+trap 'rm -f $tmp.*; exit $status' 0 1 2 3 15
 
 for file
 do
@@ -56,7 +56,7 @@ $verbose && ( echo "+ source lines"; cat $tmp.work )
 if [ ! -s $tmp.work ]
 then
     echo "Error: no pmSetShortOptions call or .short_options assignment, nothing to work with"
-elif [ `wc -l <$tmp.work | sed -e 's/ //g'` -gt 1 ]
+elif [ "$(wc -l <"$tmp".work | sed -e 's/ //g')" -gt 1 ]
 then
     cat $tmp.work
     echo "Error: more than one pmSetShortOptions call or .short_options assignment, I am confused"

--- a/src/libpcp/doc/mk.cgraph
+++ b/src/libpcp/doc/mk.cgraph
@@ -5,13 +5,12 @@
 # Assumes libpcp source and cscope index are in ../src
 #
 
-tmp=/var/tmp/$$
-trap "rm -f $tmp.*; exit \$sts" 0 1 2 3 15
+tmp=${TMPDIR:-/tmp}/$$
+sts=1
+trap 'rm -f $tmp.*; exit $sts' 0 1 2 3 15
 
 rm -f $tmp.*
 touch $tmp.stop
-
-sts=1
 recursive=true
 eflag=false
 fflag=false

--- a/src/libpcp/src/check-errorcodes
+++ b/src/libpcp/src/check-errorcodes
@@ -6,9 +6,10 @@
 # Check error codes exposure in QA tests.
 #
 
-tmp=/var/tmp/check-errorcodes-$$
-rm -f $tmp.err
-trap "sts=0; [ -f $tmp.err ] && sts=1; rm -f $tmp.*; exit \$sts" 0 1 2 3 15
+tmp=${TMPDIR:-/tmp}/check-errorcodes-$$
+sts=0
+rm -f "$tmp".err
+trap '[ -f $tmp.err ] && sts=1; rm -f $tmp.*; exit $sts' 0 1 2 3 15
 
 for file in ../../include/pcp/pmapi.h \
 	    ../../perl/PMDA/PMDA.pm ../../python/pmapi.c

--- a/src/libpcp3/src/check-errorcodes
+++ b/src/libpcp3/src/check-errorcodes
@@ -6,9 +6,10 @@
 # Check error codes exposure in QA tests.
 #
 
-tmp=/var/tmp/check-errorcodes-$$
-rm -f $tmp.err
-trap "sts=0; [ -f $tmp.err ] && sts=1; rm -f $tmp.*; exit \$sts" 0 1 2 3 15
+tmp=${TMPDIR:-/tmp}/check-errorcodes-$$
+sts=0
+rm -f "$tmp".err
+trap '[ -f $tmp.err ] && sts=1; rm -f $tmp.*; exit $sts' 0 1 2 3 15
 
 for file in ../../include/pcp/pmapi.h \
 	    ../../perl/PMDA/PMDA.pm ../../python/pmapi.c

--- a/src/pmdas/bind2/mk.rewrite
+++ b/src/pmdas/bind2/mk.rewrite
@@ -11,9 +11,9 @@
 # and generate pmlogrewrite(1) rules to force the PMIDs to be correct.
 #
 
-tmp=/var/tmp/mk.rewrite-$$
+tmp=${TMPDIR:-/tmp}/mk.rewrite-$$
 status=0
-trap "rm -f $tmp.*; exit \$status" 0 1 2 3 15
+trap 'rm -f $tmp.*; exit $status' 0 1 2 3 15
 
 cat <<End-of-File >rewrite.conf
 # Rewriting rules for bind2 PMDA metrics to ensure consistent

--- a/src/pmdas/jbd2/mk.rewrite
+++ b/src/pmdas/jbd2/mk.rewrite
@@ -6,10 +6,10 @@
 #	platform dependent.
 #
 
-tmp=/var/tmp/$$
-trap "rm -f $tmp.*; exit 0" 0 1 2 3 15
+tmp=${TMPDIR:-/tmp}/$$
+trap 'rm -f $tmp.*; exit 0' 0 1 2 3 15
 
-cat <<End-of-File >$tmp.c
+cat <<End-of-File >"$tmp".c
 #include <pcp/platform_defs.h>
 #if defined(HAVE_64BIT_LONG)
 KERNEL_ULONG=PM_TYPE_U64
@@ -20,8 +20,8 @@ KERNEL_ULONG=PM_TYPE_U32
 #endif
 End-of-File
 
-eval `${CPP-cpp} -I${INCDIR-.} $tmp.c \
-      | sed -n -e '/KERNEL_ULONG/s/PM_TYPE_//p'`
+eval "$(${CPP-cpp} -I"${INCDIR-.}" "$tmp".c \
+      | sed -n -e '/KERNEL_ULONG/s/PM_TYPE_//p')"
 
 cat <<End-of-File >jbd2_kernel_ulong.conf
 # These metrics are all exported from the jbd2 PMDA

--- a/src/pmdas/linux/mk.rewrite
+++ b/src/pmdas/linux/mk.rewrite
@@ -6,10 +6,10 @@
 #	platform dependent.
 #
 
-tmp=/var/tmp/$$
-trap "rm -f $tmp.*; exit 0" 0 1 2 3 15
+tmp=${TMPDIR:-/tmp}/$$
+trap 'rm -f $tmp.*; exit 0' 0 1 2 3 15
 
-cat <<End-of-File >$tmp.c
+cat <<End-of-File >"$tmp".c
 #include <pcp/platform_defs.h>
 #if defined(HAVE_64BIT_LONG)
 KERNEL_ULONG=PM_TYPE_U64
@@ -20,8 +20,8 @@ KERNEL_ULONG=PM_TYPE_U32
 #endif
 End-of-File
 
-eval `${CPP-cpp} -I${INCDIR-.} $tmp.c \
-      | sed -n -e '/KERNEL_ULONG/s/PM_TYPE_//p'`
+eval "$(${CPP-cpp} -I"${INCDIR-.}" "$tmp".c \
+      | sed -n -e '/KERNEL_ULONG/s/PM_TYPE_//p')"
 
 cat <<End-of-File >kernel_ulong.conf
 # These metrics are all exported from the linux PMDA

--- a/src/pmdas/linux_proc/mk.rewrite
+++ b/src/pmdas/linux_proc/mk.rewrite
@@ -9,10 +9,10 @@
 #	to msec, requiring the type to be PM_TYPE_U64
 #
 
-tmp=/var/tmp/$$
-trap "rm -f $tmp.*; exit 0" 0 1 2 3 15
+tmp=${TMPDIR:-/tmp}/$$
+trap 'rm -f $tmp.*; exit 0' 0 1 2 3 15
 
-cat <<End-of-File >$tmp.c
+cat <<End-of-File >"$tmp".c
 #include <pcp/platform_defs.h>
 #if defined(HAVE_64BIT_LONG)
 KERNEL_ULONG=PM_TYPE_U64
@@ -23,13 +23,13 @@ KERNEL_ULONG=PM_TYPE_U32
 #endif
 End-of-File
 
-eval `${CPP-cpp} -I${INCDIR-.} $tmp.c \
-      | sed -n -e '/KERNEL_ULONG/s/PM_TYPE_//p'`
+eval "$(${CPP-cpp} -I"${INCDIR-.}" "$tmp".c \
+      | sed -n -e '/KERNEL_ULONG/s/PM_TYPE_//p')"
 
 cat <<End-of-File >proc_kernel_ulong.conf
 # These metrics are all exported from the proc PMDA
 # using the KERNEL_ULONG type which might be PM_TYPE_U32
-# or could be PM_TYPE_U64. 
+# or could be PM_TYPE_U64.
 
 metric proc.psinfo.wchan { type -> $KERNEL_ULONG }
 metric proc.schedstat.pcount { type -> $KERNEL_ULONG }

--- a/src/pmlogcompress/check-optimize
+++ b/src/pmlogcompress/check-optimize
@@ -9,12 +9,12 @@
 # below there)
 #
 
-tmp=/var/tmp/check-optimize-$$
-here=`pwd`
+tmp=${TMPDIR:-/tmp}/check-optimize-$$
+here=$(pwd)
 
 verbose=false
 
-trap "rm -rf $tmp $tmp.*; exit 0" 0 1 2 3 15
+trap 'rm -rf $tmp $tmp.*; exit 0' 0 1 2 3 15
 
 _doit()
 {


### PR DESCRIPTION
## Shell Script Portability Improvements

### Summary

This PR improves portability of PCP's build scripts for non-FHS systems (like NixOS, Guix) and sandboxed build environments. It also fixes shellcheck warnings to improve script quality.

New Pull request in response to
https://github.com/performancecopilot/pcp/pull/2444#pullrequestreview-3647196062

### Changes

#### 1. Portable `ar` fallback in configure
The configure script had a hardcoded fallback to `/usr/bin/ar`, which doesn't exist on systems that don't follow the Filesystem Hierarchy Standard. Changed to just `ar` which will be found via PATH.

```diff
-test -n "$AR" || AR="/usr/bin/ar"
+test -n "$AR" || AR="ar"
```

Please note that the configure script has a very large number of shellcheck exceptions, so this pull request did NOT attempt to resolve these. 

#### 2. Use `${TMPDIR:-/tmp}` instead of `/var/tmp`
Several build scripts hardcode `/var/tmp` for temporary files. This fails in sandboxed build environments (like Nix) where `/var/tmp` is not writable. The fix uses `${TMPDIR:-/tmp}` which:
- Uses `$TMPDIR` when set (required for sandboxed builds)
- Falls back to `/tmp` on traditional systems
- Is POSIX-compliant

**Affected files:**
- `src/pmdas/bind2/mk.rewrite`
- `src/pmdas/jbd2/mk.rewrite`
- `src/pmdas/linux/mk.rewrite`
- `src/pmdas/linux_proc/mk.rewrite`
- `src/bashrc/getargs`
- `src/libpcp/src/check-errorcodes`
- `src/libpcp3/src/check-errorcodes`
- `src/libpcp/doc/mk.cgraph`
- `src/pmlogcompress/check-optimize`

#### 3. Shellcheck warning fixes (all POSIX sh compatible)

| Fix | Issue | Description |
|-----|-------|-------------|
| Trap quoting | SC2064 | Use single quotes so `$tmp` expands at signal time, not trap definition time |
| Test portability | SC2166 | Replace `[ -a ]` with `[ ] && [ ]` (more portable) |
| Command substitution | SC2046 | Quote `$()` to prevent word splitting |
| Variable init | SC2154 | Initialize `sts` before trap to avoid false warning |

### Testing

- Verified build completes successfully
- Tested with Nix flake build and NixOS VM test
- All shellcheck warnings resolved in modified files

