### PR TITLE
qa/common.check: fix _check_key_server_version() when multiple servers run

### DIFF
--- a/qa/common.check
+++ b/qa/common.check
@@ -1560,11 +1560,11 @@ _check_key_server_version()
     fi
 
     
-    if which valkey-cli >/dev/null 2>&1 && test -n `_get_pids_by_name valkey-server`
+    if which valkey-cli >/dev/null 2>&1 && test -n "`_get_pids_by_name valkey-server`"
     then
 	keys_cli=valkey-cli
 	keys_ver=valkey_version
-    elif which redis-cli >/dev/null 2>&1 && test -n _get_pids_by_name redis-server
+    elif which redis-cli >/dev/null 2>&1 && test -n "`_get_pids_by_name redis-server`"
     then
 	keys_cli=redis-cli
 	keys_ver=redis_version


### PR DESCRIPTION
The backtick substitution in the valkey-server process check was unquoted, so test -n received multiple arguments when more than one valkey-server was running (e.g. the system server plus the test's own), causing "binary operator expected" and skipping all tests that use _check_key_server_version().  The redis-server branch was also missing backticks entirely, making it always evaluate to true. Quote both command substitutions properly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced server detection validation to ensure consistent and reliable test execution across different key-server configurations. This fix prevents evaluation errors and standardizes test behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/performancecopilot/pcp/pull/2596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->