### PR TITLE
pmcd: fix endianness state extraction issue

### DIFF
--- a/qa/1321
+++ b/qa/1321
@@ -72,7 +72,7 @@ done
 
 # When new dynamic metrics are detected, the _next_ fetch will fetch them.
 # So wait for a bit so pmlogger has a chance to fetch the new metrics.
-sleep 2
+sleep 3
 
 # now kill pmlogger and check the new metrics appeared dynamically
 $sudo $PCP_BINADM_DIR/pmsignal -s TERM $pmlogger_pid >/dev/null 2>&1

--- a/src/libpcp_pmda/src/callback.c
+++ b/src/libpcp_pmda/src/callback.c
@@ -476,18 +476,18 @@ pmdaInstance(pmInDom indom, int inst, char *name, pmInResult **result, pmdaExt *
  * The first byte of the (unused) timestamp field has been
  * co-opted as a flags byte - now indicating state changes
  * that have happened within a PMDA and that need to later
- * be propogated through to any connected clients.
+ * be propagated through to any connected clients.
  */
 
 static void
 __pmdaEncodeStatus(pmdaResult *result, unsigned char byte)
 {
-    unsigned char	*flags;
+    uint64_t    *flags;
 
     memset(&result->timestamp, 0, sizeof(result->timestamp));
     if (byte) {
-	flags = (unsigned char *)&result->timestamp;
-	*flags |= byte;
+        flags = (uint64_t *)&result->timestamp;
+        *flags = byte;
     }
 }
 

--- a/src/pmcd/src/dofetch.c
+++ b/src/pmcd/src/dofetch.c
@@ -356,9 +356,8 @@ SendFetch(DomPmidList *dpList, AgentInfo *aPtr, ClientInfo *cPtr, int ctxnum)
 static int
 ExtractState(int i, void *timestamp)
 {
-    unsigned char	byte;
+    uint64_t flag = *((uint64_t *) timestamp);
 
-    memcpy(&byte, timestamp, sizeof(unsigned char));
     /*
      * integrity checks on the state change ...
      * - only 7 bits defined in pmapi.h (so max value is 0x3f)
@@ -366,30 +365,30 @@ ExtractState(int i, void *timestamp)
      *   are set by pmcd, not a PMDA)
      * - ditto for the PMCD_HOSTNAME_CHANGE bit
      */
-    if (byte > 0x3f ||
-        (byte & PMCD_AGENT_CHANGE) ||
-	(byte & PMCD_HOSTNAME_CHANGE)) {
+    if (flag > 0x3f ||
+        (flag & PMCD_AGENT_CHANGE) ||
+	(flag & PMCD_HOSTNAME_CHANGE)) {
 	/*
 	 * mapping to at most PMCD_LABEL_CHANGE | PMCD_NAMES_CHANGE
 	 * is probably not right (the PMDA is broken), but this is a
 	 * pretty harmless state change for upstream clients,
 	 * e.g. won't kill pmlogger!
 	 */
-	unsigned char	new_byte = byte & (PMCD_LABEL_CHANGE | PMCD_NAMES_CHANGE);
+	unsigned char	new_flag = flag & (PMCD_LABEL_CHANGE | PMCD_NAMES_CHANGE);
 
 	pmNotifyErr(LOG_WARNING,
-	    "ExtractState: \"%s\" agent returned a bogus state change (0x%x) modified to 0x%x\n",
-	    agent[i].pmDomainLabel, byte, new_byte);
-	byte = new_byte;
+	    "ExtractState: \"%s\" agent returned a bogus state change (0x%lx) modified to 0x%x\n",
+	    agent[i].pmDomainLabel, flag, new_flag);
+	flag = new_flag;
     }
 
-    if (byte != 0 && pmDebugOptions.appl6) {
+    if (flag != 0 && pmDebugOptions.appl6) {
 	fprintf(stderr, "ExtractState: %s agent (dom %d) set ", agent[i].pmDomainLabel, agent[i].pmDomainId);
-	__pmDumpFetchFlags(stderr, byte);
+	__pmDumpFetchFlags(stderr, flag);
 	fputc('\n', stderr);
     }
 
-    return (int)byte;
+    return (int)flag;
 }
 
 /*


### PR DESCRIPTION
On Big-Endian systems (s390x), the flags used by pmda fetch functions to signal a PMDA change fail to be sent and extracted by PMCD.

Raw memory access via memcpy and pointer aliasing correctly targets the most significant byte, causing the status flags to be misplaced or zeroed.

The proposed changes replace byte-level manipulation with numeric assignment to the tv_sec field, ensuring architecture-neutral behavoir.