### PR TITLE
Fix of pmseries core dumps for invalid expressions

### DIFF
--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -5063,7 +5063,7 @@ series_query_funcs_report_values(void *arg)
     seriesBatonReference(baton, "series_query_funcs_report_values");
 
     /* For function-type nodes, calculate actual values */
-    has_function = series_calculate(baton->query.root, 0, baton->userdata);
+    has_function = series_calculate(baton->query.root, 0, baton);
 
     /*
      * Store the canonical query to Redis if this query statement has


### PR DESCRIPTION
Fixes a crash in pmseries caused by expressions with improper types or units. The crash occurred because the serving function (batton->info) received an invalid data structure; this change ensures the correct structure is used.