### PR TITLE
darwin pmdaproc: fix Mach port leak in darwin_process_threads()

### DIFF
--- a/src/pmdas/darwin_proc/kinfo_proc.c
+++ b/src/pmdas/darwin_proc/kinfo_proc.c
@@ -336,8 +336,10 @@ darwin_process_threads(darwin_procs_t *processes, darwin_runq_t *runq,
 	}
     }
 
+    for (i = 0; i < thread_count; i++)
+	mach_port_deallocate(mach_task_self(), threads[i]);
     count = thread_count - count;
-    bytes = count * sizeof(thread_port_array_t);
+    bytes = thread_count * sizeof(thread_act_t);
     vm_deallocate(mach_task_self(), (vm_address_t)threads, bytes);
     mach_port_deallocate(mach_task_self(), task);
     return count;


### PR DESCRIPTION
task_threads() returns an array of thread port send rights, each of which must be individually deallocated with mach_port_deallocate(). The existing code only freed the backing array memory (vm_deallocate) and the task port, but never released the per-thread send rights.

Also fix the vm_deallocate size argument: sizeof(thread_port_array_t) is the size of a pointer, not the element size. Use sizeof(thread_act_t) to match the actual array element type.