### PR TITLE
pmdaopentelemetry: metric removal & timestamp

### DIFF
--- a/qa/1843
+++ b/qa/1843
@@ -1,0 +1,114 @@
+#!/bin/sh
+# PCP QA Test No. 1843
+# Test pmdaopentelemetry metric removal
+#
+# Copyright (c) 2026 Red Hat.  All Rights Reserved.
+#
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.opentelemetry
+
+_pmdaopentelemetry_check || _notrun "opentelemetry pmda not installed"
+
+status=1        # failure is the default!
+
+_cleanup()
+{
+    cd $here
+    _pmdaopentelemetry_cleanup
+    $sudo rm -rf $tmp $tmp.*
+}
+
+_prepare_pmda opentelemetry
+trap "_cleanup; exit \$status" 0 1 2 3 15
+_stop_auto_restart pmcd
+
+_pmdaopentelemetry_save_config
+
+# add all the sample text files as urls.
+# need to be a place the user $PCP_USER (pmcd) can read
+#
+( cd $here/opentelemetry/samples; ls -1 *.txt ) | sort | while read file
+do
+    cp $here/opentelemetry/samples/$file $tmp.$file
+    urlbase=`basename "$file" .txt | tr .- _`
+    echo 'file://'$tmp.$file >$tmp.tmp
+    $sudo cp $tmp.tmp $PCP_PMDAS_DIR/opentelemetry/config.d/$urlbase.url
+done
+ls -l $PCP_PMDAS_DIR/openmetrics/config.d >>$seq_full
+
+# add all the sample scripts
+cp -a $here/opentelemetry/scripts/* $PCP_PMDAS_DIR/opentelemetry/config.d
+find $PCP_PMDAS_DIR/opentelemetry/config.d -name GNU\* -exec rm -f {} ";"
+
+_pmdaopentelemetry_install
+
+iam=opentelemetry
+# append -R option to pmcd config
+sed < $PCP_PMCDCONF_PATH \
+        -e "/^$iam.*/s/$/ -R 1/" \
+        > $tmp.conf
+$sudo cp $tmp.conf $PCP_PMCDCONF_PATH
+if ! _service pmcd restart 2>&1; then _exit 1; fi \
+| _filter_pcp_restart
+sleep 2
+
+if ! _pmdaopentelemetry_wait_for_metric opentelemetry.simplemetric
+then
+    status=1
+    exit
+fi
+
+echo "-- metric removal of new source/metric --"
+$sudo rm $PCP_PMDAS_DIR/opentelemetry/config.d/simplemetric.url
+pminfo opentelemetry.simplemetric
+echo
+
+echo "-- check control metrics disappeared --"
+pminfo -dfmt opentelemetry.control.status_code
+echo
+
+echo "-- source re-addition --"
+# same access controls logic as above, user $PCP_USER needs to be
+# able to read the file at the end of the URL
+#
+cp $here/opentelemetry/samples/simplemetric.txt $tmp.simplemetric.txt
+echo 'file:///'$tmp.simplemetric.txt > $PCP_PMDAS_DIR/opentelemetry/config.d/simplemetric.url
+pminfo opentelemetry.simplemetric
+echo
+
+echo "-- check control metrics reappeared --"
+pminfo -dfmt opentelemetry.control.status_code
+echo
+
+echo "-- metric removal of recognized source/metric --"
+$sudo rm $PCP_PMDAS_DIR/opentelemetry/config.d/simplemetric.url
+pminfo opentelemetry.simplemetric
+echo
+
+echo "-- source re-addition with epoch timestamp --"
+cp $here/opentelemetry/samples/simplemetric.txt $tmp.simplemetric.txt
+echo 'file:///'$tmp.simplemetric.txt > $PCP_PMDAS_DIR/opentelemetry/config.d/simplemetric.url
+$sudo touch -t 197001010000 $PCP_PMDAS_DIR/opentelemetry/config.d/simplemetric.url
+pminfo opentelemetry.simplemetric
+echo
+
+echo "-- metric removal by modifying source file, source persists --"
+$sudo sed -i -e '52,72d' $tmp'.simplemetric.txt'
+
+echo "-- sleep to allow for old_enough_for_refresh() --"
+sleep 2
+echo
+
+echo "-- metric2 removed --"
+pminfo opentelemetry.simplemetric
+sleep 10
+
+
+_pmdaopentelemetry_remove >/dev/null 2>&1
+
+# success, all done
+status=0
+exit

