### PR TITLE
Revert to using fedora:latest and pcp-zeroconf now

### DIFF
--- a/build/containers/archive-analysis/Containerfile
+++ b/build/containers/archive-analysis/Containerfile
@@ -1,5 +1,5 @@
 ## Deploy
-FROM quay.io/fedora/fedora:rawhide
+FROM quay.io/fedora/fedora:latest
 
 COPY build/containers/archive-analysis/root /
 

--- a/build/containers/pcp/Containerfile
+++ b/build/containers/pcp/Containerfile
@@ -1,11 +1,10 @@
 ## Deploy
-FROM quay.io/fedora/fedora:rawhide
+FROM quay.io/fedora/fedora:latest
 
 COPY build/containers/pcp/root /
 
-# pcp-zeroconf currently failing to install cleanly in rawhide
 RUN microdnf install -y --setopt=install_weak_deps=0 --setopt=tsflags=nodocs \
-    gettext-envsubst pcp pcp-pmda-* pcp-import-* pcp-export-* zstd && \
+    gettext-envsubst pcp-zeroconf pcp-pmda-* pcp-import-* pcp-export-* && \
     microdnf clean all
 
 # ensure pmcd and pmproxy ports are both accessible on startup


### PR DESCRIPTION
Back in commit 493f8395ad0869 we switch the containers over to using rawhide so we could get access to PCP v7 quickly - we now have this everywhere, and its better to use a stable fedora version.

Also, there was a zeroconf issue back then, which means we stopped have recorded proc metric data on faster intervals by default - lets see if we can switch this back too.

Finally, zstd was added as a pcp rpm package dep, so that's another cleanup we can do now.