### PR TITLE
zeroconf: drop dependency on pcp-pmda-bpftrace and bpftrace

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -2144,9 +2144,6 @@ Requires: pcp-pmda-dm = @package_version@
 %if "@pmda_bpf@" == "true"
 Requires: pcp-pmda-bpf = @package_version@
 %endif
-%if "@pmda_bpftrace@" == "true"
-Requires: pcp-pmda-bpftrace = @package_version@
-%endif
 %if "@have_python@" == "true"
 Requires: pcp-pmda-nfsclient = @package_version@
 %endif

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -2119,9 +2119,6 @@ Requires: pcp-pmda-dm = %{version}-%{release}
 %if !%{disable_bpf}
 Requires: pcp-pmda-bpf = %{version}-%{release}
 %endif
-%if !%{disable_bpftrace}
-Requires: pcp-pmda-bpftrace = %{version}-%{release}
-%endif
 %if !%{disable_python3}
 Requires: pcp-pmda-nfsclient = %{version}-%{release}
 Requires: pcp-pmda-openmetrics = %{version}-%{release}


### PR DESCRIPTION
The link to bpftrace brings in an additional 200MiB+ (Fedora) and 400MiB+ (RHEL) dependencies via clang (and gcc-toolset on RHEL) - which is simply too much to justify as a default dep.

Resolves Red Hat issue RHEL-180384