### PR TITLE
darwin: fix physmem and used memory metrics

### DIFF
--- a/src/pmdas/darwin/pmda.c
+++ b/src/pmdas/darwin/pmda.c
@@ -72,6 +72,7 @@ float			mach_loadavg[3] = { 0,0,0 };
 int			mach_cpuload_error = 0;
 struct host_cpu_load_info	mach_cpuload = { { 0 } };
 
+uint64_t		mach_physmem;
 int			mach_vmstat_error = 0;
 struct vm_statistics64	mach_vmstat = { 0 };
 extern int refresh_vmstat(struct vm_statistics64 *);
@@ -390,6 +391,7 @@ darwin_init(pmdaInterface *dp)
     mach_host = mach_host_self();
     host_page_size(mach_host, &mach_page_size);
     mach_page_shift = ffs(mach_page_size) - 1;
+    refresh_physmem(&mach_physmem);
     if (refresh_hertz(&mach_hertz) != 0)
 	mach_hertz = 100;
     if ((sts = refresh_hinv()) != 0)

--- a/src/pmdas/darwin/vmstat.c
+++ b/src/pmdas/darwin/vmstat.c
@@ -23,6 +23,16 @@
 #define page_count_to_mb(x) (((__uint64_t)(x) << mach_page_shift) >> 20)
 
 int
+refresh_physmem(uint64_t *physmem)
+{
+	size_t	size = sizeof(*physmem);
+
+	if (sysctlbyname("hw.memsize", physmem, &size, NULL, 0) == -1)
+		return -oserror();
+	return 0;
+}
+
+int
 refresh_vmstat(struct vm_statistics64 *vmstat)
 {
 	extern mach_port_t mach_host;
@@ -94,19 +104,16 @@ fetch_vmstat(unsigned int item, unsigned int inst, pmAtomValue *atom)
 	extern struct compressor_stats mach_compressor;
 	extern int mach_compressor_error;
 	extern unsigned int mach_page_shift;
+	extern uint64_t mach_physmem;
 
 	if (mach_vmstat_error)
 		return mach_vmstat_error;
 	switch (item) {
 	case 2: /* hinv.physmem */
-		atom->ul = (__uint32_t)page_count_to_mb(
-				mach_vmstat.free_count + mach_vmstat.wire_count +
-				mach_vmstat.active_count + mach_vmstat.inactive_count);
+		atom->ul = (__uint32_t)(mach_physmem >> 20);
 		return 1;
 	case 3: /* mem.physmem */
-		atom->ull = page_count_to_kb(
-				mach_vmstat.free_count + mach_vmstat.wire_count +
-				mach_vmstat.active_count + mach_vmstat.inactive_count);
+		atom->ull = mach_physmem >> 10;
 		return 1;
 	case 4: /* mem.freemem */
 		atom->ull = page_count_to_kb(mach_vmstat.free_count);
@@ -132,7 +139,8 @@ fetch_vmstat(unsigned int item, unsigned int inst, pmAtomValue *atom)
 	case 23: /* mem.util.used */
 		atom->ull = page_count_to_kb(mach_vmstat.wire_count +
 				mach_vmstat.active_count +
-				mach_vmstat.inactive_count);
+				mach_vmstat.inactive_count +
+				mach_vmstat.compressor_page_count);
 		return 1;
 	case 24: /* swap.length */
 		if (mach_swap_error)

--- a/src/pmdas/darwin/vmstat.h
+++ b/src/pmdas/darwin/vmstat.h
@@ -35,6 +35,7 @@ struct compressor_stats {
     uint64_t lz4_compressions;
 };
 
+extern int refresh_physmem(uint64_t *);
 extern int refresh_vmstat(struct vm_statistics64 *);
 extern int refresh_swap(struct xsw_usage *);
 extern int refresh_compressor_stats(struct compressor_stats *);


### PR DESCRIPTION
The hinv.physmem and mem.physmem metrics were computed by summing vm_statistics page counts, which excludes compressor and purgeable pages and underreports total RAM. Use sysctlbyname("hw.memsize") to retrieve the actual hardware memory size instead.

Also include compressor_page_count in mem.util.used, matching the Activity Monitor "Memory Used" calculation.