### PR TITLE
qa: fixed tests 025, 151, 1041, 1215, 1478, 1483, 1484

### DIFF
--- a/qa/1041
+++ b/qa/1041
@@ -34,10 +34,28 @@ $python -c "import libvirt" >/dev/null 2>&1
 $python -c "import lxml" >/dev/null 2>&1
 [ $? -eq 0 ] || _notrun "python lxml module not installed"
 
+# libvirtd must be installed (systemd unit or rc script)
+#
+[ -f $PCP_SYSTEMDUNIT_DIR/libvirtd.service -o -f $PCP_RC_DIR/libvirtd ] \
+    || _notrun "libvirtd not installed"
+
 # start libvirtd
 #
-if ! _service libvirtd start >$seq_full 2>&1; then _exit 1; fi
-[ -e /var/run/libvirt/libvirt-sock-ro ] || _notrun "no socket, libvirtd not running?"
+if ! _service libvirtd start >>$seq_full 2>&1
+then
+    _notrun "libvirtd could not be started"
+fi
+[ -e /run/libvirt/libvirt-sock-ro -o -e /var/run/libvirt/libvirt-sock-ro ] \
+    || _notrun "no libvirt socket, libvirtd not running?"
+
+$python -c "
+import libvirt
+conn = libvirt.openReadOnly('qemu:///system')
+if conn is None:
+    raise SystemExit(1)
+conn.close()
+" >/dev/null 2>&1 \
+    || _notrun "no libvirt qemu:///system connection driver available"
 
 status=1	# failure is the default!
 
@@ -70,7 +88,7 @@ EOF
     echo
     echo "=== libvirt agent installation ==="
     PCPQA_CHECK_DELAY=10; export PCPQA_CHECK_DELAY
-    $sudo ./Install </dev/null >$tmp.out 2>&1
+    $sudo env PCPQA_CHECK_DELAY=$PCPQA_CHECK_DELAY ./Install </dev/null >$tmp.out 2>&1
     cat $tmp.out >>$seq_full
     # Check metrics have appeared ... X metrics and Y values
     # skip lines like ...

--- a/qa/1215
+++ b/qa/1215
@@ -115,12 +115,12 @@ echo "=== pmlogger won't stop ... stop case"
 # SIGHUP is change volume, will not terminate pmlogger
 #
 PCPQA_KILL_SIGNAL=HUP; export PCPQA_KILL_SIGNAL
-$sudo pmlogctl -V -p $tmp.policy -c $seq stop localhost 2>&1 | _filter
+$sudo env PCPQA_KILL_SIGNAL=$PCPQA_KILL_SIGNAL pmlogctl -V -p $tmp.policy -c $seq stop localhost 2>&1 | _filter
 pmlogctl status localhost | _filter_status
 
 echo
 echo "=== pmlogger won't stop ... restart case"
-$sudo pmlogctl -V -p $tmp.policy -c $seq restart localhost 2>&1 | _filter
+$sudo env PCPQA_KILL_SIGNAL=$PCPQA_KILL_SIGNAL pmlogctl -V -p $tmp.policy -c $seq restart localhost 2>&1 | _filter
 pmlogctl status localhost | _filter_status
 
 # success, all done

--- a/qa/1478
+++ b/qa/1478
@@ -38,6 +38,14 @@ _filter()
     # end
 }
 
+# pcp-reboot-init must run as root, but needs the test's $PCP_DIR layout
+#
+_pcp_reboot_init()
+{
+    $sudo env PCP_DIR=$PCP_DIR PCP_LOG_DIR=$PCP_LOG_DIR \
+	$PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+}
+
 mkdir $tmp
 
 # setup a "correct" NOTICES to avoid babble from trying to
@@ -68,22 +76,22 @@ echo
 echo "=== missing vars from pcp.conf"
 touch $tmp/etc/pcp.conf
 echo "PCP_FOO=bar" >>$tmp/etc/pcp.conf
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+_pcp_reboot_init
 echo "PCP_USER=pcpqa" >>$tmp/etc/pcp.conf
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+_pcp_reboot_init
 echo "PCP_GROUP=pcpqa" >>$tmp/etc/pcp.conf
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+_pcp_reboot_init
 echo "PCP_RUN_DIR=$tmp/run" >>$tmp/etc/pcp.conf
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+_pcp_reboot_init
 
 echo
 echo "=== \$PCP_RUN_DIR missing"
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+_pcp_reboot_init
 ls -ld $tmp/run | _filter_ls -s | _filter
 
 echo
 echo "=== \$PCP_RUN_DIR exists and OK, so do nothing"
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+_pcp_reboot_init
 ls -ld $tmp/run | _filter_ls -s | _filter
 
 echo
