### PR TITLE
libpcp_web, pmproxy: support for optional labels

### DIFF
--- a/qa/1744
+++ b/qa/1744
@@ -1,0 +1,118 @@
+#!/bin/sh
+# PCP QA Test No. 1744
+# Test pmproxy / pmseries label storing mechanism
+#
+# Copyright (c) 2026 Red Hat.  All Rights Reserved.
+#
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.python
+. ./common.keys
+
+_check_series
+
+status=1	# failure is the default!
+
+_cleanup()
+{
+    cd $here
+    [ -n "$pmloggerpid" ] && $sudo kill -TERM $pmloggerpid 2>/dev/null
+    if [ -n "$key_server_port" ]; then
+        echo "Shutting down key server on port $key_server_port..." >>$here/$seq.full
+        $keys_cli -p $key_server_port shutdown >>$here/$seq.full 2>&1
+        sleep 1
+        # Verify it's actually dead
+        if $keys_cli -p $key_server_port PING >>$here/$seq.full 2>&1; then
+            echo "WARNING: Key server still running after shutdown!" >>$here/$seq.full
+        else
+            echo "Key server shutdown confirmed" >>$here/$seq.full
+        fi
+    fi
+    _sighup_pmcd
+    _restore_auto_restart pmcd
+    _restore_config $PCP_SYSCONF_DIR/pmseries
+    $sudo rm -rf $tmp $tmp.*
+}
+
+trap "_cleanup; exit \$status" 0 1 2 3 15
+_stop_auto_restart pmcd
+
+A="$here/archives/pcp-atop-nvidia"
+
+_filter()
+{
+    # Replace machine-specific label values with placeholders
+    sed \
+    -e "s/\"hostname\":\"[a-z]*\"/\"hostname\":\"HOSTNAME\"/g" \
+    -e 's/"uuid":"GPU-[0-9a-f-]*"/"uuid":"UUID"/g'
+}
+
+_filter_series()
+{
+    sed \
+	-e 's/[0-9a-z]\{40\}/TIMESERIES/g' \
+    #end
+}
+
+# real QA test starts here
+key_server_port=`_find_free_port`
+_save_config $PCP_SYSCONF_DIR/pmseries
+$sudo rm -f $PCP_SYSCONF_DIR/pmseries/*
+
+# Create pmseries config pointing to our test key server
+$sudo tee $PCP_SYSCONF_DIR/pmseries/pmseries.conf > /dev/null <<EOF
+[pmseries]
+servers = localhost:$key_server_port
+EOF
+
+echo "Start test key server on port $key_server_port..." >>$seq.full
+$key_server --port $key_server_port --save "" > $tmp.keys 2>&1 &
+_check_key_server_ping $key_server_port
+_check_key_server $key_server_port
+echo
+
+_check_key_server_version $key_server_port
+
+
+# Check key server port and flush
+echo "Using key server on port $key_server_port" >>$seq_full
+echo "Flushing key server on port $key_server_port ..."
+flush_result=`echo "FLUSHALL" | $keys_cli -p $key_server_port 2>&1`
+echo "Flush result: $flush_result" >>$seq_full
+if [ "$flush_result" != "OK" ]; then
+    echo "ERROR: Failed to flush key server, got: $flush_result"
+    status=1
+    exit
+fi
+echo "Key server flushed successfully"
+
+# Load the archive into pmseries
+echo "Loading test archive into pmseries ..."
+pmseries $options --load "{source.path: \"$A\"}" 2>&1 | \
+    sed "s|$A|ARCHIVE|g" | tee -a $seq_full
+
+# Wait for metrics to be indexed
+echo "Waiting for metrics to be indexed ..."
+pmsleep 2
+
+# Query for the first metric (identifying labels only)
+echo
+echo "=== nvidia.gpuactive (optional labels "gpu" & "uuid") ==="
+series1=`pmseries $options 'nvidia.gpuactive'`
+if [ -z "$series1" ]; then
+    echo "ERROR: No series found for nvidia.gpuactive"
+    status=1
+    exit
+else
+    pmseries $series1 | _filter_series | _filter
+fi
+
+echo == Note: check $seq.full for details
+echo == pmlogger LOG == >>$seq_full
+cat $tmp.pmlogger.log >>$seq_full 2>&1
+
+# success, all done
+status=0
+exit

--- a/qa/1744.out
+++ b/qa/1744.out
@@ -1,0 +1,21 @@
+QA output created by 1744
+PING
+PONG
+
+Flushing key server on port 54321 ...
+Key server flushed successfully
+Loading test archive into pmseries ...
+pmseries: [Info] processed 11 archive records from ARCHIVE
+Waiting for metrics to be indexed ...
+
+=== nvidia.gpuactive (optional labels gpu & uuid) ===
+
+TIMESERIES
+    PMID: 120.0.7
+    Data Type: 32-bit unsigned int  InDom: 120.0 0x1e000000
+    Semantics: instant  Units: none
+    Source: TIMESERIES
+    Metric: nvidia.gpuactive
+    inst [0 or "gpu0"] series TIMESERIES
+    inst [0 or "gpu0"] labels {"agent":"nvidia","device_type":"gpu","gpu":0,"hostname":"HOSTNAME","indom_name":"per gpu","uuid":"UUID"}
+== Note: check 1744.full for details

--- a/qa/group
+++ b/qa/group
@@ -2258,6 +2258,7 @@ suse
 1727 pmproxy libpcp_web pmda.openmetrics local
 1735 python pmimport local
 1740 pmda.proc local
+1744 pmseries local
 1745 pmlogger libpcp pmval local pmda.sample pmda.simple pmlogdump
 1747 pmlogger labels local
 1748 atop local

--- a/src/libpcp_web/src/load.c
+++ b/src/libpcp_web/src/load.c
@@ -126,9 +126,9 @@ get_instance_metadata(seriesLoadBaton *baton, pmInDom indom, int force_refresh)
 	if ((dp = pmwebapi_add_domain(cp, pmInDom_domain(indom))))
 	    pmwebapi_add_domain_labels(cp, dp);
 	if ((ip = pmwebapi_add_indom(cp, dp, indom)) != NULL) {
-	    if (force_refresh)
-		ip->updated = 1;
-	    if (ip->updated) {
+	    if (force_refresh || !ip->updated) {
+		if (force_refresh)
+		   ip->updated = 0;
 		pmwebapi_add_indom_instances(cp, ip);
 		pmwebapi_add_instances_labels(cp, ip);
 	    }

--- a/src/libpcp_web/src/util.c
+++ b/src/libpcp_web/src/util.c
@@ -279,6 +279,12 @@ context_labels_str(context_t *c, char *buffer, int length)
     return pmMergeLabelSets(&c->labelset, 1, buffer, length, NULL, NULL);
 }
 
+static int
+context_labels_str_identifying(context_t *c, char *buffer, int length)
+{
+    return pmMergeLabelSets(&c->labelset, 1, buffer, length, labels, NULL);
+}
+
 int
 pmLogLevelIsTTY(void)
 {
@@ -447,6 +453,7 @@ int
 pmwebapi_context_hash(context_t *context)
 {
     char		labels[PM_MAXLABELJSONLEN];
+    char		idlabels[PM_MAXLABELJSONLEN];
     int			sts;
 
     if (context->labels == NULL) {
@@ -454,7 +461,9 @@ pmwebapi_context_hash(context_t *context)
 	    return sts;
 	context->labels = sdsnewlen(labels, sts);
     }
-    return pmwebapi_source_hash(context->name.hash, context->labels, sdslen(context->labels));
+    if ((sts = context_labels_str_identifying(context, idlabels, sizeof(idlabels))) < 0)
+        return sts;
+    return pmwebapi_source_hash(context->name.hash, idlabels, sts);
 }
 
 void
@@ -464,22 +473,26 @@ pmwebapi_metric_hash(metric_t *metric)
     pmDesc		*desc = &metric->desc;
     sds			identifier;
     char		buf[PM_MAXLABELJSONLEN];
+    char		idbuf[PM_MAXLABELJSONLEN];
     char		sem[32], type[32], units[64];
     int			len, i;
 
     if (metric->labels == NULL) {
-	len = metric_labelsets(metric, buf, sizeof(buf), labels, NULL);
+	len = metric_labelsets(metric, buf, sizeof(buf), NULL, NULL);
 	if (len <= 0)
 	    len = pmsprintf(buf, sizeof(buf), "null");
 	metric->labels = sdsnewlen(buf, len);
     }
 
+    if (metric_labelsets(metric, idbuf, sizeof(idbuf), labels, NULL) <= 0)
+        pmsprintf(idbuf, sizeof(idbuf), "null");
+
     identifier = sdsempty();
     for (i = 0; i < metric->numnames; i++) {
 	identifier = sdscatfmt(identifier,
-		"{\"series\":\"metric\",\"name\":\"%S\",\"labels\":%S,"
+		"{\"series\":\"metric\",\"name\":\"%S\",\"labels\":%s,"
 		 "\"semantics\":\"%s\",\"type\":\"%s\",\"units\":\"%s\"}",
-		metric->names[i].sds, metric->labels,
+		metric->names[i].sds, idbuf,
 		pmSemStr_r(desc->sem, sem, sizeof(sem)),
 		pmTypeStr_r(desc->type, type, sizeof(type)),
 		pmUnitsStr_r(&desc->units, units, sizeof(units)));
@@ -501,7 +514,7 @@ pmwebapi_add_indom_labels(indom_t *indom)
     int			len;
 
     if (indom->labels == NULL) {
-	len = instance_labelsets(indom, NULL, buf, sizeof(buf), labels, NULL);
+	len = instance_labelsets(indom, NULL, buf, sizeof(buf), NULL, NULL);
 	if (len <= 0)
 	    len = pmsprintf(buf, sizeof(buf), "null");
 	indom->labels = sdsnewlen(buf, len);


### PR DESCRIPTION
Added support for optional labels to be ingested into a key-value server by pmproxy. SHA1 hash calculations are not affected.

libpcp_web code additions include creating a new buffer to separate hash calculation from display calculation and creating a new context hash function to separate context hash w/ identifying labels and context hash w/ identifying + optional labels. 

Added qa test 1744 to test optional label ingestion and display.