### PR TITLE
pcp2openmetrics: add live timestamp mode

### DIFF
--- a/qa/1131
+++ b/qa/1131
@@ -62,8 +62,9 @@ _filter_pcp2openmetrics()
 	-e '/userid=/s/userid="*[0-9][0-9]*"*/userid="USERID"/' \
 	-e '/version=/s/version="*[^"]*"*/version="VERSION"/' \
 	-e '/agent=/s/agent="*[^"]*"*/agent="AGENT"/' \
-	-e 's/\(.*}\).*/\1 NCPU/' \
-	-e '/PCP5 kernel.all.load/{
+	-e 's/\(.*} \)[^ ]*/\1VALUE/' \
+    -e 's/\(.*VALUE \)[0-9].*/\1TIMESTAMP/' \
+    -e '/PCP5 kernel.all.load/{
 s/ 60.2.0 / PMID /
 s/ 60.2 / PMID /
 }' \
@@ -103,6 +104,8 @@ echo "--- pcp2openmetrics -s1 -z hinv.ncpu"
 pcp2openmetrics -s1 -z hinv.ncpu | _filter_pcp2openmetrics
 echo "--- pcp2openmetrics -s2 -x hinv.ncpu"
 pcp2openmetrics -s2 -x hinv.ncpu | _filter_pcp2openmetrics
+echo "--- pcp2openmetrics -s2 --times hinv.ncpu"
+pcp2openmetrics -s2 --times hinv.ncpu | _filter_pcp2openmetrics
 echo "--- pcp2openmetrics -s2 -a archives/20201109-b hinv.ncpu kernel.all.load"
 pcp2openmetrics -s2 -a $A1 hinv.ncpu kernel.all.load | _filter_pcp2openmetrics | _archive_filter
 echo "--- pcp2opentelemetry -s1 -z hinv.ncpu"

--- a/qa/1131.out
+++ b/qa/1131.out
@@ -2271,13 +2271,20 @@ QA output created by 1131
 # HELP hinv_ncpu number of CPUs in the system
 # PCP5 hinv_ncpu PMID u32 PM_INDOM_NULL discrete
 # TYPE hinv_ncpu gauge
-hinv_ncpu{domainname="DOMAINID",groupid="GROUPID",hostname="HOST",machineid="MACHINEID",userid="USERID",agent="AGENT"} NCPU
+hinv_ncpu{domainname="DOMAINID",groupid="GROUPID",hostname="HOST",machineid="MACHINEID",userid="USERID",agent="AGENT"} VALUE
 --- pcp2openmetrics -s2 -x hinv.ncpu
 # EOF
 # HELP hinv_ncpu number of CPUs in the system
 # TYPE hinv_ncpu gauge
-hinv_ncpu{domainname="DOMAINID",groupid="GROUPID",hostname="HOST",machineid="MACHINEID",userid="USERID",agent="AGENT"} NCPU
-hinv_ncpu{domainname="DOMAINID",groupid="GROUPID",hostname="HOST",machineid="MACHINEID",userid="USERID",agent="AGENT"} NCPU
+hinv_ncpu{domainname="DOMAINID",groupid="GROUPID",hostname="HOST",machineid="MACHINEID",userid="USERID",agent="AGENT"} VALUE
+hinv_ncpu{domainname="DOMAINID",groupid="GROUPID",hostname="HOST",machineid="MACHINEID",userid="USERID",agent="AGENT"} VALUE
+--- pcp2openmetrics -s2 --times hinv.ncpu
+# EOF
+# HELP hinv_ncpu number of CPUs in the system
+# PCP5 hinv_ncpu PMID u32 PM_INDOM_NULL discrete
+# TYPE hinv_ncpu gauge
+hinv_ncpu{domainname="DOMAINID",groupid="GROUPID",hostname="HOST",machineid="MACHINEID",userid="USERID",agent="AGENT"} VALUE TIMESTAMP
+hinv_ncpu{domainname="DOMAINID",groupid="GROUPID",hostname="HOST",machineid="MACHINEID",userid="USERID",agent="AGENT"} VALUE TIMESTAMP
 --- pcp2openmetrics -s2 -a archives/20201109-b hinv.ncpu kernel.all.load
 # EOF
 # HELP hinv_ncpu number of CPUs in the system
