### PR TITLE
build: PCP_IMPORT_DIR needs to mirror PCP_RUN_DIR setup

### DIFF
--- a/debian/control.pcp
+++ b/debian/control.pcp
@@ -257,8 +257,8 @@ Description: Performance Co-Pilot application tracing library
 Package: libpcp-import2-dev
 Section: libdevel
 Depends: ${misc:Depends}, libpcp-import2 (= ${binary:Version}), libpcp4-dev
-Breaks: pcp (<< 7.1.5), libpcp-import2-dev (<< 7.1.5)
-Replaces: pcp (<< 7.1.5), libpcp-import2-dev (<< 7.1.5)
+Breaks: pcp (<< 7.1.5), libpcp-import1-dev (<< 7.1.5)
+Replaces: pcp (<< 7.1.5), libpcp-import1-dev (<< 7.1.5)
 Architecture: any
 Description: Performance Co-Pilot data import library and headers
  The libpcp-import2-dev package contains the library and header files

--- a/debian/libpcp-import2.install
+++ b/debian/libpcp-import2.install
@@ -1,3 +1,2 @@
-run/pmimport
 usr/lib/*/libpcp_import.so.2
 usr/lib/tmpfiles.d/libpcp_import.conf

--- a/src/libpcp_import/src/GNUmakefile
+++ b/src/libpcp_import/src/GNUmakefile
@@ -57,9 +57,6 @@ install: default
 ifeq ($(ENABLE_SYSTEMD),true)
 	$(INSTALL) -m 644 $(TMPFILESCONF) $(PCP_SYSTEMDTMPFILES_DIR)/$(TMPFILESCONF)
 endif
-ifneq ($(PCP_IMPORT_DIR),)
-	$(INSTALL) -m 755 -d $(PCP_IMPORT_DIR)
-endif
 ifneq ($(LIBTARGET),)
 	$(INSTALL) -m 755 $(LIBTARGET) $(PCP_LIB_DIR)/$(LIBTARGET)
 ifneq ($(DEB_HOST_MULTIARCH),)


### PR DESCRIPTION
Resolves issues Ken encountered with Debian builds.