### PR TITLE
Fix selinux issue after pmproxy startup scrip relocation

### DIFF
--- a/src/selinux/pcp.fc
+++ b/src/selinux/pcp.fc
@@ -5,6 +5,9 @@
 
 /usr/libexec/pcp/bin/pmcd	--	gen_context(system_u:object_r:pcp_pmcd_exec_t,s0)
 /usr/libexec/pcp/bin/pmproxy    --      gen_context(system_u:object_r:pcp_pmproxy_exec_t,s0)
+/usr/libexec/pcp/services/pmproxy  --   gen_context(system_u:object_r:pcp_pmproxy_exec_t,s0)
+/usr/libexec/pcp/services/pmlogger --   gen_context(system_u:object_r:pcp_pmlogger_exec_t,s0)
+/usr/libexec/pcp/services/pmie     --   gen_context(system_u:object_r:pcp_pmie_exec_t,s0)
 
 /usr/libexec/pcp/bin/pmie_check --      gen_context(system_u:object_r:pcp_pmie_exec_t,s0)
 /usr/libexec/pcp/bin/pmie_daily --      gen_context(system_u:object_r:pcp_pmie_exec_t,s0)


### PR DESCRIPTION
Fixes issue #2481, where the pmproxy startup script lost its SELinux context after relocation from /etc/pcp/pmproxy/rc to /usr/libexec/pcp/services/pmproxy.