### PR TITLE
Makepkgs: add --ci mode to reduce output volume, preserving error context

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -28,7 +28,7 @@ jobs:
         id: Build
         run: |
           xcodebuild -version
-          ./Makepkgs -verbose
+          ./Makepkgs --ci
       # Validate PMID consistency
       - name: Validate PMID Consistency
         id: pmid-validation

--- a/Makepkgs
+++ b/Makepkgs
@@ -19,6 +19,7 @@
 topdir=`pwd`
 signed=false
 verbose=false
+cibuild=false
 srconly=false
 cfgonly=false
 dorpm=unknown
@@ -195,6 +196,10 @@ do
 	;;
     -verbose|--verbose)
 	verbose=true
+	shift
+	;;
+    -ci|--ci)
+	cibuild=true
 	shift
 	;;
     --check)
@@ -402,10 +407,36 @@ esac
 #
 [ -n "$cmdline_configopts" ] && configopts="$configopts $cmdline_configopts"
 
+# Grep pattern for --ci mode: phase headers, errors, and make failures.
+CI_LOG_RE='(^==|[Ee]rror[: ]|[Ff]ailed|[Ff]atal[: ]|make(\[[0-9]+\])?: \*\*\*)'
+
+# Tee build output to $LOGDIR/pcp, streaming to stdout based on mode:
+#   verbose  - stream everything (full tee)
+#   cibuild  - stream only lines matching CI_LOG_RE
+#   default  - silent; full output goes to log only
+#
+_tee_log()
+{
+    if $verbose ; then
+	tee -a "$LOGDIR/pcp"
+    elif $cibuild ; then
+	# grep exits 1 if no lines match; that is harmless here since
+	# build failure is detected via $tmp/failed, not pipeline status.
+	tee -a "$LOGDIR/pcp" | grep -E "$CI_LOG_RE" || true
+    else
+	cat >> "$LOGDIR/pcp"
+    fi
+}
+
 build_failure()
 {
-    # only print in non-verbose mode, otherwise we see double
-    if ! $verbose ; then
+    if $cibuild ; then
+	echo "$@ failed, see log in $LOGDIR/pcp"
+	echo "=== Error summary ==="
+	grep -n -E "$CI_LOG_RE" "$LOGDIR/pcp" | tail -20
+	echo "=== Last 100 lines ==="
+	tail -100 "$LOGDIR/pcp"
+    elif ! $verbose ; then
 	echo "$@ failed, see log in $LOGDIR/pcp"
 	tail "$LOGDIR/pcp"
     fi
@@ -617,11 +648,7 @@ debian_buildpackage()
     unset SOURCE_DATE_EPOCH
 
     rm -f $tmp/failed
-    if $verbose ; then
-	(dpkg-buildpackage $opts || touch $tmp/failed) 2>&1 | tee -a "$LOGDIR/pcp"
-    else
-	(dpkg-buildpackage $opts || touch $tmp/failed) >>"$LOGDIR/pcp" 2>&1
-    fi
+    (dpkg-buildpackage $opts || touch $tmp/failed) 2>&1 | _tee_log
     [ -f $tmp/failed ] && build_failure dpkg-buildpackage
 }
 
@@ -679,11 +706,7 @@ prepare_debian_control()
     # remake debian/control and update the source tarball
     #
     rm -f $tmp/failed debian/control
-    if $verbose ; then
-	($MAKE -C debian control 2>&1 || touch $tmp/failed) 2>&1 | tee -a "$LOGDIR/pcp"
-    else
-	($MAKE -C debian control 2>&1 || touch $tmp/failed) >>"$LOGDIR/pcp" 2>&1
-    fi
+    ($MAKE -C debian control 2>&1 || touch $tmp/failed) 2>&1 | _tee_log
     [ -f $tmp/failed ] && build_failure debian control
     $ZIP -d "$orig.gz"
     $TAR -f "$orig" --delete "$source/debian/control"
@@ -763,12 +786,7 @@ configure_pcp()
     [ -n "$configenv" ] && export $configenv
 
     rm -f $tmp/failed
