### PR TITLE
Fix broken readthedocs builds

### DIFF
--- a/docs/_templates/redoc.html
+++ b/docs/_templates/redoc.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>PMWEBAPI - REST API Reference</title>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+      body { margin: 0; padding: 0; }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='../openapi.yaml'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@latest/bundles/redoc.standalone.js"></script>
+  </body>
+</html>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,8 +41,6 @@ with open('../VERSION.pcp') as f:
 # ones.
 extensions = [
     'sphinx.ext.autosectionlabel',
-    'sphinxcontrib.redoc',
-    'sphinxcontrib.openapi',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -82,19 +80,6 @@ html_theme = 'sphinx_rtd_theme'
 
 html_logo = '../images/pcp_icon.png'
 
-redoc = [
-    {
-        'name': 'PMWEBAPI',
-        'page': 'api/index',
-        'spec': 'specs/openapi.yaml',
-        'opts': {
-            'lazy-rendering': True,
-        },
-    },
-]
-
-redoc_uri = 'https://cdn.jsdelivr.net/npm/redoc@next/bundle/redoc.standalone.js'
-
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
@@ -107,6 +92,10 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+html_extra_path = ['specs']
+
+html_additional_pages = {'api/index': 'redoc.html'}
 
 # These paths are either relative to html_static_path
 # or fully qualified paths (eg. https://...)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ PCP is a feature-rich, mature, extensible, cross-platform toolkit supporting bot
    PG/AboutProgrammersGuide
    HowTos/nix/index
    HowTos/scaling/index
-   REST API Specification <https://pcp.readthedocs.io/en/latest/api/>
+   REST API Specification <https://pcp.readthedocs.io/en/latest/api/index.html>
 
 .. toctree::
    :caption: Quick Guides

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,1 @@
 sphinx-rtd-theme>=0.5.1
-sphinxcontrib-redoc
-sphinxcontrib-openapi
-
-# temporary fix for AttributeError: module 'mistune' has no attribute 'BlockGrammar'
-mistune<2.0.0

--- a/docs/specs/openapi.yaml
+++ b/docs/specs/openapi.yaml
@@ -100,6 +100,9 @@ paths:
         description: Append sample times (milliseconds since epoch), only relevent for the text response form as JSON response form includes times (nanoseconds since epoch) by default.
         schema:
           type: boolean
+      responses:
+        200:
+          description: OK
 
   /series/query:
     get:
@@ -672,6 +675,9 @@ paths:
         description: M results to include in response
         schema:
           type: number
+      responses:
+        200:
+          description: OK
 
   /search/info:
     get:
@@ -1548,7 +1554,10 @@ paths:
         description: Request identifier sent back with response
         schema:
           type: string
-    
+      responses:
+        200:
+          description: OK
+
 components:
   schemas:
     seriesIDs:


### PR DESCRIPTION
The build for https://pcp.readthedocs.io/en/latest/ have been broken for some time now. This patch fixes the broken build while keeping the docs looking the same as before.