--- a/qa/1843.out
+++ b/qa/1843.out
@@ -1,0 +1,56 @@
+QA output created by 1843
+
+=== opentelemetry agent installation ===
+-- metric removal of new source/metric --
+Error: opentelemetry.simplemetric: Unknown metric name
+
+-- check control metrics disappeared --
+
+opentelemetry.control.status_code PMID: 164.0.6 [per-end-point source URL response status code after the most recent fetch]
+    Data Type: 32-bit int  InDom: 164.0 0x29000000
+    Semantics: discrete  Units: none
+    inst [0 or "control"] value 0
+    inst [1 or "curl.script"] value 0
+    inst [2 or "curl_scripted"] value 0
+    inst [3 or "duplicate"] value 0
+    inst [4 or "labelfiltering"] value 0
+    inst [5 or "python_scripted"] value 0
+
+-- source re-addition --
+opentelemetry.simplemetric.metric3_sum
+opentelemetry.simplemetric.metric3_count
+opentelemetry.simplemetric.metric3
+opentelemetry.simplemetric.metric2
+opentelemetry.simplemetric.metric1
+
+-- check control metrics reappeared --
+
+opentelemetry.control.status_code PMID: 164.0.6 [per-end-point source URL response status code after the most recent fetch]
+    Data Type: 32-bit int  InDom: 164.0 0x29000000
+    Semantics: discrete  Units: none
+    inst [0 or "control"] value 0
+    inst [1 or "curl.script"] value 0
+    inst [2 or "curl_scripted"] value 0
+    inst [3 or "duplicate"] value 0
+    inst [4 or "labelfiltering"] value 0
+    inst [5 or "python_scripted"] value 0
+    inst [6 or "simplemetric"] value 0
+
+-- metric removal of recognized source/metric --
+Error: opentelemetry.simplemetric: Unknown metric name
+
+-- source re-addition with epoch timestamp --
+opentelemetry.simplemetric.metric3_sum
+opentelemetry.simplemetric.metric3_count
+opentelemetry.simplemetric.metric3
+opentelemetry.simplemetric.metric2
+opentelemetry.simplemetric.metric1
+
+-- metric removal by modifying source file, source persists --
+-- sleep to allow for old_enough_for_refresh() --
+
+-- metric2 removed --
+opentelemetry.simplemetric.metric3_sum
+opentelemetry.simplemetric.metric3_count
+opentelemetry.simplemetric.metric3
+opentelemetry.simplemetric.metric1

--- a/qa/group
+++ b/qa/group
@@ -2245,6 +2245,7 @@ telnet-probe
 1829 archive pmlogrewrite local archive_v3 pmlogdump local pmconfig
 1837 pmproxy local
 1838 pmda.linux kernel local
+1843 pmda.opentelemetry local
 1844 pmdumptext libpcp_qmc remote
 1845 logutil pmlogger_daily local
 1848 libpcp local valgrind

--- a/src/pmdas/opentelemetry/pmdaopentelemetry.1
+++ b/src/pmdas/opentelemetry/pmdaopentelemetry.1
@@ -25,6 +25,7 @@
 [\f3\-c\f1 \f2config\f1]
 [\f3\-d\f1 \f2domain\f1]
 [\f3\-l\f1 \f2logfile\f1]
+[\f3\-R\f1 \f2refresh_timeout\f1]
 [\f3\-r\f1 \f2root\f1]
 [\f3\-t\f1 \f2timeout\f1]
 [\f3\-u\f1 \f2user\f1]
@@ -137,6 +138,13 @@ Use of the
 .B \-r
 option may also change the defaults for some other command line options,
 e.g. the default log file name and the default configuration directory.
+.PP
+The
+.B \-R
+option allows the user to configure the \fItimeout\fR,
+in seconds, between cluster refreshes. The default value is
+.B 10
+seconds.
 .SH "CONFIGURATION SOURCES"
 As it runs,
 .B pmdaopentelemetry

--- a/src/pmdas/opentelemetry/pmdaopentelemetry.python
+++ b/src/pmdas/opentelemetry/pmdaopentelemetry.python
@@ -34,7 +34,7 @@ import threading
 import subprocess
 from ctypes import c_int
 from socket import gethostname
-from stat import ST_MODE, S_IXUSR, ST_CTIME
+from stat import ST_MODE, S_IXUSR
 import requests
 import json
 
@@ -48,10 +48,6 @@ import cpmda
 # Config file list sorting is expensive with a large number of URLs
 # and/or scripts.  See the --nosort option to turn it off.
 sort_conf_list = True
-
-# Number of seconds to wait between poll attempts on a source that
-# we've never been able to connect to & collect a list of metrics from.
-empty_source_pmns_poll = 10.0
 
 MAX_CLUSTER = 0xfff    # ~ max. number of opentelemetry sources
 MAX_METRIC = 0x3ff     # ~ max. number of metrics per source
@@ -453,7 +449,7 @@ class Source(object):
         self.path = path # pathname to .url or executable file
         self.url = None
         self.parse_error = False
-        self.parse_url_time = 0 # timestamp of config file when it was last parsed
+        self.parse_time = 0 # last time config file was parsed
         self.is_scripted = is_scripted
         self.pmda = thispmda # the shared pmda
         self.requests = None
