### PR TITLE
libpcp: relax label name rules, skip invalid keys gracefully

### DIFF
--- a/man/man3/pmlookuplabels.3
+++ b/man/man3/pmlookuplabels.3
@@ -187,9 +187,9 @@ subtree names.
 .PP
 Each component in a label
 .I name
-must begin with an alphabetic character, and be followed by zero
-or more characters drawn from the alphabetics, the digits and the
-underscore (``_'') character.  For alphabetic characters in a
+must be composed of one or more characters drawn from
+the alphabetics, the digits and the underscore (``_'')
+character.  For alphabetic characters in a
 .IR name ,
 upper and lower case are distinguished.
 .PP

--- a/qa/2008
+++ b/qa/2008
@@ -1,0 +1,58 @@
+#!/bin/sh
+# PCP QA Test No. 2008
+# Exercise label name parsing: underscore-prefixed keys, invalid
+# characters skipped without rejecting the entire label set.
+#
+# Copyright (c) 2026 Red Hat.  All Rights Reserved.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+. ./common.product
+. ./common.filter
+. ./common.check
+
+status=1	# failure is the default!
+trap "rm -f $tmp.*; exit \$status" 0 1 2 3 15
+
+# real QA test starts here
+
+echo "=== leading underscore in label name ==="
+src/parselabels '{"_private":"yes","public":"no"}'
+
+echo
+echo "=== all underscores ==="
+src/parselabels '{"___":"triple","_":"single"}'
+
+echo
+echo "=== mixed valid labels with digits ==="
+src/parselabels '{"abc123":"ok","x_y_z":"ok","A":"ok"}'
+
+echo
+echo "=== invalid key skipped, rest preserved ==="
+src/parselabels '{"good":"yes","bad-key":"no","also_good":"yes"}'
+
+echo
+echo "=== vllm-style large labelset with underscore prefix ==="
+src/parselabels '{"_block_size_resolved":"True","block_size":"16","cache_dtype":"auto","enable_prefix_caching":"True","gpu_memory_utilization":"0.9","num_gpu_blocks":"48973"}'
+
+echo
+echo "=== empty key rejected ==="
+src/parselabels '{"":"empty","ok":"fine"}'
+
+echo
+echo "=== invalid key with nested object value ==="
+src/parselabels '{"bad-key":{"nested":"x","deep":{"y":1}},"ok":"yes"}'
+
+echo
+echo "=== invalid key with list value ==="
+src/parselabels '{"bad-key":[1,2,3],"ok":"yes"}'
+
+echo
+echo "=== multiple invalid keys with mixed value types ==="
+src/parselabels '{"bad-1":{"x":1},"good":"yes","bad-2":[1,2],"also":"ok"}'
+
+# success, all done
+status=0
+exit

--- a/qa/2008.out
+++ b/qa/2008.out
@@ -1,0 +1,56 @@
+QA output created by 2008
+=== leading underscore in label name ===
+Parser input: {"_private":"yes","public":"no"}
+Parsed {"_private":"yes","public":"no"} labels (len=32) with 2 labels:
+[0] _private="yes"
+[1] public="no"
+
+=== all underscores ===
+Parser input: {"___":"triple","_":"single"}
+Parsed {"___":"triple","_":"single"} labels (len=29) with 2 labels:
+[0] _="single"
+[1] ___="triple"
+
+=== mixed valid labels with digits ===
+Parser input: {"abc123":"ok","x_y_z":"ok","A":"ok"}
+Parsed {"abc123":"ok","x_y_z":"ok","A":"ok"} labels (len=37) with 3 labels:
+[0] A="ok"
+[1] abc123="ok"
+[2] x_y_z="ok"
+
+=== invalid key skipped, rest preserved ===
+Parser input: {"good":"yes","bad-key":"no","also_good":"yes"}
+Parsed {"good":"yes","also_good":"yes"} labels (len=32) with 2 labels:
+[0] also_good="yes"
+[1] good="yes"
+
+=== vllm-style large labelset with underscore prefix ===
+Parser input: {"_block_size_resolved":"True","block_size":"16","cache_dtype":"auto","enable_prefix_caching":"True","gpu_memory_utilization":"0.9","num_gpu_blocks":"48973"}
+Parsed {"_block_size_resolved":"True","block_size":"16","cache_dtype":"auto","enable_prefix_caching":"True","gpu_memory_utilization":"0.9","num_gpu_blocks":"48973"} labels (len=157) with 6 labels:
+[0] _block_size_resolved="True"
+[1] block_size="16"
+[2] cache_dtype="auto"
+[3] enable_prefix_caching="True"
+[4] gpu_memory_utilization="0.9"
+[5] num_gpu_blocks="48973"
+
+=== empty key rejected ===
+Parser input: {"":"empty","ok":"fine"}
+Parsed {"ok":"fine"} labels (len=13) with 1 labels:
+[0] ok="fine"
+
+=== invalid key with nested object value ===
+Parser input: {"bad-key":{"nested":"x","deep":{"y":1}},"ok":"yes"}
+Parsed {"ok":"yes"} labels (len=12) with 1 labels:
+[0] ok="yes"
+
+=== invalid key with list value ===
+Parser input: {"bad-key":[1,2,3],"ok":"yes"}
+Parsed {"ok":"yes"} labels (len=12) with 1 labels:
+[0] ok="yes"
+
+=== multiple invalid keys with mixed value types ===
+Parser input: {"bad-1":{"x":1},"good":"yes","bad-2":[1,2],"also":"ok"}
+Parsed {"good":"yes","also":"ok"} labels (len=26) with 2 labels:
+[0] also="ok"
+[1] good="yes"

