### PR TITLE
libpcp_web: accept NaN/Inf in series_pmAtomValue_conv_str on float/double

### DIFF
--- a/src/libpcp_web/src/query.c
+++ b/src/libpcp_web/src/query.c
@@ -3033,10 +3033,14 @@ series_pmAtomValue_conv_str(int type, char *str, pmAtomValue *val, int max_len)
     case PM_TYPE_U32:
     case PM_TYPE_64:
     case PM_TYPE_U64:
+        s = pmAtomStr_r(val, type, str, max_len);
+	if (s && (isdigit((unsigned char)*s) || *s == '-' || *s == '+'))
+            return strlen(str);
+        break;
     case PM_TYPE_FLOAT:
     case PM_TYPE_DOUBLE:
         s = pmAtomStr_r(val, type, str, max_len);
-	if (s && (isdigit(*s) || *s == '-' || *s == '+'))
+        if (s != NULL)
             return strlen(str);
         break;
 


### PR DESCRIPTION
The first-character digit check rejected pmAtomStr_r() output like "nan" from 0.0/0.0 on s390x (positive quiet NaN), breaking pmseries division tests 1886 and 1906.

For some reason the FPU on `s390x` returns NaN with sign bit clear which is different from most of the other architectures which return negative NaN (sign bit set). Both ways are allowed by IEEE 754 which states only that Nan should be returned (no sign defined).

Edit: I can reproduce this on `ppc64le` arch as well, so it is not specific for `s390x` FPUs.