@@ -2286,11 +2293,11 @@ hinv_ncpu{domainname="DOMAINID",groupid="GROUPID",hostname="HOST",machineid="MAC
 # PCP5 kernel_all_load PMID float PMID instant
 # TYPE hinv_ncpu gauge
 # TYPE kernel_all_load gauge
-hinv_ncpu{,hostname="shard"} NCPU
-hinv_ncpu{,hostname="shard"} NCPU
-kernel_all_load{,hostname="shard",instname="1 minute",instid="1"} NCPU
-kernel_all_load{,hostname="shard",instname="15 minute",instid="15"} NCPU
-kernel_all_load{,hostname="shard",instname="5 minute",instid="5"} NCPU
+hinv_ncpu{,hostname="shard"} VALUE TIMESTAMP
+hinv_ncpu{,hostname="shard"} VALUE TIMESTAMP
+kernel_all_load{,hostname="shard",instname="1 minute",instid="1"} VALUE TIMESTAMP
+kernel_all_load{,hostname="shard",instname="15 minute",instid="15"} VALUE TIMESTAMP
+kernel_all_load{,hostname="shard",instname="5 minute",instid="5"} VALUE TIMESTAMP
 --- pcp2opentelemetry -s1 -z hinv.ncpu
 {
   "resourceMetrics": [

--- a/src/pcp2openmetrics/pcp2openmetrics.1
+++ b/src/pcp2openmetrics/pcp2openmetrics.1
@@ -418,6 +418,9 @@ More than one
 .B \-K
 option may be used.
 .TP
+\fB\-l\fR, \fB\-\-times\fR
+Live timestamp mode. When configured metric values are accompanied by their respective timestamp
+.TP
 \fB\-L\fR, \fB\-\-local\-PMDA\fR
 Use a local context to collect metrics from DSO PMDAs on the local host
 without PMCD.

--- a/src/pcp2openmetrics/pcp2openmetrics.py
+++ b/src/pcp2openmetrics/pcp2openmetrics.py
@@ -55,7 +55,7 @@ class PCP2OPENMETRICS(object):
         # Configuration directives
         self.keys = ('source', 'output', 'derived', 'globals',
                      'samples', 'interval', 'precision', 'daemonize',
-                     'timefmt', 'everything',
+                     'timefmt', 'everything', 'times',
                      'count_scale', 'space_scale', 'time_scale', 'version',
                      'count_scale_force', 'space_scale_force', 'time_scale_force',
                      'precision_force', 'limit_filter', 'limit_filter_force',
@@ -111,6 +111,7 @@ class PCP2OPENMETRICS(object):
         self.space_scale_force = None
         self.time_scale = None
         self.time_scale_force = None
+        self.times = 0
 
         # Not in pcp2openmetrics.conf, won't overwrite
         self.outfile = None
@@ -150,7 +151,7 @@ class PCP2OPENMETRICS(object):
         opts = pmapi.pmOptions()
         opts.pmSetOptionCallback(self.option)
         opts.pmSetOverrideCallback(self.option_override)
-        opts.pmSetShortOptions("a:h:LK:c:Ce:D:V?GA:S:T:O:s:t:Ii:jJ:4:58:9:nN:vmP:0:q:b:y:Q:B:Y:F:f:Z:zXo:p:U:u:x")
+        opts.pmSetShortOptions("a:h:LK:lc:Ce:D:V?GA:S:T:O:s:t:Ii:jJ:4:58:9:nN:vmP:0:q:b:y:Q:B:Y:F:f:Z:zXo:p:U:u:x")
         opts.pmSetShortUsage("[option...] metricspec [...]")
 
         opts.pmSetLongOptionHeader("General options")
@@ -200,6 +201,7 @@ class PCP2OPENMETRICS(object):
         opts.pmSetLongOption("space-scale-force", 1, "B", "SCALE", "forced space unit")
         opts.pmSetLongOption("time-scale", 1, "y", "SCALE", "default time unit")
         opts.pmSetLongOption("time-scale-force", 1, "Y", "SCALE", "forced time unit")
+        opts.pmSetLongOption("times", 0, "l", "", "live timestamp mode")
 
         opts.pmSetLongOption("with-everything", 0, "X", "", "write everything, incl. internal IDs")
         opts.pmSetLongOption("no-comment", 0, "x", "", "omit comment lines")
@@ -221,6 +223,8 @@ class PCP2OPENMETRICS(object):
         """ Perform setup for individual command line option """
         if opt == 'daemonize':
             self.daemonize = 1
+        elif opt == 'l':
+            self.times = 1
         elif opt == 'K':
             if not self.speclocal or not self.speclocal.startswith(";"):
                 self.speclocal = ";" + optarg
@@ -340,6 +344,8 @@ class PCP2OPENMETRICS(object):
         if self.context.type != PM_CONTEXT_ARCHIVE:
             self.delay = 1
             self.interpol = 1
+        else:
+            self.times = 1
 
         # Common preparations
         self.context.prepare_execute(self.opts, False, self.interpol, self.interval)
@@ -498,7 +504,7 @@ class PCP2OPENMETRICS(object):
                 else:
                     openmetrics_name_end = openmetrics_name(metric)
 
-                if self.context.type == PM_CONTEXT_ARCHIVE:
+                if self.times:
                     body += '%s%s %s %s\n' % (openmetrics_name_end, openmetrics_labels(inst, name, desc, labels), value, ts)
                 else:
                     body += '%s%s %s\n' % (openmetrics_name_end, openmetrics_labels(inst, name, desc, labels), value)


### PR DESCRIPTION
update pcp2openmetrics tool to allow for live timestamp mode option. This update follows openmetric / prometheus exposing timestamp guidelines. Updated man page & QA #1131

Resolves issue #2538 
