### PR TITLE
Reserve PMDA domain 256 for UniFi PMDA

### DIFF
--- a/src/pmns/stdpmid.pcp
+++ b/src/pmns/stdpmid.pcp
@@ -164,7 +164,8 @@ SIMPLE		253
 MEMORY_PYTHON	254
 # end QA section
 RDS		255
-### MORE FREE SLOTS 256..510 ###
+UNIFI		256
+### MORE FREE SLOTS 257..510 ###
 #
 # 511 is REALLY reserved ... see DYNAMIC_PMID in libpcp.h
 #


### PR DESCRIPTION
## Summary

Reserve PMDA domain number 256 for [`pmunifi`](https://github.com/tallpsmith/pmunifi) — a Python PMDA that exposes Ubiquiti UniFi network controller metrics (sites, devices, clients, uplinks, port tables, etc.) via PCP.

- Adds `UNIFI 256` to `stdpmid.pcp`
- Updates the free-slot comment range to `257..510`

Related: https://github.com/tallpsmith/pmunifi