### PR TITLE
Nix microvm tap preflight and update

### DIFF
--- a/build/nix/grafana.nix
+++ b/build/nix/grafana.nix
@@ -142,6 +142,10 @@ in
         security = {
           admin_user = "admin";
           admin_password = cfg.adminPassword;
+          # Newer NixOS grafana modules assert this is set explicitly (no default).
+          # The dev microvm has no real secrets to protect — the file already
+          # warns this is for local development only.
+          secret_key = "pcp-microvm-dev-only-not-a-real-secret";
         };
 
         # Disable analytics/phone-home

--- a/build/nix/tests/test-all-microvms.nix
+++ b/build/nix/tests/test-all-microvms.nix
@@ -81,6 +81,7 @@ pkgs.writeShellApplication {
     gnugrep
     procps
     nix
+    iproute2
   ];
   text = ''
     set +e  # Don't exit on error - we want to continue and report all results
@@ -91,6 +92,8 @@ pkgs.writeShellApplication {
     SSH_RETRY_DELAY=${toString constants.test.sshRetryDelaySeconds}
     BASE_SSH_PORT=${toString constants.ports.sshForward}
     TAP_VM_IP="${constants.network.vmIp}"
+    TAP_BRIDGE="${constants.network.bridge}"
+    TAP_DEVICE="${constants.network.tap}"
 
     # Service warmup: wait for services to fully start after SSH connects
     # pmlogger takes ~9s, Grafana HTTP takes ~17s after service activation
@@ -257,6 +260,16 @@ pkgs.writeShellApplication {
       local host="$1"
       local port="$2"
       run_ssh_check "$host" "$port" "pminfo kernel.all.load" "pminfo -f kernel.all.load"
+    }
+
+    # Check whether host TAP networking has been set up.
+    # Returns 0 if both the bridge and TAP device exist on the host.
+    # Note: operational state may be DOWN when no VM is attached — that is
+    # the normal pre-test condition, so we only check for existence.
+    check_tap_network() {
+      ip link show "$TAP_BRIDGE" >/dev/null 2>&1 || return 1
+      ip link show "$TAP_DEVICE" >/dev/null 2>&1 || return 1
+      return 0
     }
 
     # Check Grafana HTTP endpoint (with retry - Grafana needs extra startup time)
@@ -546,6 +559,24 @@ pkgs.writeShellApplication {
     # Ensure clean state
     stop_all_vms
 
+    # Preflight: detect whether host TAP networking is set up.
+    # When it is not, tap variants are skipped with an actionable hint
+    # instead of failing with an opaque VM_START_FAILED.
+    TAP_NETWORK_READY=true
+    if check_tap_network; then
+      log "TAP networking detected ($TAP_BRIDGE, $TAP_DEVICE)"
+    else
+      TAP_NETWORK_READY=false
+      log_section "TAP networking not set up — tap variants will be skipped"
+      echo "Bridge '$TAP_BRIDGE' or TAP device '$TAP_DEVICE' is not present/up."
+      echo ""
+      echo "To enable tap variants (base-tap, eval-tap, grafana-tap), run:"
+      echo "    nix run .#pcp-check-host"
+      echo "    sudo nix run .#pcp-network-setup"
+      echo ""
+      echo "Then re-run this test. To suppress this message, pass --skip-tap."
+    fi
+
     # Define test order (NOTE: BCC is deprecated - use BPF PMDA instead)
     VARIANT_ORDER=(base base-tap eval eval-tap grafana grafana-tap bpf)
 
@@ -555,12 +586,20 @@ pkgs.writeShellApplication {
         continue
       fi
 
-      # Skip TAP variants if requested
-      if [[ "$SKIP_TAP" == "true" ]] && [[ "$key" == *"-tap" ]]; then
-        RESULTS[$key]="SKIPPED"
-        DURATIONS[$key]=0
-        TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
-        continue
+      # Skip TAP variants when requested or when host networking is not set up.
+      if [[ "$key" == *"-tap" ]]; then
+        if [[ "$SKIP_TAP" == "true" ]]; then
+          RESULTS[$key]="SKIPPED (--skip-tap)"
+          DURATIONS[$key]=0
+          TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
+          continue
+        fi
+        if [[ "$TAP_NETWORK_READY" == "false" ]]; then
+          RESULTS[$key]="SKIPPED (tap network not set up)"
+          DURATIONS[$key]=0
+          TOTAL_SKIPPED=$((TOTAL_SKIPPED + 1))
+          continue
+        fi
       fi
 
       # Get variant properties

--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "spectrum": "spectrum"
       },
       "locked": {
-        "lastModified": 1771802632,
-        "narHash": "sha256-UAH8YfrHRvXAMeFxUzJ4h4B1loz1K1wiNUNI8KiPqOg=",
+        "lastModified": 1778669912,
+        "narHash": "sha256-WT2iimtOBZM/6AcZeBoJU2EgUSaywtlItsEgNkZBda0=",
         "owner": "astro",
         "repo": "microvm.nix",
-        "rev": "b67e3d80df3ec35bdfd3a00ad64ee437ef4fcded",
+        "rev": "a7a7009064cec75d9da652c6723412ce27b9bc44",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767640445,
-        "narHash": "sha256-UWYqmD7JFBEDBHWYcqE6s6c77pWdcU/i+bwD6XxMb8A=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9f0c42f8bc7151b8e7e5840fb3bd454ad850d8c5",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     "spectrum": {
       "flake": false,
       "locked": {
-        "lastModified": 1759482047,
-        "narHash": "sha256-H1wiXRQHxxPyMMlP39ce3ROKCwI5/tUn36P8x6dFiiQ=",
+        "lastModified": 1772189877,
+        "narHash": "sha256-i1p90Rgssb//aNiTDFq46ZG/fk3LmyRLChtp/9lddyA=",
         "ref": "refs/heads/main",
-        "rev": "c5d5786d3dc938af0b279c542d1e43bce381b4b9",
-        "revCount": 996,
+        "rev": "fe39e122d898f66e89ffa17d4f4209989ccb5358",
+        "revCount": 1255,
         "type": "git",
         "url": "https://spectrum-os.org/git/spectrum"
       },


### PR DESCRIPTION
# nix: TAP-preflight in MicroVM test runner + bump lock for current nixos-unstable

G'day,

I hope you are doing well.

This PR updates the nix to latest and slightly improves the automated testing.

I was pleased to see the nix continues to work well, when updating the 200+ commits.

Thanks,
Dave

## Summary

Three related changes that make `nix run .#pcp-test-all-microvms` work cleanly on current `nixos-unstable` and give a better error when host TAP networking has not been set up.

## Changes

- **TAP preflight in the test runner** (`build/nix/tests/test-all-microvms.nix`, +45/-6)
  - Detect host bridge `pcpbr0` and TAP device `pcptap0` once before the variant loop
  - When absent, print an actionable banner pointing at `nix run .#pcp-check-host` and `sudo nix run .#pcp-network-setup`, then mark the three tap variants as `SKIPPED (tap network not set up)` in the summary
  - Rename the existing `--skip-tap` result to `SKIPPED (--skip-tap)` so the summary distinguishes the two skip reasons
  - Exit code unchanged — matches existing `--skip-tap` semantics
- **Bump flake inputs** (`flake.lock`, +10/-10)
  - `nixpkgs` 2026-01-05 → 2026-05-10
  - `microvm.nix` 2026-02-22 → 2026-05-13 (the older microvm.nix fails to eval against the newer nixpkgs because of stricter `fileSystems."/nix/store".fsType` resolution via the ZFS module)
- **Grafana secret_key for new nixpkgs** (`build/nix/grafana.nix`, +4/-0)
  - Newer NixOS Grafana module asserts `services.grafana.settings.security.secret_key` is set explicitly (no default)
  - MicroVM is documented dev-only (admin password is the literal `pcp`, activation warning emitted) so a hardcoded non-default value satisfies the assertion without changing the security posture

## Testing

All 7 lifecycle variants pass on a host with TAP networking set up:

| Variant | Result | Checks | Duration |
| --- | --- | --- | --- |
| base | PASSED | 6 | 40s |
| base-tap | PASSED | 6 | 39s |
| eval | PASSED | 7 | 45s |
| eval-tap | PASSED | 7 | 40s |
| grafana | PASSED | 11 | 126s |
| grafana-tap | PASSED | 11 | 41s |
| bpf | PASSED | 8 | 41s |

TAP preflight verified across all three behaviour branches:

- **TAP not set up** — `sudo nix run .#pcp-network-teardown` then `nix run .#pcp-test-all-microvms -- --only=base-tap`: banner appears, `SKIPPED (tap network not set up)` row in summary, exit 0
- **TAP set up, full run** — `nix run .#pcp-test-all-microvms`: `TAP networking detected (pcpbr0, pcptap0)` logged, all 7 variants pass
- **`--skip-tap`** — `nix run .#pcp-test-all-microvms -- --skip-tap`: no preflight banner, `SKIPPED (--skip-tap)` rows in summary

Build / shellcheck of the modified runner: `nix run .#pcp-test-all-microvms -- --help` succeeds.

## Follow-up (not in this PR)

While iterating I hit a stale `pcp-bpf-vm` qemu process from a prior session still holding the virtcon ports (24530/24531); the runner's `stop_all_vms` did not reach it. Worth tightening cleanup in a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added TAP network preflight detection to test runner: detects host bridge and TAP device availability before running variants; marks TAP variants as skipped when networking not available instead of failing, with actionable setup instructions
- Updated flake inputs for nixos-unstable compatibility: bumped nixpkgs to 2026-05-10 and microvm.nix to 2026-05-13 to address stricter ZFS module option resolution
- Set explicit Grafana secret_key for compatibility with newer NixOS Grafana module assertions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/performancecopilot/pcp/pull/2593)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->