### PR TITLE
coderabbit: enable settings inheritance

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,5 @@
 # .coderabbit.yaml
+inheritance: true
 reviews:
   auto_review:
     enabled: true


### PR DESCRIPTION
Coderabbit inheritance is disabled by default. With the current .coderabbit.yaml file, this causes only the rules stated explicitly there to be used rather than rules set in the coderabbit web ui at both the repo and the organization level. Setting inheritance to true in the .coderabbit.yaml should result in settings from the web ui being used in addition to what is set in .coderabbit.yaml. Documentation on how this inheritance works can be found here, https://docs.coderabbit.ai/configuration/configuration-inheritance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated configuration to enable inheritance from parent configurations, allowing settings to be shared and layered while preserving the existing automated review behavior; this streamlines setup for multi-level projects and reduces manual repetition across configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/performancecopilot/pcp/pull/2597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->