### PR TITLE
selinux: Update nvidia pmda policy

### DIFF
--- a/src/selinux/pcp.te
+++ b/src/selinux/pcp.te
@@ -1041,7 +1041,7 @@ allow pcp_pmcd_t fixed_disk_device_t:blk_file { open read ioctl };
 # type=AVC msg=audit(N): avc: denied { read } for pid=PID comm="pmdanvidia" name="nvidia-cap2" dev="devtmpfs" ino=INO scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=unconfined_u:object_r:device_t:s0 tclass=chr_file permissive=0
 #RHEL-83594
 allow pcp_pmcd_t default_t:file { execute };
-allow pcp_pmcd_t device_t:chr_file { create open read setattr write };
+allow pcp_pmcd_t device_t:chr_file { create ioctl open read setattr write };
 allow pcp_pmcd_t device_t:dir { add_name remove_name write };
 allow pcp_pmcd_t device_t:lnk_file { create unlink };
 allow pcp_pmcd_t self:capability mknod;
@@ -1049,7 +1049,7 @@ allow pcp_pmcd_t dri_device_t:chr_file { ioctl open read write };
 allow pcp_pmcd_t device_t:dir write;
 allow pcp_pmcd_t device_t:dir { create setattr };
 allow pcp_pmcd_t sysctl_vm_t:file read;
-allow pcp_pmcd_t xserver_misc_device_t:chr_file { ioctl open read write };
+allow pcp_pmcd_t xserver_misc_device_t:chr_file { ioctl map open read write };
 
 # type=AVC msg=audit(N): avc: denied { sys_rawio } for pid=PID comm="pmdaX" name="/" dev="tracefs" ino=INO scontext=system_u:system_r:pcp_pmcd_t:s0 tcontext=system_u:object_r:pcp_pmcd_t:s0 tclass=capability permissive=0
 allow pcp_pmcd_t self:capability sys_rawio;


### PR DESCRIPTION
When running the nvidia pmda found a couple more AVC denials that needed to be addressed.

RHEL-133519