### PR TITLE
local.conf and local.root PMDA sub-package dropins

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -233,6 +233,35 @@ else
 fi
 }
 
+%global pmda_local_add() \
+PCP_PMDAS_DIR=@pcp_pmdas_dir@ \
+PCP_PMNS_DIR=@pcp_pmns_dir@ \
+LOCAL_CONF=@pcp_sysconf_dir@/local.conf \
+LOCAL_ROOT=$PCP_PMNS_DIR/local.root \
+PMNS=$PCP_PMNS_DIR/%1.pmns \
+if [ -f "$LOCAL_CONF" ] && ! grep -q "^%1[[:space:]]" "$LOCAL_CONF" ; then \
+    cat "$PCP_PMDAS_DIR/%1/local.conf.entry" >> "$LOCAL_CONF" 2>/dev/null \
+fi \
+if [ -f "$LOCAL_ROOT" ] && [ -f "$PMNS" ] && ! grep -q "^%1[[:space:]]" "$LOCAL_ROOT" ; then \
+    sed -i "0,/^}/s/^}/\\t%1\\n&/" "$LOCAL_ROOT" \
+    sed '1,/^}/d' "$PMNS" >> "$LOCAL_ROOT" \
+fi \
+%{nil}
+
+%global pmda_local_remove() \
+if [ %1 -eq 0 ] ; then \
+    LOCAL_CONF=@pcp_sysconf_dir@/local.conf \
+    LOCAL_ROOT=@pcp_pmns_dir@/local.root \
+    [ -f "$LOCAL_CONF" ] && sed -i '/^%2[[:space:]]/d' "$LOCAL_CONF" \
+    if [ -f "$LOCAL_ROOT" ] ; then \
+        sed -i -e '/^[[:space:]]*%2[[:space:]]*$/d' \
+               -e '/^[[:space:]]*%2[[:space:]]/d' \
+               -e '/^%2[[:space:]]*{/,/^}/d' \
+               -e '/^%2\..*[[:space:]]*{/,/^}/d' "$LOCAL_ROOT" \
+    fi \
+fi \
+%{nil}
+
 %if "@enable_selinux@" == "true"
 # rpm boolean dependencies are supported since RHEL 8, but not reliably
 # across all platforms, so be conservative here
@@ -2655,17 +2684,29 @@ done
 %endif
 
 %if "@pmda_infiniband@" == "true"
+%post pmda-infiniband
+%{pmda_local_add "infiniband"}
+
 %preun pmda-infiniband
 %{pmda_remove "$1" "infiniband"}
+%{pmda_local_remove "$1" "infiniband"}
 %endif
 
 %if "@pmda_perfevent@" == "true"
+%post pmda-perfevent
+%{pmda_local_add "perfevent"}
+
 %preun pmda-perfevent
 %{pmda_remove "$1" "perfevent"}
+%{pmda_local_remove "$1" "perfevent"}
 %endif
+
+%post pmda-podman
+%{pmda_local_add "podman"}
 
 %preun pmda-podman
 %{pmda_remove "$1" "podman"}
+%{pmda_local_remove "$1" "podman"}
 
 %if "@pmda_statsd@" == "true"
 %preun pmda-statsd
@@ -2774,8 +2815,12 @@ done
 %preun pmda-gpsd
 %{pmda_remove "$1" "gpsd"}
 
+%post pmda-docker
+%{pmda_local_add "docker"}
+
 %preun pmda-docker
 %{pmda_remove "$1" "docker"}
+%{pmda_local_remove "$1" "docker"}
 
 %preun pmda-lustre
 %{pmda_remove "$1" "lustre"}
@@ -2805,15 +2850,23 @@ done
 %{pmda_remove "$1" "zimbra"}
 %endif
 
+%post pmda-lustrecomm
+%{pmda_local_add "lustrecomm"}
+
 %preun pmda-lustrecomm
 %{pmda_remove "$1" "lustrecomm"}
+%{pmda_local_remove "$1" "lustrecomm"}
 
 %preun pmda-dm
 %{pmda_remove "$1" "dm"}
 
 %if "@pmda_bpf@" == "true"
+%post pmda-bpf
+%{pmda_local_add "bpf"}
+
 %preun pmda-bpf
 %{pmda_remove "$1" "bpf"}
+%{pmda_local_remove "$1" "bpf"}
 %endif
 
 %if "@pmda_bpftrace@" == "true"
@@ -2872,8 +2925,12 @@ done
 %{pmda_remove "$1" "apache"}
 
 %if "@pmda_amdgpu@" == "true"
+%post pmda-amdgpu
+%{pmda_local_add "amdgpu"}
+
 %preun pmda-amdgpu
 %{pmda_remove "$1" "amdgpu"}
+%{pmda_local_remove "$1" "amdgpu"}
 %endif
 
 %preun pmda-bash
@@ -2882,16 +2939,28 @@ done
 %preun pmda-cisco
 %{pmda_remove "$1" "cisco"}
 
+%post pmda-farm
+%{pmda_local_add "farm"}
+
 %preun pmda-farm
 %{pmda_remove "$1" "farm"}
+%{pmda_local_remove "$1" "farm"}
 
 %if "@pmda_gfs2@" == "true"
+%post pmda-gfs2
+%{pmda_local_add "gfs2"}
+
 %preun pmda-gfs2
 %{pmda_remove "$1" "gfs2"}
+%{pmda_local_remove "$1" "gfs2"}
 %endif
+
+%post pmda-hacluster
+%{pmda_local_add "hacluster"}
 
 %preun pmda-hacluster
 %{pmda_remove "$1" "hacluster"}
+%{pmda_local_remove "$1" "hacluster"}
 
 %preun pmda-logger
 %{pmda_remove "$1" "logger"}
@@ -2902,22 +2971,38 @@ done
 %preun pmda-mounts
 %{pmda_remove "$1" "mounts"}
 
+%post pmda-nvidia-gpu
+%{pmda_local_add "nvidia"}
+
 %preun pmda-nvidia-gpu
 %{pmda_remove "$1" "nvidia"}
+%{pmda_local_remove "$1" "nvidia"}
 
 %if "@pmda_resctrl@" == "true"
+%post pmda-resctrl
+%{pmda_local_add "resctrl"}
+
 %preun pmda-resctrl
 %{pmda_remove "$1" "resctrl"}
+%{pmda_local_remove "$1" "resctrl"}
 %endif
+
+%post pmda-sendmail
+%{pmda_local_add "sendmail"}
 
 %preun pmda-sendmail
 %{pmda_remove "$1" "sendmail"}
+%{pmda_local_remove "$1" "sendmail"}
 
 %preun pmda-shping
 %{pmda_remove "$1" "shping"}
 
+%post pmda-smart
+%{pmda_local_add "smart"}
+
 %preun pmda-smart
 %{pmda_remove "$1" "smart"}
+%{pmda_local_remove "$1" "smart"}
 
 %preun pmda-summary
 %{pmda_remove "$1" "summary"}

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -44,8 +44,8 @@ ExcludeArch: %{ix86}
 %endif
 %endif
 
-# Resource Control kernel feature is on recent Intel/AMD processors only
-%ifarch x86_64
+# Resource Control kernel feature is on recent Intel/AMD/ARM processors only
+%ifarch x86_64 aarch64
 %global disable_resctrl 0
 %else
 %global disable_resctrl 1

--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -548,6 +548,12 @@ LOCALCONF_MAKERULE = \
 	    fi; \
 	fi
 
+LOCALENTRY_MAKERULE = \
+	@echo $(LOCALCONF_LINE) > $(IAM).localentry
+
+LOCALPMNS_MAKERULE = \
+	$(PMCPP) root_$(IAM) | grep -v '^#' > $(IAM).pmns
+
 ifeq "$(TARGET_OS)" "mingw"
 INSTALL_MAN =
 else

--- a/src/pmdas/amdgpu/.gitignore
+++ b/src/pmdas/amdgpu/.gitignore
@@ -1,5 +1,7 @@
 help.dir
 help.pag
 domain.h
+exports
 pmdaamdgpu
 pmda_amdgpu.so
+*.pmns

--- a/src/pmdas/amdgpu/GNUmakefile
+++ b/src/pmdas/amdgpu/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Red Hat.
+# Copyright (c) 2024,2026 Red Hat.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -25,14 +25,13 @@ PMDAINIT = $(IAM)_init
 CFILES	= drm.c amdgpu.c
 
 # for debugging without hardware and using fake libraries include fake.c here
-# 
+#
 #CFILES	+= fake.c
 
 HFILES	= drm.h
 DFILES	= README
 LLDLIBS	= $(PCP_PMDALIB) $(LIB_FOR_LIBDRM) $(LIB_FOR_LIBDRM_AMDGPU)
 LCFLAGS += -DDSOSUFFIX=\"$(DSOSUFFIX)\" $(CFLAGS_FOR_LIBDRM) $(CFLAGS_FOR_LIBDRM_AMDGPU)
-LDIRT	= domain.h *.log *.dir *.pag so_locations
 
 PMDAADMDIR = $(PCP_PMDASADM_DIR)/$(IAM)
 PMDATMPDIR = $(PCP_PMDAS_DIR)/$(IAM)
@@ -40,8 +39,14 @@ PMDATMPDIR = $(PCP_PMDAS_DIR)/$(IAM)
 REWRITEDIR	= $(PCP_SYSCONF_DIR)/pmlogrewrite
 REWRITEVARDIR	= $(PCP_VAR_DIR)/config/pmlogrewrite
 
+LOCALCONF_LINE = "amdgpu	162	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
+VERSION_SCRIPT	= exports
+HELPTARGETS	= help.dir help.pag
+
+LDIRT	= domain.h *.log $(HELPTARGETS) so_locations $(VERSION_SCRIPT)
+
 ifeq "$(PMDA_AMDGPU)" "true"
-default_pcp default:	$(LIBTARGET) $(CMDTARGET)
+default_pcp default:	$(LIBTARGET) $(CMDTARGET) $(HELPTARGETS)
 
 include $(BUILDRULES)
 
@@ -50,7 +55,9 @@ install_pcp install:	default
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(PMDAADMDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) $(DFILES) root help pmns domain.h $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) $(DFILES) root root_amdgpu help help.dir help.pag pmns domain.h $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_amdgpu root_amdgpu $(PMDAADMDIR)/root_amdgpu
+	$(INSTALL) -S $(PMDAADMDIR)/root_amdgpu $(PCP_PMNSADM_DIR)/root_amdgpu
 	$(INSTALL) -m 644 -t $(REWRITEVARDIR)/$(IAM).conf rewrite.conf $(REWRITEDIR)/$(IAM).conf
 else
 
@@ -66,3 +73,9 @@ $(OBJECTS): domain.h
 
 domain.h: ../../pmns/stdpmid
 	$(DOMAIN_MAKERULE)
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_amdgpu -v 2 -o help < help
+
+$(VERSION_SCRIPT):
+	$(VERSION_SCRIPT_MAKERULE)

--- a/src/pmdas/amdgpu/Install
+++ b/src/pmdas/amdgpu/Install
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=amdgpu
+pmns_source=root_amdgpu
 dso_opt=true
 
 pmdaSetup

--- a/src/pmdas/amdgpu/help
+++ b/src/pmdas/amdgpu/help
@@ -27,7 +27,7 @@
 # blank lines before the @ line are ignored
 #
 
-@ AMDGPU.0 AMD graphics cards installed in this system
+@ 162.0 AMD graphics cards installed in this system
 
 @ amdgpu.numcards Number of Graphics Cards
 The number of AMD Graphics cards installed in this system

--- a/src/pmdas/amdgpu/root
+++ b/src/pmdas/amdgpu/root
@@ -4,7 +4,4 @@
 
 #include <stdpmid>
 
-root { amdgpu }
-
-#include "pmns"
-
+#include "root_amdgpu"