@@ -91,16 +99,16 @@ echo "=== \$PCP_RUN_DIR exists but various problems ..."
 echo "--- wrong user"
 iam=`id -u`
 $sudo chown $iam:pcpqa $tmp/run
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+_pcp_reboot_init
 ls -ld $tmp/run | _filter_ls -s | _filter
 echo "--- wrong group"
 iam=`id -g`
 $sudo chown pcpqa:$iam $tmp/run
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+_pcp_reboot_init
 ls -ld $tmp/run | _filter_ls -s | _filter
 echo "--- wrong mode"
 $sudo chmod 755 $tmp/run
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+_pcp_reboot_init
 ls -ld $tmp/run | _filter_ls -s | _filter
 
 # success, all done

--- a/qa/1483
+++ b/qa/1483
@@ -77,6 +77,8 @@ _filter()
 		-e '/pmcd\[[0-9]*]: .*\/pmcd: .* cannot start pmcd/d' \
 		-e '/pmcd\[[0-9]*]: pmprobe: Cannot connect to PMCD on host "local:"/d' \
 		-e '/systemctl\[[0-9]*]: .* pmcd\.service changed on disk/d' \
+		-e '/pmcd\[[0-9]*]: .*OpenRequestSocket(.*, \/tmp\/[0-9]*-[0-9]*\.socket, unix).*Address already in use/d' \
+		-e '/pmcd\[[0-9]*]: .*pmcd may already be running/d' \
 	    #end
 	    ;;
 

--- a/qa/1484
+++ b/qa/1484
@@ -67,6 +67,19 @@ _myls()
     | _filter
 }
 
+# pcp-reboot-init must run as root, but needs the test's $PCP_LOG_DIR
+#
+_pcp_reboot_init()
+{
+    $sudo env PCP_LOG_DIR=$PCP_LOG_DIR \
+	$PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+}
+
+_pcp_reboot_init_to_myls()
+{
+    _pcp_reboot_init | _myls
+}
+
 umask 022
 mkdir $tmp
 PCP_LOG_DIR=$tmp/log; export PCP_LOG_DIR
@@ -75,7 +88,7 @@ PCP_LOG_DIR=$tmp/log; export PCP_LOG_DIR
 
 echo
 echo "=== \$PCP_LOG_DIR missing"
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+_pcp_reboot_init
 ls -ld $tmp/log 2>&1 | _myls
 
 echo
@@ -84,22 +97,20 @@ mkdir "$PCP_LOG_DIR"
 touch "$PCP_LOG_DIR"/NOTICES
 $sudo chown $PCP_USER:$PCP_GROUP "$PCP_LOG_DIR"
 $sudo chown $PCP_USER:$PCP_GROUP "$PCP_LOG_DIR"/NOTICES
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter 
+_pcp_reboot_init
 ls -l $tmp/log/NOTICES* 2>&1 | _myls
 
 echo
 echo "=== \$PCP_LOG_DIR/NOTICES does not exist ..."
 $sudo rm -f "$PCP_LOG_DIR"/NOTICES
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter 
+_pcp_reboot_init
 ls -l $tmp/log/NOTICES* 2>&1 | _myls
 
 echo
 echo "=== \$PCP_LOG_DIR/NOTICES does not exist, but cannot create ..."
 $sudo rm -f "$PCP_LOG_DIR"/NOTICES
 $sudo chown pcpqa:pcpqa "$PCP_LOG_DIR"
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 \
-| _filter  \
-| _myls
+_pcp_reboot_init_to_myls
 ls -l $tmp/log/NOTICES* 2>&1 | _myls
 $sudo chown $PCP_USER:$PCP_GROUP "$PCP_LOG_DIR"
 
@@ -108,7 +119,7 @@ echo "=== \$PCP_LOG_DIR/NOTICES exists, but wrong ownership, no NOTICES.old ..."
 $sudo rm -f "$PCP_LOG_DIR"/NOTICES*
 $sudo touch "$PCP_LOG_DIR"/NOTICES
 $sudo chown root:root "$PCP_LOG_DIR"/NOTICES
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter 
+_pcp_reboot_init
 ls -l $tmp/log/NOTICES* 2>&1 | _myls
 
 echo
@@ -118,7 +129,7 @@ $sudo touch "$PCP_LOG_DIR"/NOTICES.old
 $sudo chown root:root "$PCP_LOG_DIR"/NOTICES.old
 $sudo touch "$PCP_LOG_DIR"/NOTICES
 $sudo chown pcpqa:pcpqa "$PCP_LOG_DIR"/NOTICES
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter 
+_pcp_reboot_init
 ls -l $tmp/log/NOTICES* 2>&1 | _myls
 
 echo
@@ -127,9 +138,7 @@ $sudo rm -f "$PCP_LOG_DIR"/NOTICES*
 $sudo touch "$PCP_LOG_DIR"/NOTICES
 $sudo chown pcpqa:pcpqa "$PCP_LOG_DIR"/NOTICES
 $sudo chown pcpqa:pcpqa "$PCP_LOG_DIR"
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 \
-| _filter \
-| _myls
+_pcp_reboot_init_to_myls
 ls -l $tmp/log/NOTICES* 2>&1 | _myls
 $sudo chown $PCP_USER:$PCP_GROUP "$PCP_LOG_DIR"
 