-    if $verbose
-    then
-	($configure $configopts 2>&1 || touch $tmp/failed) 2>&1 | tee -a "$LOGDIR/pcp"
-    else
-	($configure $configopts 2>&1 || touch $tmp/failed) >>"$LOGDIR/pcp" 2>&1
-    fi
+    ($configure $configopts 2>&1 || touch $tmp/failed) 2>&1 | _tee_log
     if [ -f src/include/pcp/autoheader-dummmy.h ]
     then
 	# dodge autoheader(1) interference with configure.ac
@@ -780,7 +798,7 @@ configure_pcp()
     fi
     if [ -f $tmp/failed ]
     then
-	test -f config.log && cat config.log | tee -a "$LOGDIR/pcp"
+	test -f config.log && cat config.log | _tee_log
 	build_failure Configure
     fi
     if $cfgonly
@@ -798,11 +816,7 @@ check_pcp()
     echo "== Checking pcp, log is in $LOGDIR/pcp" | tee -a "$LOGDIR/pcp"
 
     rm -f $tmp/failed
-    if $verbose ; then
-	($MAKE check 2>&1 || touch $tmp/failed) 2>&1 | tee -a "$LOGDIR/pcp"
-    else
-	($MAKE check 2>&1 || touch $tmp/failed) >>"$LOGDIR/pcp" 2>&1
-    fi
+    ($MAKE check 2>&1 || touch $tmp/failed) 2>&1 | _tee_log
     [ -f $tmp/failed ] && build_failure Checking
 }
 
@@ -812,11 +826,7 @@ default_build()
     echo "== Building pcp, log is in $LOGDIR/pcp"
 
     rm -f $tmp/failed
-    if $verbose ; then
-	($MAKE default_pcp 2>&1 || touch $tmp/failed) 2>&1 | tee -a "$LOGDIR/pcp"
-    else
-	($MAKE default_pcp 2>&1 || touch $tmp/failed) >>"$LOGDIR/pcp" 2>&1
-    fi
+    ($MAKE default_pcp 2>&1 || touch $tmp/failed) 2>&1 | _tee_log
     [ -f $tmp/failed ] && build_failure Make default_pcp
 }
 
@@ -826,11 +836,7 @@ packaging_pcp()
     echo "== Packaging pcp, log is in $LOGDIR/pcp" | tee -a "$LOGDIR/pcp"
 
     rm -f $tmp/failed
-    if $verbose ; then
-	($MAKE -C build pack_pcp 2>&1 || touch $tmp/failed) 2>&1 | tee -a "$LOGDIR/pcp"
-    else
-	($MAKE -C build pack_pcp 2>&1 || touch $tmp/failed) >>"$LOGDIR/pcp" 2>&1
-    fi
+    ($MAKE -C build pack_pcp 2>&1 || touch $tmp/failed) 2>&1 | _tee_log
     [ -f $tmp/failed ] && build_failure Packaging via pack_pcp
 }
 
@@ -843,11 +849,7 @@ packaging_rpm()
     DIST_ROOT="$topdir/build/rpm/$source"; export DIST_ROOT
     # sign if --signed and $RPM_SIGN_KEYID set in the environment
     $signed && [ -z "$RPM_SIGN_KEYID" ] && unset RPM_SIGN_KEYID
-    if $verbose ; then
-	($MAKE -C build/rpm pack_pcp 2>&1 || touch $tmp/failed) 2>&1 | tee -a "$LOGDIR/pcp"
-    else
-	($MAKE -C build/rpm pack_pcp 2>&1 || touch $tmp/failed) >>"$LOGDIR/pcp" 2>&1
-    fi
+    ($MAKE -C build/rpm pack_pcp 2>&1 || touch $tmp/failed) 2>&1 | _tee_log
     [ -f $tmp/failed ] && build_failure Packaging RPMs via pack_pcp
 }
 

