### PR TITLE
pmdacifs: switch to using a default-installed DSO agent

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -36,6 +36,11 @@ Conflicts: librapi < 0.16
 Obsoletes: pcp-pmda-kvm < 4.1.1
 Provides: pcp-pmda-kvm = %{version}-%{release}
 
+# CIFS PMDA moved into pcp (kernel metrics, default on)
+Obsoletes: pcp-pmda-cifs < 7.1.6
+Obsoletes: pcp-pmda-cifs-debuginfo < 7.1.6
+Provides: pcp-pmda-cifs = %{version}-%{release}
+
 # RPM PMDA retired completely
 Obsoletes: pcp-pmda-rpm < 5.3.2
 Obsoletes: pcp-pmda-rpm-debuginfo < 5.3.2
@@ -1852,19 +1857,6 @@ collecting metrics about the Bash shell.
 # end pcp-pmda-bash
 
 #
-# pcp-pmda-cifs
-#
-%package pmda-cifs
-License: GPL-2.0-or-later
-Summary: Performance Co-Pilot (PCP) metrics for the CIFS protocol
-URL: https://pcp.io
-Requires: pcp = @package_version@ pcp-libs = @package_version@
-%description pmda-cifs
-This package contains the PCP Performance Metrics Domain Agent (PMDA) for
-collecting metrics about the Common Internet Filesytem.
-# end pcp-pmda-cifs
-
-#
 # pcp-pmda-cisco
 #
 %package pmda-cisco
@@ -2342,7 +2334,6 @@ basic_manifest | keep '(etc/pcp|pmdas)/bind2(/|$)' >pcp-pmda-bind2-files
 basic_manifest | keep '(etc/pcp|pmdas)/bonding(/|$)' >pcp-pmda-bonding-files
 basic_manifest | keep '(etc/pcp|pmdas)/bpf(/|$)' >pcp-pmda-bpf-files
 basic_manifest | keep '(etc/pcp|pmdas)/bpftrace(/|$)' >pcp-pmda-bpftrace-files
-basic_manifest | keep '(etc/pcp|pmdas)/cifs(/|$)' >pcp-pmda-cifs-files
 basic_manifest | keep '(etc/pcp|pmdas)/cisco(/|$)' >pcp-pmda-cisco-files
 basic_manifest | keep '(etc/pcp|pmdas)/dbping(/|$)' >pcp-pmda-dbping-files
 basic_manifest | keep '(etc/pcp|pmdas)/denki(/|$)' >pcp-pmda-denki-files
@@ -2419,7 +2410,7 @@ rm -f packages.list
 for pmda_package in \
     activemq amdgpu apache \
     bash bind2 bonding bpf bpftrace \
-    cifs cisco \
+    cisco \
     dbping denki docker dm ds389 ds389log \
     elasticsearch \
     farm \
@@ -2890,9 +2881,6 @@ done
 %preun pmda-bash
 %{pmda_remove "$1" "bash"}
 
-%preun pmda-cifs
-%{pmda_remove "$1" "cifs"}
-
 %preun pmda-cisco
 %{pmda_remove "$1" "cisco"}
 
@@ -3261,8 +3249,6 @@ fi
 %endif
 
 %files pmda-bash -f pcp-pmda-bash-files.rpm
-
-%files pmda-cifs -f pcp-pmda-cifs-files.rpm
 
 %files pmda-cisco -f pcp-pmda-cisco-files.rpm
 

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -199,6 +199,11 @@ Conflicts: librapi < 0.16
 Obsoletes: pcp-pmda-kvm < 4.1.1
 Provides: pcp-pmda-kvm = %{version}-%{release}
 
+# CIFS PMDA moved into pcp (kernel metrics, default on)
+Obsoletes: pcp-pmda-cifs < 7.1.6
+Obsoletes: pcp-pmda-cifs-debuginfo < 7.1.6
+Provides: pcp-pmda-cifs = %{version}-%{release}
+
 # RPM PMDA retired completely
 Obsoletes: pcp-pmda-rpm < 5.3.2
 Obsoletes: pcp-pmda-rpm-debuginfo < 5.3.2
@@ -1830,19 +1835,6 @@ collecting metrics about the Bash shell.
 # end pcp-pmda-bash
 
 #
-# pcp-pmda-cifs
-#
-%package pmda-cifs
-License: GPL-2.0-or-later
-Summary: Performance Co-Pilot (PCP) metrics for the CIFS protocol
-URL: https://pcp.io
-Requires: pcp = %{version}-%{release} pcp-libs = %{version}-%{release}
-%description pmda-cifs
-This package contains the PCP Performance Metrics Domain Agent (PMDA) for
-collecting metrics about the Common Internet Filesytem.
-# end pcp-pmda-cifs
-
-#
 # pcp-pmda-cisco
 #
 %package pmda-cisco