@@ -139,7 +148,7 @@ $sudo rm -f "$PCP_LOG_DIR"/NOTICES*
 $sudo touch "$PCP_LOG_DIR"/NOTICES
 $sudo chmod 666 "$PCP_LOG_DIR"/NOTICES
 $sudo chown $PCP_USER:$PCP_GROUP "$PCP_LOG_DIR"/NOTICES
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+_pcp_reboot_init
 ls -l $tmp/log/NOTICES* 2>&1 | _myls
 
 echo
@@ -150,7 +159,7 @@ $sudo touch /etc/$seq-foobar
 echo "Created by PCP QA $seq on `date`" | $sudo dd of=/etc/$seq-foobar 2>/dev/null
 $sudo chmod 400 /etc/$seq-foobar
 $sudo ln -s /etc/$seq-foobar "$PCP_LOG_DIR"/NOTICES
-$sudo $PCP_BINADM_DIR/pcp-reboot-init 2>&1 | _filter
+_pcp_reboot_init
 ls -l $tmp/log/NOTICES* 2>&1 | _myls
 ls -l /etc/$seq-foobar | _myls
 $sudo rm -f /etc/$seq-foobar

--- a/qa/151
+++ b/qa/151
@@ -138,7 +138,15 @@ do
     min_set=`expr 10 - $now_min`
     [ "$min_set" -ge 0 ] && min_set="+$min_set"
     namea=`pmdate -${day}d ${hr_set}H ${min_set}M %Y%m%d`
-    stampa=`echo $namea | sed -e 's/\.//g'`0010
+    if [ $day -ge 5 ]
+    then
+	# find-filter mtime +5 discards archives strictly older than 5*24
+	# hours from "now".  00:10 on the calendar day $day days ago can
+	# be just inside that window when QA runs soon after midnight.
+	stampa=`pmdate -${day}d -25H +10M %Y%m%d%H%M`
+    else
+	stampa=`echo $namea | sed -e 's/\.//g'`0010
+    fi
     echo "s/$namea/TODAY-$day/g" >>$tmp/sed
 
     for ext in 0 index meta

--- a/qa/common.check
+++ b/qa/common.check
@@ -1021,8 +1021,11 @@ _wait_for_pmlogger()
 	then
 	    # pmlogger socket has been set up ...
 	    __dead=false
-	    echo "_wait_for_pmlogger() success at iter $__i ..." >>$seq_full
-	    cat $tmp._wait_for_pmlogger.tmp >>$seq_full
+	    if [ -n "$seq_full" ]
+	    then
+		echo "_wait_for_pmlogger() success at iter $__i ..." >>$seq_full
+		cat $tmp._wait_for_pmlogger.tmp >>$seq_full
+	    fi
 	    # give pmlogger a chance to detect that pmlc has gone away
 	    # so the port is free
 	    pmsleep 0.25


### PR DESCRIPTION
qa/025 - _wait_for_pmlogger() should append to $seq_full only if $seq_full is set _wait_for_pmlogger() in common.check appends success diagnostics to $seq_full. When that variable is empty, ">>$seq_full" becomes with no target, which produces shell errors i.e. in test 025 (cannot create : Directory nonexistent) polluting test output.

qa/1041 - propagate PCPQA_CHECK_DELAY to the sudo session PCPQA_CHECK_DELAY is not propagated to the "sudo ./Install" session, so it waits only for the default 1s instead of 10s. The fix implements propagation of the PCPQA_CHECK_DELAY. Reworked requirements when the test runs or is skipped.

qa/1215 - propagate PCPQA_KILL_SIGNAL to the sudo session The PCPQA_KILL_SIGNAL is not propagated to sudo session, so the test output expects HUP signal, but the default TERM is received instead. The fix propagates the PCPQA_KILL_SIGNAL to the sudo seesion, so HUP signal is used instead.

qa/1478 - propagate PCP_DIR and PCP_LOG_DIR to the sudo session The test builds an isolated config under $tmp. sudo does not preserve PCP_DIR or PCP_LOG_DIR, so those invocations used the system /etc/pcp.conf instead of $tmp/etc/pcp.conf. The fix propagates PCP_DIR and PCP_LOG_DIR to the sudo session

qa/1483 - fix filtering of syslog/journal noise

qa/1484 - propagate PCP_LOG_DIR to the sudo session pcp-reboot-init must run as root, so the test uses sudo. sudo does not preserve PCP_LOG_DIR, so the script used the system log directory (/var/log/pcp/...) instead of $tmp/log. The fix propagates the PCP_LOG_DIR to the sudo session

qa/151 - fix timing edge case when the test runs around midnight When the test runs soon after midnight (as in CI), “5 days ago at 00:10” can be only ~5.0 days old and survive the cull, while “6 days ago at 00:10” is ~6.0 days old and is removed. That matches the report: only TODAY-6 culled, TODAY-5 kept. The fix handles this specific edge case.