### PR TITLE
ci: use classic sudo in ubuntu2604-container

### DIFF
--- a/build/ci/platforms/ubuntu2604-container.yml
+++ b/build/ci/platforms/ubuntu2604-container.yml
@@ -11,7 +11,8 @@ artifactory:
 container:
   containerfile: |
     FROM docker.io/library/ubuntu:26.04
-    RUN apt-get update && apt-get install -y systemd sudo
+    RUN apt-get update && apt-get install -y systemd sudo \
+     && update-alternatives --set sudo /usr/bin/sudo.ws
     RUN useradd --create-home pcpbuild
     RUN echo 'pcpbuild ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/pcpbuild
 


### PR DESCRIPTION
Ubuntu 26.04 defaults to `sudo-rs`, which does not support `-E`. Switch to `sudo.ws` so QA environment propagation matches other CI platforms.