### PR TITLE
pmdas: comment out default configurations

### DIFF
--- a/src/pmdas/hdb/hdb.conf
+++ b/src/pmdas/hdb/hdb.conf
@@ -3,6 +3,8 @@
 #
 
 [hdb]
+# Connection settings must be configured before use
+
 # IP address or DNS name of the SAP HANA service
 #host=localhost
 
@@ -10,10 +12,10 @@
 #port=39017
 
 # SAP HANA user used for authentication
-user=user
+#user=CHANGE_ME
 
 # Password of the SAP HANA user
-password=password
+#password=CHANGE_ME
 
 # Connection timeout in miliSeconds
 #connect_timeout=60000

--- a/src/pmdas/mssql/mssql.conf
+++ b/src/pmdas/mssql/mssql.conf
@@ -8,8 +8,9 @@ timeout=2
 #https://docs.microsoft.com/en-us/sql/relational-databases/security/choose-an-authentication-mode
 
 # Option 1: Mixed mode authentication
-username=sa
-password=P4$$W0rd
+# username and password must be configured before use
+#username=CHANGE_ME
+#password=CHANGE_ME
 
 # Option 2: Windows authentication
 #trusted=true

--- a/src/pmdas/oracle/sample.conf
+++ b/src/pmdas/oracle/sample.conf
@@ -1,5 +1,6 @@
-$username = 'oastoltp';
-$password = 'oastoltp';
+# username and password must be configured before use
+#$username = 'CHANGE_ME';
+#$password = 'CHANGE_ME';
 @sids = ( 'oast1' );
 $disable_object_cache = 1;
 

--- a/src/pmdas/postgresql/pmdapostgresql.conf
+++ b/src/pmdas/postgresql/pmdapostgresql.conf
@@ -1,7 +1,8 @@
 [authentication]
-host=local
-port=5432
-dbname=postgres
-user=postgres
-password=password
-osuser=postgres
+# Connection settings must be configured before use
+#host=local
+#port=5432
+#dbname=postgres
+#user=CHANGE_ME
+#password=CHANGE_ME
+#osuser=postgres

--- a/src/pmdas/rabbitmq/rabbitmq.conf
+++ b/src/pmdas/rabbitmq/rabbitmq.conf
@@ -1,5 +1,6 @@
 # Rabbitmq configuration
 [pmda]
-username = guest
-password = guest
+# username and password must be configured before use
+#username = CHANGE_ME
+#password = CHANGE_ME
 port = 15672


### PR DESCRIPTION
The .conf files for certain pmdas ship active default credentials (i.e. username and password). When a user installs these pmdas with a matching database, the pmdas will silently authenticate without any warnings that there are configurations that must be set. This PR comments out those fields with a clear CHANGE_ME placeholder to prevent silent authentication and inform users that these fields must be configured for the service they want to monitor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Default connection templates for SAP HANA, MSSQL, Oracle, PostgreSQL, and RabbitMQ no longer include active credentials. Users must explicitly supply or uncomment credential values in their configuration files before connecting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/performancecopilot/pcp/pull/2592)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->