@@ -2453,7 +2445,6 @@ basic_manifest | keep '(etc/pcp|pmdas)/bind2(/|$)' >pcp-pmda-bind2-files
 basic_manifest | keep '(etc/pcp|pmdas)/bonding(/|$)' >pcp-pmda-bonding-files
 basic_manifest | keep '(etc/pcp|pmdas)/bpf(/|$)' >pcp-pmda-bpf-files
 basic_manifest | keep '(etc/pcp|pmdas)/bpftrace(/|$)' >pcp-pmda-bpftrace-files
-basic_manifest | keep '(etc/pcp|pmdas)/cifs(/|$)' >pcp-pmda-cifs-files
 basic_manifest | keep '(etc/pcp|pmdas)/cisco(/|$)' >pcp-pmda-cisco-files
 basic_manifest | keep '(etc/pcp|pmdas)/dbping(/|$)' >pcp-pmda-dbping-files
 basic_manifest | keep '(etc/pcp|pmdas|pmieconf)/dm(/|$)' >pcp-pmda-dm-files
@@ -2530,7 +2521,7 @@ rm -f packages.list
 for pmda_package in \
     activemq amdgpu apache \
     bash bind2 bonding bpf bpftrace \
-    cifs cisco \
+    cisco \
     dbping denki docker dm ds389 ds389log \
     elasticsearch \
     farm \
@@ -2942,9 +2933,6 @@ exit 0
 %preun pmda-bash
 %{pmda_remove "$1" "bash"}
 
-%preun pmda-cifs
-%{pmda_remove "$1" "cifs"}
-
 %preun pmda-cisco
 %{pmda_remove "$1" "cisco"}
 
@@ -3341,8 +3329,6 @@ fi
 %files pmda-apache -f pcp-pmda-apache-files.rpm
 
 %files pmda-bash -f pcp-pmda-bash-files.rpm
-
-%files pmda-cifs -f pcp-pmda-cifs-files.rpm
 
 %files pmda-cisco -f pcp-pmda-cisco-files.rpm
 

--- a/qa/common.filter
+++ b/qa/common.filter
@@ -274,6 +274,7 @@ _filter_optional_pmdas()
 	-e '/pmdabpf/d' \
 	-e '/pmdabpftrace/d' \
 	-e '/pmdabrocade/d' \
+	-e '/pmdacifs/d' \
 	-e '/pmdacisco/d' \
 	-e '/pmdadbping/d' \
 	-e '/pmdadenki/d' \
@@ -415,8 +416,9 @@ _filter_optional_pmda_instances()
 	-e '/inst \[109 or "mssql"]/d' \
 	-e '/inst \[110 or "postgresql"]/d' \
 	-e '/inst \[114 or "systemd"]/d' \
-        -e '/inst \[120 or "nvidia"]/d' \
-        -e '/inst \[122 or "jbd2"]/d' \
+	-e '/inst \[120 or "nvidia"]/d' \
+	-e '/inst \[121 or "cifs"]/d' \
+	-e '/inst \[122 or "jbd2"]/d' \
 	-e '/inst \[123 or "rpm"]/d' \
 	-e '/inst \[125 or "zswap"]/d' \
 	-e '/inst \[127 or "perfevent"]/d' \
@@ -461,6 +463,7 @@ _filter_top_pmns()
 	-e '/^    broken /d' \
 	-e '/^    cgroup /d' \
 	-e '/^    containers /d' \
+	-e '/^    cifs /d' \
 	-e '/^    cisco /d' \
 	-e '/^    datatape /d' \
 	-e '/^    dbping /d' \
@@ -965,6 +968,7 @@ _filter_torture_api()
 	-e '/^    services /d' \
 	-e '/^    apache /d' \
 	-e '/^    bonding /d' \
+	-e '/^    cifs /d' \
 	-e '/^    cihb /d' \
 	-e '/^    cms /d' \
 	-e '/^    cxfs /d' \

--- a/src/pmdas/cifs/.gitignore
+++ b/src/pmdas/cifs/.gitignore
@@ -1,4 +1,6 @@
 domain.h
+exports
+help.dir
+help.pag
 pmdacifs
 pmda_cifs.so
-

--- a/src/pmdas/cifs/GNUmakefile
+++ b/src/pmdas/cifs/GNUmakefile
@@ -15,19 +15,23 @@
 TOPDIR = ../../..
 include	$(TOPDIR)/src/include/builddefs
 
