### PR TITLE
build: fix the configure.ac USDT check for armhf platform

### DIFF
--- a/configure
+++ b/configure
@@ -6578,7 +6578,7 @@ _ACEOF
 if ac_fn_c_try_link "$LINENO"
 then :
 
-if test $target_cpu = "armv8l"; then
+if test $target_cpu = "arm"; then
      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf "%s\n" "no" >&6; }
      result=0

--- a/configure.ac
+++ b/configure.ac
@@ -805,7 +805,7 @@ AC_MSG_CHECKING([if USDT probes should be used])
 AC_LINK_IFELSE([AC_LANG_SOURCE([
 #include "vendor/github.com/libbpf/usdt/usdt.h"
 void main() { USDT(pcp, check, 1); }])], [
-if test $target_cpu = "armv8l"; then
+if test $target_cpu = "arm"; then
      AC_MSG_RESULT(no)
      result=0
 else

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 pcp (7.1.4-1) unstable; urgency=high
 
   * New release (full details in CHANGELOG).
+  * Additional armhf configure.ac fix related to #1133063 (USDT check)
 
  -- Nathan Scott <nathans@debian.org>  Fri, 31 Jul 2026 07:59:33 +1000
 


### PR DESCRIPTION
Ensure the target_cpu now injected through the correction to configure.ac handling in Debian builds (via commit 704b93c3) matches with what configure.ac USDT check is looking for.

Resolves Debian bug #1133063

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed detection of static USDT probes on ARM platforms, restoring/enabling USDT support on ARM-based systems (including armhf).
  * This improves performance monitoring and tracing reliability on affected ARM deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/performancecopilot/pcp/pull/2595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->