### PR TITLE
Fix heap corruption crash in pmproxy

### DIFF
--- a/src/libpcp_web/src/load.h
+++ b/src/libpcp_web/src/load.h
@@ -47,10 +47,13 @@ typedef struct context {
     unsigned int	garbage	: 1;	/* context pending removal */
     unsigned int	inactive: 1;	/* context removal deferred */
     unsigned int	updated : 1;	/* context labels are updated */
-    unsigned int	padding : 3;	/* zero-filled struct padding */
+    unsigned int	timer_init : 1;	/* timer has been initialized */
+    unsigned int	padding : 2;	/* zero-filled struct padding */
     unsigned int	refcount : 16;	/* currently-referenced counter */
     unsigned int	timeout;	/* context timeout in milliseconds */
+    uint64_t		last_active;	/* last use timestamp (uv_hrtime) */
     uv_timer_t		timer;
+    struct context	*next_pending;	/* pending timer init list */
     int			context;	/* PMAPI context handle */
     int			randomid;	/* random number identifier */
     struct dict		*pmids;		/* metric pmID to metric struct */

--- a/src/libpcp_web/src/webgroup.c
+++ b/src/libpcp_web/src/webgroup.c
@@ -60,9 +60,12 @@ typedef struct webgroups {
 
     uv_loop_t		*events;
     uv_timer_t		timer;
+    uv_async_t		async;
     uv_mutex_t		mutex;
 
+    struct context	*pending_timer_init;
     unsigned int	active;
+    unsigned int	gc_timer_started;
 } webgroups;
 
 static struct webgroups *
@@ -109,14 +112,18 @@ webgroup_drop_context(struct context *context, struct webgroups *groups)
     if (webgroup_deref_context(context) == 0) {
 	if (context->garbage == 0) {
 	    context->garbage = 1;
-	    uv_timer_stop(&context->timer);
+	    if (context->timer_init)
+		uv_timer_stop(&context->timer);
 	}
 	if (groups) {
 	    uv_mutex_lock(&groups->mutex);
 	    dictDelete(groups->contexts, &context->randomid);
 	    uv_mutex_unlock(&groups->mutex);
 	}
-	uv_close((uv_handle_t *)&context->timer, webgroup_release_context);
+	if (context->timer_init)
+	    uv_close((uv_handle_t *)&context->timer, webgroup_release_context);
+	else
+	    pmwebapi_free_context(context);
     }
 }
 
