### PR TITLE
pmcd: restrict control metric stores to root users

### DIFF
--- a/qa/1746
+++ b/qa/1746
@@ -1,0 +1,80 @@
+#!/bin/sh
+# PCP QA Test No. 1746
+# Exercise root-only stores to pmcd.control metrics.
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+
+seq=`basename $0`
+echo "QA output created by $seq"
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+[ "$PCP_PLATFORM" != mingw ] || _notrun "Unix credentials not supported"
+[ `id -u` -ne 0 ] || _notrun "Test must run as an unprivileged user"
+
+metric=pmcd.control.timeout
+original=`pmprobe -h unix: -v $metric 2>/dev/null \
+    | $PCP_AWK_PROG '{ print $3 }'`
+[ -n "$original" ] || _notrun "Cannot access $metric over the local socket"
+
+_cleanup()
+{
+    if [ -n "$original" ] && \
+	! $sudo pmstore -h unix: $metric "$original" >/dev/null 2>&1
+    then
+	echo "Failed to restore $metric to $original" >>$seq_full
+	status=1
+    fi
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=1	# failure is the default!
+failed=false
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_value()
+{
+    label=$1
+    expected=$2
+    value=`pmprobe -h unix: -v $metric | $PCP_AWK_PROG '{ print $3 }'`
+    echo "$label: $value"
+    [ "$value" = "$expected" ] || failed=true
+}
+
+# real QA test starts here
+$sudo pmstore -h unix: $metric 20 >/dev/null 2>&1 \
+    || _notrun "Root cannot initialize $metric"
+
+if pmstore -h unix: $metric 21 >$tmp.out 2>&1
+then
+    echo "pmstore without sudo: allowed"
+    failed=true
+elif grep -q "No permission to perform requested operation" $tmp.out
+then
+    echo "pmstore without sudo: denied"
+else
+    echo "pmstore without sudo: unexpected error"
+    failed=true
+fi
+_value "value after without sudo" 20
+
+if $sudo pmstore -h unix: $metric 21 >/dev/null 2>&1
+then
+    echo "pmstore with sudo: allowed"
+else
+    echo "pmstore with sudo: denied"
+    failed=true
+fi
+_value "value after with sudo" 21
+
+# success, all done
+if ! $failed
+then
+    status=0
+fi
+exit

--- a/qa/1746.out
+++ b/qa/1746.out
@@ -1,0 +1,5 @@
+QA output created by 1746
+pmstore without sudo: denied
+value after without sudo: 20
+pmstore with sudo: allowed
+value after with sudo: 21

--- a/qa/group
+++ b/qa/group
@@ -2277,6 +2277,7 @@ suse
 1735 python pmimport local
 1740 pmda.proc local
 1745 pmlogger libpcp pmval local pmda.sample pmda.simple pmlogdump
+1746 pmcd pmda.pmcd pmstore local
 1747 pmlogger labels local
 1748 atop local
 1753 fetch valgrind local

--- a/src/pmdas/pmcd/src/pmcd.c
+++ b/src/pmdas/pmcd/src/pmcd.c
@@ -31,6 +31,12 @@
  */
 #define _TOTAL			16
 
+#define PMCD_CONTROL_DEBUG_ITEM			0
+#define PMCD_CONTROL_TIMEOUT_ITEM		4
+#define PMCD_CONTROL_REGISTER_ITEM		8
+#define PMCD_CONTROL_SIGHUP_ITEM		15
+#define PMCD_CONTROL_CREDS_TIMEOUT_ITEM	30
+
 /*
  * all metrics supported in this PMD - one table entry for each
  */
@@ -1322,6 +1328,7 @@ end_context(int ctx)
 	memset(&ctxtab[ctx], 0, sizeof(ctxtab[ctx]));
 	ctxtab[ctx].seq = -1;
 	ctxtab[ctx].id = -1;
+	ctxtab[ctx].uid = -1;
     }
 }
 
@@ -1924,6 +1931,18 @@ pmcd_store(pmdaResult *result, pmdaExt *pmda)
 	item = pmID_item(vsp->pmid);
 
 	if (cluster == 0) {
+	    if (item == PMCD_CONTROL_DEBUG_ITEM ||
+		item == PMCD_CONTROL_TIMEOUT_ITEM ||
+		(item >= PMCD_CONTROL_REGISTER_ITEM &&
+		 item <= PMCD_CONTROL_SIGHUP_ITEM) ||
+		item == PMCD_CONTROL_CREDS_TIMEOUT_ITEM) {
+		if (ctx >= num_ctx)
+		    grow_ctxtab(ctx);
+		if (ctxtab[ctx].uid != 0) {
+		    sts = PM_ERR_PERMISSION;
+		    break;
+		}
+	    }
 	    if (item == 0) {	/* pmcd.control.debug */
 		pmClearDebug("all");
 		sts = pmSetDebug(vsp->vlist[0].value.pval->vbuf);


### PR DESCRIPTION
Require root credentials when writing privileged pmcd control metrics to prevent unauthorized runtime configuration changes.

## Pull Request Description

## Related Issues
Fixes # https://github.com/performancecopilot/pcp/issues/2652