--- a/qa/group
+++ b/qa/group
@@ -2399,5 +2399,6 @@ suse
 2000 pmda.btrfs local valgrind
 2001 pmda.btrfs local
 2002 pmda.db2 local
+2008 libpcp labels local
 4751 libpcp threads valgrind local pcp helgrind
 9000 other local

--- a/src/libpcp/src/labels.c
+++ b/src/libpcp/src/labels.c
@@ -81,6 +81,11 @@ typedef struct parser {
     unsigned int	stacklen;	/* length of compound name 'stack' */
     unsigned int	stackseq;	/* number of 'stack' name changes */
     unsigned int	labelflags;	/* new flags (compound/optional) */
+    unsigned int	skipping;	/* depth counter for invalid key skip */
+    unsigned int	skipped;	/* count of skipped invalid labels */
+    char		*rewind;	/* buffer position before key comma */
+    unsigned int	rewindlen;	/* buflen before key comma */
+    unsigned int	rewindcomma;	/* comma state before key */
     char		*stack;		/* accumulated compound label name */
 } parser_t;
 
@@ -490,13 +495,14 @@ verify_label_name(const char *name, size_t length, int nested)
 	return -EINVAL;
     if (length >= MAXLABELNAMELEN)
 	return -E2BIG;
-    if (!isalpha((int)*name))	/* first character must be alphanumeric */
-	return -EINVAL;
-    while (++name < (start + length)) {
-	if (isalnum((int)*name) || *name == '_')	/* all the rest */
+    while (name < (start + length)) {
+	if (isalnum((unsigned char)*name) || *name == '_') {
+	    name++;
 	    continue;
+	}
 	if (*name == '.' && nested) {
 	    sts = 1;
+	    name++;
 	    continue;
 	}
 	return -EINVAL;
@@ -657,6 +663,10 @@ labels_token_callback(jsonsl_t json, jsonsl_action_t action,
     if (action == JSONSL_ACTION_PUSH) {
 	switch (state->type) {
 	case JSONSL_T_OBJECT:
+	    if (parser->skipping) {
+		parser->skipping++;
+		break;
+	    }
 	    if (parser->comma)
 		stash_chars(",", 1, &parser->buffer, &parser->buflen);
 	    stash_chars("{", 1, &parser->buffer, &parser->buflen);
@@ -665,6 +675,10 @@ labels_token_callback(jsonsl_t json, jsonsl_action_t action,
 	    break;
 
 	case JSONSL_T_LIST:
+	    if (parser->skipping) {
+		parser->skipping++;
+		break;
+	    }
 	    if (parser->comma)
 		stash_chars(",", 1, &parser->buffer, &parser->buflen);
 	    stash_chars("[", 1, &parser->buffer, &parser->buflen);
@@ -673,6 +687,11 @@ labels_token_callback(jsonsl_t json, jsonsl_action_t action,
 	    break;
 
 	case JSONSL_T_HKEY:
+	    if (parser->skipping)
+		break;
+	    parser->rewind = parser->buffer;
+	    parser->rewindlen = parser->buflen;
+	    parser->rewindcomma = parser->comma;
 	    if (parser->comma)
 		stash_chars(",", 1, &parser->buffer, &parser->buflen);
 	    parser->token = parser->start + json->pos;
@@ -681,6 +700,8 @@ labels_token_callback(jsonsl_t json, jsonsl_action_t action,
 
 	case JSONSL_T_STRING:
 	case JSONSL_T_SPECIAL:
+	    if (parser->skipping)
+		break;
 	    if (parser->comma)
 		stash_chars(",", 1, &parser->buffer, &parser->buflen);
 	    parser->token = parser->start + json->pos;
@@ -694,6 +715,11 @@ labels_token_callback(jsonsl_t json, jsonsl_action_t action,
     else if (action == JSONSL_ACTION_POP) {
 	switch (state->type) {
 	case JSONSL_T_OBJECT:
+	    if (parser->skipping) {
+		if (--parser->skipping == 1)
+		    parser->skipping = 0;
+		break;
+	    }
 	    stash_chars("}", 1, &parser->buffer, &parser->buflen);
 	    if (parser->namelevel == state->level && parser->name != 0)
 		add_label_value(parser, 2, 1);	/* empty map */
@@ -702,6 +728,11 @@ labels_token_callback(jsonsl_t json, jsonsl_action_t action,
 	    break;
 
 	case JSONSL_T_LIST:
+	    if (parser->skipping) {
+		if (--parser->skipping == 1)
+		    parser->skipping = 0;
+		break;
+	    }
 	    stash_chars("]", 1, &parser->buffer, &parser->buflen);
 	    string = parser->array;
 	    length = (at - string) + 1;
@@ -712,13 +743,22 @@ labels_token_callback(jsonsl_t json, jsonsl_action_t action,
 	    break;
 
 	case JSONSL_T_HKEY:
+	    if (parser->skipping)
+		break;
 	    string = parser->token + 1;
 	    length = at - string;
 	    nested = parser->labelflags & PM_LABEL_COMPOUND;
 	    if ((sts = verify_label_name(string, length, nested)) < 0) {
 		if (pmDebugOptions.labels)
-		    fprintf(stderr, "Label name is invalid %.*s", length, string);
-		parser->error = sts;
+		    fprintf(stderr, "Label name is invalid %.*s (skipping)",
+				    length, string);
+		parser->skipping = 1;
+		parser->skipped++;
+		parser->buffer = parser->rewind;
+		parser->buflen = parser->rewindlen;
+		parser->comma = parser->rewindcomma;
+		parser->token = NULL;
+		break;
 	    }
 	    parser->name = (parser->buffer - parser->jsonb) + 1;
 	    if (sts > 0 && parser->compound) {
@@ -735,6 +775,12 @@ labels_token_callback(jsonsl_t json, jsonsl_action_t action,
 
 	case JSONSL_T_STRING:
 	case JSONSL_T_SPECIAL:
+	    if (parser->skipping) {
+		if (parser->skipping == 1)
+		    parser->skipping = 0;
+		parser->token = NULL;
+		break;
+	    }
 	    string = parser->token;
 	    length = at - string;
 	    if (state->type == JSONSL_T_STRING)
@@ -809,13 +855,13 @@ __pmParseLabels(const char *s, int slen,
 
     if (parser.nlabels == 0) {
 	/*
-	 * Zero labels happens if we are passed an empty labelset string.
-	 * Argument buffer is set to a zero length string and 0 returned.
+	 * Zero labels from empty input ({}) is fine.
+	 * Zero labels because all keys were invalid is an error.
 	 */
 	*buflen = 0;
 	buffer[0] = '\0';
 	labels_hash_destroy(compound);
-	return 0;
+	return parser.skipped ? -EINVAL : 0;
     }
 
     if (pmDebugOptions.labels && pmDebugOptions.desperate) {


### PR DESCRIPTION
Allow underscore as a valid first character in label names.  The previous rule required the first character to be alphabetic, which rejected labels like "_block_size_resolved" exported by vLLM and other Prometheus-compatible systems.

When a label key contains invalid characters (e.g. hyphens), skip that key-value pair and continue parsing the remaining labels. Previously, a single invalid key name caused the entire label set to be rejected.  The buffer and comma state are rewound so the resulting JSON remains valid.

Add QA test 2008 covering: leading underscores, all-underscore names, invalid keys at first/middle/last positions, and vLLM-style large label sets.