### PR TITLE
libpcp: fix heap buffer over-read in __pmLogLoadLabelSet

### DIFF
--- a/src/libpcp/src/e_labels.c
+++ b/src/libpcp/src/e_labels.c
@@ -242,6 +242,11 @@ __pmLogLoadLabelSet(char *tbuf, int rlen, int rtype, __pmTimestamp *stamp,
     }
 
     for (i = 0; i < nsets; i++) {
+	if (k + 2*sizeof(__int32_t) > rlen) {
+	    sts = PM_ERR_LOGREC;
+	    free(labelsets);
+	    return sts;
+	}
 	inst = *((unsigned int*)&tbuf[k]);
 	inst = ntohl(inst);
 	k += sizeof(inst);
@@ -260,6 +265,11 @@ __pmLogLoadLabelSet(char *tbuf, int rlen, int rtype, __pmTimestamp *stamp,
 	    return sts;
 	}
 
+	if (k + jsonlen > rlen) {
+	    free(labelsets);
+	    return PM_ERR_LOGREC;
+	}
+
 	if ((labelsets[i].json = (char *)malloc(jsonlen+1)) == NULL) {
 	    sts = -oserror();
 	    free(labelsets);
@@ -271,6 +281,11 @@ __pmLogLoadLabelSet(char *tbuf, int rlen, int rtype, __pmTimestamp *stamp,
 	k += jsonlen;
 
 	/* label nlabels */
+	if (k + sizeof(__int32_t) > rlen) {
+	    free(labelsets[i].json);
+	    free(labelsets);
+	    return PM_ERR_LOGREC;
+	}
 	nlabels = ntohl(*((unsigned int *)&tbuf[k]));
 	k += sizeof(nlabels);
 	labelsets[i].nlabels = nlabels;

--- a/src/libpcp3/src/e_labels.c
+++ b/src/libpcp3/src/e_labels.c
@@ -247,6 +247,11 @@ __pmLogLoadLabelSet(char *tbuf, int rlen, int rtype, __pmTimestamp *stamp,
     }
 
     for (i = 0; i < nsets; i++) {
+	if (k + 2*sizeof(__int32_t) > rlen) {
+	    sts = PM_ERR_LOGREC;
+	    free(labelsets);
+	    return sts;
+	}
 	inst = *((unsigned int*)&tbuf[k]);
 	inst = ntohl(inst);
 	k += sizeof(inst);
@@ -265,6 +270,11 @@ __pmLogLoadLabelSet(char *tbuf, int rlen, int rtype, __pmTimestamp *stamp,
 	    return sts;
 	}
 
+	if (k + jsonlen > rlen) {
+	    free(labelsets);
+	    return PM_ERR_LOGREC;
+	}
+
 	if ((labelsets[i].json = (char *)malloc(jsonlen+1)) == NULL) {
 	    sts = -oserror();
 	    free(labelsets);
@@ -276,6 +286,11 @@ __pmLogLoadLabelSet(char *tbuf, int rlen, int rtype, __pmTimestamp *stamp,
 	k += jsonlen;
 
 	/* label nlabels */
+	if (k + sizeof(__int32_t) > rlen) {
+	    free(labelsets[i].json);
+	    free(labelsets);
+	    return PM_ERR_LOGREC;
+	}
 	nlabels = ntohl(*((unsigned int *)&tbuf[k]));
 	k += sizeof(nlabels);
 	labelsets[i].nlabels = nlabels;


### PR DESCRIPTION
## Fix: heap buffer over-read in `__pmLogLoadLabelSet`

### Vulnerability

`__pmLogLoadLabelSet()` in both `src/libpcp3/src/e_labels.c` and `src/libpcp/src/e_labels.c` copies `jsonlen` bytes from `tbuf[k]` via `memcpy` without checking that `k + jsonlen <= rlen`. A malicious PCP archive can set `jsonlen` to a value that exceeds the remaining buffer space, causing a **heap buffer over-read** of up to `PM_MAXLABELJSONLEN` (65535) bytes.

### Root cause

The function parses label set data from an archive metadata record. The offset `k` advances through the buffer as fields are read (timestamp, type, ident, nsets, inst, jsonlen, json data, nlabels, labels), but `k` is never checked against `rlen` before reading `inst`, `jsonlen`, or before the `memcpy` that copies `jsonlen` bytes of JSON data. Only `nlabels` has a partial bounds check (`k + nlabels * sizeof(pmLabel) > rlen`), but this check comes too late — after the `memcpy` has already occurred.

### Attack vector

A user opens a malicious PCP archive file with `pmlogdump`, `pmlogextract`, or any PCP tool that calls `__pmLogLoadMeta()`. The `.meta` file contains a `TYPE_LABEL_V2` record with a `jsonlen` field larger than the record body.

### Impact

- **Heap information disclosure**: up to 65535 bytes of heap data leaked into the `json` buffer
- **Denial of service**: crash via `SIGSEGV` if the over-read hits an unmapped page

### Fix

Add three bounds checks in the `nsets` loop:
1. Before reading `inst` and `jsonlen`: check `k + 2*sizeof(__int32_t) <= rlen`
2. Before `memcpy` of JSON data: check `k + jsonlen <= rlen`
3. Before reading `nlabels`: check `k + sizeof(__int32_t) <= rlen`

All checks return `PM_ERR_LOGREC` on failure, consistent with existing error handling in the function.

### Testing

- PoC: crafted archive with `TYPE_LABEL_V2` record, `jsonlen=1000`, `rlen=32`
- Before fix: `SIGSEGV` (exit 139) — heap over-read crosses guard page
- After fix: `pmlogdump` reports "Corrupted record in a PCP archive" (exit 1)
- Normal archives: unaffected (bounds checks only reject invalid records)

### Files changed

- `src/libpcp3/src/e_labels.c`: +15 lines
- `src/libpcp/src/e_labels.c`: +15 lines
- Total: 30 insertions, 0 deletions