--- a/src/pmdas/amdgpu/root_amdgpu
+++ b/src/pmdas/amdgpu/root_amdgpu
@@ -1,0 +1,54 @@
+/*
+ * Metrics for amd GPU PMDA
+ *
+ * Copyright (c) 2024,2026 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef AMDGPU
+#define AMDGPU    162
+#endif
+
+root {
+    amdgpu
+}
+
+amdgpu {
+    numcards			AMDGPU:0:0
+    cardname			AMDGPU:0:1
+    cardid			AMDGPU:0:2
+    control
+    memory
+    gpu
+}
+
+amdgpu.memory {
+    used			AMDGPU:1:0
+    total			AMDGPU:1:1
+    free			AMDGPU:1:2
+    usedaccum			AMDGPU:1:3
+    clock			AMDGPU:1:4
+    clock_max			AMDGPU:1:5
+}
+
+amdgpu.gpu {
+    temperature			AMDGPU:3:0
+    load			AMDGPU:3:1
+    average_power		AMDGPU:3:2
+    clock			AMDGPU:3:3
+    clock_max			AMDGPU:3:4
+    old_temperature		AMDGPU:3:5
+}
+
+amdgpu.control {
+    debug			AMDGPU:0:3
+}

--- a/src/pmdas/bpf/.gitignore
+++ b/src/pmdas/bpf/.gitignore
@@ -3,6 +3,7 @@ domain.h
 exports
 pmdabpf
 pmda_bpf.so
+*.pmns
 modules/*.skel.h
 modules/*.so
 modules/vmlinux.h

--- a/src/pmdas/bpf/GNUmakefile
+++ b/src/pmdas/bpf/GNUmakefile
@@ -18,16 +18,19 @@ SUBDIRS	= modules
 
 IAM	= bpf
 DOMAIN	= BPF
+PMDAINIT = $(IAM)_init
 
 PMDATMPDIR = $(PCP_PMDAS_DIR)/$(IAM)
 PMDACONFIG = $(PCP_SYSCONF_DIR)/$(IAM)
 PMDAADMDIR = $(PCP_PMDASADM_DIR)/$(IAM)
+LOCALCONF_LINE = "bpf	157	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
 
 MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
 MAN_DEST = $(PCP_MAN_DIR)/man$(MAN_SECTION)
 
-LDIRT	= domain.h *.o $(IAM).log pmda$(IAM) pmda_$(IAM).$(DSOSUFFIX) bpf
+VERSION_SCRIPT = exports
+LDIRT	= domain.h *.o $(IAM).log pmda$(IAM) pmda_$(IAM).$(DSOSUFFIX) bpf $(VERSION_SCRIPT)
 
 default: build-me
 
@@ -43,7 +46,8 @@ install:	default $(SUBDIRS)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(CMDTARGET) $(LIBTARGET) $(SCRIPTS) $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/domain.h domain.h $(PMDAADMDIR)/domain.h
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/root_bpf root_bpf $(PMDAADMDIR)/root_bpf
-	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_bpf root_bpf $(PCP_PMNSADM_DIR)/root_bpf
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_bpf root_bpf $(PMDAADMDIR)/root_bpf
+	$(INSTALL) -S $(PMDAADMDIR)/root_bpf $(PCP_PMNSADM_DIR)/root_bpf
 	$(INSTALL) -m 755 -d $(PMDACONFIG)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/$(CONFIG) $(CONFIG) $(PMDACONFIG)/$(CONFIG)
 	@$(INSTALL_MAN)
@@ -62,6 +66,9 @@ $(OBJECTS): domain.h bpf
 
 domain.h: ../../pmns/stdpmid
 	$(DOMAIN_MAKERULE)
+
+$(VERSION_SCRIPT):
+	$(VERSION_SCRIPT_MAKERULE)
 
 bpf:
 	$(LN_S) -f $(TOPDIR)/vendor/github.com/libbpf/bpftool/src/bootstrap/libbpf bpf

--- a/src/pmdas/docker/.gitignore
+++ b/src/pmdas/docker/.gitignore
@@ -1,3 +1,7 @@
 pmda_docker.so
 pmdadocker
 domain.h
+exports
+help.dir
+help.pag
+*.pmns

--- a/src/pmdas/docker/GNUmakefile
+++ b/src/pmdas/docker/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016-2017,2020 Red Hat.
+# Copyright (c) 2016-2017,2020,2026 Red Hat.
 # 
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -20,6 +20,8 @@ DOMAIN	= DOCKER
 CMDTARGET = pmda$(IAM)$(EXECSUFFIX)
 LIBTARGET = pmda_$(IAM).$(DSOSUFFIX)
 PMDAINIT = $(IAM)_init
+PMCDCONF_LINE  = "docker	141	pipe	binary		$(PMDATMPDIR)/$(CMDTARGET) -d 141"
+LOCALCONF_LINE  = "docker	141	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
 
 PMDAADMDIR = $(PCP_PMDASADM_DIR)/$(IAM)
 PMDATMPDIR = $(PCP_PMDAS_DIR)/$(IAM)
@@ -29,7 +31,9 @@ LLDLIBS = $(PCP_WEBLIB) $(LIB_FOR_PTHREADS)
 CFILES	= docker.c
 DFILES	= help
 
-LDIRT	= domain.h *.o $(IAM).log $(CMDTARGET) $(LIBTARGET)
+VERSION_SCRIPT	= exports
+HELPTARGETS	= help.dir help.pag
+LDIRT	= $(HELPTARGETS) domain.h *.o $(IAM).log $(CMDTARGET) $(LIBTARGET) $(VERSION_SCRIPT)
 
 MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
@@ -40,19 +44,24 @@ default_pcp default:	build-me
 include $(BUILDRULES)
 
 ifeq "$(TARGET_OS)" "linux"
-build-me:	$(CMDTARGET) $(LIBTARGET)
+build-me:	$(CMDTARGET) $(LIBTARGET) $(HELPTARGETS)
 
-install_pcp install:	default 
+install_pcp install:	default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(CMDTARGET) $(LIBTARGET) $(PMDAADMDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) root pmns domain.h $(DFILES) $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) help.dir help.pag root root_docker pmns domain.h $(DFILES) $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_docker root_docker $(PMDAADMDIR)/root_docker
+	$(INSTALL) -S $(PMDAADMDIR)/root_docker $(PCP_PMNSADM_DIR)/root_docker
 	@$(INSTALL_MAN)
 else
 build-me:
 install_pcp install:
 	@$(INSTALL_MAN)
 endif
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_docker -v 2 -o help < help
 
 $(VERSION_SCRIPT):
 	$(VERSION_SCRIPT_MAKERULE)

--- a/src/pmdas/docker/Install
+++ b/src/pmdas/docker/Install
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=docker
+pmns_source=root_docker
 dso_opt=true
 
 pmdaSetup

--- a/src/pmdas/docker/help
+++ b/src/pmdas/docker/help
@@ -86,5 +86,5 @@
 @ docker.memory_stats.stats.total_unevictable Hierarchical, cumulative version of stat.unevictable
 @ docker.memory_stats.stats.total_writeback Hierarchical, cumulative version of stat.writeback
 @ docker.memory_stats.stats.unevictable Memory that cannot be reclaimed (e.g. mlocked)
-@ docker.memory_stats.stats.writeback Bytes of file/anonymous cache queued for syncing]
+@ docker.memory_stats.stats.writeback Bytes of file/anonymous cache queued for syncing
 @ docker.control.timing Timing frequency querying the docker api

--- a/src/pmdas/docker/root
+++ b/src/pmdas/docker/root
@@ -4,6 +4,4 @@
 
 #include <stdpmid>
 
-root { docker }
-
-#include "pmns"
+#include "root_docker"

--- a/src/pmdas/docker/root_docker
+++ b/src/pmdas/docker/root_docker
@@ -1,0 +1,112 @@
+/*
+ * Metrics for docker PMDA
+ *
+ * Copyright (c) 2016 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef DOCKER
+#define DOCKER    141
+#endif
+
+root {
+    docker
+}
+
+docker {
+    pid                     DOCKER:0:0
+    name                    DOCKER:0:1
+    running                 DOCKER:0:2
+    paused                  DOCKER:0:3
+    restarting              DOCKER:0:4
+    version                 DOCKER:1:0
+    os                      DOCKER:1:1
+    kernel                  DOCKER:1:2
+    go                      DOCKER:1:3
+    commit                  DOCKER:1:4
+    arch                    DOCKER:1:5
+    api_version             DOCKER:1:6
+    cpu_stats
+    memory_stats
+    control
+}
+
+docker.control {
+    timing                  DOCKER:3:0
+}
+
+docker.cpu_stats {
+    cpu_usage
+    system_cpu_usage        DOCKER:2:3
+    throttling_data
+}
+
+docker.cpu_stats.cpu_usage {
+    total_usage             DOCKER:2:0
+    usage_in_kernelmode     DOCKER:2:1
+    usage_in_usermode       DOCKER:2:2
+}
+
+docker.cpu_stats.throttling_data {
+    periods                 DOCKER:2:4
+    throttled_periods       DOCKER:2:5
+    throttled_time          DOCKER:2:6
+}
+
+docker.memory_stats {
+    failcnt                 DOCKER:2:7
+    limit                   DOCKER:2:8
+    max_usage               DOCKER:2:9
+    stats
+    usage                   DOCKER:2:48
+}
+
+docker.memory_stats.stats {
+    active_anon                DOCKER:2:10
+    active_file                DOCKER:2:11
+    cache                      DOCKER:2:12
+    dirty                      DOCKER:2:13
+    hierarchical_memory_limit  DOCKER:2:14
+    hierarchical_memsw_limit   DOCKER:2:15
+    inactive_anon              DOCKER:2:16
+    inactive_file              DOCKER:2:17
+    mapped_file                DOCKER:2:18
+    pgfault                    DOCKER:2:19
+    pgmajfault                 DOCKER:2:20
+    pgpgin                     DOCKER:2:21
+    pgpgout                    DOCKER:2:22
+    recent_rotated_anon        DOCKER:2:23
+    recent_rotated_file        DOCKER:2:24
+    recent_scanned_anon        DOCKER:2:25
+    recent_scanned_file        DOCKER:2:26
+    rss                        DOCKER:2:27
+    rss_huge                   DOCKER:2:28
+    swap                       DOCKER:2:29
+    total_active_anon          DOCKER:2:30
+    total_active_file          DOCKER:2:31
+    total_cache                DOCKER:2:32
+    total_dirty                DOCKER:2:33
+    total_inactive_anon        DOCKER:2:34
+    total_inactive_file        DOCKER:2:35
+    total_mapped_file          DOCKER:2:36
+    total_pgfault              DOCKER:2:37
+    total_pgmajfault           DOCKER:2:38
+    total_pgpgin               DOCKER:2:39
+    total_pgpgout              DOCKER:2:40
+    total_rss                  DOCKER:2:41
+    total_rss_huge             DOCKER:2:42
+    total_swap                 DOCKER:2:43
+    total_unevictable          DOCKER:2:44
+    total_writeback            DOCKER:2:45
+    unevictable                DOCKER:2:46
+    writeback                  DOCKER:2:47
+}

--- a/src/pmdas/farm/.gitignore
+++ b/src/pmdas/farm/.gitignore
@@ -3,3 +3,6 @@ domain.h
 exports
 pmda_farm.so
 pmdafarm
+help.dir
+help.pag
+*.pmns

--- a/src/pmdas/farm/GNUmakefile
+++ b/src/pmdas/farm/GNUmakefile
@@ -1,11 +1,11 @@
 #
-# Copyright (c) 2023 Red Hat.
-# 
+# Copyright (c) 2023,2026 Red Hat.
+#
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
@@ -26,13 +26,16 @@ PMDAINIT	= $(IAM)_init
 LLDLIBS		= $(PCP_PMDALIB)
 LCFLAGS		= $(INVISIBILITY)
 
-LDIRT		= domain.h $(IAM).log $(VERSION_SCRIPT)
-
 SCRIPTS		= Install Remove
 VERSION_SCRIPT	= exports
+HELPTARGETS	= help.dir help.pag
 
 PMDAADMDIR	= $(PCP_PMDASADM_DIR)/$(IAM)
 PMDATMPDIR	= $(PCP_PMDAS_DIR)/$(IAM)
+
+LOCALCONF_LINE = "farm	160	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
+
+LDIRT		= domain.h $(IAM).log $(VERSION_SCRIPT) $(HELPTARGETS)
 
 MAN_SECTION	= 1
 MAN_PAGES	= pmda$(IAM).$(MAN_SECTION)
@@ -43,13 +46,15 @@ default:	build-me
 include $(BUILDRULES)
 
 ifeq "$(TARGET_OS)" "linux"
-build-me: $(CMDTARGET) $(LIBTARGET)
+build-me: $(CMDTARGET) $(LIBTARGET) $(HELPTARGETS)
 
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) root pmns domain.h help $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) root root_farm pmns domain.h help help.dir help.pag $(PMDAADMDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(SCRIPTS) $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_farm root_farm $(PMDAADMDIR)/root_farm
+	$(INSTALL) -S $(PMDAADMDIR)/root_farm $(PCP_PMNSADM_DIR)/root_farm
 	@$(INSTALL_MAN)
 else
 build-me:
@@ -67,6 +72,9 @@ $(VERSION_SCRIPT):
 
 domain.h: ../../pmns/stdpmid
 	$(DOMAIN_MAKERULE)
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_farm -v 2 -o help < help
 
 pmda.o:			pmdafarm.h
 pmda.o farm_stats.o:	farm_stats.h

--- a/src/pmdas/farm/Install
+++ b/src/pmdas/farm/Install
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=farm
+pmns_source=root_farm
 
 which smartctl > /dev/null 2>&1
 if [ $? -ne 0 ]

--- a/src/pmdas/farm/root
+++ b/src/pmdas/farm/root
@@ -4,10 +4,4 @@
 
 #include <stdpmid>
 
-root { farm }
-
-#ifndef FARM
-#define FARM 160
-#endif
-
-#include "pmns"
+#include "root_farm"

--- a/src/pmdas/farm/root_farm
+++ b/src/pmdas/farm/root_farm
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2023-2025,2026 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef FARM
+#define FARM    160
+#endif
+
+root {
+    farm
+}
+
+farm {
+    ata
+    scsi
+}
+
+farm.ata {
+    log_header
+    drive_information
+    workload_statistics
+    error_statistics
+    environment_statistics
+    reliability_statistics
+}
+
+farm.ata.log_header {
+    log_version						FARM:0:0
+    pages_supported					FARM:0:1
+    log_size						FARM:0:2
+    page_size						FARM:0:3
+    heads_supported					FARM:0:4
+    number_of_copies					FARM:0:5
+    reason_for_frame_capture				FARM:0:6
+}
+
+farm.ata.drive_information {
+    serial_number					FARM:1:0
+    world_wide_name					FARM:1:1
+    device_interface					FARM:1:2
+    device_capacity_in_sectors				FARM:1:3
+    physical_sector_size				FARM:1:4
+    logical_sector_size					FARM:1:5
+    device_buffer_size					FARM:1:6
+    number_of_heads					FARM:1:7
+    device_form_factor					FARM:1:8
+    rotation_rate					FARM:1:9
+    firmware_rev					FARM:1:10
+    ata_security_state					FARM:1:11
+    ata_features_supported				FARM:1:12
+    ata_features_enabled				FARM:1:13
+    power_on_hours					FARM:1:14
+    spindle_power_on_hours				FARM:1:15
+    head_flight_hours					FARM:1:16
+    head_load_events					FARM:1:17
+    power_cycle_count					FARM:1:18
+    hardware_reset_count				FARM:1:19
+    spin_up_time					FARM:1:20
+    time_to_ready_last_power_cycle			FARM:1:21
+    time_drive_held_in_staggered_spin			FARM:1:22
+    model_number					FARM:1:23
+    drive_recording_type				FARM:1:24
+    max_number_available_sectors_reassignment		FARM:1:25
+    assembly_date					FARM:1:26
+    depopulation_head_mask				FARM:1:27
+}
+
+farm.ata.workload_statistics {
+    total_read_commands					FARM:2:0
+    total_write_commands				FARM:2:1
+    total_random_read_commands				FARM:2:2
+    total_random_write_commands				FARM:2:3
+    total_other_commands				FARM:2:4
+    logical_sectors_written				FARM:2:5
+    logical_sectors_read				FARM:2:6
+    dither_events_current_power_cycle			FARM:2:7
+    dither_held_off_random_workloads			FARM:2:8
+    dither_held_off_sequential_workloads		FARM:2:9
+    read_commands_0_3_lba_space_last_3_smart_frames	FARM:2:10
+    read_commands_3_25_lba_space_last_3_smart_frames	FARM:2:11
+    read_commands_25_75_lba_space_last_3_smart_frames	FARM:2:12
+    read_commands_75_100_lba_space_last_3_smart_frames	FARM:2:13
+    write_commands_0_3_lba_space_last_3_smart_frames	FARM:2:14
+    write_commands_3_25_lba_space_last_3_smart_frames	FARM:2:15
+    write_commands_25_75_lba_space_last_3_smart_frames	FARM:2:16
+    write_commands_75_100_lba_space_last_3_smart_frames	FARM:2:17
+}
+
+farm.ata.error_statistics {
+    unrecoverable_read_errors				FARM:3:0
+    unrecoverable_write_errors				FARM:3:1
+    reallocated_sectors					FARM:3:2
+    read_recovery_attempts				FARM:3:3
+    mechanical_start_failures				FARM:3:4
+    reallocated_candidate_sectors			FARM:3:5
+    asr_events						FARM:3:6
+    interface_crc_errors				FARM:3:7
+    spin_retry_count					FARM:3:8
+    spin_retry_count_normalized				FARM:3:9
+    spin_retry_count_worst				FARM:3:10
+    ioedc_errors					FARM:3:11
+    cto_count_total					FARM:3:12
+    cto_count_over_5s					FARM:3:13
+    cto_count_over_7s					FARM:3:14
+    total_flash_led_assert_events			FARM:3:15
+    index_of_last_flash_led				FARM:3:16
+    flash_led_event_information				FARM:6:0
+    flash_led_event_timestamp				FARM:6:1
+    flash_led_event_power_cycle				FARM:6:2
+    uncorrectable_errors				FARM:3:17
+    cumulative_lifetime_unrecoverable_errors_due_to_erc	FARM:3:18
+    cumulative_lifetime_unrecoverable_read_repeating	FARM:7:0
+    cumulative_lifetime_unrecoverable_read_unique	FARM:7:1
+}
+
+farm.ata.environment_statistics {
+    current_temperature					FARM:4:0
+    highest_temperature					FARM:4:1
+    lowest_temperature					FARM:4:2
+    average_short_term_temperature			FARM:4:3
+    average_long_term_temperature			FARM:4:4
+    highest_average_short_term_temperature		FARM:4:5
+    lowest_average_short_term_temperature		FARM:4:6
+    highest_average_long_term_temperature		FARM:4:7
+    lowest_average_long_term_temperature		FARM:4:8
+    time_in_over_temperature				FARM:4:9
+    time_in_under_temperature				FARM:4:10
+    specified_max_operating_temperature			FARM:4:11
+    specified_min_operating_temperature			FARM:4:12
+    current_relative_humidity				FARM:4:13
+    current_motor_power					FARM:4:14
+    current_12_volts					FARM:4:15
+    minimum_12_volts					FARM:4:16
+    maximum_12_volts					FARM:4:17
+    current_5_volts					FARM:4:18
+    minimum_5_volts					FARM:4:19
+    maximum_5_volts					FARM:4:20
+    power_average_12v					FARM:4:21
+    power_minimum_12v					FARM:4:22
+    power_maximum_12v					FARM:4:23
+    power_average_5v					FARM:4:24
+    power_minimum_5v					FARM:4:25
+    power_maximum_5v					FARM:4:26
+}
+
+farm.ata.reliability_statistics {
+    error_rate_smart_1_raw				FARM:5:0
+    error_rate_smart_1_normalized			FARM:5:1
+    error_rate_smart_1_worst				FARM:5:2
+    seek_error_rate_smart_7_raw				FARM:5:3
+    seek_error_rate_smart_7_normalized			FARM:5:4
+    seek_error_rate_smart_7_worst			FARM:5:5
+    high_priority_unload_events				FARM:5:6
+    helium_pressure_threshold_tripped			FARM:5:7
+    lbas_corrected_by_parity_sector			FARM:5:8
+    dvga_skip_write_detected				FARM:7:2
+    rvga_skip_write_detected				FARM:7:3
+    fvga_skip_write_detected				FARM:7:4
+    skip_write_detect_threshold_detect			FARM:7:5
+    write_power_secs					FARM:7:6
+    mr_head_resistance					FARM:7:7
+    second_mr_head_resistance				FARM:7:8
+    number_of_reallocated_sectors			FARM:7:9
+    number_of_reallocation_candidate_sectors		FARM:7:10
+}
+
+farm.scsi {
+    log_header
+    drive_information
+    workload_statistics
+    error_statistics
+    environment_statistics
+    reliability_statistics
+    drive_information_continued
+    environmental_information_continued
+    per_head_statistics
+    per_actuator_statistics
+    per_actuator_actuator_recallocation
+}
+
+farm.scsi.log_header {
+    log_version						FARM:10:0
+    pages_supported					FARM:10:1
+    log_size						FARM:10:2
+    heads_supported					FARM:10:3
+    reason_for_frame_capture				FARM:10:4
+}
+
+farm.scsi.drive_information {
+    serial_number					FARM:11:0
+    world_wide_name					FARM:11:1
+    firmware_revision					FARM:11:2
+    device_interface					FARM:11:3
+    device_capacity_in_sectors				FARM:11:4
+    physical_sector_size				FARM:11:5
+    logical_sector_size					FARM:11:6
+    device_buffer_size					FARM:11:7
+    number_of_heads					FARM:11:8
+    device_form_factor					FARM:11:9
+    rotation_rate					FARM:11:10
+    power_on_hours					FARM:11:11
+    power_cycle_count					FARM:11:12
+    hardware_reset_count				FARM:11:13
+    assembly_date					FARM:11:14
+}
+
+farm.scsi.workload_statistics {
+    total_read_commands					FARM:12:0
+    total_write_commands				FARM:12:1
+    total_random_read_commands				FARM:12:2
+    total_random_write_commands				FARM:12:3
+    total_other_commands				FARM:12:4
+    logical_sectors_written				FARM:12:5
+    logical_sectors_read				FARM:12:6
+    read_commands_0_3_lba_space				FARM:12:7
+    read_commands_3_25_lba_space			FARM:12:8
+    read_commands_25_75_lba_space			FARM:12:9
+    read_commands_75_100_lba_space			FARM:12:10
+    write_commands_0_3_lba_space			FARM:12:11
+    write_commands_3_25_lba_space			FARM:12:12
+    write_commands_25_75_lba_space			FARM:12:13
+    write_commands_75_100_lba_space			FARM:12:14
+}
+
+farm.scsi.error_statistics {
+    unrecoverable_read_errors				FARM:13:0
+    unrecoverable_write_errors				FARM:13:1
+    mechanical_start_errors				FARM:13:2
+    fru_code_most_recent_smart_frame			FARM:13:3
+    invalid_dword_count_port_a				FARM:13:4
+    invalid_dword_count_port_b				FARM:13:5
+    disparity_error_count_port_a			FARM:13:6
+    disparity_error_count_port_b			FARM:13:7
+    loss_of_dword_sync_port_a				FARM:13:8
+    loss_of_dword_sync_port_b				FARM:13:9
+    phy_reset_problem_port_a				FARM:13:10
+    phy_reset_problem_port_b				FARM:13:11
+}
+
+farm.scsi.environment_statistics {
+    current_temperature					FARM:14:0
+    highest_temperature					FARM:14:1
+    lowest_temperature					FARM:14:2
+    specified_max_operating_temperature			FARM:14:3
+    specified_min_operating_temperature			FARM:14:4
+    current_relative_humidity				FARM:14:5
+    current_motor_power					FARM:14:6
+    power_average_12v					FARM:14:7
+    power_minimum_12v					FARM:14:8
+    power_maximum_12v					FARM:14:9
+    power_average_5v					FARM:14:10
+    power_minimum_5v					FARM:14:11
+    power_maximum_5v					FARM:14:12
+}
+
+farm.scsi.reliability_statistics {
+    helium_pressure_threshold_tripped			FARM:15:0
+}
+
+farm.scsi.drive_information_continued {
+    depopulation_head_mask				FARM:16:0
+    product_id						FARM:16:1
+    drive_recording_type				FARM:16:2
+    drive_been_depopped					FARM:16:3
+    max_available_sectors_for_reassignment		FARM:16:4
+    time_to_ready_last_power_cycle			FARM:16:5
+    time_drive_held_in_staggered_spin			FARM:16:6
+    last_servo_spin_up_time				FARM:16:7
+}
+
+farm.scsi.environmental_information_continued {
+    current_12_volts					FARM:17:0
+    minimum_12_volts					FARM:17:1
+    maximum_12_volts					FARM:17:2
+    current_5_volts					FARM:17:3
+    minimum_5_volts					FARM:17:4
+    maximum_5_volts					FARM:17:5
+}
+
+farm.scsi.per_head_statistics {
+    mr_head_resistance					FARM:18:0
+    reallocated_sectors					FARM:18:1
+    reallocated_candidate_sectors			FARM:18:2
+    power_on_hours					FARM:18:3
+    head_cumulative_lifetime_unrecoverable_read_repeating	FARM:18:4
+    head_cumulative_lifetime_unrecoverable_read_unique	FARM:18:5
+    second_mr_head_resistance				FARM:18:6
+}
+
+farm.scsi.per_actuator_statistics {
+    head_load_events					FARM:19:0
+    timestamp_of_last_idd_test				FARM:19:1
+    subcommand_of_last_idd_test				FARM:19:2
+    number_of_reallocated_sector_reclamations		FARM:19:3
+    servo_status					FARM:19:4
+    slipped_sectors_after_idd_scan			FARM:19:5
+    resident_reallocated_sectors_after_idd_scan		FARM:19:6
+    successfully_scrubbed_sectors_after_idd_scan	FARM:19:7
+    number_of_dos_scans_performed			FARM:19:8
+    number_of_lbas_corrected_by_isp			FARM:19:9
+    number_of_valid_parity_sectors			FARM:19:10
+    number_of_lbas_corrected_by_parity_sector		FARM:19:11
+}
+
+farm.scsi.per_actuator_actuator_recallocation {
+    number_reallocated_sectors				FARM:20:0
+    number_recallocated_candidate_sectors		FARM:20:1
+}

--- a/src/pmdas/gfs2/.gitignore
+++ b/src/pmdas/gfs2/.gitignore
@@ -2,4 +2,6 @@ domain.h
 exports
 pmda_gfs2.so
 pmdagfs2
-
+help.dir
+help.pag
+*.pmns

--- a/src/pmdas/gfs2/GNUmakefile
+++ b/src/pmdas/gfs2/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2023 Red Hat.
+# Copyright (c) 2013-2023,2026 Red Hat.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -22,11 +22,13 @@ HFILES		= glockfd.h latency.h control.h glstats.h worst_glock.h glocks.h sbstats
 CMDTARGET	= pmda$(IAM)
 LIBTARGET	= pmda_$(IAM).$(DSOSUFFIX)
 PMDAINIT	= $(IAM)_init
+LOCALCONF_LINE	= "gfs2	115	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
 
 LLDLIBS		= $(PCP_PMDALIB)
 LCFLAGS		= $(INVISIBILITY)
 
-LDIRT		= domain.h $(IAM).log $(VERSION_SCRIPT)
+HELPTARGETS	= help.dir help.pag
+LDIRT		= $(HELPTARGETS) domain.h $(IAM).log $(VERSION_SCRIPT)
 
 SCRIPTS		= Install Remove
 VERSION_SCRIPT	= exports
@@ -43,13 +45,15 @@ default:	build-me
 include $(BUILDRULES)
 
 ifeq "$(PMDA_GFS2)" "true"
-build-me: $(CMDTARGET) $(LIBTARGET)
+build-me: $(CMDTARGET) $(LIBTARGET) $(HELPTARGETS)
 
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) root pmns domain.h help $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) help.dir help.pag root root_gfs2 pmns domain.h help $(PMDAADMDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(SCRIPTS) $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_gfs2 root_gfs2 $(PMDAADMDIR)/root_gfs2
+	$(INSTALL) -S $(PMDAADMDIR)/root_gfs2 $(PCP_PMNSADM_DIR)/root_gfs2
 	@$(INSTALL_MAN)
 else
 build-me:
@@ -59,6 +63,9 @@ endif
 default_pcp : default
 
 install_pcp : install
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_gfs2 -v 2 -o help < help
 
 $(OBJECTS): domain.h
 

--- a/src/pmdas/gfs2/Install
+++ b/src/pmdas/gfs2/Install
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=gfs2
+pmns_source=root_gfs2
 
 pmdaSetup
 pmdaInstall

--- a/src/pmdas/gfs2/help
+++ b/src/pmdas/gfs2/help
@@ -26,7 +26,7 @@
 #
 # blank lines before the @ line are ignored
 #
-@ GFS2.0 Instance domain for mounted GFS2 filesystems
+@ 115.0 Instance domain for mounted GFS2 filesystems
 
 @ gfs2.glocks.total Count of total observed incore GFS2 global locks
 Count of total incore GFS2 glock data structures based on parsing the contents

--- a/src/pmdas/gfs2/root
+++ b/src/pmdas/gfs2/root
@@ -4,13 +4,4 @@
 
 #include <stdpmid>
 
-root { 
-        gfs2 
-
-}
-
-#ifndef GFS2
-#define GFS2 115
-#endif
-
-#include "pmns"
+#include "root_gfs2"

--- a/src/pmdas/gfs2/root_gfs2
+++ b/src/pmdas/gfs2/root_gfs2
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2013 - 2025 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef GFS2
+#define GFS2    115
+#endif
+
+root {
+    gfs2
+}
+
+gfs2 {
+    glocks
+    holders
+    sbstats                 GFS2:*:*
+    glstats
+    glockfd
+    tracepoints
+    worst_glock             GFS2:*:*
+    latency
+    control
+}
+
+gfs2.glocks {
+    total                   GFS2:0:0
+    shared                  GFS2:0:1
+    unlocked                GFS2:0:2
+    deferred                GFS2:0:3
+    exclusive               GFS2:0:4
+    flags
+}
+
+gfs2.glocks.flags {
+    locked                  GFS2:0:5
+    demote                  GFS2:0:6
+    demote_pending          GFS2:0:7
+    demote_progress         GFS2:0:8
+    dirty                   GFS2:0:9
+    log_flush               GFS2:0:10
+    invalidate              GFS2:0:11
+    reply_pending           GFS2:0:12
+    initial                 GFS2:0:13
+    frozen                  GFS2:0:14
+    queued                  GFS2:0:15
+    object_attached         GFS2:0:16
+    blocking_request        GFS2:0:17
+    lru                     GFS2:0:18
+    instantiate_needed      GFS2:0:35
+    instantiate_in_prog     GFS2:0:36
+    try_to_evict            GFS2:0:37
+    verify_delete           GFS2:0:38
+}
+
+gfs2.holders {
+    total                   GFS2:0:19
+    shared                  GFS2:0:20
+    unlocked                GFS2:0:21
+    defered                 GFS2:0:22
+    exclusive               GFS2:0:23
+    flags
+}
+
+gfs2.holders.flags {
+    async                   GFS2:0:24
+    any                     GFS2:0:25
+    no_cache                GFS2:0:26
+    no_expire               GFS2:0:27
+    exact                   GFS2:0:28
+    first                   GFS2:0:29
+    holder                  GFS2:0:30
+    priority                GFS2:0:31
+    try                     GFS2:0:32
+    try_1cb                 GFS2:0:33
+    wait                    GFS2:0:34
+}
+
+gfs2.glstats {
+    total                   GFS2:2:0
+    trans                   GFS2:2:1
+    inode                   GFS2:2:2
+    rgrp                    GFS2:2:3
+    meta                    GFS2:2:4
+    iopen                   GFS2:2:5
+    flock                   GFS2:2:6
+    quota                   GFS2:2:8
+    journal                 GFS2:2:9
+}
+
+gfs2.glockfd {
+    total                   GFS2:7:0
+    pids                    GFS2:8:0
+    fds                     GFS2:8:1
+}
+
+gfs2.tracepoints {
+    glock_state_change
+    glock_put
+    demote_rq
+    promote
+    glock_queue
+    glock_lock_time
+    pin
+    log_flush
+    log_block
+    ail_flush
+    block_alloc
+    bmap
+    rs
+}
+
+gfs2.tracepoints.glock_state_change {
+    total                   GFS2:3:0
+    null_lock               GFS2:3:1
+    concurrent_read         GFS2:3:2
+    concurrent_write        GFS2:3:3
+    protected_read          GFS2:3:4
+    protected_write         GFS2:3:5
+    exclusive               GFS2:3:6
+    glocks
+}
+
+gfs2.tracepoints.glock_state_change.glocks {
+    changed_target          GFS2:3:7
+    missed_target           GFS2:3:8
+}
+
+gfs2.tracepoints.glock_put {
+    total                   GFS2:3:9
+    null_lock               GFS2:3:10
+    concurrent_read         GFS2:3:11
+    concurrent_write        GFS2:3:12
+    protected_read          GFS2:3:13
+    protected_write         GFS2:3:14
+    exclusive               GFS2:3:15
+}
+
+gfs2.tracepoints.demote_rq {
+    total                   GFS2:3:16
+    null_lock               GFS2:3:17
+    concurrent_read         GFS2:3:18
+    concurrent_write        GFS2:3:19
+    protected_read          GFS2:3:20
+    protected_write         GFS2:3:21
+    exclusive               GFS2:3:22
+    requested
+}
+
+gfs2.tracepoints.demote_rq.requested {
+    remote                  GFS2:3:23
+    local                   GFS2:3:24
+}
+
+gfs2.tracepoints.promote {
+    total                   GFS2:3:25
+    first
+    other
+}
+
+gfs2.tracepoints.promote.first {
+    null_lock               GFS2:3:26
+    concurrent_read         GFS2:3:27
+    concurrent_write        GFS2:3:28
+    protected_read          GFS2:3:29
+    protected_write         GFS2:3:30
+    exclusive               GFS2:3:31
+}
+
+gfs2.tracepoints.promote.other {
+    null_lock               GFS2:3:32
+    concurrent_read         GFS2:3:33
+    concurrent_write        GFS2:3:34
+    protected_read          GFS2:3:35
+    protected_write         GFS2:3:36
+    exclusive               GFS2:3:37
+}
+
+gfs2.tracepoints.glock_queue {
+    total                   GFS2:3:38
+    queue
+    dequeue
+}
+
+gfs2.tracepoints.glock_queue.queue {
+    total                   GFS2:3:39
+    null_lock               GFS2:3:40
+    concurrent_read         GFS2:3:41
+    concurrent_write        GFS2:3:42
+    protected_read          GFS2:3:43
+    protected_write         GFS2:3:44
+    exclusive               GFS2:3:45
+}
+
+gfs2.tracepoints.glock_queue.dequeue {
+    total                   GFS2:3:46
+    null_lock               GFS2:3:47
+    concurrent_read         GFS2:3:48
+    concurrent_write        GFS2:3:49
+    protected_read          GFS2:3:50
+    protected_write         GFS2:3:51
+    exclusive               GFS2:3:52
+}
+
+gfs2.tracepoints.glock_lock_time {
+    total                   GFS2:3:53
+    trans                   GFS2:3:54
+    inode                   GFS2:3:55
+    rgrp                    GFS2:3:56
+    meta                    GFS2:3:57
+    iopen                   GFS2:3:58
+    flock                   GFS2:3:59
+    quota                   GFS2:3:60
+    journal                 GFS2:3:61
+}
+
+gfs2.tracepoints.pin {
+    total                   GFS2:3:62
+    pin_total               GFS2:3:63
+    unpin_total             GFS2:3:64
+    longest_pinned          GFS2:3:65
+}
+
+gfs2.tracepoints.log_flush {
+    total                   GFS2:3:66
+}
+
+gfs2.tracepoints.log_block {
+    total                   GFS2:3:67
+}
+
+gfs2.tracepoints.ail_flush {
+    total                   GFS2:3:68
+}
+
+gfs2.tracepoints.block_alloc {
+    total                   GFS2:3:69
+    free                    GFS2:3:70
+    used                    GFS2:3:71
+    dinode                  GFS2:3:72
+    unlinked                GFS2:3:73
+}
+
+gfs2.tracepoints.bmap {
+    total                   GFS2:3:74
+    create                  GFS2:3:75
+    nocreate                GFS2:3:76
+}
+
+gfs2.tracepoints.rs {
+    total                   GFS2:3:77
+    del                     GFS2:3:78
+    tdel                    GFS2:3:79
+    ins                     GFS2:3:80
+    clm                     GFS2:3:81
+}
+
+gfs2.latency {
+    grant
+    demote
+    queue
+}
+
+gfs2.latency.grant {
+    all                     GFS2:5:0
+    null_lock               GFS2:5:1
+    concurrent_read         GFS2:5:2
+    concurrent_write        GFS2:5:3
+    protected_read          GFS2:5:4
+    protected_write         GFS2:5:5
+    exclusive               GFS2:5:6
+}
+
+gfs2.latency.demote {
+    all                     GFS2:5:7
+    null_lock               GFS2:5:8
+    concurrent_read         GFS2:5:9
+    concurrent_write        GFS2:5:10
+    protected_read          GFS2:5:11
+    protected_write         GFS2:5:12
+    exclusive               GFS2:5:13
+}
+
+gfs2.latency.queue {
+    all                     GFS2:5:14
+    null_lock               GFS2:5:15
+    concurrent_read         GFS2:5:16
+    concurrent_write        GFS2:5:17
+    protected_read          GFS2:5:18
+    protected_write         GFS2:5:19
+    exclusive               GFS2:5:20
+}
+
+gfs2.control {
+    tracepoints
+    buffer_size_kb          GFS2:6:14
+    global_tracing          GFS2:6:15
+    worst_glock             GFS2:6:16
+    latency                 GFS2:6:17
+    glock_threshold         GFS2:6:18
+}
+
+gfs2.control.tracepoints {
+    all                     GFS2:6:0
+    glock_state_change      GFS2:6:1
+    glock_put               GFS2:6:2
+    demote_rq               GFS2:6:3
+    promote                 GFS2:6:4
+    glock_queue             GFS2:6:5
+    glock_lock_time         GFS2:6:6
+    pin                     GFS2:6:7
+    log_flush               GFS2:6:8
+    log_blocks              GFS2:6:9
+    ail_flush               GFS2:6:10
+    block_alloc             GFS2:6:11
+    bmap                    GFS2:6:12
+    rs                      GFS2:6:13
+}

--- a/src/pmdas/hacluster/.gitignore
+++ b/src/pmdas/hacluster/.gitignore
@@ -2,3 +2,6 @@ domain.h
 exports
 pmda_hacluster.so
 pmdahacluster
+help.dir
+help.pag
+*.pmns

--- a/src/pmdas/hacluster/GNUmakefile
+++ b/src/pmdas/hacluster/GNUmakefile
@@ -22,11 +22,13 @@ HFILES		= pmdahacluster.h pacemaker.h corosync.h sbd.h drbd.h
 CMDTARGET	= pmda$(IAM)
 LIBTARGET	= pmda_$(IAM).$(DSOSUFFIX)
 PMDAINIT	= $(IAM)_init
+LOCALCONF_LINE	= "hacluster	155	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
 
 LLDLIBS		= $(PCP_PMDALIB)
 LCFLAGS		= $(INVISIBILITY)
 
-LDIRT		= domain.h $(IAM).log $(VERSION_SCRIPT)
+HELPTARGETS	= help.dir help.pag
+LDIRT		= $(HELPTARGETS) domain.h $(IAM).log $(VERSION_SCRIPT)
 
 SCRIPTS		= Install Remove
 VERSION_SCRIPT	= exports
@@ -43,13 +45,15 @@ default:	build-me
 include $(BUILDRULES)
 
 ifeq "$(TARGET_OS)" "linux"
-build-me: $(CMDTARGET) $(LIBTARGET)
+build-me: $(CMDTARGET) $(LIBTARGET) $(HELPTARGETS)
 
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) root pmns domain.h help $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) help.dir help.pag root root_hacluster pmns domain.h help $(PMDAADMDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(SCRIPTS) $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_hacluster root_hacluster $(PMDAADMDIR)/root_hacluster
+	$(INSTALL) -S $(PMDAADMDIR)/root_hacluster $(PCP_PMNSADM_DIR)/root_hacluster
 	@$(INSTALL_MAN)
 else
 build-me:
@@ -59,6 +63,9 @@ endif
 default_pcp : default
 
 install_pcp : install
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_hacluster -v 2 -o help < help
 
 $(OBJECTS): domain.h
 

--- a/src/pmdas/hacluster/Install
+++ b/src/pmdas/hacluster/Install
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=hacluster
+pmns_source=root_hacluster
 pmns_name=ha_cluster	# differs to PMDA name
 
 pmdaSetup

--- a/src/pmdas/hacluster/help
+++ b/src/pmdas/hacluster/help
@@ -26,7 +26,7 @@
 #
 # blank lines before the @ line are ignored
 #
-@ HACLUSTER.0 Instance domain for High Availability Cluster component metrics
+@ 155.0 Instance domain for High Availability Cluster component metrics
 
 @ ha_cluster.pacemaker.config_last_change Unix timestamp corresponding to last Pacemaker configuration change
 Unix timestamp in seconds corresponding to the last time that the Pacemaker

--- a/src/pmdas/hacluster/root
+++ b/src/pmdas/hacluster/root
@@ -4,12 +4,4 @@
 
 #include <stdpmid>
 
-root { 
-	ha_cluster 
-}
-
-#ifndef HACLUSTER
-#define HACLUSTER 155
-#endif
-
-#include "pmns"
+#include "root_hacluster"

--- a/src/pmdas/hacluster/root_hacluster
+++ b/src/pmdas/hacluster/root_hacluster
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2020 - 2021 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef HACLUSTER
+#define HACLUSTER    155
+#endif
+
+root {
+    ha_cluster
+}
+
+ha_cluster {
+    pacemaker
+    corosync
+    sbd
+    drbd
+}
+
+ha_cluster.pacemaker {
+    config_last_change          HACLUSTER:0:0
+    fail_count                  HACLUSTER:1:0
+    location_constraints
+    migration_threshold         HACLUSTER:1:1
+    nodes
+    node_attributes             HACLUSTER:4:0
+    node_attributes_all         HACLUSTER:13:0
+    resources
+    stonith_enabled             HACLUSTER:0:1
+}
+
+ha_cluster.pacemaker.location_constraints {
+    node                        HACLUSTER:2:0
+    resource                    HACLUSTER:2:1
+    role                        HACLUSTER:2:2
+    score                       HACLUSTER:2:3
+    all                         HACLUSTER:12:0
+}
+
+ha_cluster.pacemaker.nodes {
+    status
+    type                        HACLUSTER:3:9
+}
+
+ha_cluster.pacemaker.nodes.status {
+    online                      HACLUSTER:3:0
+    standby                     HACLUSTER:3:1
+    standby_on_fail             HACLUSTER:3:2
+    maintenance                 HACLUSTER:3:3
+    pending                     HACLUSTER:3:4
+    unclean                     HACLUSTER:3:5
+    shutdown                    HACLUSTER:3:6
+    expected_up                 HACLUSTER:3:7
+    dc                          HACLUSTER:3:8
+    health                      HACLUSTER:3:10
+    feature_set                 HACLUSTER:3:11
+}
+
+ha_cluster.pacemaker.resources {
+    agent                       HACLUSTER:5:0
+    clone                       HACLUSTER:5:1
+    group                       HACLUSTER:5:2
+    managed                     HACLUSTER:5:3
+    role                        HACLUSTER:5:4
+    status
+    all                         HACLUSTER:14:0
+}
+
+ha_cluster.pacemaker.resources.status {
+    active                      HACLUSTER:5:5
+    orphaned                    HACLUSTER:5:6
+    blocked                     HACLUSTER:5:7
+    failed                      HACLUSTER:5:8
+    failure_ignored             HACLUSTER:5:9
+}
+
+ha_cluster.corosync {
+    member_votes
+    quorate                     HACLUSTER:7:0
+    quorum_votes
+    ring_errors                 HACLUSTER:7:5
+    rings
+}
+
+ha_cluster.corosync.member_votes {
+    votes                       HACLUSTER:6:0
+    local                       HACLUSTER:6:1
+    node_id                     HACLUSTER:6:2
+}
+
+ha_cluster.corosync.quorum_votes {
+    expected_votes              HACLUSTER:7:1
+    highest_expected            HACLUSTER:7:2
+    total_votes                 HACLUSTER:7:3
+    quorum                      HACLUSTER:7:4
+}
+
+ha_cluster.corosync.rings {
+    status                      HACLUSTER:8:0
+    address                     HACLUSTER:8:1
+    node_id                     HACLUSTER:8:2
+    number                      HACLUSTER:8:3
+    ring_id                     HACLUSTER:8:4
+    all                         HACLUSTER:15:0
+}
+
+ha_cluster.sbd {
+    devices
+    timeouts
+    all                         HACLUSTER:16:0
+}
+
+ha_cluster.sbd.devices {
+    path                        HACLUSTER:9:0
+    status                      HACLUSTER:9:1
+}
+
+ha_cluster.sbd.timeouts {
+    mgswait                     HACLUSTER:9:2
+    allocate                    HACLUSTER:9:3
+    loop                        HACLUSTER:9:4
+    watchdog                    HACLUSTER:9:5
+}
+
+ha_cluster.drbd {
+    resources
+    written                     HACLUSTER:10:4
+    read                        HACLUSTER:10:5
+    al_writes                   HACLUSTER:10:6
+    bm_writes                   HACLUSTER:10:7
+    upper_pending               HACLUSTER:10:8
+    lower_pending               HACLUSTER:10:9
+    quorum                      HACLUSTER:10:10
+    connections
+    connections_sync            HACLUSTER:11:5
+    connections_received        HACLUSTER:11:6
+    connections_sent            HACLUSTER:11:7
+    connections_pending         HACLUSTER:11:8
+    connections_unacked         HACLUSTER:11:9
+    split_brain                 HACLUSTER:10:11
+}
+
+ha_cluster.drbd.resources {
+    resource                    HACLUSTER:10:0
+    role                        HACLUSTER:10:1
+    volume                      HACLUSTER:10:2
+    disk_state                  HACLUSTER:10:3
+    all                         HACLUSTER:17:0
+}
+
+ha_cluster.drbd.connections {
+    resource                    HACLUSTER:11:0
+    peer_node_id                HACLUSTER:11:1
+    peer_role                   HACLUSTER:11:2
+    volume                      HACLUSTER:11:3
+    peer_disk_state             HACLUSTER:11:4
+    all                         HACLUSTER:18:0
+}

--- a/src/pmdas/infiniband/.gitignore
+++ b/src/pmdas/infiniband/.gitignore
@@ -4,3 +4,4 @@ help.dir
 help.pag
 pmdaib
 pmda_ib.so
+*.pmns

--- a/src/pmdas/infiniband/GNUmakefile
+++ b/src/pmdas/infiniband/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2015,2020,2025 Red Hat.
+# Copyright (c) 2013-2015,2020,2025,2026 Red Hat.
 # Copyright (c) 2007-2009 Silicon Graphics, Inc.  All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ LDIRT = $(HELPTARGETS) domain.h *.o $(IAM).log $(LIBTARGET) $(VERSION_SCRIPT) $(
 
 PMDAADMDIR = $(PCP_PMDASADM_DIR)/infiniband
 PMDATMPDIR = $(PCP_PMDAS_DIR)/infiniband
+LOCALCONF_LINE = "infiniband	91	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
 
 MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
@@ -49,8 +50,9 @@ install_pcp install: default
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Upgrade Remove $(PMDAADMDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(PMDAADMDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) domain.h help $(HELPTARGETS) $(PMDAADMDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) pmns root $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) domain.h help help.dir help.pag root root_infiniband pmns $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_infiniband root_infiniband $(PMDAADMDIR)/root_infiniband
+	$(INSTALL) -S $(PMDAADMDIR)/root_infiniband $(PCP_PMNSADM_DIR)/root_infiniband
 	@$(INSTALL_MAN)
 else
 build-me:
@@ -61,7 +63,7 @@ endif
 $(OBJECTS): domain.h
 
 $(HELPTARGETS) : help
-	$(NEWHELP) -n root -v 2 -o help < help
+	$(NEWHELP) -n root_infiniband -v 2 -o help < help
 
 $(VERSION_SCRIPT):
 	$(VERSION_SCRIPT_MAKERULE)

--- a/src/pmdas/infiniband/Install
+++ b/src/pmdas/infiniband/Install
@@ -18,6 +18,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=infiniband
+pmns_source=root_infiniband
 daemon_opt=true
 dso_opt=true
 pipe_opt=true

--- a/src/pmdas/infiniband/root
+++ b/src/pmdas/infiniband/root
@@ -2,6 +2,6 @@
  * fake "root" for validating the local PMNS subtree
  */
 