--- a/build/ci/platforms/amazonlinux2023-aarch64-container.yml
+++ b/build/ci/platforms/amazonlinux2023-aarch64-container.yml
@@ -18,7 +18,7 @@ tasks:
     sudo dnf install -y which hostname
     sudo dnf -y install $(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
   build: |
-    ./Makepkgs --verbose --check
+    ./Makepkgs --ci --check
     rpm -qp --requires $(echo pcp-*/build/rpm/pcp-*.src.rpm | sed "s/src/$(arch)/") | grep -q libuv.so
   copy_build_artifacts: |
     cp pcp-*/build/rpm/*.rpm ../artifacts/build

--- a/build/ci/platforms/amazonlinux2023-container.yml
+++ b/build/ci/platforms/amazonlinux2023-container.yml
@@ -18,7 +18,7 @@ tasks:
     sudo dnf install -y which hostname
     sudo dnf -y install $(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
   build: |
-    ./Makepkgs --verbose --check
+    ./Makepkgs --ci --check
     rpm -qp --requires $(echo pcp-*/build/rpm/pcp-*.src.rpm | sed "s/src/$(arch)/") | grep -q libuv.so
   copy_build_artifacts: |
     cp pcp-*/build/rpm/*.rpm ../artifacts/build

--- a/build/ci/platforms/centos-stream10-container.yml
+++ b/build/ci/platforms/centos-stream10-container.yml
@@ -24,7 +24,7 @@ tasks:
     sudo dnf install -y which hostname
     sudo dnf -y -b install $(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
   build: |
-    ./Makepkgs --verbose
+    ./Makepkgs --ci
     rpm -qp --requires $(echo pcp-*/build/rpm/pcp-*.src.rpm | sed 's/src/x86_64/') | grep -q libuv.so
   copy_build_artifacts: |
     cp pcp-*/build/rpm/*.rpm ../artifacts/build

--- a/build/ci/platforms/centos-stream8-container.yml
+++ b/build/ci/platforms/centos-stream8-container.yml
@@ -25,7 +25,7 @@ tasks:
     sudo dnf install -y which hostname
     sudo dnf -y -b install $(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
   build: |
-    ./Makepkgs --verbose
+    ./Makepkgs --ci
     rpm -qp --requires $(echo pcp-*/build/rpm/pcp-*.src.rpm | sed 's/src/x86_64/') | grep -q libuv.so
   copy_build_artifacts: |
     cp pcp-*/build/rpm/*.rpm ../artifacts/build

--- a/build/ci/platforms/centos-stream9-container.yml
+++ b/build/ci/platforms/centos-stream9-container.yml
@@ -24,7 +24,7 @@ tasks:
     sudo dnf install -y which hostname
     sudo dnf -y -b install $(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
   build: |
-    ./Makepkgs --verbose
+    ./Makepkgs --ci
     rpm -qp --requires $(echo pcp-*/build/rpm/pcp-*.src.rpm | sed 's/src/x86_64/') | grep -q libuv.so
   copy_build_artifacts: |
     cp pcp-*/build/rpm/*.rpm ../artifacts/build

--- a/build/ci/platforms/debian10-container.yml
+++ b/build/ci/platforms/debian10-container.yml
@@ -27,7 +27,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/debian11-container.yml
+++ b/build/ci/platforms/debian11-container.yml
@@ -27,7 +27,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/debian12-container.yml
+++ b/build/ci/platforms/debian12-container.yml
@@ -27,7 +27,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/debian13-container.yml
+++ b/build/ci/platforms/debian13-container.yml
@@ -27,7 +27,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/fedora-rawhide-container.yml
+++ b/build/ci/platforms/fedora-rawhide-container.yml
@@ -15,7 +15,7 @@ tasks:
     sudo dnf install -y which hostname
     sudo dnf install -y $(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
   build: |
-    ./Makepkgs --verbose
+    ./Makepkgs --ci
     rpm -qp --requires $(echo pcp-*/build/rpm/pcp-*.src.rpm | sed 's/src/x86_64/') | grep -q libuv.so
   copy_build_artifacts: |
     cp pcp-*/build/rpm/*.rpm ../artifacts/build

--- a/build/ci/platforms/fedora42-container.yml
+++ b/build/ci/platforms/fedora42-container.yml
@@ -18,7 +18,7 @@ tasks:
     sudo dnf install -y which hostname
     sudo dnf -y install $(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
   build: |
-    ./Makepkgs --verbose --check
+    ./Makepkgs --ci --check
     rpm -qp --requires $(echo pcp-*/build/rpm/pcp-*.src.rpm | sed 's/src/x86_64/') | grep -q libuv.so
   copy_build_artifacts: |
     cp pcp-*/build/rpm/*.rpm ../artifacts/build

--- a/build/ci/platforms/fedora43-container.yml
+++ b/build/ci/platforms/fedora43-container.yml
@@ -18,7 +18,7 @@ tasks:
     sudo dnf install -y which hostname
     sudo dnf -y install $(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
   build: |
-    ./Makepkgs --verbose --check
+    ./Makepkgs --ci --check
     rpm -qp --requires $(echo pcp-*/build/rpm/pcp-*.src.rpm | sed 's/src/x86_64/') | grep -q libuv.so
   copy_build_artifacts: |
     cp pcp-*/build/rpm/*.rpm ../artifacts/build

--- a/build/ci/platforms/fedora44-container.yml
+++ b/build/ci/platforms/fedora44-container.yml
@@ -18,7 +18,7 @@ tasks:
     sudo dnf install -y which hostname
     sudo dnf -y install $(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
   build: |
-    ./Makepkgs --verbose --check
+    ./Makepkgs --ci --check
     rpm -qp --requires $(echo pcp-*/build/rpm/pcp-*.src.rpm | sed 's/src/x86_64/') | grep -q libuv.so
   copy_build_artifacts: |
     cp pcp-*/build/rpm/*.rpm ../artifacts/build

--- a/build/ci/platforms/ubuntu1804-container.yml
+++ b/build/ci/platforms/ubuntu1804-container.yml
@@ -31,7 +31,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/ubuntu1804-i386-container.yml
+++ b/build/ci/platforms/ubuntu1804-i386-container.yml
@@ -23,7 +23,7 @@ tasks:
     pkgs=$(linux32 qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive linux32 apt-get install -y $pkgs
   build: |
-    linux32 ./Makepkgs --nonrpm --verbose
+    linux32 ./Makepkgs --nonrpm --ci
     linux32 dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/ubuntu2004-container.yml
+++ b/build/ci/platforms/ubuntu2004-container.yml
@@ -27,7 +27,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/ubuntu2004.yml
+++ b/build/ci/platforms/ubuntu2004.yml
@@ -7,7 +7,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/ubuntu2204-container.yml
+++ b/build/ci/platforms/ubuntu2204-container.yml
@@ -27,7 +27,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/ubuntu2204.yml
+++ b/build/ci/platforms/ubuntu2204.yml
@@ -7,7 +7,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/ubuntu2404-container.yml
+++ b/build/ci/platforms/ubuntu2404-container.yml
@@ -27,7 +27,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/ubuntu2404.yml
+++ b/build/ci/platforms/ubuntu2404.yml
@@ -7,7 +7,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/ubuntu2604-container.yml
+++ b/build/ci/platforms/ubuntu2604-container.yml
@@ -28,7 +28,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build

--- a/build/ci/platforms/ubuntu2604.yml
+++ b/build/ci/platforms/ubuntu2604.yml
@@ -7,7 +7,7 @@ tasks:
     pkgs=$(qa/admin/list-packages -m -v -x cpan -x pip3 -x not4ci)
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y $pkgs
   build: |
-    ./Makepkgs --nonrpm --verbose
+    ./Makepkgs --nonrpm --ci
     dpkg -I build/deb/pcp_*.deb | grep Depends | grep -q libuv1
   copy_build_artifacts: |
     cp build/deb/*.deb ../artifacts/build


### PR DESCRIPTION
--verbose floods container CI platforms with enough output to trigger internal container runtime timeouts (libpod exit-file races etc.). Dropping --verbose silently loses the error context on build failure.

Add --ci mode as a middle ground: all output still goes to Logs/pcp in full, but only phase headers and error/failure lines are streamed to stdout in real time via a single _tee_log() helper.  On failure, build_failure() emits a filtered error summary and the last 100 lines of the log, which is far more useful than the previous 10-line tail.

Switch all CI platform configs and the macOS workflow to --ci.
