### PR TITLE
docs: Update docs to use current live URL for the sphinxcontrib-redoc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,7 +93,7 @@ redoc = [
     },
 ]
 
-redoc_uri = 'https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js'
+redoc_uri = 'https://cdn.jsdelivr.net/npm/redoc@next/bundle/redoc.standalone.js'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
When making the documentation an error like the following would be generated:

sphinx.errors.ExtensionError: Handler <function assets at 0x7f83fbd3a3e0> for event 'build-finished' threw an exception (exception: HTTP Error 404: Not Found)

This was caused by conf.py using the a dead link for redoc_url. Updated redoc_url to the current link and documentation can be rebuilt.