### PR TITLE
qa: unset LC_ALL in the check script to fix locale-dependent sort order

### DIFF
--- a/qa/check
+++ b/qa/check
@@ -21,6 +21,9 @@ __aborted=true
 myname=`basename $0`
 __scriptname=$myname  #  a synonym
 
+# Ensure LC_ALL is not set to allow locale-dependent sort order
+unset LC_ALL
+
 # lock (and PID) file to prevent concurrent QA execution
 #
 CHECKLOCK=/tmp/PCP-QA-LOCK


### PR DESCRIPTION
  When LC_ALL is set in the caller's environment (e.g. LC_ALL=en_US.utf8),
  it overrides any per-command LC_COLLATE=POSIX setting used inside
  individual QA tests, causing locale-sensitive sort ordering instead of
  the expected POSIX byte-value ordering.  This manifests as spurious
  output mismatches in tests such as 821/1663 where metric names are
  enumerated via "LC_COLLATE=POSIX sort".
  Unsetting LC_ALL at the start of the check script removes the inherited
  override while still allowing individual tests to apply their own
  per-command locale settings (e.g. "LC_COLLATE=en_US.utf8 sort") as
  intended by their authors.