-root { infiniband }
+#include <stdpmid>
 
-#include "pmns"
+#include "root_infiniband"

--- a/src/pmdas/infiniband/root_infiniband
+++ b/src/pmdas/infiniband/root_infiniband
@@ -1,0 +1,252 @@
+/*
+ * Metrics for infiniband PMDA
+ *
+ * Copyright (c) 2013-2015,2025,2026 Red Hat.
+ * Copyright (c) 2007-2009 Silicon Graphics, Inc.  All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef IB
+#define IB    91
+#endif
+
+root {
+    infiniband
+}
+
+infiniband {
+    hca
+    port
+    control
+}
+
+infiniband.hca {
+    type                IB:0:0
+    ca_type             IB:0:1
+    numports            IB:0:2
+    fw_ver              IB:0:3
+    hw_ver              IB:0:4
+    node_guid           IB:0:5
+    system_guid         IB:0:6
+    transport           IB:0:16
+    board_id            IB:0:17
+    vendor_id           IB:0:18
+    res
+}
+
+infiniband.hca.res {
+    pd                  IB:0:19
+    cq                  IB:0:20
+    qp                  IB:0:21
+    cm_id               IB:0:22
+    mr                  IB:0:23
+    ctx                 IB:0:24
+    srq                 IB:0:25
+}
+
+infiniband.port {
+    guid                IB:0:7
+    gid_prefix          IB:0:8
+    lid                 IB:0:9
+    state               IB:0:10
+    phystate            IB:0:11
+    rate                IB:0:12
+    capabilities        IB:0:13
+    linkspeed           IB:0:14
+    linkwidth           IB:0:15
+    sm_lid              IB:0:26
+    lmc                 IB:0:27
+    max_mtu             IB:0:28
+    active_mtu          IB:0:29
+    link_layer          IB:0:30
+    netdev_name         IB:0:31
+    capmask             IB:0:32
+    node_desc           IB:0:33
+    select              IB:1:20
+    counter_select      IB:1:21
+    in
+    out
+    total
+    switch
+    cm
+    diag
+}
+
+infiniband.port.in {
+    bytes               IB:1:0
+    packets             IB:1:1
+    ucast_packets       IB:1:22
+    mcast_packets       IB:1:23
+    data                IB:1:27
+    errors
+}
+
+infiniband.port.in.errors {
+    drop                IB:1:4
+    filter              IB:1:9
+    local               IB:1:10
+    remote              IB:1:11
+}
+
+infiniband.port.out {
+    bytes               IB:1:2
+    packets             IB:1:3
+    ucast_packets       IB:1:24
+    mcast_packets       IB:1:25
+    data                IB:1:26
+    errors
+}
+
+infiniband.port.out.errors {
+    drop                IB:1:5
+    filter              IB:1:12
+}
+
+infiniband.port.total {
+    bytes               IB:1:6
+    packets             IB:1:7
+    errors
+}
+
+infiniband.port.total.errors {
+    drop                IB:1:8
+    filter              IB:1:13
+    link                IB:1:14
+    recover             IB:1:15
+    integrity           IB:1:16
+    vl15                IB:1:17
+    overrun             IB:1:18
+    symbol              IB:1:19
+}
+
+infiniband.port.switch {
+    in
+    out
+    total
+}
+
+infiniband.port.switch.in {
+    bytes               IB:3:0
+    packets             IB:3:1
+}
+
+infiniband.port.switch.out {
+    bytes               IB:3:2
+    packets             IB:3:3
+}
+
+infiniband.port.switch.total {
+    bytes               IB:3:4
+    packets             IB:3:5
+}
+
+infiniband.control {
+    query_timeout       IB:2:0
+    hiwat               IB:2:1
+}
+
+infiniband.port.cm {
+    rx_duplicates
+    rx_msgs
+    tx_msgs
+    tx_retries
+}
+
+infiniband.port.cm.rx_duplicates {
+    apr                 IB:4:1
+    drep                IB:4:2
+    dreq                IB:4:3
+    lap                 IB:4:4
+    mra                 IB:4:5
+    rej                 IB:4:6
+    rep                 IB:4:7
+    req                 IB:4:8
+    rtu                 IB:4:9
+    sidr_rep            IB:4:10
+    sidr_req            IB:4:11
+}
+
+infiniband.port.cm.rx_msgs {
+    apr                 IB:4:12
+    drep                IB:4:13
+    dreq                IB:4:14
+    lap                 IB:4:15
+    mra                 IB:4:16
+    rej                 IB:4:17
+    rep                 IB:4:18
+    req                 IB:4:19
+    rtu                 IB:4:20
+    sidr_rep            IB:4:21
+    sidr_req            IB:4:22
+}
+
+infiniband.port.cm.tx_msgs {
+    apr                 IB:4:23
+    drep                IB:4:24
+    dreq                IB:4:25
+    lap                 IB:4:26
+    mra                 IB:4:27
+    rej                 IB:4:28
+    rep                 IB:4:29
+    req                 IB:4:30
+    rtu                 IB:4:31
+    sidr_rep            IB:4:32
+    sidr_req            IB:4:33
+}
+
+infiniband.port.cm.tx_retries {
+    apr                 IB:4:34
+    drep                IB:4:35
+    dreq                IB:4:36
+    lap                 IB:4:37
+    mra                 IB:4:38
+    rej                 IB:4:39
+    rep                 IB:4:40
+    req                 IB:4:41
+    rtu                 IB:4:42
+    sidr_rep            IB:4:43
+    sidr_req            IB:4:44
+}
+
+infiniband.port.diag {
+    rq
+    sq
+}
+
+infiniband.port.diag.rq {
+    dup                 IB:4:45
+    lle                 IB:4:46
+    lpe                 IB:4:47
+    lqpoe               IB:4:48
+    oos                 IB:4:49
+    rae                 IB:4:50
+    rire                IB:4:51
+    rnr                 IB:4:52
+    wrfe                IB:4:53
+}
+
+infiniband.port.diag.sq {
+    bre                 IB:4:54
+    lle                 IB:4:55
+    lpe                 IB:4:56
+    lqpoe               IB:4:57
+    mwbe                IB:4:58
+    oos                 IB:4:59
+    rae                 IB:4:60
+    rire                IB:4:61
+    rnr                 IB:4:62
+    roe                 IB:4:63
+    rree                IB:4:64
+    to                  IB:4:65
+    tree                IB:4:66
+    wrfe                IB:4:67
+}

--- a/src/pmdas/lustrecomm/.gitignore
+++ b/src/pmdas/lustrecomm/.gitignore
@@ -1,2 +1,7 @@
 domain.h
+exports
+help.dir
+help.pag
 pmdalustrecomm
+pmda_lustrecomm.so
+*.pmns

--- a/src/pmdas/lustrecomm/GNUmakefile
+++ b/src/pmdas/lustrecomm/GNUmakefile
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2008 Silicon Graphics, Inc.  All Rights Reserved.
-# Copyright (c) 2015,2020 Red Hat, Inc.
+# Copyright (c) 2015,2020,2026 Red Hat, Inc.
 #
 # Author: Scott Emery <emery@sgi.com> 
 #
@@ -20,23 +20,28 @@ include $(TOPDIR)/src/include/builddefs
 
 IAM	= lustrecomm
 DOMAIN	= LUSTRECOMM
+PMDAINIT = $(IAM)_init
 
 PMDAADMDIR = $(PCP_PMDASADM_DIR)/$(IAM)
 PMDATMPDIR = $(PCP_PMDAS_DIR)/$(IAM)
+LOCALCONF_LINE = "lustrecomm	93	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
 
 DFILES 	= README
 HFILES	= libreadfiles.h
 CFILES	= $(IAM).c file_indexed.c file_single.c refresh_file.c timespec_routines.c
 
-LIBTARGET = pmda_$(IAM).so
+LIBTARGET = pmda_$(IAM).$(DSOSUFFIX)
 CMDTARGET = pmda$(IAM)
-TARGETS = $(CMDTARGET)
+TARGETS = $(CMDTARGET) $(LIBTARGET)
+
+VERSION_SCRIPT = exports
+HELPTARGETS = help.dir help.pag
 
 LDOPTS	=
 LLDLIBS = $(PCP_PMDALIB) $(LIB_FOR_RT)
 LCFLAGS = -I.
 
-LDIRT	= domain.h *.o $(IAM).log pmda$(IAM) pmda_$(IAM).so
+LDIRT	= $(HELPTARGETS) domain.h *.o $(IAM).log pmda$(IAM) pmda_$(IAM).$(DSOSUFFIX) $(VERSION_SCRIPT)
 
 MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
@@ -47,13 +52,15 @@ default: build-me
 include $(BUILDRULES)
 
 ifeq "$(TARGET_OS)" "linux"
-build-me:	$(TARGETS)
+build-me:	$(HELPTARGETS) $(TARGETS)
 
 install:	default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
-	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(CMDTARGET) $(PMDAADMDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) $(DFILES) root pmns domain.h help $(PMDAADMDIR)
+	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(CMDTARGET) $(LIBTARGET) $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) $(DFILES) root root_lustrecomm pmns domain.h help help.dir help.pag $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_lustrecomm root_lustrecomm $(PMDAADMDIR)/root_lustrecomm
+	$(INSTALL) -S $(PMDAADMDIR)/root_lustrecomm $(PCP_PMNSADM_DIR)/root_lustrecomm
 	@$(INSTALL_MAN)
 else
 build-me:
@@ -65,6 +72,12 @@ default_pcp: default
 install_pcp: install
 
 $(OBJECTS): domain.h
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_lustrecomm -v 2 -o help < help
+
+$(VERSION_SCRIPT):
+	$(VERSION_SCRIPT_MAKERULE)
 
 domain.h: ../../pmns/stdpmid
 	$(DOMAIN_MAKERULE)

--- a/src/pmdas/lustrecomm/Install
+++ b/src/pmdas/lustrecomm/Install
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=lustrecomm
+pmns_source=root_lustrecomm
 
 pmdaSetup
 pmdaInstall

--- a/src/pmdas/lustrecomm/root
+++ b/src/pmdas/lustrecomm/root
@@ -4,7 +4,4 @@
 
 #include <stdpmid>
 
-root { lustrecomm }
-
-#include "pmns"
-
+#include "root_lustrecomm"

--- a/src/pmdas/lustrecomm/root_lustrecomm
+++ b/src/pmdas/lustrecomm/root_lustrecomm
@@ -1,0 +1,53 @@
+/*
+ * Metrics for lustrecomm PMDA
+ *
+ * Copyright (c) 2008 Silicon Graphics, Inc.  All Rights Reserved.
+ * Copyright (c) 2026 Red Hat.
+ *
+ * Author: Scott Emery <emery@sgi.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef LUSTRECOMM
+#define LUSTRECOMM    93
+#endif
+
+root {
+    lustrecomm
+}
+
+lustrecomm {
+    timeout             LUSTRECOMM:0:0
+    ldlm_timeout        LUSTRECOMM:0:1
+    dump_on_timeout      LUSTRECOMM:0:2
+    lustre_memused      LUSTRECOMM:0:3
+    lnet_memused        LUSTRECOMM:0:4
+    stats
+}
+
+lustrecomm.stats {
+    msgs_alloc          LUSTRECOMM:1:0
+    msgs_max            LUSTRECOMM:1:1
+    errors              LUSTRECOMM:1:2
+    send_count          LUSTRECOMM:1:3
+    recv_count          LUSTRECOMM:1:4
+    route_count         LUSTRECOMM:1:5
+    drop_count          LUSTRECOMM:1:6
+    send_length         LUSTRECOMM:1:7
+    recv_length         LUSTRECOMM:1:8
+    route_length        LUSTRECOMM:1:9
+    drop_length         LUSTRECOMM:1:10
+}

--- a/src/pmdas/nvidia/.gitignore
+++ b/src/pmdas/nvidia/.gitignore
@@ -1,7 +1,9 @@
 help.dir
 help.pag
 domain.h
+exports
 pmdanvidia
 pmda_nvidia.so
 pmda_nvidia.dll
 pmda_nvidia.dylib
+*.pmns

--- a/src/pmdas/nvidia/GNUmakefile
+++ b/src/pmdas/nvidia/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015,2020,2025 Red Hat.
+# Copyright (c) 2014-2015,2020,2025,2026 Red Hat.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -20,12 +20,12 @@ DOMAIN	= NVML
 
 CMDTARGET = pmdanvidia$(EXECSUFFIX)
 LIBTARGET = pmda_nvidia.$(DSOSUFFIX)
+PMDAINIT = nvidia_init
 CFILES	= localnvml.c nvidia.c
 HFILES	= localnvml.h
 DFILES	= README
 LLDLIBS	= $(PCP_PMDALIB) $(LIB_FOR_DLOPEN)
 LCFLAGS += -DDSOSUFFIX=\"$(DSOSUFFIX)\"
-LDIRT	= domain.h *.log *.dir *.pag so_locations
 
 PMDAADMDIR = $(PCP_PMDASADM_DIR)/$(IAM)
 PMDATMPDIR = $(PCP_PMDAS_DIR)/$(IAM)
@@ -34,7 +34,13 @@ LOGCONFVARDIR = $(PCP_VAR_DIR)/config/pmlogconf/$(IAM)
 REWRITEDIR	= $(PCP_SYSCONF_DIR)/pmlogrewrite
 REWRITEVARDIR	= $(PCP_VAR_DIR)/config/pmlogrewrite
 
-default:	$(LIBTARGET) $(CMDTARGET)
+LOCALCONF_LINE = "nvidia	120	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
+VERSION_SCRIPT	= exports
+HELPTARGETS	= help.dir help.pag
+
+LDIRT	= domain.h *.log $(HELPTARGETS) so_locations $(VERSION_SCRIPT)
+
+default:	$(LIBTARGET) $(CMDTARGET) $(HELPTARGETS)
 
 include $(BUILDRULES)
 
@@ -43,7 +49,9 @@ install:	default
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(PMDAADMDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(PMDAADMDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) $(DFILES) root help pmns domain.h $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) $(DFILES) root root_nvidia help help.dir help.pag pmns domain.h $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_nvidia root_nvidia $(PMDAADMDIR)/root_nvidia
+	$(INSTALL) -S $(PMDAADMDIR)/root_nvidia $(PCP_PMNSADM_DIR)/root_nvidia
 	$(INSTALL) -m 755 -d $(LOGCONFDIR)
 	$(INSTALL) -m 755 -d $(LOGCONFVARDIR)
 	$(INSTALL) -m 644 -t $(LOGCONFVARDIR)/config pmlogconf.config $(LOGCONFDIR)/config
@@ -54,6 +62,12 @@ $(OBJECTS): domain.h
 
 domain.h: ../../pmns/stdpmid
 	$(DOMAIN_MAKERULE)
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_nvidia -v 2 -o help < help
+
+$(VERSION_SCRIPT):
+	$(VERSION_SCRIPT_MAKERULE)
 
 default_pcp:	default
 

--- a/src/pmdas/nvidia/Install
+++ b/src/pmdas/nvidia/Install
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=nvidia
+pmns_source=root_nvidia
 dso_opt=true
 
 pmdaSetup

--- a/src/pmdas/nvidia/root
+++ b/src/pmdas/nvidia/root
@@ -4,7 +4,4 @@
 
 #include <stdpmid>
 
-root { nvidia }
-
-#include "pmns"
-
+#include "root_nvidia"

--- a/src/pmdas/nvidia/root_nvidia
+++ b/src/pmdas/nvidia/root_nvidia
@@ -1,0 +1,96 @@
+/*
+ * Metrics for nvidia GPU PMDA
+ *
+ * Copyright (c) 2014,2019,2021,2026 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef NVML
+#define NVML    120
+#endif
+
+root {
+    nvidia
+}
+
+nvidia {
+    numcards			NVML:0:0
+    gpuid			NVML:0:1
+    cardname			NVML:0:2
+    busid			NVML:0:3
+    temperature			NVML:0:4
+    fanspeed			NVML:0:5
+    perfstate			NVML:0:6
+    gpuactive			NVML:0:7
+    memactive			NVML:0:8
+    memused			NVML:0:9
+    memtotal			NVML:0:10
+    memfree			NVML:0:11
+    carduuid			NVML:0:19
+    energy			NVML:0:20
+    power			NVML:0:21
+    nprocs			NVML:0:22
+    samples			NVML:0:23
+    gpuutilaccum		NVML:0:24
+    memutilaccum		NVML:0:25
+    memusedaccum		NVML:0:26
+    proc
+}
+
+nvidia.proc {
+    samples			NVML:1:12
+    memused			NVML:1:13
+    memaccum			NVML:1:14
+    gpuactive			NVML:1:15
+    memactive			NVML:1:16
+    time			NVML:1:17
+    running			NVML:1:18
+    all
+    compute
+    graphics
+}
+
+nvidia.proc.all {
+    samples			NVML:2:0
+    memused			NVML:2:1
+    memaccum			NVML:2:2
+    gpuactive			NVML:2:3
+    memactive			NVML:2:4
+    time			NVML:2:5
+    running			NVML:2:6
+    gpulist			NVML:2:7
+    ngpus			NVML:2:8
+}
+
+nvidia.proc.compute {
+    samples			NVML:3:0
+    memused			NVML:3:1
+    memaccum			NVML:3:2
+    gpuactive			NVML:3:3
+    memactive			NVML:3:4
+    time			NVML:3:5
+    running			NVML:3:6
+    gpulist			NVML:3:7
+    ngpus			NVML:3:8
+}
+
+nvidia.proc.graphics {
+    samples			NVML:4:0
+    memused			NVML:4:1
+    memaccum			NVML:4:2
+    gpuactive			NVML:4:3
+    memactive			NVML:4:4
+    time			NVML:4:5
+    running			NVML:4:6
+    gpulist			NVML:4:7
+    ngpus			NVML:4:8
+}

--- a/src/pmdas/perfevent/.gitignore
+++ b/src/pmdas/perfevent/.gitignore
@@ -5,3 +5,5 @@ help.pag
 perfalloc
 pmdaperfevent
 pmda_perfevent.so
+exports
+*.pmns

--- a/src/pmdas/perfevent/GNUmakefile
+++ b/src/pmdas/perfevent/GNUmakefile
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2000,2003,2004,2008 Silicon Graphics, Inc.  All Rights Reserved.
 # Copyright (c) 2007-2010 Aconex.  All Rights Reserved.
-# Copyright (c) 2013-2015,2020 Red Hat.
+# Copyright (c) 2013-2015,2020,2026 Red Hat.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -22,6 +22,7 @@ DOMAIN		= PERFEVENT
 CMDTARGET	= pmdaperfevent
 LIBTARGET	= pmda_perfevent.so
 PMDAINIT	= perfevent_init
+LOCALCONF_LINE	= "perfevent	127	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
 PMDAADMDIR	= $(PCP_PMDASADM_DIR)/$(IAM)
 PMDACONFIG	= $(PCP_SYSCONF_DIR)/$(IAM)
 PMDATMPDIR	= $(PCP_PMDAS_DIR)/$(IAM)
@@ -39,7 +40,9 @@ DFILES	= README help
 
 TARGETS = $(CMDTARGET) $(LIBTARGET) perfalloc
 
-LDIRT	= $(HELPTARGETS) domain.h
+VERSION_SCRIPT	= exports
+HELPTARGETS	= help.dir help.pag
+LDIRT	= $(HELPTARGETS) domain.h $(VERSION_SCRIPT)
 
 LLDLIBS = $(PCP_PMDALIB) $(PFM_LIBS)
 LLDLIBS += $(LIB_FOR_RT) $(LIB_FOR_MATH) $(LIB_FOR_PTHREADS)
@@ -53,19 +56,27 @@ default_pcp default:	build-me
 include $(BUILDRULES)
 
 ifeq "$(PMDA_PERFEVENT)" "true"
-build-me: $(TARGETS)
+build-me: $(TARGETS) $(HELPTARGETS)
 
 install_pcp install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) domain.h help root pmns $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) help.dir help.pag root root_perfevent pmns domain.h help $(PMDAADMDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(CMDTARGET) $(LIBTARGET) $(SCRIPTS) perfalloc $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDACONFIG)
 	$(INSTALL) -m 644 -t $(PMDATMPDIR)/$(IAM).conf $(IAM).conf $(PMDACONFIG)/$(IAM).conf
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_perfevent root_perfevent $(PMDAADMDIR)/root_perfevent
+	$(INSTALL) -S $(PMDAADMDIR)/root_perfevent $(PCP_PMNSADM_DIR)/root_perfevent
 else
 build-me:
 install_pcp install:
 endif
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_perfevent -v 2 -o help < help
+
+$(VERSION_SCRIPT):
+	$(VERSION_SCRIPT_MAKERULE)
 
 $(OBJECTS): domain.h
 

--- a/src/pmdas/perfevent/Install
+++ b/src/pmdas/perfevent/Install
@@ -20,6 +20,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=perfevent
+pmns_source=root_perfevent
 
 dso_opt=false
 perl_opt=false

--- a/src/pmdas/perfevent/root
+++ b/src/pmdas/perfevent/root
@@ -4,7 +4,4 @@
 
 #include <stdpmid>
 
-root { perfevent }
-
-#include "pmns"
-
+#include "root_perfevent"

--- a/src/pmdas/perfevent/root_perfevent
+++ b/src/pmdas/perfevent/root_perfevent
@@ -1,0 +1,30 @@
+/*
+ * Metrics for perfevent PMDA
+ *
+ * Copyright (c) 2000-2004 Silicon Graphics, Inc.  All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef PERFEVENT
+#define PERFEVENT    127
+#endif
+
+root {
+    perfevent
+}
+
+perfevent {
+    version     PERFEVENT:0:0
+    active      PERFEVENT:0:1
+    hwcounters  PERFEVENT:*:*
+    derived     PERFEVENT:*:*
+}

--- a/src/pmdas/podman/.gitignore
+++ b/src/pmdas/podman/.gitignore
@@ -5,3 +5,4 @@ pmda_podman.so
 help.dir
 help.pag
 exports
+*.pmns

--- a/src/pmdas/podman/GNUmakefile
+++ b/src/pmdas/podman/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018,2020-2021 Red Hat.
+# Copyright (c) 2018,2020-2021,2026 Red Hat.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -20,6 +20,7 @@ DOMAIN		= PODMAN
 CMDTARGET	= pmda$(IAM)
 LIBTARGET	= pmda_$(IAM).$(DSOSUFFIX)
 PMDAINIT	= $(IAM)_init
+LOCALCONF_LINE	= "podman	33	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
 
 PMDAADMDIR	= $(PCP_PMDASADM_DIR)/$(IAM)
 PMDATMPDIR	= $(PCP_PMDAS_DIR)/$(IAM)
@@ -37,7 +38,8 @@ LCFLAGS		= -I$(TOPDIR)/src/libpcp_web/src -Ideps
 
 SCRIPTS		= Install Remove
 VERSION_SCRIPT	= exports
-LDIRT		= domain.h $(VERSION_SCRIPT) $(JSONSL_XFILES)
+HELPTARGETS	= help.dir help.pag
+LDIRT		= $(HELPTARGETS) domain.h $(VERSION_SCRIPT) $(JSONSL_XFILES)
 
 MAN_SECTION	= 1
 MAN_PAGES	= pmda$(IAM).$(MAN_SECTION)
@@ -48,13 +50,15 @@ default:	build-me
 include $(BUILDRULES)
 
 ifeq "$(TARGET_OS)" "linux"
-build-me: $(JSONSL_XFILES) $(LIBTARGET) $(CMDTARGET)
+build-me: $(JSONSL_XFILES) $(LIBTARGET) $(CMDTARGET) $(HELPTARGETS)
 
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) domain.h help root pmns $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) help.dir help.pag root root_podman pmns domain.h help $(PMDAADMDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(SCRIPTS) $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_podman root_podman $(PMDAADMDIR)/root_podman
+	$(INSTALL) -S $(PMDAADMDIR)/root_podman $(PCP_PMNSADM_DIR)/root_podman
 	@$(INSTALL_MAN)
 else
 build-me:
@@ -68,6 +72,9 @@ $(JSONSL_XFILES):
 default_pcp : default
 
 install_pcp : install
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_podman -v 2 -o help < help
 
 $(VERSION_SCRIPT):
 	$(VERSION_SCRIPT_MAKERULE)

--- a/src/pmdas/podman/Install
+++ b/src/pmdas/podman/Install
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=podman
+pmns_source=root_podman
 daemon_opt=true
 pipe_opt=true
 

--- a/src/pmdas/podman/root
+++ b/src/pmdas/podman/root
@@ -4,12 +4,4 @@
 
 #include <stdpmid>
 
-#ifndef PODMAN
-#define PODMAN 33
-#endif
-
-root {
-    podman
-}
-
-#include "pmns"
+#include "root_podman"

--- a/src/pmdas/podman/root_podman
+++ b/src/pmdas/podman/root_podman
@@ -1,0 +1,59 @@
+/*
+ * Metrics for the podman PMDA
+ *
+ * Copyright (c) 2018,2021 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef PODMAN
+#define PODMAN    33
+#endif
+
+root {
+    podman
+}
+
+podman {
+    container
+    pod
+}
+
+podman.pod {
+    name                    PODMAN:2:0
+    cgroup                  PODMAN:2:1
+    status                  PODMAN:2:2
+    containers              PODMAN:2:3
+}
+
+podman.container {
+    stats
+    name                    PODMAN:1:0
+    command                 PODMAN:1:1
+    status                  PODMAN:1:2
+    running                 PODMAN:1:5
+    image                   PODMAN:1:6
+    pod                     PODMAN:1:7
+}
+
+podman.container.stats {
+    net_input               PODMAN:0:0
+    net_output              PODMAN:0:1
+    block_input             PODMAN:0:2
+    block_output            PODMAN:0:3
+    cpu                     PODMAN:0:4
+    cpu_nano                PODMAN:0:5
+    system_nano             PODMAN:0:6
+    mem_usage               PODMAN:0:7
+    mem_limit               PODMAN:0:8
+    mem_perc                PODMAN:0:9
+    pids                    PODMAN:0:10
+}

--- a/src/pmdas/resctrl/.gitignore
+++ b/src/pmdas/resctrl/.gitignore
@@ -1,3 +1,7 @@
 domain.h
+exports
 pmdaresctrl
 pmda_resctrl.so
+help.dir
+help.pag
+*.pmns

--- a/src/pmdas/resctrl/GNUmakefile
+++ b/src/pmdas/resctrl/GNUmakefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Red Hat.
+# Copyright (c) 2023,2026 Red Hat.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -25,12 +25,17 @@ PMDAADMDIR = $(PCP_PMDASADM_DIR)/$(IAM)
 PMDATMPDIR = $(PCP_PMDAS_DIR)/$(IAM)
 PMDACONFIG = $(PCP_SYSCONF_DIR)/$(IAM)
 
+LOCALCONF_LINE = "resctrl	159	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
+
 LLDLIBS = $(PCP_PMDALIB)
 
 CFILES	= resctrl.c
 DFILES	= help
 
-LDIRT	= domain.h *.o $(IAM).log $(CMDTARGET) $(LIBTARGET)
+VERSION_SCRIPT	= exports
+HELPTARGETS	= help.dir help.pag
+
+LDIRT	= domain.h *.o $(IAM).log $(CMDTARGET) $(LIBTARGET) $(HELPTARGETS) $(VERSION_SCRIPT)
 
 MAN_SECTION = 1
 MAN_PAGES = pmda$(IAM).$(MAN_SECTION)
@@ -43,13 +48,15 @@ default_pcp default:	build-me
 include $(BUILDRULES)
 
 ifeq "$(PMDA_RESCTRL)" "true"
-build-me:	$(CMDTARGET) $(LIBTARGET)
+build-me:	$(CMDTARGET) $(LIBTARGET) $(HELPTARGETS)
 
-install_pcp install:	default 
+install_pcp install:	default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) Install Remove $(CMDTARGET) $(LIBTARGET) $(PMDAADMDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) root pmns domain.h $(DFILES) $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) root root_resctrl pmns domain.h help.dir help.pag $(DFILES) $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_resctrl root_resctrl $(PMDAADMDIR)/root_resctrl
+	$(INSTALL) -S $(PMDAADMDIR)/root_resctrl $(PCP_PMNSADM_DIR)/root_resctrl
 	$(INSTALL) -m 644 sys-fs-resctrl.mount $(PCP_SYSTEMDUNIT_DIR)/sys-fs-resctrl.mount
 	@$(INSTALL_MAN)
 else
@@ -63,6 +70,9 @@ $(VERSION_SCRIPT):
 
 domain.h: ../../pmns/stdpmid
 	$(DOMAIN_MAKERULE)
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_resctrl -v 2 -o help < help
 
 $(OBJECTS): domain.h
 

--- a/src/pmdas/resctrl/Install
+++ b/src/pmdas/resctrl/Install
@@ -39,6 +39,7 @@ else
 fi
 
 iam=resctrl
+pmns_source=root_resctrl
 dso_opt=true
 
 pmdaSetup

--- a/src/pmdas/resctrl/root
+++ b/src/pmdas/resctrl/root
@@ -4,7 +4,4 @@
 
 #include <stdpmid>
 
-root { resctrl }
-
-#include "pmns"
-
+#include "root_resctrl"

--- a/src/pmdas/resctrl/root_resctrl
+++ b/src/pmdas/resctrl/root_resctrl
@@ -1,0 +1,33 @@
+/*
+ * Metrics for LLC PMDA
+ *
+ * Copyright (c) 2023,2026 Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#ifndef RESCTRL
+#define RESCTRL    159
+#endif
+
+root {
+    resctrl
+}
+
+resctrl {
+    llc
+}
+
+resctrl.llc {
+    occupancy		RESCTRL:0:0
+    mbm_local		RESCTRL:0:1
+    mbm_total		RESCTRL:0:2
+}

--- a/src/pmdas/sendmail/.gitignore
+++ b/src/pmdas/sendmail/.gitignore
@@ -1,7 +1,9 @@
 domain.h
+exports
+help.dir
+help.pag
 pmda_sendmail.dll
 pmda_sendmail.so
-pmda_sendmail.dll
 pmda_sendmail.dylib
 sendmail
-exports
+*.pmns

--- a/src/pmdas/sendmail/GNUmakefile
+++ b/src/pmdas/sendmail/GNUmakefile
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2000-2001,2004 Silicon Graphics, Inc.  All Rights Reserved.
-# Copyright (c) 2015,2020 Red Hat.
+# Copyright (c) 2015,2020,2026 Red Hat.
 #
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
@@ -29,23 +29,29 @@ PMDAINIT = $(IAM)_init
 
 PMDATMPDIR = $(PCP_PMDAS_DIR)/$(IAM)
 PMDAADMDIR = $(PCP_PMDASADM_DIR)/$(IAM)
+LOCALCONF_LINE = "sendmail	15	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
+HELPTARGETS = help.dir help.pag
 PMCHARTDIR = $(PCP_SYSCONF_DIR)/pmchart
 PMCHARTVARDIR = $(PCP_VAR_DIR)/config/pmchart
 
-LDIRT	= domain.h *.o $(IAM).log $(LIBTARGET) $(CMDTARGET) $(VERSION_SCRIPT)
+LDIRT	= $(HELPTARGETS) domain.h *.o $(IAM).log $(LIBTARGET) $(CMDTARGET) $(VERSION_SCRIPT)
 LLDLIBS	= $(PCP_PMDALIB)
 LCFLAGS = $(INVISIBILITY)
 
-default_pcp default:	$(CMDTARGET) $(LIBTARGET)
+default_pcp default:	build-me
 
 include $(BUILDRULES)
+
+build-me:	$(HELPTARGETS) $(CMDTARGET) $(LIBTARGET)
 
 install install_pcp:	default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR)/pmda$(IAM)$(EXECSUFFIX) $(CMDTARGET) $(PMDAADMDIR)/pmda$(IAM)$(EXECSUFFIX)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(SCRIPTS) $(PMDAADMDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) $(DFILES) pmns help root domain.h $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) $(DFILES) pmns help help.dir help.pag root root_sendmail domain.h $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_sendmail root_sendmail $(PMDAADMDIR)/root_sendmail
+	$(INSTALL) -S $(PMDAADMDIR)/root_sendmail $(PCP_PMNSADM_DIR)/root_sendmail
 ifeq "$(ENABLE_QT)" "true"
 	$(INSTALL) -m 644 -t $(PMCHARTVARDIR)/Sendmail Sendmail.pmchart $(PMCHARTDIR)/Sendmail
 endif
@@ -55,6 +61,9 @@ $(CMDTARGET):	$(OBJECTS)
 $(LIBTARGET):	$(OBJECTS) $(VERSION_SCRIPT)
 
 $(OBJECTS): domain.h
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_sendmail -v 2 -o help < help
 
 domain.h: ../../pmns/stdpmid
 	$(DOMAIN_MAKERULE)

--- a/src/pmdas/sendmail/Install
+++ b/src/pmdas/sendmail/Install
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=sendmail
+pmns_source=root_sendmail
 
 pmdaSetup
 pmdaInstall

--- a/src/pmdas/sendmail/help
+++ b/src/pmdas/sendmail/help
@@ -27,7 +27,7 @@
 # blank lines before the @ line are ignored
 #
 
-@ SENDMAIL.0 Instance domain "mailer" for sendmail PMDA
+@ 15.0 Instance domain "mailer" for sendmail PMDA
 The mailers 0 (prog), 1 (*file*), and 2 (*include*) are fixed.  Other
 mailers are defined by the order of any additional "M" records in the
 sendmail.cf file.

--- a/src/pmdas/sendmail/root
+++ b/src/pmdas/sendmail/root
@@ -4,7 +4,4 @@
 
 #include <stdpmid>
 
-root { sendmail }
-
-#include "pmns"
-
+#include "root_sendmail"

--- a/src/pmdas/sendmail/root_sendmail
+++ b/src/pmdas/sendmail/root_sendmail
@@ -1,0 +1,48 @@
+/*
+ * Metrics for sendmail PMDA
+ *
+ * Copyright (c) 2000-2004 Silicon Graphics, Inc.  All Rights Reserved.
+ * Copyright (c) 2026 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef SENDMAIL
+#define SENDMAIL    15
+#endif
+
+root {
+    sendmail
+}
+
+sendmail {
+    start_date          SENDMAIL:0:0
+    permailer
+    total
+}
+
+sendmail.permailer {
+    msgs_from           SENDMAIL:1:0
+    bytes_from          SENDMAIL:1:1
+    msgs_to             SENDMAIL:1:2
+    bytes_to            SENDMAIL:1:3
+}
+
+sendmail.total {
+    msgs_from           SENDMAIL:2:0
+    bytes_from          SENDMAIL:2:1
+    msgs_to             SENDMAIL:2:2
+    bytes_to            SENDMAIL:2:3
+}

--- a/src/pmdas/smart/.gitignore
+++ b/src/pmdas/smart/.gitignore
@@ -2,4 +2,6 @@ domain.h
 exports
 pmda_smart.so
 pmdasmart
-
+help.dir
+help.pag
+*.pmns

--- a/src/pmdas/smart/GNUmakefile
+++ b/src/pmdas/smart/GNUmakefile
@@ -1,11 +1,11 @@
 #
-# Copyright (c) 2018-2023 Red Hat.
-# 
+# Copyright (c) 2018-2023,2026 Red Hat.
+#
 # This program is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the
 # Free Software Foundation; either version 2 of the License, or (at your
 # option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
 # or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
@@ -26,13 +26,16 @@ PMDAINIT	= $(IAM)_init
 LLDLIBS		= $(PCP_PMDALIB)
 LCFLAGS		= $(INVISIBILITY)
 
-LDIRT		= domain.h $(IAM).log $(VERSION_SCRIPT)
-
 SCRIPTS		= Install Remove
 VERSION_SCRIPT	= exports
+HELPTARGETS	= help.dir help.pag
 
 PMDAADMDIR	= $(PCP_PMDASADM_DIR)/$(IAM)
 PMDATMPDIR	= $(PCP_PMDAS_DIR)/$(IAM)
+
+LOCALCONF_LINE = "smart	150	dso	$(PMDAINIT)	$(PMDATMPDIR)/$(LIBTARGET)"
+
+LDIRT		= domain.h $(IAM).log $(VERSION_SCRIPT) $(HELPTARGETS)
 
 MAN_SECTION	= 1
 MAN_PAGES	= pmda$(IAM).$(MAN_SECTION)
@@ -43,13 +46,15 @@ default:	build-me
 include $(BUILDRULES)
 
 ifeq "$(TARGET_OS)" "linux"
-build-me: $(CMDTARGET) $(LIBTARGET)
+build-me: $(CMDTARGET) $(LIBTARGET) $(HELPTARGETS)
 
 install: default
 	$(INSTALL) -m 755 -d $(PMDAADMDIR)
 	$(INSTALL) -m 755 -d $(PMDATMPDIR)
-	$(INSTALL) -m 644 -t $(PMDATMPDIR) root pmns domain.h help $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PMDATMPDIR) root root_smart pmns domain.h help help.dir help.pag $(PMDAADMDIR)
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(SCRIPTS) $(PMDAADMDIR)
+	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_smart root_smart $(PMDAADMDIR)/root_smart
+	$(INSTALL) -S $(PMDAADMDIR)/root_smart $(PCP_PMNSADM_DIR)/root_smart
 	@$(INSTALL_MAN)
 else
 build-me:
@@ -67,6 +72,9 @@ $(VERSION_SCRIPT):
 
 domain.h: ../../pmns/stdpmid
 	$(DOMAIN_MAKERULE)
+
+$(HELPTARGETS) : help
+	$(NEWHELP) -n root_smart -v 2 -o help < help
 
 pmda.o:			pmdasmart.h
 pmda.o smart_stats.o:	smart_stats.h

--- a/src/pmdas/smart/Install
+++ b/src/pmdas/smart/Install
@@ -19,6 +19,7 @@
 . $PCP_SHARE_DIR/lib/pmdaproc.sh
 
 iam=smart
+pmns_source=root_smart
 
 which smartctl > /dev/null 2>&1
 if [ $? -ne 0 ]

--- a/src/pmdas/smart/root
+++ b/src/pmdas/smart/root
@@ -4,10 +4,4 @@
 
 #include <stdpmid>
 
-root { smart }
-
-#ifndef SMART
-#define SMART 150
-#endif
-
-#include "pmns"
+#include "root_smart"

--- a/src/pmdas/smart/root_smart
+++ b/src/pmdas/smart/root_smart
@@ -1,0 +1,1238 @@
+/*
+ * Copyright (c) 2018-2023,2026 Red Hat.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+/* PMNS Tree values for smart attributes tries to follow SMART attribute ID's
+ */
+
+#ifndef SMART
+#define SMART    150
+#endif
+
+root {
+    smart
+}
+
+smart {
+    info
+    health			SMART:0:0
+    attributes
+    nvme_info
+    nvme_attributes
+    nvme_power_states
+    nvme_error_log
+    wwid
+}
+
+smart.info {
+    model_family		SMART:0:1
+    device_model		SMART:0:2
+    serial_number		SMART:0:3
+    capacity_bytes		SMART:0:4
+    sector_size			SMART:0:5
+    rotation_rate		SMART:0:6
+    firmware_version		SMART:0:7
+    uuid			SMART:0:8
+    device			SMART:0:9
+}
+
+smart.attributes {
+    raw_read_error_rate
+    throughput_performance
+    spin_up_time
+    start_stop_count
+    reallocated_sector_count
+    seek_error_count
+    seek_time_performance
+    power_on_hours
+    spin_retry_count
+    calibration_retry_count
+    power_cycle_count
+    read_soft_error_rate
+    current_helium_level
+    erase_fail_count_chip
+    wear_leveling_count
+    used_reserved_block_count_total
+    unused_reserved_block_count_total
+    program_fail_count_total
+    erase_fail_count_total
+    runtime_bad_block
+    end_to_end_error
+    reported_uncorrect
+    command_timeout
+    high_fly_writes
+    airflow_temp_celsius
+    g_sense_error_rate
+    power_off_retract_count
+    load_cycle_count
+    temperature_celsius
+    hardware_ecc_recovered
+    reallocated_event_count
+    current_pending_sector
+    offline_uncorrectable
+    udma_crc_error_count
+    multi_zone_error_rate
+    soft_read_error_rate
+    disk_shift
+    loaded_hours
+    load_retry_count
+    load_friction
+    load_cycle
+    load_in_time
+    head_flying_hours
+    total_lbas_written
+    total_lbas_read
+    read_error_retry_rate
+    free_fall_sensor
+}
+
+smart.attributes.raw_read_error_rate {
+    id				SMART:1:0
+    value			SMART:1:1
+    worst			SMART:1:2
+    thresh			SMART:1:3
+    raw				SMART:1:4
+}
+
+smart.attributes.throughput_performance {
+    id				SMART:2:0
+    value			SMART:2:1
+    worst			SMART:2:2
+    thresh			SMART:2:3
+    raw				SMART:2:4
+}
+
+smart.attributes.spin_up_time {
+    id				SMART:3:0
+    value			SMART:3:1
+    worst			SMART:3:2
+    thresh			SMART:3:3
+    raw				SMART:3:4
+}
+
+smart.attributes.start_stop_count {
+    id				SMART:4:0
+    value			SMART:4:1
+    worst			SMART:4:2
+    thresh			SMART:4:3
+    raw				SMART:4:4
+}
+
+smart.attributes.reallocated_sector_count {
+    id				SMART:5:0
+    value			SMART:5:1
+    worst			SMART:5:2
+    thresh			SMART:5:3
+    raw				SMART:5:4
+}
+
+smart.attributes.seek_error_count {
+    id				SMART:7:0
+    value			SMART:7:1
+    worst			SMART:7:2
+    thresh			SMART:7:3
+    raw				SMART:7:4
+}
+
+smart.attributes.seek_time_performance {
+    id				SMART:8:0
+    value			SMART:8:1
+    worst			SMART:8:2
+    thresh			SMART:8:3
+    raw				SMART:8:4
+}
+
+smart.attributes.power_on_hours {
+    id				SMART:9:0
+    value			SMART:9:1
+    worst			SMART:9:2
+    thresh			SMART:9:3
+    raw				SMART:9:4
+}
+
+smart.attributes.spin_retry_count {
+    id				SMART:10:0
+    value			SMART:10:1
+    worst			SMART:10:2
+    thresh			SMART:10:3
+    raw				SMART:10:4
+}
+
+smart.attributes.calibration_retry_count {
+    id				SMART:11:0
+    value			SMART:11:1
+    worst			SMART:11:2
+    thresh			SMART:11:3
+    raw				SMART:11:4
+}
+
+smart.attributes.power_cycle_count {
+    id				SMART:12:0
+    value			SMART:12:1
+    worst			SMART:12:2
+    thresh			SMART:12:3
+    raw				SMART:12:4
+}
+
+smart.attributes.read_soft_error_rate {
+    id				SMART:13:0
+    value			SMART:13:1
+    worst			SMART:13:2
+    thresh			SMART:13:3
+    raw				SMART:13:4
+}
+
+smart.attributes.current_helium_level {
+    id				SMART:22:0
+    value			SMART:22:1
+    worst			SMART:22:2
+    thresh			SMART:22:3
+    raw				SMART:22:4
+}
+
+smart.attributes.erase_fail_count_chip {
+    id				SMART:176:0
+    value			SMART:176:1
+    worst			SMART:176:2
+    thresh			SMART:176:3
+    raw				SMART:176:4
+}
+
+smart.attributes.wear_leveling_count {
+    id				SMART:177:0
+    value			SMART:177:1
+    worst			SMART:177:2
+    thresh			SMART:177:3
+    raw				SMART:177:4
+}
+
+smart.attributes.used_reserved_block_count_total {
+    id				SMART:179:0
+    value			SMART:179:1
+    worst			SMART:179:2
+    thresh			SMART:179:3
+    raw				SMART:179:4
+}
+
+smart.attributes.unused_reserved_block_count_total {
+    id				SMART:180:0
+    value			SMART:180:1
+    worst			SMART:180:2
+    thresh			SMART:180:3
+    raw				SMART:180:4
+}
+
+smart.attributes.program_fail_count_total {
+    id				SMART:181:0
+    value			SMART:181:1
+    worst			SMART:181:2
+    thresh			SMART:181:3
+    raw				SMART:181:4
+}
+
+smart.attributes.erase_fail_count_total {
+    id				SMART:182:0
+    value			SMART:182:1
+    worst			SMART:182:2
+    thresh			SMART:182:3
+    raw				SMART:182:4
+}
+
+smart.attributes.runtime_bad_block {
+    id				SMART:183:0
+    value			SMART:183:1
+    worst			SMART:183:2
+    thresh			SMART:183:3
+    raw				SMART:183:4
+}
+
+smart.attributes.end_to_end_error {
+    id				SMART:184:0
+    value			SMART:184:1
+    worst			SMART:184:2
+    thresh			SMART:184:3
+    raw				SMART:184:4
+}
+
+smart.attributes.reported_uncorrect {
+    id				SMART:187:0
+    value			SMART:187:1
+    worst			SMART:187:2
+    thresh			SMART:187:3
+    raw				SMART:187:4
+}
+
+smart.attributes.command_timeout {
+    id				SMART:188:0
+    value			SMART:188:1
+    worst			SMART:188:2
+    thresh			SMART:188:3
+    raw				SMART:188:4
+}
+
+smart.attributes.high_fly_writes {
+    id				SMART:189:0
+    value			SMART:189:1
+    worst			SMART:189:2
+    thresh			SMART:189:3
+    raw				SMART:189:4
+}
+
+smart.attributes.airflow_temp_celsius {
+    id				SMART:190:0
+    value			SMART:190:1
+    worst			SMART:190:2
+    thresh			SMART:190:3
+    raw				SMART:190:4
+}
+
+smart.attributes.g_sense_error_rate {
+    id				SMART:191:0
+    value			SMART:191:1
+    worst			SMART:191:2
+    thresh			SMART:191:3
+    raw				SMART:191:4
+}
+
+smart.attributes.power_off_retract_count {
+    id				SMART:192:0
+    value			SMART:192:1
+    worst			SMART:192:2
+    thresh			SMART:192:3
+    raw				SMART:192:4
+}
+
+smart.attributes.load_cycle_count {
+    id				SMART:193:0
+    value			SMART:193:1
+    worst			SMART:193:2
+    thresh			SMART:193:3
+    raw				SMART:193:4
+}
+
+smart.attributes.temperature_celsius {
+    id				SMART:194:0
+    value			SMART:194:1
+    worst			SMART:194:2
+    thresh			SMART:194:3
+    raw				SMART:194:4
+}
+
+smart.attributes.hardware_ecc_recovered {
+    id				SMART:195:0
+    value			SMART:195:1
+    worst			SMART:195:2
+    thresh			SMART:195:3
+    raw				SMART:195:4
+}
+
+smart.attributes.reallocated_event_count {
+    id				SMART:196:0
+    value			SMART:196:1
+    worst			SMART:196:2
+    thresh			SMART:196:3
+    raw				SMART:196:4
+}
+
+smart.attributes.current_pending_sector {
+    id				SMART:197:0
+    value			SMART:197:1
+    worst			SMART:197:2
+    thresh			SMART:197:3
+    raw				SMART:197:4
+}
+
+smart.attributes.offline_uncorrectable {
+    id				SMART:198:0
+    value			SMART:198:1
+    worst			SMART:198:2
+    thresh			SMART:198:3
+    raw				SMART:198:4
+}
+
+smart.attributes.udma_crc_error_count {
+    id				SMART:199:0
+    value			SMART:199:1
+    worst			SMART:199:2
+    thresh			SMART:199:3
+    raw				SMART:199:4
+}
+
+smart.attributes.multi_zone_error_rate {
+    id				SMART:200:0
+    value			SMART:200:1
+    worst			SMART:200:2
+    thresh			SMART:200:3
+    raw				SMART:200:4
+}
+
+smart.attributes.soft_read_error_rate {
+    id				SMART:201:0
+    value			SMART:201:1
+    worst			SMART:201:2
+    thresh			SMART:201:3
+    raw				SMART:201:4
+}
+
+smart.attributes.disk_shift {
+    id				SMART:220:0
+    value			SMART:220:1
+    worst			SMART:220:2
+    thresh			SMART:220:3
+    raw				SMART:220:4
+}
+
+smart.attributes.loaded_hours {
+    id				SMART:222:0
+    value			SMART:222:1
+    worst			SMART:222:2
+    thresh			SMART:222:3
+    raw				SMART:222:4
+}
+
+smart.attributes.load_retry_count {
+    id				SMART:223:0
+    value			SMART:223:1
+    worst			SMART:223:2
+    thresh			SMART:223:3
+    raw				SMART:223:4
+}
+
+smart.attributes.load_friction {
+    id				SMART:224:0
+    value			SMART:224:1
+    worst			SMART:224:2
+    thresh			SMART:224:3
+    raw				SMART:224:4
+}
+
+smart.attributes.load_cycle {
+    id				SMART:225:0
+    value			SMART:225:1
+    worst			SMART:225:2
+    thresh			SMART:225:3
+    raw				SMART:225:4
+}
+
+smart.attributes.load_in_time {
+    id				SMART:226:0
+    value			SMART:226:1
+    worst			SMART:226:2
+    thresh			SMART:226:3
+    raw				SMART:226:4
+}
+
+smart.attributes.head_flying_hours {
+    id				SMART:240:0
+    value			SMART:240:1
+    worst			SMART:240:2
+    thresh			SMART:240:3
+    raw				SMART:240:4
+}
+
+smart.attributes.total_lbas_written {
+    id				SMART:241:0
+    value			SMART:241:1
+    worst			SMART:241:2
+    thresh			SMART:241:3
+    raw				SMART:241:4
+}
+
+smart.attributes.total_lbas_read {
+    id				SMART:242:0
+    value			SMART:242:1
+    worst			SMART:242:2
+    thresh			SMART:242:3
+    raw				SMART:242:4
+}
+
+smart.attributes.read_error_retry_rate {
+    id				SMART:250:0
+    value			SMART:250:1
+    worst			SMART:250:2
+    thresh			SMART:250:3
+    raw				SMART:250:4
+}
+
+smart.attributes.free_fall_sensor {
+    id				SMART:254:0
+    value			SMART:254:1
+    worst			SMART:254:2
+    thresh			SMART:254:3
+    raw				SMART:254:4
+}
+
+smart.nvme_info {
+    model_number					SMART:256:0
+    serial_number					SMART:256:1
+    firmware_version				SMART:256:2
+    pci_vendor_subsystem_id				SMART:256:3
+    ieee_oui_identifier				SMART:256:4
+    total_nvm_capacity				SMART:256:5
+    unallocated_nvm_capacity			SMART:256:6
+    controller_id					SMART:256:7
+    nvme_version					SMART:256:8
+    namespace_1_capacity				SMART:256:18
+    namespace_1_utilization				SMART:256:19
+    namespace_1_formatted_lba_size			SMART:256:20
+    namespace_1_ieee_eui_64				SMART:256:21
+    namespaces						SMART:256:9
+    firware_updates					SMART:256:10
+    maximum_data_transfer_size			SMART:256:11
+    warning_temp_threshold				SMART:256:12
+    critical_temp_thresold				SMART:256:13
+    active_power_state				SMART:256:14
+    apst_state						SMART:256:15
+    completion_queue_length_completion		SMART:256:16
+    completion_queue_length_submission		SMART:256:17
+}
+
+smart.nvme_attributes {
+    critical_warning					SMART:255:0
+    composite_temperature				SMART:255:1
+    available_spare					SMART:255:2
+    available_spare_threshold			SMART:255:3
+    percentage_used					SMART:255:4
+    data_units_read					SMART:255:5
+    data_units_written				SMART:255:6
+    host_read_commands				SMART:255:7
+    host_write_commands				SMART:255:8
+    controller_busy_time				SMART:255:9
+    power_cycles					SMART:255:10
+    power_on_hours					SMART:255:11
+    unsafe_shutdowns					SMART:255:12
+    media_and_data_integrity_errors			SMART:255:13
+    number_of_error_information_log_entries		SMART:255:14
+    warning_composite_temperature_time		SMART:255:15
+    critical_composite_temperature_time		SMART:255:16
+    temperature_sensor_one				SMART:255:17
+    temperature_sensor_two				SMART:255:18
+    temperature_sensor_three			SMART:255:19
+    temperature_sensor_four				SMART:255:20
+    temperature_sensor_five				SMART:255:21
+    temperature_sensor_six				SMART:255:22
+    temperature_sensor_seven			SMART:255:23
+    temperature_sensor_eight			SMART:255:24
+}
+
+smart.nvme_power_states {
+    power_state_0
+    power_state_1
+    power_state_2
+    power_state_3
+    power_state_4
+    power_state_5
+}
+
+smart.nvme_power_states.power_state_0 {
+    state						SMART:257:0
+    max_power					SMART:257:1
+    non_operational_state				SMART:257:2
+    active_power					SMART:257:3
+    idle_power					SMART:257:4
+    relative_read_latency				SMART:257:5
+    relative_read_throughput			SMART:257:6
+    relative_write_latency				SMART:257:7
+    relative_write_throughput			SMART:257:8
+    entry_latency					SMART:257:9
+    exit_latency					SMART:257:10
+}
+
+smart.nvme_power_states.power_state_1 {
+    state						SMART:258:0
+    max_power					SMART:258:1
+    non_operational_state				SMART:258:2
+    active_power					SMART:258:3
+    idle_power					SMART:258:4
+    relative_read_latency				SMART:258:5
+    relative_read_throughput			SMART:258:6
+    relative_write_latency				SMART:258:7
+    relative_write_throughput			SMART:258:8
+    entry_latency					SMART:258:9
+    exit_latency					SMART:258:10
+}
+
+smart.nvme_power_states.power_state_2 {
+    state						SMART:259:0
+    max_power					SMART:259:1
+    non_operational_state				SMART:259:2
+    active_power					SMART:259:3
+    idle_power					SMART:259:4
+    relative_read_latency				SMART:259:5
+    relative_read_throughput			SMART:259:6
+    relative_write_latency				SMART:259:7
+    relative_write_throughput			SMART:259:8
+    entry_latency					SMART:259:9
+    exit_latency					SMART:259:10
+}
+
+smart.nvme_power_states.power_state_3 {
+    state						SMART:260:0
+    max_power					SMART:260:1
+    non_operational_state				SMART:260:2
+    active_power					SMART:260:3
+    idle_power					SMART:260:4
+    relative_read_latency				SMART:260:5
+    relative_read_throughput			SMART:260:6
+    relative_write_latency				SMART:260:7
+    relative_write_throughput			SMART:260:8
+    entry_latency					SMART:260:9
+    exit_latency					SMART:260:10
+}
+
+smart.nvme_power_states.power_state_4 {
+    state						SMART:261:0
+    max_power					SMART:261:1
+    non_operational_state				SMART:261:2
+    active_power					SMART:261:3
+    idle_power					SMART:261:4
+    relative_read_latency				SMART:261:5
+    relative_read_throughput			SMART:261:6
+    relative_write_latency				SMART:261:7
+    relative_write_throughput			SMART:261:8
+    entry_latency					SMART:261:9
+    exit_latency					SMART:261:10
+}
+
+smart.nvme_power_states.power_state_5 {
+    state						SMART:262:0
+    max_power					SMART:262:1
+    non_operational_state				SMART:262:2
+    active_power					SMART:262:3
+    idle_power					SMART:262:4
+    relative_read_latency				SMART:262:5
+    relative_read_throughput			SMART:262:6
+    relative_write_latency				SMART:262:7
+    relative_write_throughput			SMART:262:8
+    entry_latency					SMART:262:9
+    exit_latency					SMART:262:10
+}
+
+smart.nvme_error_log {
+    total			SMART:264:0
+    error_count			SMART:263:0
+    sqid			SMART:263:1
+    cmdid			SMART:263:2
+    status_field		SMART:263:3
+    status_type			SMART:263:4
+    status_code			SMART:263:5
+    param_error_loc		SMART:263:6
+    lba				SMART:263:7
+    nsid			SMART:263:8
+}
+
+smart.wwid {
+    info
+    attributes
+    nvme_info
+    nvme_attributes
+    nvme_power_states
+    nvme_error_log
+}
+
+smart.wwid.info {
+    model_family		SMART:1000:1
+    device_model		SMART:1000:2
+    serial_number		SMART:1000:3
+    capacity_bytes		SMART:1000:4
+    sector_size			SMART:1000:5
+    rotation_rate		SMART:1000:6
+    firmware_version		SMART:1000:7
+    uuid			SMART:1000:8
+    device			SMART:1000:9
+}
+
+smart.wwid.attributes {
+    raw_read_error_rate
+    throughput_performance
+    spin_up_time
+    start_stop_count
+    reallocated_sector_count
+    seek_error_count
+    seek_time_performance
+    power_on_hours
+    spin_retry_count
+    calibration_retry_count
+    power_cycle_count
+    read_soft_error_rate
+    current_helium_level
+    erase_fail_count_chip
+    wear_leveling_count
+    used_reserved_block_count_total
+    unused_reserved_block_count_total
+    program_fail_count_total
+    erase_fail_count_total
+    runtime_bad_block
+    end_to_end_error
+    reported_uncorrect
+    command_timeout
+    high_fly_writes
+    airflow_temp_celsius
+    g_sense_error_rate
+    power_off_retract_count
+    load_cycle_count
+    temperature_celsius
+    hardware_ecc_recovered
+    reallocated_event_count
+    current_pending_sector
+    offline_uncorrectable
+    udma_crc_error_count
+    multi_zone_error_rate
+    soft_read_error_rate
+    disk_shift
+    loaded_hours
+    load_retry_count
+    load_friction
+    load_cycle
+    load_in_time
+    head_flying_hours
+    total_lbas_written
+    total_lbas_read
+    read_error_retry_rate
+    free_fall_sensor
+}
+
+smart.wwid.attributes.raw_read_error_rate {
+    id				SMART:1001:0
+    value			SMART:1001:1
+    worst			SMART:1001:2
+    thresh			SMART:1001:3
+    raw				SMART:1001:4
+}
+
+smart.wwid.attributes.throughput_performance {
+    id				SMART:1002:0
+    value			SMART:1002:1
+    worst			SMART:1002:2
+    thresh			SMART:1002:3
+    raw				SMART:1002:4
+}
+
+smart.wwid.attributes.spin_up_time {
+    id				SMART:1003:0
+    value			SMART:1003:1
+    worst			SMART:1003:2
+    thresh			SMART:1003:3
+    raw				SMART:1003:4
+}
+
+smart.wwid.attributes.start_stop_count {
+    id				SMART:1004:0
+    value			SMART:1004:1
+    worst			SMART:1004:2
+    thresh			SMART:1004:3
+    raw				SMART:1004:4
+}
+
+smart.wwid.attributes.reallocated_sector_count {
+    id				SMART:1005:0
+    value			SMART:1005:1
+    worst			SMART:1005:2
+    thresh			SMART:1005:3
+    raw				SMART:1005:4
+}
+
+smart.wwid.attributes.seek_error_count {
+    id				SMART:1007:0
+    value			SMART:1007:1
+    worst			SMART:1007:2
+    thresh			SMART:1007:3
+    raw				SMART:1007:4
+}
+
+smart.wwid.attributes.seek_time_performance {
+    id				SMART:1008:0
+    value			SMART:1008:1
+    worst			SMART:1008:2
+    thresh			SMART:1008:3
+    raw				SMART:1008:4
+}
+
+smart.wwid.attributes.power_on_hours {
+    id				SMART:1009:0
+    value			SMART:1009:1
+    worst			SMART:1009:2
+    thresh			SMART:1009:3
+    raw				SMART:1009:4
+}
+
+smart.wwid.attributes.spin_retry_count {
+    id				SMART:1010:0
+    value			SMART:1010:1
+    worst			SMART:1010:2
+    thresh			SMART:1010:3
+    raw				SMART:1010:4
+}
+
+smart.wwid.attributes.calibration_retry_count {
+    id				SMART:1011:0
+    value			SMART:1011:1
+    worst			SMART:1011:2
+    thresh			SMART:1011:3
+    raw				SMART:1011:4
+}
+
+smart.wwid.attributes.power_cycle_count {
+    id				SMART:1012:0
+    value			SMART:1012:1
+    worst			SMART:1012:2
+    thresh			SMART:1012:3
+    raw				SMART:1012:4
+}
+
+smart.wwid.attributes.read_soft_error_rate {
+    id				SMART:1013:0
+    value			SMART:1013:1
+    worst			SMART:1013:2
+    thresh			SMART:1013:3
+    raw				SMART:1013:4
+}
+
+smart.wwid.attributes.current_helium_level {
+    id				SMART:1022:0
+    value			SMART:1022:1
+    worst			SMART:1022:2
+    thresh			SMART:1022:3
+    raw				SMART:1022:4
+}
+
+smart.wwid.attributes.erase_fail_count_chip {
+    id				SMART:1176:0
+    value			SMART:1176:1
+    worst			SMART:1176:2
+    thresh			SMART:1176:3
+    raw				SMART:1176:4
+}
+
+smart.wwid.attributes.wear_leveling_count {
+    id				SMART:1177:0
+    value			SMART:1177:1
+    worst			SMART:1177:2
+    thresh			SMART:1177:3
+    raw				SMART:1177:4
+}
+
+smart.wwid.attributes.used_reserved_block_count_total {
+    id				SMART:1179:0
+    value			SMART:1179:1
+    worst			SMART:1179:2
+    thresh			SMART:1179:3
+    raw				SMART:1179:4
+}
+
+smart.wwid.attributes.unused_reserved_block_count_total {
+    id				SMART:1180:0
+    value			SMART:1180:1
+    worst			SMART:1180:2
+    thresh			SMART:1180:3
+    raw				SMART:1180:4
+}
+
+smart.wwid.attributes.program_fail_count_total {
+    id				SMART:1181:0
+    value			SMART:1181:1
+    worst			SMART:1181:2
+    thresh			SMART:1181:3
+    raw				SMART:1181:4
+}
+
+smart.wwid.attributes.erase_fail_count_total {
+    id				SMART:1182:0
+    value			SMART:1182:1
+    worst			SMART:1182:2
+    thresh			SMART:1182:3
+    raw				SMART:1182:4
+}
+
+smart.wwid.attributes.runtime_bad_block {
+    id				SMART:1183:0
+    value			SMART:1183:1
+    worst			SMART:1183:2
+    thresh			SMART:1183:3
+    raw				SMART:1183:4
+}
+
+smart.wwid.attributes.end_to_end_error {
+    id				SMART:1184:0
+    value			SMART:1184:1
+    worst			SMART:1184:2
+    thresh			SMART:1184:3
+    raw				SMART:1184:4
+}
+
+smart.wwid.attributes.reported_uncorrect {
+    id				SMART:1187:0
+    value			SMART:1187:1
+    worst			SMART:1187:2
+    thresh			SMART:1187:3
+    raw				SMART:1187:4
+}
+
+smart.wwid.attributes.command_timeout {
+    id				SMART:1188:0
+    value			SMART:1188:1
+    worst			SMART:1188:2
+    thresh			SMART:1188:3
+    raw				SMART:1188:4
+}
+
+smart.wwid.attributes.high_fly_writes {
+    id				SMART:1189:0
+    value			SMART:1189:1
+    worst			SMART:1189:2
+    thresh			SMART:1189:3
+    raw				SMART:1189:4
+}
+
+smart.wwid.attributes.airflow_temp_celsius {
+    id				SMART:1190:0
+    value			SMART:1190:1
+    worst			SMART:1190:2
+    thresh			SMART:1190:3
+    raw				SMART:1190:4
+}
+
+smart.wwid.attributes.g_sense_error_rate {
+    id				SMART:1191:0
+    value			SMART:1191:1
+    worst			SMART:1191:2
+    thresh			SMART:1191:3
+    raw				SMART:1191:4
+}
+
+smart.wwid.attributes.power_off_retract_count {
+    id				SMART:1192:0
+    value			SMART:1192:1
+    worst			SMART:1192:2
+    thresh			SMART:1192:3
+    raw				SMART:1192:4
+}
+
+smart.wwid.attributes.load_cycle_count {
+    id				SMART:1193:0
+    value			SMART:1193:1
+    worst			SMART:1193:2
+    thresh			SMART:1193:3
+    raw				SMART:1193:4
+}
+
+smart.wwid.attributes.temperature_celsius {
+    id				SMART:1194:0
+    value			SMART:1194:1
+    worst			SMART:1194:2
+    thresh			SMART:1194:3
+    raw				SMART:1194:4
+}
+
+smart.wwid.attributes.hardware_ecc_recovered {
+    id				SMART:1195:0
+    value			SMART:1195:1
+    worst			SMART:1195:2
+    thresh			SMART:1195:3
+    raw				SMART:1195:4
+}
+
+smart.wwid.attributes.reallocated_event_count {
+    id				SMART:1196:0
+    value			SMART:1196:1
+    worst			SMART:1196:2
+    thresh			SMART:1196:3
+    raw				SMART:1196:4
+}
+
+smart.wwid.attributes.current_pending_sector {
+    id				SMART:1197:0
+    value			SMART:1197:1
+    worst			SMART:1197:2
+    thresh			SMART:1197:3
+    raw				SMART:1197:4
+}
+
+smart.wwid.attributes.offline_uncorrectable {
+    id				SMART:1198:0
+    value			SMART:1198:1
+    worst			SMART:1198:2
+    thresh			SMART:1198:3
+    raw				SMART:1198:4
+}
+
+smart.wwid.attributes.udma_crc_error_count {
+    id				SMART:1199:0
+    value			SMART:1199:1
+    worst			SMART:1199:2
+    thresh			SMART:1199:3
+    raw				SMART:1199:4
+}
+
+smart.wwid.attributes.multi_zone_error_rate {
+    id				SMART:1200:0
+    value			SMART:1200:1
+    worst			SMART:1200:2
+    thresh			SMART:1200:3
+    raw				SMART:1200:4
+}
+
+smart.wwid.attributes.soft_read_error_rate {
+    id				SMART:1201:0
+    value			SMART:1201:1
+    worst			SMART:1201:2
+    thresh			SMART:1201:3
+    raw				SMART:1201:4
+}
+
+smart.wwid.attributes.disk_shift {
+    id				SMART:1220:0
+    value			SMART:1220:1
+    worst			SMART:1220:2
+    thresh			SMART:1220:3
+    raw				SMART:1220:4
+}
+
+smart.wwid.attributes.loaded_hours {
+    id				SMART:1222:0
+    value			SMART:1222:1
+    worst			SMART:1222:2
+    thresh			SMART:1222:3
+    raw				SMART:1222:4
+}
+
+smart.wwid.attributes.load_retry_count {
+    id				SMART:1223:0
+    value			SMART:1223:1
+    worst			SMART:1223:2
+    thresh			SMART:1223:3
+    raw				SMART:1223:4
+}
+
+smart.wwid.attributes.load_friction {
+    id				SMART:1224:0
+    value			SMART:1224:1
+    worst			SMART:1224:2
+    thresh			SMART:1224:3
+    raw				SMART:1224:4
+}
+
+smart.wwid.attributes.load_cycle {
+    id				SMART:1225:0
+    value			SMART:1225:1
+    worst			SMART:1225:2
+    thresh			SMART:1225:3
+    raw				SMART:1225:4
+}
+
+smart.wwid.attributes.load_in_time {
+    id				SMART:1226:0
+    value			SMART:1226:1
+    worst			SMART:1226:2
+    thresh			SMART:1226:3
+    raw				SMART:1226:4
+}
+
+smart.wwid.attributes.head_flying_hours {
+    id				SMART:1240:0
+    value			SMART:1240:1
+    worst			SMART:1240:2
+    thresh			SMART:1240:3
+    raw				SMART:1240:4
+}
+
+smart.wwid.attributes.total_lbas_written {
+    id				SMART:1241:0
+    value			SMART:1241:1
+    worst			SMART:1241:2
+    thresh			SMART:1241:3
+    raw				SMART:1241:4
+}
+
+smart.wwid.attributes.total_lbas_read {
+    id				SMART:1242:0
+    value			SMART:1242:1
+    worst			SMART:1242:2
+    thresh			SMART:1242:3
+    raw				SMART:1242:4
+}
+
+smart.wwid.attributes.read_error_retry_rate {
+    id				SMART:1250:0
+    value			SMART:1250:1
+    worst			SMART:1250:2
+    thresh			SMART:1250:3
+    raw				SMART:1250:4
+}
+
+smart.wwid.attributes.free_fall_sensor {
+    id				SMART:1254:0
+    value			SMART:1254:1
+    worst			SMART:1254:2
+    thresh			SMART:1254:3
+    raw				SMART:1254:4
+}
+
+smart.wwid.nvme_info {
+    model_number					SMART:1256:0
+    serial_number					SMART:1256:1
+    firmware_version				SMART:1256:2
+    pci_vendor_subsystem_id				SMART:1256:3
+    ieee_oui_identifier				SMART:1256:4
+    total_nvm_capacity				SMART:1256:5
+    unallocated_nvm_capacity			SMART:1256:6
+    controller_id					SMART:1256:7
+    nvme_version					SMART:1256:8
+    namespace_1_capacity				SMART:1256:18
+    namespace_1_utilization				SMART:1256:19
+    namespace_1_formatted_lba_size			SMART:1256:20
+    namespace_1_ieee_eui_64				SMART:1256:21
+    namespaces						SMART:1256:9
+    firware_updates					SMART:1256:10
+    maximum_data_transfer_size			SMART:1256:11
+    warning_temp_threshold				SMART:1256:12
+    critical_temp_thresold				SMART:1256:13
+    active_power_state				SMART:1256:14
+    apst_state						SMART:1256:15
+    completion_queue_length_completion		SMART:1256:16
+    completion_queue_length_submission		SMART:1256:17
+}
+
+smart.wwid.nvme_attributes {
+    critical_warning					SMART:1255:0
+    composite_temperature				SMART:1255:1
+    available_spare					SMART:1255:2
+    available_spare_threshold			SMART:1255:3
+    percentage_used					SMART:1255:4
+    data_units_read					SMART:1255:5
+    data_units_written				SMART:1255:6
+    host_read_commands				SMART:1255:7
+    host_write_commands				SMART:1255:8
+    controller_busy_time				SMART:1255:9
+    power_cycles					SMART:1255:10
+    power_on_hours					SMART:1255:11
+    unsafe_shutdowns					SMART:1255:12
+    media_and_data_integrity_errors			SMART:1255:13
+    number_of_error_information_log_entries		SMART:1255:14
+    warning_composite_temperature_time		SMART:1255:15
+    critical_composite_temperature_time		SMART:1255:16
+    temperature_sensor_one				SMART:1255:17
+    temperature_sensor_two				SMART:1255:18
+    temperature_sensor_three			SMART:1255:19
+    temperature_sensor_four				SMART:1255:20
+    temperature_sensor_five				SMART:1255:21
+    temperature_sensor_six				SMART:1255:22
+    temperature_sensor_seven			SMART:1255:23
+    temperature_sensor_eight			SMART:1255:24
+}
+
+smart.wwid.nvme_power_states {
+    power_state_0
+    power_state_1
+    power_state_2
+    power_state_3
+    power_state_4
+    power_state_5
+}
+
+smart.wwid.nvme_power_states.power_state_0 {
+    state						SMART:1257:0
+    max_power					SMART:1257:1
+    non_operational_state				SMART:1257:2
+    active_power					SMART:1257:3
+    idle_power					SMART:1257:4
+    relative_read_latency				SMART:1257:5
+    relative_read_throughput			SMART:1257:6
+    relative_write_latency				SMART:1257:7
+    relative_write_throughput			SMART:1257:8
+    entry_latency					SMART:1257:9
+    exit_latency					SMART:1257:10
+}
+
+smart.wwid.nvme_power_states.power_state_1 {
+    state						SMART:1258:0
+    max_power					SMART:1258:1
+    non_operational_state				SMART:1258:2
+    active_power					SMART:1258:3
+    idle_power					SMART:1258:4
+    relative_read_latency				SMART:1258:5
+    relative_read_throughput			SMART:1258:6
+    relative_write_latency				SMART:1258:7
+    relative_write_throughput			SMART:1258:8
+    entry_latency					SMART:1258:9
+    exit_latency					SMART:1258:10
+}
+
+smart.wwid.nvme_power_states.power_state_2 {
+    state						SMART:1259:0
+    max_power					SMART:1259:1
+    non_operational_state				SMART:1259:2
+    active_power					SMART:1259:3
+    idle_power					SMART:1259:4
+    relative_read_latency				SMART:1259:5
+    relative_read_throughput			SMART:1259:6
+    relative_write_latency				SMART:1259:7
+    relative_write_throughput			SMART:1259:8
+    entry_latency					SMART:1259:9
+    exit_latency					SMART:1259:10
+}
+
+smart.wwid.nvme_power_states.power_state_3 {
+    state						SMART:1260:0
+    max_power					SMART:1260:1
+    non_operational_state				SMART:1260:2
+    active_power					SMART:1260:3
+    idle_power					SMART:1260:4
+    relative_read_latency				SMART:1260:5
+    relative_read_throughput			SMART:1260:6
+    relative_write_latency				SMART:1260:7
+    relative_write_throughput			SMART:1260:8
+    entry_latency					SMART:1260:9
+    exit_latency					SMART:1260:10
+}
+
+smart.wwid.nvme_power_states.power_state_4 {
+    state						SMART:1261:0
+    max_power					SMART:1261:1
+    non_operational_state				SMART:1261:2
+    active_power					SMART:1261:3
+    idle_power					SMART:1261:4
+    relative_read_latency				SMART:1261:5
+    relative_read_throughput			SMART:1261:6
+    relative_write_latency				SMART:1261:7
+    relative_write_throughput			SMART:1261:8
+    entry_latency					SMART:1261:9
+    exit_latency					SMART:1261:10
+}
+
+smart.wwid.nvme_power_states.power_state_5 {
+    state						SMART:1262:0
+    max_power					SMART:1262:1
+    non_operational_state				SMART:1262:2
+    active_power					SMART:1262:3
+    idle_power					SMART:1262:4
+    relative_read_latency				SMART:1262:5
+    relative_read_throughput			SMART:1262:6
+    relative_write_latency				SMART:1262:7
+    relative_write_throughput			SMART:1262:8
+    entry_latency					SMART:1262:9
+    exit_latency					SMART:1262:10
+}
+
+smart.wwid.nvme_error_log {
+    total			SMART:1264:0
+    error_count			SMART:1263:0
+    sqid			SMART:1263:1
+    cmdid			SMART:1263:2
+    status_field		SMART:1263:3
+    status_type			SMART:1263:4
+    status_code			SMART:1263:5
+    param_error_loc		SMART:1263:6
+    lba				SMART:1263:7
+    nsid			SMART:1263:8
+}


### PR DESCRIPTION
RPM packaging changes to allow PMDAs with dependencies to be added/removed from the local-context-only setup through spec file %post / %preun scripting.