### PR TITLE
Extended test 1212 with invalid semantic case

### DIFF
--- a/qa/1212
+++ b/qa/1212
@@ -37,6 +37,9 @@ pmseries kernel.all.!bang
 echo "== Query parse error handling - invalid sample"
 pmseries kernel.all.load[badness]
 
+echo "== Query parse error handling - invalid semantic"
+pmseries 'kernel.all.pswitch[count:1] / kernel.all.pswitch[count:1]'
+
 # success, all done
 status=0
 exit

--- a/qa/1212.out
+++ b/qa/1212.out
@@ -12,3 +12,6 @@ pmseries: [Error] cannot parse given string
 kernel.all.load[badness]
                 ^ -- syntax error
 
+== Query parse error handling - invalid semantic
+pmseries: [Error] Both operands have the semantics of counter, only addition or subtraction is allowed.
+


### PR DESCRIPTION
Added `invalid semantic` case to the pmseries test 1212
This is a follow up of https://github.com/performancecopilot/pcp/pull/2451