-CFILES		= pmda.c stats.c
-HFILES		= pmdagcifs.h stats.h
-CMDTARGET	= pmdacifs
-LIBTARGET	= pmda_$(IAM).$(DSOSUFFIX)
-
-LLDLIBS		= $(PCP_PMDALIB)
-
 IAM		= cifs
 DOMAIN		= CIFS
-PMDAINIT	= $(IAM)_init
-PMDATMPDIR	= $(PCP_PMDAS_DIR)/$(IAM)
 PMDAADMDIR	= $(PCP_PMDASADM_DIR)/$(IAM)
+PMDATMPDIR	= $(PCP_PMDAS_DIR)/$(IAM)
+CMDTARGET	= pmda$(IAM)
+LIBTARGET	= pmda_$(IAM).$(DSOSUFFIX)
+PMDAINIT	= $(IAM)_init
+CONF_LINE	= "cifs	121	dso	cifs_init	$(PMDATMPDIR)/$(LIBTARGET)"
 
+CFILES		= pmda.c stats.c
+HFILES		= pmdacifs.h stats.h
+SCRIPTS		= Install Remove
+
+VERSION_SCRIPT	= exports
+HELPTARGETS	= help.dir help.pag
+LLDLIBS		= $(PCP_PMDALIB)
+DFILES		= help
 LDIRT		= domain.h $(IAM).log
 
 MAN_SECTION	= 1
@@ -39,13 +43,19 @@ default:	build-me
 include $(BUILDRULES)
 
 ifeq "$(TARGET_OS)" "linux"
-build-me: $(CMDTARGET) $(LIBTARGET)
+build-me: $(CMDTARGET) $(LIBTARGET) $(HELPTARGETS)
+	@if [ -f ../pmcd.conf ]; then \
+	    if [ `grep -c $(CONF_LINE) ../pmcd.conf` -eq 0 ]; then \
+		echo $(CONF_LINE) >> ../pmcd.conf ; \
+	    fi; \
+	fi
 
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) root pmns domain.h help $(PMDAADMDIR)
-	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(CMDTARGET) $(LIBTARGET) $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) domain.h help help.dir help.pag root root_cifs $(PMDAADMDIR)
+	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(SCRIPTS) $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_cifs root_cifs $(PCP_PMNSADM_DIR)/root_cifs
 	@$(INSTALL_MAN)
 else
 build-me:
@@ -60,6 +70,12 @@ $(OBJECTS): domain.h
 
 domain.h: ../../pmns/stdpmid
 	$(DOMAIN_MAKERULE)
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_cifs -v 2 -o help < help
+
+$(VERSION_SCRIPT):
+	$(VERSION_SCRIPT_MAKERULE)
 
 pmda.o:			pmdacifs.h
 pmda.o stats.o:		stats.h

--- a/src/pmdas/cifs/Install
+++ b/src/pmdas/cifs/Install
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Copyright (c) 2014 Red Hat.
+# Copyright (c) 2014,2026 Red Hat.
 # 
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -22,6 +22,7 @@ iam=cifs
 dso_opt=true
 daemon_opt=true
 pipe_opt=true
+pmns_source=root_cifs
 
 pmdaSetup
 pmdaInstall

--- a/src/pmdas/cifs/help
+++ b/src/pmdas/cifs/help
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2018, 2025 Red Hat.
+# Copyright (c) 2014, 2018, 2025-2026 Red Hat.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -26,7 +26,7 @@
 #
 # blank lines before the @ line are ignored
 #
-@ CIFS.0 Instance domain for mounted CIFS filesystems
+@ 121.0 Instance domain for mounted CIFS filesystems
 
 @ cifs.session Number of sessions
 Count of the number of active CIFS sessions.

--- a/src/pmdas/cifs/root
+++ b/src/pmdas/cifs/root
@@ -3,7 +3,4 @@
  */
 
 #include <stdpmid>
-
-root { cifs }
-
-#include "pmns"
+#include "root_cifs"

--- a/src/pmdas/cifs/root_cifs
+++ b/src/pmdas/cifs/root_cifs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014,2018, 2025 Red Hat.
+ * Copyright (c) 2014,2018,2025-2026 Red Hat.
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -11,6 +11,14 @@
  * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
  * for more details.
  */
+
+#ifndef CIFS
+#define CIFS	121
+#endif
+
+root {
+    cifs
+}
 
 cifs {
     session		 CIFS:0:0


### PR DESCRIPTION
Make this PMDA (which contains Linux kernel metrics only) part of core PCP and default installed, as we did for kvm and for all the same reasons.