### PR TITLE
docs: Eliminate some unsatisfied references

### DIFF
--- a/docs/HowTos/scaling/index.rst
+++ b/docs/HowTos/scaling/index.rst
@@ -144,7 +144,7 @@ Results and Analysis
 Centralized logging (pmlogger farm)
 -----------------------------------
 
-The following results were gathered on a :ref:`pmlogger farm<C. Centralized logging (pmlogger farm)>` deployment,
+The following results were gathered on a :ref:`pmlogger farm<C.1 Centralized logging (pmlogger farm)>` deployment,
 with a default **pcp-zeroconf 5.3.2** installation (version 5.3.1-3 on RHEL), where each remote host is an identical container instance
 running `pmcd(1)`_ on a server with 64 CPU cores, 376 GB RAM and 1 disk attached (as mentioned above, 64 CPUs increases per-CPU metric volume).
 The key server is co-located on the same host as pmlogger and pmproxy, and ``proc`` metrics of remote nodes are *not* included.
@@ -184,8 +184,8 @@ For further troubleshooting, please see the `High memory usage`_ section in the 
 Federated setup (multiple pmlogger farms)
 -----------------------------------------
 
-The following results were observed with a :ref:`federated setup<D. Federated setup (multiple pmlogger farms)>`
-consisting of three :ref:`pmlogger farms<C. Centralized logging (pmlogger farm)>`, where each pmlogger farm
+The following results were observed with a :ref:`federated setup<Federated setup (multiple pmlogger farms)>`
+consisting of three :ref:`pmlogger farms<C.1 Centralized logging (pmlogger farm)>`, where each pmlogger farm
 was monitoring 100 remote hosts, i.e. 300 hosts in total.
 The setup of the pmlogger farms was identical to the configuration above (60s logging interval), except that the key servers were operating in cluster mode.
 

--- a/docs/QG/QuickGuides.rst
+++ b/docs/QG/QuickGuides.rst
@@ -43,15 +43,13 @@ This guide contains the following topics:
 
 15. :ref:`Establishing Secure Connections`, covers setting up secure connections between PCP collector and monitor components. Also, how network connections can be made secure against eavesdropping, data tampering and man-in-the-middle class attacks.
 
-16. :ref:`Establishing Secure Client Connections`, covers setting up secure connections between PCP collector and monitor components and discuss setting up certificates on both the collector and monitor hosts.
+16. :ref:`Setup Authenticated Connections`, covers setting up authenticated connections between PCP collector and monitor components.
 
-17. :ref:`Setup Authenticated Connections`, covers setting up authenticated connections between PCP collector and monitor components.
+17. :ref:`Importing data and creating PCP archives`, describes an alternative method of importing performance data into PCP by creating PCP archives from files or data streams that have no knowledge of PCP.
 
-18. :ref:`Importing data and creating PCP archives`, describes an alternative method of importing performance data into PCP by creating PCP archives from files or data streams that have no knowledge of PCP.
+18. :ref:`Using 3D views`, covers performance visualisation with *pmview*.
 
-19. :ref:`Using 3D views`, covers performance visualisation with *pmview*.
-
-20. :ref:`Compare Archives and Report Significant Differences`, introduces the *pmdiff* tool that compares the average values for every metric in a given time window, for changes that are likely to be of interest when searching for performance regressions.
+19. :ref:`Compare Archives and Report Significant Differences`, introduces the *pmdiff* tool that compares the average values for every metric in a given time window, for changes that are likely to be of interest when searching for performance regressions.
 
 Audience for This Guide
 ************************


### PR DESCRIPTION
When attempting to build the documentation locally I noticed there were the following unsatisfied references with a `make epub`:

```
writing output... [100%] refs
/home/wcohen/research/profiling/pcp/pcp/docs/HowTos/scaling/index.rst:147: WARNING: undefined label: 'c. centralized logging (pmlogger farm)' [ref.ref]
/home/wcohen/research/profiling/pcp/pcp/docs/HowTos/scaling/index.rst:187: WARNING: undefined label: 'd. federated setup (multiple pmlogger farms)' [ref.ref]
/home/wcohen/research/profiling/pcp/pcp/docs/HowTos/scaling/index.rst:187: WARNING: undefined label: 'c. centralized logging (pmlogger farm)' [ref.ref]
/home/wcohen/research/profiling/pcp/pcp/docs/QG/QuickGuides.rst:46: WARNING: undefined label: 'establishing secure client connections' [ref.ref]
generating indices... genindex done
```

That patch update corrects the references in the `scaling.rst` HowTos and removes one that no longer has a matching entry in `QuickGuides.rst`.