### PR TITLE
pmcd, pmproxy: ensure pmcd.services metric functions on macOS

### DIFF
--- a/build/mac/io.pcp.pmcd.plist
+++ b/build/mac/io.pcp.pmcd.plist
@@ -7,13 +7,8 @@
         <key>ProgramArguments</key>
         <array>
             <string>/etc/init.d/pmcd</string>
-            <string>start</string>
+            <string>start-launchd</string>
         </array>
-        <key>EnvironmentVariables</key>
-        <dict>
-            <key>LAUNCHED_BY_LAUNCHD</key>
-            <string>1</string>
-        </dict>
         <key>Disabled</key>
         <false/>
         <key>UserName</key>

--- a/build/mac/io.pcp.pmproxy.plist
+++ b/build/mac/io.pcp.pmproxy.plist
@@ -7,13 +7,8 @@
         <key>ProgramArguments</key>
         <array>
             <string>/etc/init.d/pmproxy</string>
-            <string>start</string>
+            <string>start-launchd</string>
         </array>
-        <key>EnvironmentVariables</key>
-        <dict>
-            <key>LAUNCHED_BY_LAUNCHD</key>
-            <string>1</string>
-        </dict>
         <key>Disabled</key>
         <false/>
         <key>UserName</key>

--- a/build/mac/qa/TESTING.md
+++ b/build/mac/qa/TESTING.md
@@ -58,10 +58,7 @@ wait_pmcd() {
 ### Test 1: Verify Configuration Changes
 
 ```bash
-# Check plist has environment variable and KeepAlive
-cat /Library/LaunchDaemons/io.pcp.pmcd.plist | grep -A4 EnvironmentVariables
-# Should show: LAUNCHED_BY_LAUNCHD = 1
-
+# Check plist has KeepAlive
 cat /Library/LaunchDaemons/io.pcp.pmcd.plist | grep -A1 KeepAlive
 # Should show: <true/>
 ```
@@ -87,9 +84,9 @@ wait_pmcd
 # Verify pmcd is running
 ps aux | grep pmcd | grep -v grep
 
-# Check that pmcd is running with -f flag (foreground mode)
-ps aux | grep '[p]mcd' | grep -- '-f'
-# Should see the -f flag in the command line
+# Check that pmcd is running with -F flag (foreground mode)
+ps aux | grep '[p]mcd' | grep -- '-F'
+# Should see the -F flag in the command line
 
 # Verify exactly one pmcd process (no fork issues)
 echo "pmcd process count: $(ps aux | grep '[p]mcd' | wc -l | tr -d ' ')"
@@ -202,8 +199,8 @@ pminfo -f pmcd.version
 
 ## Expected Results Summary
 
-✅ **Configuration**: LAUNCHED_BY_LAUNCHD env var present, KeepAlive = true
-✅ **Foreground mode**: pmcd runs with `-f` flag
+✅ **Configuration**: KeepAlive = true
+✅ **Foreground mode**: pmcd runs with `-F` flag
 ✅ **No fork issues**: Only one pmcd process exists
 ✅ **launchctl tracking**: Service shows in `launchctl list` with PID
 ✅ **KeepAlive works**: pmcd automatically restarts after crash
@@ -240,5 +237,5 @@ Check if rc_pmcd is detecting it:
 sudo launchctl unload /Library/LaunchDaemons/io.pcp.pmcd.plist
 sudo launchctl load /Library/LaunchDaemons/io.pcp.pmcd.plist
 wait_pmcd
-ps aux | grep '[p]mcd'  # Should show -f flag
+ps aux | grep '[p]mcd'  # Should show -F flag
 ```

--- a/build/mac/qa/test-pmcd-launchctl.sh
+++ b/build/mac/qa/test-pmcd-launchctl.sh
@@ -88,13 +88,6 @@ if [ ! -f "$PLIST_PATH" ]; then
     exit 1
 fi
 
-if grep -q "LAUNCHED_BY_LAUNCHD" "$PLIST_PATH"; then
-    echo "✓ LAUNCHED_BY_LAUNCHD environment variable present"
-else
-    echo "✗ LAUNCHED_BY_LAUNCHD environment variable missing"
-    exit 1
-fi
-
 if grep -A1 "KeepAlive" "$PLIST_PATH" | grep -q "<true/>"; then
     echo "✓ KeepAlive enabled"
 else
@@ -137,13 +130,13 @@ else
     exit 1
 fi
 
-# Test 3: Verify foreground mode
-echo -e "\n[Test 3] Verifying foreground mode..."
+# Test 3: Verify managed mode
+echo -e "\n[Test 3] Verifying managed mode..."
 
-if ps aux | grep '[p]mcd' | grep -q -- '-f'; then
-    echo "✓ pmcd running in foreground mode (-f flag present)"
+if ps aux | grep '[p]mcd' | grep -q -- '-F'; then
+    echo "✓ pmcd running in managed mode (-F flag present)"
 else
-    echo "⚠ Warning: pmcd not running with -f flag"
+    echo "⚠ Warning: pmcd not running with -F flag"
     echo "Command line: $(ps aux | grep '[p]mcd')"
 fi
 
@@ -303,8 +296,8 @@ fi
 echo -e "\n=== All tests passed! ==="
 echo ""
 echo "Summary:"
-echo "  ✓ Configuration correct (LAUNCHED_BY_LAUNCHD + KeepAlive)"
-echo "  ✓ pmcd runs in foreground mode (-f flag)"
+echo "  ✓ Configuration correct (KeepAlive)"
+echo "  ✓ pmcd runs in managed mode (-F flag)"
 echo "  ✓ No fork issues (single pmcd process)"
 echo "  ✓ launchctl properly tracks pmcd"
 echo "  ✓ pmcd responds to queries"

--- a/man/man1/pmcd.1
+++ b/man/man1/pmcd.1
@@ -19,7 +19,7 @@
 \f3pmcd\f1 \- performance metrics collector daemon
 .SH SYNOPSIS
 \f3pmcd\f1
-[\f3\-AfQSv?\f1]
+[\f3\-AfFQSv?\f1]
 [\f3\-c\f1 \f2config\f1]
 [\f3\-C\f1 \f2nctx\f1]
 [\f3\-D\f1 \f2debug\f1]
@@ -136,6 +136,17 @@ The
 option indicates that it should run in the foreground.
 This is most useful when trying to diagnose problems with misbehaving
 agents.
+.TP
+\f3\-F\f1, \f3\-\-managed\f1
+By default
+.B pmcd
+is started as a daemon.
+The
+.B \-F
+option indicates that it will be managed by a system service like
+.BR launchd (1).
+or
+.BR systemd (1)
 .TP
 \f3\-H\f1 \f2hostname\f1, \f3\-\-hostname\f1=\f2hostname\f1
 This option can be used to set the hostname that

--- a/man/man1/pmproxy.1
+++ b/man/man1/pmproxy.1
@@ -137,7 +137,7 @@ option indicates that it should run in the foreground.
 This is most useful when trying to diagnose problems with establishing
 connections.
 .TP
-\f3\-F\f1, \f3\-\-systemd\f1
+\f3\-F\f1, \f3\-\-managed\f1
 Like
 .BR \-f ,
 the
@@ -149,8 +149,12 @@ in the foreground, but also does some housekeeping (like create a
 .B pmproxy
 is launched from
 .BR systemd (1)
+or
+.BR launchd (1)
 and the daemonising has already been done by
 .BR systemd (1)
+or
+.BR launchd (1)
 and does not need to be done again by
 .BR pmproxy ,
 which is the case when neither

--- a/src/pmcd/rc_pmcd
+++ b/src/pmcd/rc_pmcd
@@ -44,7 +44,7 @@
 . $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/rc-proc.sh
 
-# for chasing arguments we're passed from init/systemd/...
+# for chasing arguments we're passed from init/systemd/launchd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmcd.log
 #debug# env >>$PCP_LOG_DIR/rc_pmcd.log
@@ -505,7 +505,7 @@ Warning: process ID in $PCP_RUN_DIR/pmcd.pid ($runpid) is different.
 
 _usage()
 {
-    echo "Usage: $prog [-v] {start|start-systemd|faststart|restart|condrestart|stop|stop-systemd|status|reload|force-reload}"
+    echo "Usage: $prog [-v] {start|start-launchd|start-systemd|faststart|restart|condrestart|stop|stop-launchd|stop-systemd|status|reload|force-reload}"
 }
 
 VERBOSE_CTL=on
@@ -566,7 +566,7 @@ $RC_RESET
 # considered a success.
 case "$1" in
 
-  start|start-systemd|faststart|restart|condrestart|reload|force-reload)
+  start|start-systemd|start-launchd|faststart|restart|condrestart|reload|force-reload)
 	if [ "$1" = "condrestart" ] && ! is_chkconfig_on pmcd
 	then
 	    status=0
@@ -598,7 +598,7 @@ Error: pmcd log directory $PCP_LOG_DIR/pmcd ("'"$LOGDIR"'") is missing, cannot s
 	    fi
 	    cd "$LOGDIR"
 
-	    [ "$1" = "start-systemd" ] ||\
+	    [ "$1" = "start-systemd" -o "$1" = "start-launchd" ] ||\
 	    $ECHO $PCP_ECHO_N "Starting pmcd ..." "$PCP_ECHO_C"
 
 	    # only consider variables which start with PMCD or PCP
@@ -621,8 +621,8 @@ Error: pmcd log directory $PCP_LOG_DIR/pmcd ("'"$LOGDIR"'") is missing, cannot s
 		echo $prog: pmcd --verify $OPTS failed, cannot start pmcd.
 		exit
 	    fi
-	    # When launched by launchctl on macOS, run in foreground mode
-	    [ -n "$LAUNCHED_BY_LAUNCHD" ] && OPTS="$OPTS -f"
+	    # on macOS under launchd run in "managed" mode
+	    [ "$1" = "start-launchd" ] && OPTS="$OPTS -F"
 	    $PMCD $OPTS
             _start_pmcheck
 	    $RC_STATUS -v
@@ -654,11 +654,11 @@ Error: pmcd log directory $PCP_LOG_DIR/pmcd ("'"$LOGDIR"'") is missing, cannot s
 	status=0
         ;;
 
-  stop|stop-systemd)
+  stop|stop-systemd|stop-launchd)
 	# site-local customisations before pmcd shutdown
 	#
 	[ -x $PCPLOCAL ] && $PCPLOCAL $VFLAG stop
-	if [ "$1" = stop-systemd ]
+	if [ "$1" = stop-systemd -o "$1" = stop-launchd ]
 	then
 	    _shutdown quietly
 	else

--- a/src/pmcd/src/pmcd.c
+++ b/src/pmcd/src/pmcd.c
@@ -51,6 +51,7 @@ static int	maxReqPortFd;		/* Largest request port fd */
 static char	configFileName[MAXPATHLEN]; /* path to pmcd.conf */
 static char	*logfile = "pmcd.log";	/* log file name */
 static int	run_daemon = 1;		/* run as a daemon, see -f */
+static int	run_managed;		/* run under a manager, see -F */
 static char	*fatalfile = "/dev/tty";/* fatal messages at startup go here */
 static char	*pmnsfile = PM_NS_DEFAULT;
 static char	*username;
@@ -107,6 +108,7 @@ static pmLongOptions longopts[] = {
     PMAPI_OPTIONS_HEADER("Service options"),
     { "", 0, 'A', 0, "disable service advertisement" },
     { "foreground", 0, 'f', 0, "run in the foreground" },
+    { "managed", 0, 'F', 0, "run in managed (systemd/launchd) mode" },
     { "hostname", 1, 'H', "HOST", "set the hostname to be used for pmcd.hostname metric" },
     { "username", 1, 'U', "USER", "in daemon mode, run as named user [default pcp]" },
     PMAPI_OPTIONS_HEADER("Configuration options"),
@@ -132,7 +134,7 @@ static pmLongOptions longopts[] = {
 
 static pmOptions opts = {
     .flags = PM_OPTFLAG_POSIX,
-    .short_options = "AC:c:D:fH:i:l:L:M:N:n:p:q:Qs:St:T:U:vx:?",
+    .short_options = "AC:c:D:fFH:i:l:L:M:N:n:p:q:Qs:St:T:U:vx:?",
     .long_options = longopts,
 };
 
@@ -188,6 +190,12 @@ ParseOptions(int argc, char *argv[], int *nports)
 
 	    case 'f':
 		/* foreground, i.e. do _not_ run as a daemon */
+		run_daemon = 0;
+		break;
+
+	    case 'F':
+		/* managed, like foreground but do pidfile and uid work */
+		run_managed = 1;
 		run_daemon = 0;
 		break;
 
@@ -1189,7 +1197,7 @@ main(int argc, char *argv[])
 	DontStart();
     }
 
-    if (run_daemon) {
+    if (run_daemon || run_managed) {
 	/* notify service manager, if any, we are ready */
 	__pmServerNotifyServiceManagerReady(getpid());
 	if (__pmServerCreatePIDFile(PM_SERVER_SERVICE_SPEC, PM_FATAL_ERR) < 0)

--- a/src/pmproxy/rc_pmproxy
+++ b/src/pmproxy/rc_pmproxy
@@ -23,7 +23,7 @@
 . $PCP_DIR/etc/pcp.env
 . $PCP_SHARE_DIR/lib/rc-proc.sh
 
-# for chasing arguments we're passed from init/systemd/...
+# for chasing arguments we're passed from init/launchd/systemd/...
 #
 #debug# echo "$*: `date`" >>$PCP_LOG_DIR/rc_pmproxy.log
 #debug# env >>$PCP_LOG_DIR/rc_pmproxy.log
@@ -188,7 +188,7 @@ $RC_RESET
 # considered a success.
 case "$1" in
 
-  start|start-systemd|faststart|restart|condrestart|reload|force-reload)
+  start|start-systemd|start-launchd|faststart|restart|condrestart|reload|force-reload)
 	if [ "$1" = "condrestart" ] && ! is_chkconfig_on pmproxy
 	then
 	    status=0
@@ -223,7 +223,7 @@ Error: pmproxy log directory $PCP_LOG_DIR/pmproxy ("'"$PCP_LOG_DIR/pmproxy"'") i
 	    fi
 	    cd "$PCP_LOG_DIR/pmproxy"
 
-	    [ "$1" = "start-systemd" ] ||\
+	    [ "$1" = "start-systemd" -o "$1" = "start-launchd" ] ||\
 	    $ECHO $PCP_ECHO_N "Starting pmproxy ..." "$PCP_ECHO_C"
 
 	    # only consider variables which start with PMPROXY
@@ -243,10 +243,11 @@ Error: pmproxy log directory $PCP_LOG_DIR/pmproxy ("'"$PCP_LOG_DIR/pmproxy"'") i
 
 	    $PCP_BINADM_DIR/pmpost "start pmproxy from $prog"
 
-	    if [ "$1" = "start-systemd" ]
+	    if [ "$1" = "start-systemd" -o "start-launchd" ]
 	    then
-		# Called from systemd with need to preserve the pid and
-		# systemd has already done the necessary daemonizing
+		# Called from systemd or launchd with a a need to
+		# preserve the pid - systemd/launchd has already
+		# done the necessary daemonizing
 		#
 		rm -rf $tmp
 		exec $PMPROXY -F $OPTS
@@ -255,9 +256,6 @@ Error: pmproxy log directory $PCP_LOG_DIR/pmproxy ("'"$PCP_LOG_DIR/pmproxy"'") i
 	    fi
 
 	    # otherwise, use the historical approach
-	    #
-	    # When launched by launchctl on macOS, run in foreground mode
-	    [ -n "$LAUNCHED_BY_LAUNCHD" ] && OPTS="$OPTS -f"
 	    $PMPROXY $OPTS
 	    $RC_STATUS -v
 	fi
@@ -269,7 +267,7 @@ Error: pmproxy log directory $PCP_LOG_DIR/pmproxy ("'"$PCP_LOG_DIR/pmproxy"'") i
 	status=0
         ;;
 
-  stop-systemd)
+  stop-systemd|stop-launchd)
 	_shutdown quietly
 	status=0
         ;;

--- a/src/pmproxy/src/pmproxy.c
+++ b/src/pmproxy/src/pmproxy.c
@@ -28,7 +28,7 @@
 
 #define RUN_DAEMON	1		/* default */
 #define RUN_FOREGROUND	2		/* -f */
-#define RUN_SYSTEMD	3		/* -F */
+#define RUN_MANAGED	3		/* -F */
 
 static void	*info;			/* opaque server information */
 static struct pmproxy	*server;	/* proxy server implementation */
@@ -73,7 +73,7 @@ static pmLongOptions longopts[] = {
     { "", 0, 'A', 0, "disable service advertisement" },
     { "deprecated", 0, 'd', 0, "backward-compatibility mode; no REST APIs" },
     { "foreground", 0, 'f', 0, "run in the foreground" },
-    { "systemd", 0, 'F', 0, "run in systemd mode" },
+    { "managed", 0, 'F', 0, "run in managed (systemd/launchd) mode" },
     { "timeseries", 0, 't', 0, "automatic, scalable timeseries; REST APIs" },
     { "username", 1, 'U', "USER", "in daemon mode, run as named user [default pcp]" },
     PMAPI_OPTIONS_HEADER("Configuration options"),
@@ -143,7 +143,7 @@ ParseOptions(int argc, char *argv[], int *nports, int *maxpending)
 		opts.errors++;
 	    }
 	    else
-		run_mode = RUN_SYSTEMD;
+		run_mode = RUN_MANAGED;
 	    break;
 
 	case 'f':	/* foreground, i.e. do _not_ run as a daemon */
@@ -446,7 +446,7 @@ main(int argc, char *argv[])
 	fprintf(stderr, "%s: maxpending=%d from PMPROXY_MAXPENDING=%s in environment\n",
 			"Warning", maxpending, getenv("PMPROXY_MAXPENDING"));
 
-    if (run_mode == RUN_DAEMON || run_mode == RUN_SYSTEMD) {
+    if (run_mode == RUN_DAEMON || run_mode == RUN_MANAGED) {
 	/* notify service manager, if any, we are ready */
 	__pmServerNotifyServiceManagerReady(mainpid);
 	if (__pmServerCreatePIDFile(PM_SERVER_PROXY_SPEC, PM_FATAL_ERR) < 0)

--- a/src/zshrc/_pcp
+++ b/src/zshrc/_pcp
@@ -472,7 +472,7 @@ _pcp () {
       "(-D --debug $exargs)"{-D,--debug}'[set debug options]:options:->debug_opts' \
       "(-d --interact $exargs)"{-d,--interact}'[interactive debugging mode]' \
       "(-f --foreground $exargs)"{-f,--foreground}'[run in foreground]' \
-      "(-F --systemd $exargs)"{-F,--systemd}'[notify service manager (if any) when started and ready]' \
+      "(-F --managed $exargs)"{-F,--managed}'[notify service manager (if any) when started and ready]' \
       "(-P --primary $exargs)"{-P,--primary}'[run as primary pmie instance]' \
       "(-j $exargs)"-j+'[specify stomp protocol file]:file:_files' \
       "(-l --logfile $exargs)"{-l+,--logfile=}'[specify log file]:file:_files' \


### PR DESCRIPTION
Refactor the start scripts a little to make pmproxy create a pidfile which is the missing ingredient for the pmcd.services metric search. Without this the pcp(1) command doesn't detect a running pmproxy(1).

Its a little nicer too in terms of integrating with the scripts more like other init-replacement systems, using a custom option insted of a custom env variable.

This reconciles some differences between pmcd and pmproxy in terms of handling the -F/--systemd (now --managed) command line option.