### PR TITLE
qa: cover ubuntu2604 differences in some tests

### DIFF
--- a/qa/1280
+++ b/qa/1280
@@ -72,11 +72,7 @@ _doit
 
 echo
 echo "=== volume 2 truncated ==="
-size=`stat 20180416.2 | sed -n -e '/Size:/{
-s/.*Size: *//
-s/ .*//
-p
-}'`
+size=`_filesize 20180416.2`
 size=`expr $size - 8`
 truncate -s $size 20180416.2
 _doit

--- a/qa/1429
+++ b/qa/1429
@@ -57,6 +57,8 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 #	not:
 #	  mkdir: cannot create directory '/eek/': Permission denied
 #                                        ^    ^^
+#	and uutils coreutils (Ubuntu 26.04) reports:
+#	  mkdir: Permission denied
 #
 _filter()
 {
@@ -77,6 +79,7 @@ _filter()
 	-e "/mkdir/s/: '/: /g" \
 	-e "/mkdir/s/\/': /: /g" \
 	-e "/mkdir/s/': /: /g" \
+	-e 's/^mkdir:.*Permission denied$/mkdir: Permission denied/' \
     | $PCP_AWK_PROG '
 /-rw-r--r--/	{ print $1,"...",$5,"...",$9; next }
 		{ print }' \

--- a/qa/1429.out
+++ b/qa/1429.out
@@ -7,7 +7,7 @@ Error: no pmlogger instance running for host "HOST"
 ... logging for host "HOST" unchanged
 PMLOGGER.DAILY: [TMP.control:3]
 Warning: skipping log rotation because we don't know which pmlogger to signal
-mkdir: /no: Permission denied
+mkdir: Permission denied
 PMLOGGER.DAILY: [TMP.control:3]
 Error: cannot create directory (/no/such/dir) for autosave
 ... logging for host "HOST" unchanged
@@ -64,13 +64,13 @@ Error: no pmlogger instance running for host "HOST"
 ... logging for host "HOST" unchanged
 PMLOGGER.DAILY: [TMP.control:4]
 Warning: skipping log rotation because we don't know which pmlogger to signal
-mkdir: TMP.ok/YYYY/YYYY-MM-DAYBEFOREYESTERDAY: Permission denied
+mkdir: Permission denied
 PMLOGGER.DAILY: [TMP.control:4]
 Error: cannot create directory (TMP.ok/YYYY/YYYY-MM-DAYBEFOREYESTERDAY/) for autosave
 ... logging for host "HOST" unchanged
 PMLOGGER.DAILY: [TMP.control:4]
 Warning: DAYBEFOREYESTERDAY: AUTOSAVE skipped: directory TMP.ok/YYYY/YYYY-MM-DAYBEFOREYESTERDAY/ does not exist
-mkdir: TMP.ok/YYYY/YYYY-MM-YESTERDAY: Permission denied
+mkdir: Permission denied
 PMLOGGER.DAILY: [TMP.control:4]
 Error: cannot create directory (TMP.ok/YYYY/YYYY-MM-YESTERDAY/) for autosave
 ... logging for host "HOST" unchanged

--- a/qa/common.check
+++ b/qa/common.check
@@ -82,12 +82,13 @@ _filesize()
 	# stat(1) format
 	#   File: `441'
 	#   Size: 2016      	Blocks: 8          IO Block: 4096   regular file
+	# (newer GNU coreutils uses "size:" instead of "Size:")
 	# Device: 816h/2070d	Inode: 758237      Links: 1
 	# Access: (0755/-rwxr-xr-x)  Uid: ( 1000/    kenj)   Gid: ( 1000/    kenj)
 	# Access: 2011-05-09 06:52:58.000000000 +1000
 	# Modify: 2011-02-27 14:42:30.000000000 +1100
 	# Change: 2011-02-28 19:21:27.000000000 +1100
-	stat "$__filename" 2>&1 | $PCP_AWK_PROG '$1 == "Size:" { print $2 }'
+	stat "$__filename" 2>&1 | $PCP_AWK_PROG 'tolower($1) == "size:" { print $2 }'
     fi
 }
 


### PR DESCRIPTION
qa/1429 - fix mkdir error message:
ubuntu2604 uses uutils coreutils which returns different error message when `mkdir` command fails for a permission reason.
    
fix _filesize():
On Fedora/RHEL (and older distros), `stat` prints 'Size' while on Ubuntu26.04 `stat` prints 'size'. The fix covers this difference and fixes various tests using the `stat` command to get file size.