@@ -125,6 +132,17 @@ webgroup_timeout_context(uv_timer_t *arg)
 {
     uv_handle_t		*handle = (uv_handle_t *)arg;
     struct context	*cp = (struct context *)handle->data;
+    uint64_t		elapsed;
+
+    /*
+     * Check if the context was recently used by a worker thread.
+     * Worker threads update last_active via uv_hrtime() which is
+     * thread-safe, avoiding unsafe uv_timer_start calls from
+     * non-event-loop threads that previously caused heap corruption.
+     */
+    elapsed = (uv_hrtime() - cp->last_active) / 1000000;
+    if (elapsed < cp->timeout)
+	return;
 
     if (pmDebugOptions.http || pmDebugOptions.libweb)
 	fprintf(stderr, "context %u timed out (" PRINTF_P_PFX "%p)\n", cp->randomid, cp);
@@ -209,7 +227,6 @@ webgroup_new_context(pmWebGroupSettings *sp, dict *params,
     struct webgroups	*groups = webgroups_lookup(&sp->module);
     struct context	*cp;
     unsigned int	polltime = DEFAULT_POLL_TIMEOUT;
-    uv_handle_t		*handle;
     pmWebAccess		access;
     double		seconds;
     char		*endptr;
@@ -286,13 +303,16 @@ webgroup_new_context(pmWebGroupSettings *sp, dict *params,
     dictAdd(groups->contexts, &cp->randomid, cp);
     uv_mutex_unlock(&groups->mutex);
 
-    /* leave until the end because uv_timer_init makes this visible in uv_run */
-    handle = (uv_handle_t *)&cp->timer;
-    handle->data = (void *)cp;
-    uv_timer_init(groups->events, &cp->timer);
-
     cp->privdata = groups;
     cp->setup = 1;
+    cp->last_active = uv_hrtime();
+
+    /* Defer timer init to event loop thread via async callback */
+    uv_mutex_lock(&groups->mutex);
+    cp->next_pending = groups->pending_timer_init;
+    groups->pending_timer_init = cp;
+    uv_mutex_unlock(&groups->mutex);
+    uv_async_send(&groups->async);
 
     if (pmDebugOptions.http || pmDebugOptions.libweb)
 	fprintf(stderr, "new context[%d] setup (" PRINTF_P_PFX "%p)\n", cp->randomid, cp);
@@ -303,11 +323,12 @@ webgroup_new_context(pmWebGroupSettings *sp, dict *params,
 static void
 webgroup_timers_stop(struct webgroups *groups)
 {
-    if (groups->active) {
+    if (groups->active && groups->gc_timer_started) {
 	uv_timer_stop(&groups->timer);
 	uv_close((uv_handle_t *)&groups->timer, NULL);
-	groups->active = 0;
+	groups->gc_timer_started = 0;
     }
+    groups->active = 0;
 }
 
 static void
@@ -375,12 +396,54 @@ webgroup_worker(uv_timer_t *arg)
     webgroup_garbage_collect(groups);
 }
 
+/*
+ * Async callback - runs on the event loop thread.
+ * Processes deferred timer operations that cannot safely be
+ * performed from worker threads (libuv handles are not thread-safe).
+ */
+static void
+webgroup_async_cb(uv_async_t *async)
+{
+    struct webgroups	*groups = (struct webgroups *)async->data;
+    struct context	*cp, *list;
+    uv_handle_t		*handle;
+
+    /* Start the GC timer if activation was requested from a worker thread */
+    if (groups->active && !groups->gc_timer_started) {
+	groups->gc_timer_started = 1;
+	uv_timer_init(groups->events, &groups->timer);
+	groups->timer.data = (void *)groups;
+	uv_timer_start(&groups->timer, webgroup_worker,
+			default_worker, default_worker);
+    }
+
+    /* Drain pending timer init queue (built by worker threads) */
+    uv_mutex_lock(&groups->mutex);
+    list = groups->pending_timer_init;
+    groups->pending_timer_init = NULL;
+    uv_mutex_unlock(&groups->mutex);
+
+    while (list) {
+	cp = list;
+	list = cp->next_pending;
+	cp->next_pending = NULL;
+
+	if (cp->garbage == 0) {
+	    handle = (uv_handle_t *)&cp->timer;
+	    handle->data = (void *)cp;
+	    uv_timer_init(groups->events, &cp->timer);
+	    cp->timer_init = 1;
+	    uv_timer_start(&cp->timer, webgroup_timeout_context,
+			    cp->timeout, cp->timeout);
+	}
+    }
+}
+
 static struct context *
 webgroup_use_context(struct context *cp, int *status, sds *message, void *arg)
 {
     char		errbuf[PM_MAXERRMSGLEN];
     int			sts;
-    struct webgroups    *gp = (struct webgroups *)cp->privdata;
 
     if (cp->garbage == 0 && cp->inactive == 0) {
 	if (cp->setup == 0) {
@@ -403,11 +466,15 @@ webgroup_use_context(struct context *cp, int *status, sds *message, void *arg)
 	    fprintf(stderr, "context %u timer set (" PRINTF_P_PFX "%p) to %u msec\n",
 			cp->randomid, cp, cp->timeout);
 
-	/* refresh current time: https://github.com/libuv/libuv/issues/1068 */
-	uv_update_time(gp->events);
-
-	/* if already started, uv_timer_start updates the existing timer */
-	uv_timer_start(&cp->timer, webgroup_timeout_context, cp->timeout, 0);
+	/*
+	 * Record last-active time using thread-safe uv_hrtime().
+	 * The repeating per-context timer (started at context creation)
+	 * checks this timestamp to determine if the context has truly
+	 * timed out.  This replaces the previous uv_timer_start() call
+	 * which was unsafe from worker threads and caused heap corruption
+	 * (SIGSEGV in libuv heap_remove).
+	 */
+	cp->last_active = uv_hrtime();
     } else {
 	infofmt(*message, "expired context identifier: %u", cp->randomid);
 	*status = -ENOTCONN;
@@ -429,11 +496,8 @@ webgroup_lookup_context(pmWebGroupSettings *sp, sds *id, dict *params,
 
     if (groups->active == 0) {
 	groups->active = 1;
-	/* install general background work timer (GC) */
-	uv_timer_init(groups->events, &groups->timer);
-	groups->timer.data = (void *)groups;
-	uv_timer_start(&groups->timer, webgroup_worker,
-			default_worker, default_worker);
+	/* defer GC timer init to event loop thread */
+	uv_async_send(&groups->async);
     }
 
     if (*id == NULL) {
@@ -2473,6 +2537,8 @@ pmWebGroupSetEventLoop(pmWebGroupModule *module, void *events)
 
     if (groups) {
 	groups->events = (uv_loop_t *)events;
+	uv_async_init(groups->events, &groups->async, webgroup_async_cb);
+	groups->async.data = (void *)groups;
 	return 0;
     }
     return -ENOMEM;
@@ -2583,6 +2649,8 @@ pmWebGroupClose(pmWebGroupModule *module)
 	}
 	dictRelease(groups->contexts);
 	webgroup_timers_stop(groups);
+	if (groups->events)
+	    uv_close((uv_handle_t *)&groups->async, NULL);
 	memset(groups, 0, sizeof(struct webgroups));
 	free(groups);
 	module->privdata = NULL;


### PR DESCRIPTION
Fix heap corruption crash (SIGSEGV) caused by unsafe cross-thread libuv timer operations by deferring all timer handle manipulation to the event loop thread via `uv_async_t`.

This is a followup of the `libpcp_web` commit proposed in https://github.com/performancecopilot/pcp/pull/2525 .

### src/libpcp_web/src/webgroup.c lines 112-127
Previously, `uv_timer_stop` and `uv_close` were called unconditionally. Now they are guarded by `context->timer_init`.
 If the timer was never initialized (the context was created but the async callback hasn't run yet, or the context  was destroyed before the event loop got to it), the context is freed directly via `pmwebapi_free_context()` instead of going through the` uv_close` callback path.

### src/libpcp_web/src/webgroup.c lines 131-145
The per-context timer is now a repeating timer (started once at context
  creation). Each time it fires, it computes how many milliseconds have elapsed since last_active. If the context was used recently (elapsed < timeout), the callback simply returns without marking the context for garbage collection. Previously, the timer was a one-shot that was re-armed by `uv_timer_start()` on every use -- but that call was made from worker threads, which was the root cause of the heap corruption.

### src/libpcp_web/src/webgroup.c lines 306-315
Previously, this function called `uv_timer_init()` directly (from whatever thread was creating the context). Now  it:
  1. Records the current high-resolution time in last_active.
  2. Prepends the context to the `pending_timer_init` linked list (mutex-protected).
  3. Signals the event loop thread via `uv_async_send()`.

 The local variable handle (previously used for inline timer init) is removed entirely.

### src/libpcp_web/src/webgroup.c lines 323-332
The GC timer is only stopped/closed if it was actually started (`gc_timer_started`). The active flag is always cleared. This prevents calling `uv_timer_stop` on an uninitialized handle when active was set but the async callback hadn't yet run to start the GC timer.

### src/libpcp_web/src/webgroup.c lines 404-440
  This is the central piece of the fix. It runs exclusively on the event loop thread (guaranteed by libuv's async callback semantics) and performs two operations:
  1. GC timer start: If active is set but the GC timer hasn't been started yet, it calls `uv_timer_init` +  `uv_timer_start` for the global garbage-collection timer. This was previously done inline in `webgroup_lookup_context`.
  2. Per-context timer drain: It atomically swaps out the pending list (under mutex), then iterates through it,  calling `uv_timer_init` and `uv_timer_start` for each context. The timer is started as a repeating timer (`cp->timeout`, `cp->timeout` -- both initial and repeat interval), and `timer_init` is set to `1`. Contexts that were already garbage-collected before the callback ran are skipped.

### src/libpcp_web/src/webgroup.c lines 466-478
This is where the original bug manifested.  The replacement is a single atomic-safe `uv_hrtime()` assignment. The local variable `gp` (pointer to `webgroups`, used only for `uv_update_time`) is now removed.

### src/libpcp_web/src/webgroup.c lines 497-501
  Instead of calling `uv_timer_init` + `uv_timer_start` for the GC timer directly (which could be called from a worker thread), it just sets the active flag and signals the async handle. The actual timer initialization happens in `webgroup_async_cb`.

### src/libpcp_web/src/webgroup.c lines 2539-2540
The `uv_async_t` handle is initialized here, when the event loop is first associated with the webgroup module. This must happen on the event loop thread before any worker threads are started.

### src/libpcp_web/src/webgroup.c lines 2651-2652
The async handle is properly closed during shutdown to avoid resource leaks and to allow the event loop to terminate cleanly.