### PR TITLE
pmdaamdgpu: Prevent out-of-bound references in amdgpu_fetch function

### DIFF
--- a/src/pmdas/amdgpu/amdgpu.c
+++ b/src/pmdas/amdgpu/amdgpu.c
@@ -353,7 +353,7 @@ static int amdgpu_fetch(int numpmid, pmID pmidlist[], pmdaResult **resp,
 {
   uint32_t i = 0;
 
-  for (i = 0; i <= numpmid; i++) {
+  for (i = 0; i < numpmid; i++) {
       unsigned int cluster = pmID_cluster(pmidlist[i]);
       unsigned int item = pmID_item(pmidlist[i]);
 


### PR DESCRIPTION
The valid range of indices for the pmidlist array is 0 to numpmid-1. The loop in amdgpu_fetch was incorrectly using a "i <= numpmid" rather than "i < numpmid" to terminate the loop.

Resolves: https://github.com/performancecopilot/pcp/issues/2584