### PR TITLE
libpcp, pmproxy: fix unbounded memory growth from duplicate label records

### DIFF
--- a/src/libpcp/src/logmeta.c
+++ b/src/libpcp/src/logmeta.c
@@ -253,6 +253,43 @@ PM_FAULT_POINT("libpcp/" __FILE__ ":1", PM_FAULT_ALLOC);
     return sts;
 }
 
+/*
+ * Two label records are duplicates if they carry the same labels for the same
+ * identifier at the same time.  The (type, ident) key is already fixed by the
+ * hash chain we are inserting into (just as sameindom() does not re-check the
+ * indom), so we only compare the decoded pmLabelSets: by instance, by label
+ * count and by the raw JSON payload.  The pmLabel array is merely a set of
+ * offsets into the JSON string, so an identical JSON implies identical labels.
+ */
+static int
+samelabelset(const pmLabelSet *lsp1, const pmLabelSet *lsp2)
+{
+    if (lsp1->inst != lsp2->inst)
+	return 0;
+    if (lsp1->nlabels != lsp2->nlabels)
+	return 0;
+    if (lsp1->jsonlen != lsp2->jsonlen)
+	return 0;
+    if (lsp1->json == lsp2->json)	/* both NULL, or the same buffer */
+	return 1;
+    if (lsp1->json == NULL || lsp2->json == NULL)
+	return 0;
+    return memcmp(lsp1->json, lsp2->json, lsp1->jsonlen) == 0;
+}
+
+static int
+samelabel(const __pmLogLabelSet *idp1, const __pmLogLabelSet *idp2)
+{
+    int			i;
+
+    if (idp1->nsets != idp2->nsets)
+	return 0;
+    for (i = 0; i < idp1->nsets; i++)
+	if (!samelabelset(&idp1->labelsets[i], &idp2->labelsets[i]))
+	    return 0;
+    return 1;
+}
+
 int
 addlabel(__pmArchCtl *acp, unsigned int type, unsigned int ident, int nsets,
 		pmLabelSet *labelsets, const __pmTimestamp *tsp)
@@ -334,6 +371,21 @@ PM_FAULT_POINT("libpcp/" __FILE__ ":13", PM_FAULT_ALLOC);
 	 */
 	if (timecmp < 0)
 	    break;
+
+	/*
+	 * Filter out identical labelsets.  As with instance domains (see
+	 * addindom() above), the same labels routinely recur in the metadata
+	 * stream: context labels are re-presented every time an archive's
+	 * metadata is (re)scanned by pmproxy's discovery, and are duplicated
+	 * across the archives of a multi-archive context.  Without this check
+	 * the per-(type,ident) label chain grows without bound.  Free the
+	 * wrapper we allocated and let the caller dispose of the duplicate
+	 * labelsets payload, exactly as addindom() does for a duplicate indom.
+	 */
+	if (timecmp == 0 && samelabel(idp_cached, idp)) {
+	    free(idp);
+	    return PMLOGPUTINDOM_DUP;
+	}
 
 	/*
 	 * The time of the current cached item is after our time.
@@ -934,8 +986,18 @@ PM_FAULT_POINT("libpcp/" __FILE__ ":11", PM_FAULT_ALLOC);
 		/* decode on-disk timestamp and labels from buffer */
 		sts = __pmLogLoadLabelSet(tbuf, rlen, h.type,
 				&stamp, &type, &ident, &nsets, &labelsets);
-		if (sts >= 0)
+		if (sts >= 0) {
 		    sts = addlabel(acp, type, ident, nsets, labelsets, &stamp);
+		    /*
+		     * A duplicate labelset was not stored, so we own the
+		     * decoded labelsets and must free them here (compare the
+		     * PMLOGPUTINDOM_DUP handling for indoms above).
+		     */
+		    if (sts == PMLOGPUTINDOM_DUP) {
+			pmFreeLabelSets(labelsets, nsets);
+			sts = 0;
+		    }
+		}
 	    }
 	    free(tbuf);
 	    if (sts < 0)

--- a/src/libpcp_web/src/discover.c
+++ b/src/libpcp_web/src/discover.c
@@ -1115,7 +1115,14 @@ pmDiscoverInvokeLabelsCallBacks(pmDiscover *p, __pmTimestamp *tsp,
     }
 
 out:
-    if (sts < 0)
+    /*
+     * Free the labelsets unless ownership was transferred to the archive
+     * context above (sts == 0 from __pmLogAddLabelSets).  A duplicate labelset
+     * (PMLOGPUTINDOM_DUP) was not stored, so we must free it here; likewise
+     * for any error, or when there was no archive context to add it to
+     * (sts still holds its -EAGAIN initial value).
+     */
+    if (sts != 0)
 	pmFreeLabelSets(sets, nsets);
 }
 


### PR DESCRIPTION
I've been running `pmproxy` with the Valkey-backed `pmseries` and grafana-pcp for retrospective analysis on a small, always-on box, and over the course of about a week I watched its RSS creep from ~60 MB past 1.8 GB — roughly doubling every night — until it eventually took a `SIGABRT` and got respawned by systemd, only to start climbing again from a higher floor. The key server stayed flat the whole time, so whatever was growing lived in the daemon itself, not in the stored series.

A core dump plus a `memleak` (bcc) pass over the live process kept landing on the same spot: `__pmLogLoadLabelSet()`, reached through `process_metadata()` in the discovery module — tens of MB of outstanding allocations in a single half-hour window, and next to none of it ever released. The equivalent instance-domain path barely registered, and that contrast is what finally gave it away.

## What's happening

`addlabel()` in `logmeta.c` links every label record it's handed onto the per-`(type, ident)` chain in the archive context, and — unlike its two siblings — never checks whether that record is already there. `addindom()` filters exact duplicates (its own comment spells out why: identical indoms are "very common in multi-archive contexts"), and `__pmLogAddDesc()` returns early once the PMID is known. Only labels keep every copy.

Harmless enough, if each record turned up once. It doesn't. Discovery re-presents the very same `(type, ident, timestamp, content)` labels on perfectly ordinary paths:

- when an archive is first picked up, `pmNewContext()` → `__pmLogLoadMeta()` loads all of its label records into the context, and then `process_metadata()` opens the `.meta` file directly and feeds the same records back through `pmDiscoverInvokeLabelsCallBacks()`;
- `pmlogger_daily` rotation and multi-archive contexts hand the same records back again.

Because discovery contexts are long-lived, those duplicate `pmLabelSet`s simply pile up. Nothing is technically *lost* — it all stays reachable from the context's label hash — so an ordinary valgrind leak-check comes back clean, and it only ever shows as growing RSS.

## The change

I gave `addlabel()` the same exact-duplicate rejection `addindom()` already has: when an incoming labelset matches an existing entry at the same timestamp (same instances, label counts and JSON payload), free the wrapper and return `PMLOGPUTINDOM_DUP` rather than chaining a second copy. The two callers that own the decoded labelsets when they're *not* stored — `__pmLogLoadMeta()` and `pmDiscoverInvokeLabelsCallBacks()` — free them on that return, mirroring how `__pmLogLoadMeta()` already disposes of a duplicate indom's payload.

Only byte-for-byte redundant records get dropped, so no context's effective label state changes. A genuine label change at a later timestamp is a different time slot and is kept, exactly as for indoms.

## Checking it

A small standalone program that re-presents one context labelset to `__pmLogAddLabelSets()` 30,000 times — a stand-in for the re-read paths above — makes it plain:

```
            stored   rejected   RSS delta   per add
before       30000    0         +8832 kB    301 B     (unbounded)
after            1    29999     +0 kB       0 B       (bounded)
```

`pminfo --labels` over an archive gives byte-identical output before and after, so real label state is left untouched.

## Where I'd welcome a second look

A few things I'd rather have confirmed than assume:

- the free handling across the two callers — I want to be sure the ownership is right and there's no path where a labelset ends up both stored and freed;
- whether same-timestamp plus identical content is the right notion of "duplicate" here, or whether there's a case I'm not seeing where two label records legitimately share a timestamp yet both need keeping;
- and a reality check on where this actually bites in production — my read is that it's anywhere pmproxy discovers archives that get rotated or re-scanned over a long uptime (large pmlogger farms, busy hosts churning through transient context labels), but you'll have a much better feel for the real shapes than I do.

Glad to add a `qa/` test for this if that's wanted — I kept the reproduction standalone for the moment.