### PR TITLE
add power units for pmda-denki metrics

### DIFF
--- a/src/pmdas/denki/denki.c
+++ b/src/pmdas/denki/denki.c
@@ -889,11 +889,11 @@ static pmdaMetric metrictab[] = {
 /* rapl.sysfs */
 	{ NULL,
 	{ PMDA_PMID(0,0), PM_TYPE_U64, RAPL_SYSFS_INDOM, PM_SEM_COUNTER,
-	PMDA_PMUNITS(0,0,0,0,0,0) }, },
+	PMDA_EXTRAUNITS(0, 0, 0, 0, 0, 0, PM_UNIT_POWER, PM_POWER_W) }, },
 /* rapl.msr */
 	{ NULL,
 	{ PMDA_PMID(0,1), PM_TYPE_U64, RAPL_MSR_INDOM, PM_SEM_COUNTER,
-	PMDA_PMUNITS(0,0,0,0,0,0) }, },
+	PMDA_EXTRAUNITS(0, 0, 0, 0, 0, 0, PM_UNIT_POWER, PM_POWER_W) }, },
 /* bat.energy_now */
 	{ NULL,
 	{ PMDA_PMID(1,0), PM_TYPE_DOUBLE, BAT_ENERGYNOW_INDOM, PM_SEM_INSTANT,
@@ -901,7 +901,7 @@ static pmdaMetric metrictab[] = {
 /* bat.power_now */
 	{ NULL,
 	{ PMDA_PMID(1,1), PM_TYPE_DOUBLE, BAT_POWERNOW_INDOM, PM_SEM_INSTANT,
-	PMDA_PMUNITS(0,0,0,0,0,0) }, },
+	PMDA_EXTRAUNITS(0, 0, 0, 0, 0, 0, PM_UNIT_POWER, PM_POWER_W) }, },
 /* bat.capacity */
 	{ NULL,
 	{ PMDA_PMID(1,2), PM_TYPE_32, BAT_CAPACITY_INDOM, PM_SEM_INSTANT,

--- a/src/pmdas/denki/denki.c
+++ b/src/pmdas/denki/denki.c
@@ -889,11 +889,11 @@ static pmdaMetric metrictab[] = {
 /* rapl.sysfs */
 	{ NULL,
 	{ PMDA_PMID(0,0), PM_TYPE_U64, RAPL_SYSFS_INDOM, PM_SEM_COUNTER,
-	PMDA_EXTRAUNITS(0, 0, 0, 0, 0, 0, PM_UNIT_POWER, PM_POWER_W) }, },
+	PMDA_PMUNITS(0,0,0,0,0,0) }, },
 /* rapl.msr */
 	{ NULL,
 	{ PMDA_PMID(0,1), PM_TYPE_U64, RAPL_MSR_INDOM, PM_SEM_COUNTER,
-	PMDA_EXTRAUNITS(0, 0, 0, 0, 0, 0, PM_UNIT_POWER, PM_POWER_W) }, },
+	PMDA_PMUNITS(0,0,0,0,0,0) }, },
 /* bat.energy_now */
 	{ NULL,
 	{ PMDA_PMID(1,0), PM_TYPE_DOUBLE, BAT_ENERGYNOW_INDOM, PM_SEM_INSTANT,
@@ -1273,9 +1273,11 @@ denki_label(int ident, int type, pmLabelSet **lpp, pmdaExt *pmda)
 			switch (serial) {
 				case RAPL_SYSFS_INDOM:
 					pmdaAddLabels(lpp, "{\"indom_name\":\"rapl sysfs\"}");
+					pmdaAddLabels(lpp, "{\"units\":\"watt\"}");
 					break;
 				case RAPL_MSR_INDOM:
 					pmdaAddLabels(lpp, "{\"indom_name\":\"rapl msr\"}");
+					pmdaAddLabels(lpp, "{\"units\":\"watt\"}");
 					break;
 				case BAT_ENERGYNOW_INDOM:
 					pmdaAddLabels(lpp, "{\"units\":\"watt hours\"}");

--- a/src/pmdas/denki/denki.c
+++ b/src/pmdas/denki/denki.c
@@ -897,7 +897,7 @@ static pmdaMetric metrictab[] = {
 /* bat.energy_now */
 	{ NULL,
 	{ PMDA_PMID(1,0), PM_TYPE_DOUBLE, BAT_ENERGYNOW_INDOM, PM_SEM_INSTANT,
-	PMDA_PMUNITS(0,0,0,0,0,0) }, },
+	PMDA_EXTRAUNITS(0, 1, 0, 0, PM_TIME_HOUR, 0, PM_UNIT_POWER, PM_POWER_W) }, },
 /* bat.power_now */
 	{ NULL,
 	{ PMDA_PMID(1,1), PM_TYPE_DOUBLE, BAT_POWERNOW_INDOM, PM_SEM_INSTANT,


### PR DESCRIPTION
Adding the new power units.

For metric denki.bat.energy_now, unit Watthour (Wh) would be appropriate, capacity. Should we add that?
Once could argue "it's just power delivered over a time".. but I think here in this instance we can not use that property, and would vote that we add a unit Wh.

