### PR TITLE
qa: fix tests using fmt for ubuntu2604

### DIFF
--- a/qa/1473
+++ b/qa/1473
@@ -38,10 +38,11 @@ _notrun "current time - $now_hr:$now_min - is too close to midnight"
 
 _filter()
 {
-    if fmt -g 76 -w 76 </dev/null >/dev/null 2>&1
+    if fmt -w 64 </dev/null >/dev/null 2>&1
     then
-	# GNU fmt(1) with -g
-	cmd='fmt -g 76 -w 76'
+	# GNU fmt(1) - fmt -g reflows the archive list differently (e.g.
+	# coreutils 9.x on Ubuntu 26.04) and breaks the golden file layout
+	cmd='fmt -w 64'
     elif fmt 76 76 </dev/null >/dev/null 2>&1
     then
 	# FreeBSD fmt(1) with goal [maximum]

--- a/qa/338
+++ b/qa/338
@@ -39,10 +39,11 @@ _notrun "current time - $now_hr:$now_min - is too close to midnight"
 
 _filter()
 {
-    if fmt -g 76 -w 76 </dev/null >/dev/null 2>&1
+    if fmt -w 64 </dev/null >/dev/null 2>&1
     then
-	# GNU fmt(1) with -g
-	cmd='fmt -g 76 -w 76'
+	# GNU fmt(1) - fmt -g reflows the archive list differently (e.g.
+	# coreutils 9.x on Ubuntu 26.04) and breaks the golden file layout
+	cmd='fmt -w 64'
     elif fmt 76 76 </dev/null >/dev/null 2>&1
     then
 	# FreeBSD fmt(1) with goal [maximum]


### PR DESCRIPTION
Ubuntu 26.04 ships uutils fmt, not GNU one. It breaks formating for qa/338 and qa/1473.
This fix restores back the fallback before ad0044acb8 commit.