@@ -475,6 +471,8 @@ class Source(object):
 
         self.metrics_by_name = {} # name -> Metric
         self.metrics_by_num = {} # number (last component of pmid) -> Metric
+        self.metric_removal_flags = {}
+        self.metric_fullnames = {}
 
 
     def old_enough_for_refresh(self):
@@ -484,7 +482,7 @@ class Source(object):
         '''
         now = time.time()
         last_try_age = now - self.refresh_time
-        return last_try_age > empty_source_pmns_poll
+        return last_try_age > self.pmda.refresh_timeout
 
     def check_filter(self, name, entrytype):
         '''
@@ -580,7 +578,9 @@ class Source(object):
             self.pmda.debug("included_labels '%s'" % (included_labels)) if self.pmda.dbg else None
             self.pmda.debug("optional_labels '%s'" % (optional_labels)) if self.pmda.dbg else None
             if mname in self.metrics_by_name:
-                if fullname not in self.pmda.all_metrics and self.name in self.pmda.re_add_list:
+                self.metric_removal_flags[mname] = False
+                self.metric_fullnames[mname] = fullname
+                if fullname not in self.pmda.all_metrics:
                     # re-add metric to namespace
                     help_oneline, help_text = self.helptext(metric["description"])
                     try:
@@ -773,9 +773,9 @@ class Source(object):
         self.pmda.debug("num metrics: %s" % num_metrics) if self.pmda.dbg else None
         return num_metrics
 
-    def parse_url_config(self, filepath):
+    def parse_config(self, filepath):
         '''
-        Parse a URL config file. The first line is always the URL.
+        Parse a configuration file. The first line is always the URL.
         Remaining lines are prefixed with a keyword. Supported keywords
         include '#' for a comment, 'HEADER:' to add to the header passed
         to the headers dict parameter to the get() call. Note the ':' are
@@ -859,7 +859,6 @@ class Source(object):
         # clear cached values from all my metrics
         for _, m in self.metrics_by_name.items():
             m.clear_values()
-        # TODO: ditch metrics no longer found in document
 
         # bump the fetch call counter for this source, and for the total (cluster 0)
         self.pmda.stats_fetch_calls[self.cluster] += 1
@@ -873,12 +872,12 @@ class Source(object):
                 if not s[ST_MODE] & S_IXUSR:
                     self.pmda.err("cannot execute script '%s'" % self.path)
                     return
-            elif self.parse_url_time < s[ST_CTIME]:
+            elif self.parse_time is None or self.parse_time < s.st_mtime_ns:
                 # (re)parse the URL from given file
-                self.parse_url_config(self.path)
-                self.parse_url_time = s[ST_CTIME]
+                self.parse_config(self.path)
+                self.parse_time = s.st_mtime_ns
         except Exception as e:
-            self.pmda.err("cannot read %s: %s" % (self.path, e))
+            self.pmda.err("cannot stat %s: %s" % (self.path, e))
             return
 
         # fetch the document
@@ -918,6 +917,9 @@ class Source(object):
         if self.document is None: # error during fetch?
             return
 
+        for metric in self.metrics_by_name:
+            self.metric_removal_flags[metric] = True
+
         # parse and handle the opentelemetry formatted metric data
         parse_time = time.time()
         s = self.parse_lines(json.loads(self.document))
@@ -926,6 +928,19 @@ class Source(object):
         incr = int(1000 * (time.time() - parse_time))
         self.pmda.stats_parse_time[self.cluster] += incr
         self.pmda.stats_parse_time[0] += incr # total
+
+        for metric, value in self.metric_removal_flags.items():
+            remove_name = self.metric_fullnames[metric]
+            if value is True and remove_name in self.pmda.all_metrics:
+                self.pmda.debug("removing metric from existing source: %s" % metric) if self.pmda.dbg else None
+                try:
+                    remove_object = self.pmda.all_metrics[remove_name]
+                    self.pmda.remove_metric(remove_name, remove_object)
+                    self.pmda.set_need_refresh()
+                    del self.pmda.all_metrics[remove_name]
+                    self.pmda.removed_metrics[remove_name] = remove_object
+                except Exception as e:
+                    self.pmda.debug("cannot remove metric from existing source, see error: %s" % e)
 
         # save metric & indom lookup tables changes, if any
         for _, m in self.metrics_by_name.items():
@@ -951,7 +966,7 @@ class Source(object):
             return [c_api.PM_ERR_AGAIN, 0]
 
 class OpenTelemetryPMDA(PMDA):
-    def __init__(self, pmda_name, domain, config, timeout, user, debugflag, logfile):
+    def __init__(self, pmda_name, domain, config, timeout, refresh_timeout, user, debugflag, logfile):
         '''
         Initialize the PMDA. This can take a while for large configurations.
         The opentelemetry entry in pmcd.conf specifies to start up in "notready"
