### PR TITLE
rc scripts: pmcd, pmlogger and pmproxy allow local only access by default

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -2181,14 +2181,6 @@ rm -f $DIST_MANIFEST $DIST_TMPFILES
 
 PCP_GUI='pmchart|pmconfirm|pmdumptext|pmmessage|pmquery|pmsnap|pmtime'
 
-%if 0%{?rhel} || 0%{?fedora}
-# Fedora and RHEL default local only access for pmcd, pmproxy and pmlogger
-if [ "$1" -eq 1 ]
-then
-    sed -i -e '/^# .*_LOCAL=1/s/^# //' $RPM_BUILD_ROOT/$PCP_SYSCONFIG_DIR/{pmcd,pmproxy,pmlogger}
-fi
-%endif
-
 PCP_CONF=$BACKDIR/src/include/pcp.conf
 export PCP_CONF
 . $BACKDIR/src/include/pcp.env

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -2294,14 +2294,6 @@ rm -fr $RPM_BUILD_ROOT/%{_pmdasexecdir}/mssql
 desktop-file-validate $RPM_BUILD_ROOT/%{_datadir}/applications/pmchart.desktop
 %endif
 
-%if 0%{?rhel} || 0%{?fedora}
-# Fedora and RHEL default local only access for pmcd, pmproxy and pmlogger
-if [ "$1" -eq 1 ]
-then
-    sed -i -e '/^# .*_LOCAL=1/s/^# //' $RPM_BUILD_ROOT/%{_sysconfdir}/sysconfig/{pmcd,pmproxy,pmlogger}
-fi
-%endif
-
 # default chkconfig off (all RPM platforms)
 for f in $RPM_BUILD_ROOT/%{_initddir}/{pcp,pmcd,pmlogger,pmie,pmproxy}; do
     test -f "$f" || continue

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ pcp (7.1.1-1) unstable; urgency=high
 
   * New release (full details in CHANGELOG).
   * Rework to make build source after successful build work (closes: #1045430)
+  * Default to local-only pmcd, pmlogger, pmproxy access (closes: #1128921)
 
  -- Nathan Scott <nathans@debian.org>  Tue, 31 Mar 2026 16:22:40 +1100
 

--- a/qa/common
+++ b/qa/common
@@ -817,9 +817,8 @@ then
 	case "$__x"
 	in
 	    *'Connection refused')
-		# OK, now this might be a Fedora 27 style config set up
-		# where PMCD_LOCAL is set in the environment before the
-		# pmcd start up script is run
+		# PMCD_LOCAL is typically set by default in the environment
+		# before the pmcd start up script is run
 		#
 		if [ -n "$PCP_SYSCONFIG_DIR" -a -f $PCP_SYSCONFIG_DIR/pmcd ]
 		then

--- a/src/pmcd/pmcd.defaults
+++ b/src/pmcd/pmcd.defaults
@@ -4,7 +4,7 @@
 # Behaviour regarding listening on external-facing interfaces;
 # unset PMCD_LOCAL to allow connections from remote hosts.
 # A value of 0 permits remote connections, 1 permits local only.
-# PMCD_LOCAL=1
+PMCD_LOCAL=1
 
 # Max length to which the queue of pending connections may grow
 # A value of 5 is the default.

--- a/src/pmlogger/pmlogger.defaults
+++ b/src/pmlogger/pmlogger.defaults
@@ -8,7 +8,7 @@
 # Behaviour regarding listening on external-facing interfaces;
 # unset PMLOGGER_LOCAL to allow connections from remote hosts.
 # A value of 0 permits remote connections, 1 permits local only.
-# PMLOGGER_LOCAL=1
+PMLOGGER_LOCAL=1
 
 # Max length to which the queue of pending connections may grow
 # A value of 5 is the default.

--- a/src/pmlogger/pmlogger_farm.defaults
+++ b/src/pmlogger/pmlogger_farm.defaults
@@ -6,7 +6,7 @@
 # Behaviour regarding listening on external-facing interfaces;
 # unset PMLOGGER_LOCAL to allow connections from remote hosts.
 # A value of 0 permits remote connections, 1 permits local only.
-# PMLOGGER_LOCAL=1
+PMLOGGER_LOCAL=1
 
 # Max length to which the queue of pending connections may grow
 # A value of 5 is the default.

--- a/src/pmproxy/pmproxy.defaults
+++ b/src/pmproxy/pmproxy.defaults
@@ -4,7 +4,7 @@
 # Behaviour regarding listening on external-facing interfaces;
 # unset PMPROXY_LOCAL to allow connections from remote hosts.
 # A value of 0 permits remote connections, 1 permits local only.
-# PMPROXY_LOCAL=1
+PMPROXY_LOCAL=1
 
 # Max length to which the queue of pending connections may grow
 # A value of 5 is the default.


### PR DESCRIPTION
Resolves Debian bug #1128921