### PR TITLE
Fix PCP selinux policy for rhel-8 after rc scripts relocation

### DIFF
--- a/src/selinux/pcp.te
+++ b/src/selinux/pcp.te
@@ -237,6 +237,13 @@ ifdef(`kernel_io_uring_use',`
 ')
 kernel_search_network_sysctl(pcp_pmproxy_t)
 
+domain_read_all_domains_state(pcp_pmproxy_t)
+
+corecmd_exec_bin(pcp_pmproxy_t)
+corecmd_exec_shell(pcp_pmproxy_t)
+
+allow pcp_pmproxy_t pcp_pmproxy_exec_t:file execute_no_trans;
+
 logging_send_syslog_msg(pcp_pmproxy_t)
 
 optional_policy(`
@@ -286,6 +293,13 @@ systemd_exec_systemctl(pcp_pmie_t)
 systemd_read_unit_files(pcp_pmie_t)
 systemd_search_unit_dirs(pcp_pmie_t)
 systemd_status_systemd_services(pcp_pmie_t)
+optional_policy(`
+    require {
+	type systemd_unit_file_t;
+	class service status;
+    }
+    allow pcp_pmie_t systemd_unit_file_t:service status;
+')
 
 userdom_read_user_tmp_files(pcp_pmie_t)
 
@@ -337,6 +351,13 @@ logging_send_syslog_msg(pcp_pmlogger_t)
 systemd_exec_systemctl(pcp_pmlogger_t)
 systemd_getattr_unit_files(pcp_pmlogger_t)
 systemd_status_systemd_services(pcp_pmlogger_t)
+optional_policy(`
+    require {
+	type systemd_unit_file_t;
+	class service status;
+    }
+    allow pcp_pmlogger_t systemd_unit_file_t:service status;
+')
 
 userdom_manage_tmp_dirs(pcp_pmlogger_t)
 userdom_manage_tmp_files(pcp_pmlogger_t)
@@ -847,6 +868,15 @@ can_exec(pcp_pmcd_t, pcp_tmpfs_t)
 
 # type=AVC msg=audit(N): avc: denied { getattr } for pid=PID comm="pmdaproc" path="/dev/gpmctl" dev="devtmpfs" ino=INO scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:object_r:gpmctl_t:s0 tclass=sock_file permissive=1
 allow pcp_pmcd_t gpmctl_t:sock_file getattr;
+
+optional_policy(`
+    require {
+        type initctl_t;
+    }
+    # pmdaproc
+    # type=AVC msg=audit(N): avc:  denied  { getattr } for  pid=PID comm="pmdaproc" path="/run/initctl" dev="tmpfs" ino=INO scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:object_r:initctl_t:s0 tclass=fifo_file permissive=1
+    allow pcp_pmcd_t initctl_t:fifo_file getattr;
+')
 
 # type=AVC msg=audit(N): avc: denied { write } for pid=PID comm="pmdaX" name="/" dev="tracefs" ino=INO scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:object_r:haproxy_var_lib_t:s0 tclass=sock_file permissive=0
 allow pcp_pmcd_t haproxy_var_lib_t:sock_file write;


### PR DESCRIPTION
This commit fixes selinux policy for rhel-8 after rc (startup) scripts relocation to /usr/libexec/pcp/services/.