@@ -971,10 +986,13 @@ class OpenTelemetryPMDA(PMDA):
         # and the storable metric $(pmda_name).control.debug
         self.dbg = debugflag
 
+        # Number of seconds to wait between poll attempts on a source
+        self.refresh_timeout = refresh_timeout
+
         # now everything else may take time
         self.pmda_name = pmda_name
         self.config_dir = os.path.normpath(config)
-        self.config_dir_ctime = None
+        self.config_dir_mtime = 0.0
         self.timeout = timeout
 
         # a single central Session that all our sources can concurrently reuse
@@ -1087,33 +1105,33 @@ class OpenTelemetryPMDA(PMDA):
             assert s == self.source_by_name[s.name]
 
 
-    def traverse(self, directory, ctime):
+    def traverse(self, directory, mtime):
         ''' Return list of files below dir, recursively '''
         ret = []
-        m = os.path.getctime(directory)
-        if ctime is None or m > ctime:
-            ctime = m
+        m = os.path.getmtime(directory)
+        if mtime is None or m > mtime:
+            mtime = m
 
         for path, subdirs, files in os.walk(directory):
             for f in files:
                 if not f.startswith("."):
                     fname = os.path.join(path, f)
-                    m = os.path.getctime(fname)
-                    if ctime is None or m > ctime:
-                        ctime = m
+                    m = os.path.getmtime(fname)
+                    if mtime is None or m > mtime:
+                        mtime = m
                     ret.append(fname)
             for d in subdirs:
-                m, _ = self.traverse(os.path.join(path, d), ctime)
-                if ctime is None or m > ctime:
-                    ctime = m
-        return ctime, ret
+                m, _ = self.traverse(os.path.join(path, d), mtime)
+                if mtime is None or m > mtime:
+                    mtime = m
+        return mtime, ret
 
     def initialize_controls(self, cluster):
         # initalize statistics
         self.stats_fetch_calls[cluster] = 0
         self.stats_fetch_time[cluster] = 0
         self.stats_parse_time[cluster] = 0
-        self.stats_status[cluster] = 0
+        self.stats_status[cluster] = "unknown"
         self.stats_status_code[cluster] = 0
 
         self.controls[cluster] = 1
@@ -1138,17 +1156,16 @@ class OpenTelemetryPMDA(PMDA):
         '''
 
         traverse_time = time.time()
-        dir_ctime, conf_filelist = self.traverse(self.config_dir, self.config_dir_ctime)
+        dir_mtime, conf_filelist = self.traverse(self.config_dir, self.config_dir_mtime)
         traverse_time = time.time() - traverse_time
 
-        if self.config_dir_ctime is None or self.config_dir_ctime < dir_ctime:
-            self.config_dir_ctime = dir_ctime
+        if self.config_dir_mtime is None or self.config_dir_mtime < dir_mtime:
+            self.config_dir_mtime = dir_mtime
         else: # no new or changed conf files, don't rescan directory
             return
 
         self.log("Config change detected, traversed %d config entries in %.04fs, rescanning ..." % (len(conf_filelist), traverse_time))
         nickname_regexp = self.lookup_regex(r"^[A-Za-z][A-Za-z0-9_.]*$")
-
         self.re_add_list = []
 
         # calculate config entry nicknames
@@ -1559,6 +1576,11 @@ if __name__ == '__main__':
         default=2,
         help='HTTP GET timeout for each end-point URL (default 2 seconds)')
     parser.add_argument(
+        '-R', '--refresh',
+        type=int,
+        default=10,
+        help='timeout between cluster refreshes (default 10 seconds)')
+    parser.add_argument(
         '-u', '--user',
         type=str,
         default=None,
@@ -1577,7 +1599,7 @@ if __name__ == '__main__':
     # the IPC protocol is ipc_prot="binary notready". See also pmcd(1) man page.
     # The "binary notready" setting can also be manually configured in pmcd.conf.
     # Default domain number is PMDA(164), see -d option.
-    pmda = OpenTelemetryPMDA(args.root, args.domain, args.config, args.timeout, args.user, args.debug, args.log)
+    pmda = OpenTelemetryPMDA(args.root, args.domain, args.config, args.timeout, args.refresh, args.user, args.debug, args.log)
 
     # Uncomment to force -D or use: $ pmstore opentelemetry.control.debug 1
     # pmda.dbg = True


### PR DESCRIPTION
metric removal updates to mirror pmdaopenmetrics
metric removal bugs PRs #2224 & #2242. Also updates to mirror pmdaopenmetrics PRs #2222 & #2223 addressing timestamp and configuration file issues. Addition of pmdaotel metric removal QA test #1843.