### PR TITLE
pmdalmsensors: query only the requested chip during metric fetch

### DIFF
--- a/src/pmdas/lmsensors/pmdalmsensors.python
+++ b/src/pmdas/lmsensors/pmdalmsensors.python
@@ -32,9 +32,10 @@ import cpmapi as c_api
 
 sensorvalues = {}   # lookup sensorname -> sensorvalue (temp/fan)
 sensornames = {}    # lookup sensornumber -> sensorname
+sensorchips = {}    # lookup sensorname -> original lm_sensors chip name
 basename = "lmsensors"
 
-def lmsensors_get():
+def lmsensors_get(chip=None):
     ''' read sensor data '''
 
     if args.inject:
@@ -48,7 +49,10 @@ def lmsensors_get():
     else:
         # we will read real sensor data
         with open(os.devnull, 'w') as devnull:
-            p = subprocess.Popen(["/usr/bin/sensors", "-j"], stdout=subprocess.PIPE, stderr=devnull)
+            cmd = ["/usr/bin/sensors", "-j"]
+            if chip:
+                cmd.append(chip)
+            p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=devnull)
             output = json.loads(re.sub("[0-9]_", "_", p.communicate()[0].decode("utf-8")))
 
         if args.debug_value and args.debug_value >= 0:
@@ -64,7 +68,7 @@ def lmsensors_get():
                         if "_input" in lvl2:
                             sensorname = (lvl0+"."+adapter+"."+lvl1.replace(".", ",")).lower().replace(" ", "_").replace('-', '_')
                             sensorvalues[sensorname] = output[lvl0][lvl1][lvl2]
-
+                            sensorchips[sensorname] = lvl0
         if args.debug_value and args.debug_value == 2:
             print("final array:", sensorvalues)
 
@@ -74,7 +78,7 @@ class LmsensorsPMDA(PMDA):
     def lmsensors_fetch_callback(self, cluster, item, inst):
         ''' Returns a list of value,status (single pair) for one metric '''
 
-        lmsensors_get()
+        lmsensors_get(sensorchips.get(sensornames.get(item)))
         if cluster == 0:
             # sanity checking: sort out temperatures below -127.
             # some sensors report -128 in error, from time to time.


### PR DESCRIPTION
# PMDA lmsensors: Reduce redundant sensor probing during metric fetches

## Patch Description

This patch optimizes the `lmsensors` PMDA by avoiding redundant full-system sensor scans when serving metric fetch
requests.  Currently, every metric fetch executes `sensors -j` which probes **all** sensor chips, even though only a
single metric value is ultimately returned. As a result, a PCP fetch involving multiple metrics repeatedly re-reads the
same hardware.  This patch records the originating lm_sensors chip for each metric during PMDA initialization and uses
that information to query only the chip associated with the requested metric.

In other words, instead of executing `sensors -j`, we run `sensors -j <chip>` which reduces the amount of work that is
needed.

Additionally, the cost with current implementation grows with:

- the number of sensor chips present,
- the latency of individual sensor backends,
- and the number of metrics requested by PCP clients.

## Related Issue

While investigating why the PMDA was occasionally timing out, I found that one sensor backend on my system requires
roughly half a second to respond. Because the PMDA executes a full `sensors -j` invocation for every metric, the latency
combined across all requested metrics, which then exceeded the PMCD request timeout and causing all metrics in the
request to fail. Since only one metric value is needed for each callback, querying only the corresponding sensor chip
avoids repeatedly waiting on unrelated hardware.

For the context, my environment is Fedora 44 with PCP 7.1.5:
```bash
❯ rpm -q pcp pcp-pmda-lmsensors
pcp-7.1.5-3.fc44.x86_64
pcp-pmda-lmsensors-7.1.5-3.fc44.x86_64
```


Warm Regards,
Ali :)
