### PR TITLE
mssql PMDA: update default driver to 18, add trust_server_certificate option

### DIFF
--- a/src/pmdas/mssql/mssql.conf
+++ b/src/pmdas/mssql/mssql.conf
@@ -1,7 +1,9 @@
 [connection]
-driver={ODBC Driver 17 for SQL Server}
+driver={ODBC Driver 18 for SQL Server}
 server=tcp:localhost
 timeout=2
+## Set to true when SQL Server uses a self-signed TLS certificate (common on Linux installs)
+#trust_server_certificate=true
 
 [authentication]
 ## General reference on authentication options

--- a/src/pmdas/mssql/pmdamssql.python
+++ b/src/pmdas/mssql/pmdamssql.python
@@ -1025,7 +1025,7 @@ class MSSQLPMDA(PMDA):
         try:
             self.driver = conf_vars["connection.driver"]
         except:
-            self.driver = "{ODBC Driver 17 for SQL Server}" # default driver
+            self.driver = "{ODBC Driver 18 for SQL Server}" # default driver
         try:
             self.server = conf_vars["connection.server"]
         except:
@@ -1038,7 +1038,10 @@ class MSSQLPMDA(PMDA):
             self.trusted = self.intobool(conf_vars["authentication.trusted"])
         except:
             self.trusted = False
-        print("trusted?",self.trusted)
+        try:
+            self.trust_server_certificate = self.intobool(conf_vars["connection.trust_server_certificate"])
+        except:
+            self.trust_server_certificate = False
         # first try Assessment API credentials, else our local config file,
         # otherwise just use defaults of user 'pcp' with an empty password.
         self.username = pmContext.pmGetConfig('PCP_USER')
@@ -1299,6 +1302,8 @@ class MSSQLPMDA(PMDA):
             parameters = 'DRIVER={0};SERVER={1};UID={2};PWD={3}'
             parameters = parameters.format(self.driver, self.server,
                             self.username, self.password)
+        if self.trust_server_certificate:
+            parameters += ';TrustServerCertificate=YES'
 
         try:
             self.conn = pyodbc.connect(parameters, timeout=self.timeout)


### PR DESCRIPTION
ODBC Driver 17 for SQL Server has reached end of support. Driver 18 is the current release but enables TLS encryption by default and rejects self-signed certificates, causing the PMDA to fail at startup with:

  SSL Provider: certificate verify failed: self-signed certificate

This is the common case on Linux SQL Server installs which use a self-signed certificate by default.

Changes:
- Update default driver from 17 to 18 in pmdamssql.python and mssql.conf
- Add optional trust_server_certificate key under [connection] in mssql.conf that appends TrustServerCertificate=YES to the ODBC connection string
- Remove stray debug print("trusted?", self.trusted) from startup path

The new option defaults to false so existing deployments with valid CA-signed certificates are unaffected.

Tested on SQL Server 2025 (Linux) with ODBC Driver 18.