### PR TITLE
darwin_proc: fix process state, start_time, memory units and metric gaps

### DIFF
--- a/src/pmdas/darwin_proc/GNUmakefile
+++ b/src/pmdas/darwin_proc/GNUmakefile
@@ -24,6 +24,8 @@ LIBTARGET	= pmda_proc.dylib
 PMDATMPDIR	= $(PCP_PMDAS_DIR)/$(IAM)
 PMDACONFIG	= $(PCP_SYSCONF_DIR)/$(IAM)
 PMDAADMDIR	= $(PCP_PMDASADM_DIR)/$(IAM)
+REWRITEDIR	= $(PCP_SYSCONF_DIR)/pmlogrewrite
+REWRITEVARDIR	= $(PCP_VAR_DIR)/config/pmlogrewrite
 PMCDCONF_LINE	= "proc	3	pipe	binary		$(PMDATMPDIR)/$(CMDTARGET) -d 3"
 LOCALCONF_LINE	= "proc	3	dso	proc_init	$(PMDATMPDIR)/$(LIBTARGET)"
 
@@ -52,6 +54,7 @@ install: default
 	$(INSTALL) -m 644 access.conf $(PMDACONFIG)/access.conf
 	$(INSTALL) -m 755 -t $(PMDATMPDIR) $(LIBTARGET) $(CMDTARGET) $(SCRIPTS) $(PMDAADMDIR)
 	$(INSTALL) -m 644 -t $(PCP_PMNS_DIR)/root_proc root_proc $(PCP_PMNSADM_DIR)/root_proc
+	$(INSTALL) -m 644 -t $(REWRITEVARDIR)/$(IAM).conf rewrite.conf $(REWRITEDIR)/$(IAM).conf
 else
 build-me:
 install:

--- a/src/pmdas/darwin_proc/kinfo_proc.c
+++ b/src/pmdas/darwin_proc/kinfo_proc.c
@@ -83,6 +83,23 @@ darwin_ticks_to_nsecs(uint64_t mach_ticks)
     return part1 + part2;
 }
 
+static uint64_t
+darwin_boottime_nsec(void)
+{
+    static uint64_t	boottime;
+
+    if (!boottime) {
+	struct timeval	tv;
+	size_t		size = sizeof(tv);
+	int		mib[2] = { CTL_KERN, KERN_BOOTTIME };
+
+	if (sysctl(mib, 2, &tv, &size, NULL, 0) == 0)
+	    boottime = (uint64_t)tv.tv_sec * 1000000000ULL +
+		       (uint64_t)tv.tv_usec * 1000ULL;
+    }
+    return boottime;
+}
+
 static size_t
 darwin_processes(struct kinfo_proc **kinfop)
 {
@@ -303,19 +320,20 @@ darwin_process_threads(darwin_procs_t *processes, darwin_runq_t *runq,
 	thread->stime = extended_info.pth_system_time;
 	thread->priority = extended_info.pth_curpri;
 
-	if (extended_info.pth_run_state & TH_STATE_UNINTERRUPTIBLE) {
-	    pmsprintf(thread->state, sizeof(thread->state), "B");
+	if (extended_info.pth_run_state == TH_STATE_UNINTERRUPTIBLE) {
+	    pmsprintf(thread->state, sizeof(thread->state), "D");
 	    runq->blocked++;
-	} else if (extended_info.pth_run_state & TH_STATE_RUNNING) {
+	    proc->flags |= PROC_FLAG_STUCK;
+	} else if (extended_info.pth_run_state == TH_STATE_RUNNING) {
 	    pmsprintf(thread->state, sizeof(thread->state), "R");
 	    runq->runnable++;
-	} else if (extended_info.pth_run_state & TH_STATE_STOPPED) {
+	} else if (extended_info.pth_run_state == TH_STATE_STOPPED) {
 	    pmsprintf(thread->state, sizeof(thread->state), "T");
 	    runq->stopped++;
-	} else if (extended_info.pth_run_state & TH_STATE_WAITING) {
+	} else if (extended_info.pth_run_state == TH_STATE_WAITING) {
 	    pmsprintf(thread->state, sizeof(thread->state), "S");
 	    runq->sleeping++;
-	} else if (extended_info.pth_run_state & TH_STATE_HALTED) {
+	} else if (extended_info.pth_run_state == TH_STATE_HALTED) {
 	    pmsprintf(thread->state, sizeof(thread->state), "T");
 	    runq->stopped++;
 	} else if (extended_info.pth_flags & TH_FLAGS_SWAPPED) {
@@ -367,7 +385,11 @@ static void
 darwin_process_set_basic_fields(darwin_proc_t *proc,
 		struct extern_proc *xproc, struct eproc *eproc)
 {
+	uint64_t	start_nsec;
+	uint64_t	boot_nsec;
+
 	proc->flags = PROC_FLAG_VALID;	/* new or still running */
+	proc->tgid = proc->id;
 	proc->ppid = eproc->e_ppid;
 	proc->pgid = eproc->e_pgid;
 	proc->tpgid = eproc->e_tpgid;
@@ -388,9 +410,26 @@ darwin_process_set_basic_fields(darwin_proc_t *proc,
 	memcpy(proc->wchan, eproc->e_wmesg, WMESGLEN);
 	proc->wchan[WMESGLEN] = '\0';
 	proc->wchan_addr = (uint64_t)xproc->p_wchan;
-	proc->start_time = xproc->p_starttime.tv_sec;
 	proc->translated = xproc->p_flag & P_TRANSLATED;
 	proc->threads = 1;
+
+	/* set initial state from kinfo_proc p_stat */
+	if (xproc->p_stat == SZOMB) {
+		pmsprintf(proc->state, sizeof(proc->state), "Z");
+	} else if (xproc->p_stat == SSTOP) {
+		pmsprintf(proc->state, sizeof(proc->state), "T");
+	} else if (xproc->p_stat == SIDL) {
+		pmsprintf(proc->state, sizeof(proc->state), "I");
+	} else {
+		pmsprintf(proc->state, sizeof(proc->state), "S");
+	}
+
+	/* store start_time as nanoseconds since boot */
+	start_nsec = (uint64_t)xproc->p_starttime.tv_sec * 1000000000ULL +
+		     (uint64_t)xproc->p_starttime.tv_usec * 1000ULL;
+	boot_nsec = darwin_boottime_nsec();
+	proc->start_time = (start_nsec > boot_nsec) ?
+	    start_nsec - boot_nsec : 0;
 
 	if (proc->msg_id == -1 && xproc->p_wmesg)
 		proc->msg_id = proc_strings_insert(xproc->p_wmesg);
@@ -472,7 +511,9 @@ darwin_process_set_taskinfo(darwin_proc_t *proc, struct extern_proc *xproc,
 		return 0;
 
 	proc->flags |= PROC_FLAG_PINFO;
-	proc->majflt = pti.pti_faults;
+	proc->majflt = pti.pti_pageins;
+	proc->minflt = (uint32_t)(pti.pti_faults > pti.pti_pageins ?
+	    pti.pti_faults - pti.pti_pageins : 0);
 	proc->threads = pti.pti_threadnum;
 	proc->utime = darwin_ticks_to_nsecs(pti.pti_total_user);
 	proc->stime = darwin_ticks_to_nsecs(pti.pti_total_system);
@@ -580,23 +621,9 @@ darwin_process_set_taskinfo(darwin_proc_t *proc, struct extern_proc *xproc,
 		}
 	}
 
-	/* set process state and update run queue statistics */
-	if (pti.pti_numrunning > 0) {
+	/* refine process state using taskinfo */
+	if (pti.pti_numrunning > 0)
 		pmsprintf(proc->state, sizeof(proc->state), "R");
-		runq->runnable++;
-	} else if (xproc->p_stat == SZOMB) {
-		pmsprintf(proc->state, sizeof(proc->state), "Z");
-		runq->defunct++;
-	} else if (xproc->p_stat == SSTOP) {
-		pmsprintf(proc->state, sizeof(proc->state), "T");
-		runq->stopped++;
-	} else if (xproc->p_stat == SIDL) {
-		pmsprintf(proc->state, sizeof(proc->state), "B");
-		runq->blocked++;
-	} else {
-		pmsprintf(proc->state, sizeof(proc->state), "S");
-		runq->sleeping++;
-	}
 
 	return 1;
 }
@@ -684,13 +711,27 @@ darwin_refresh_processes(pmdaIndom *indomp, darwin_procs_t *processes,
 	/* get command line, executable path, and working directory */
 	darwin_process_set_command_info(proc);
 
+	/* get task statistics and I/O counters */
+	darwin_process_set_taskinfo(proc, xproc, runq);
+
 	/* collect thread information if enabled */
 	if (have_threads && want_threads)
 		total += darwin_process_threads(processes, runq, proc);
 
-	/* get task statistics, I/O counters, and update run queue stats */
-	if (!darwin_process_set_taskinfo(proc, xproc, runq))
-		continue;
+	/* propagate uninterruptible thread state to parent */
+	if (proc->flags & PROC_FLAG_STUCK)
+		pmsprintf(proc->state, sizeof(proc->state), "D");
+
+	/* update run queue statistics from final process state */
+	switch (proc->state[0]) {
+	case 'R': runq->runnable++; break;
+	case 'D': runq->blocked++; break;
+	case 'Z': runq->defunct++; break;
+	case 'T': runq->stopped++; break;
+	case 'S': runq->sleeping++; break;
+	case 'I': runq->sleeping++; break;
+	default:  runq->unknown++; break;
+	}
     }
 
     free(procs);

--- a/src/pmdas/darwin_proc/kinfo_proc.h
+++ b/src/pmdas/darwin_proc/kinfo_proc.h
@@ -30,12 +30,14 @@
 #define PROC_FLAG_VALID  (1<<0)	/* Process observed during the current sample */
 #define PROC_FLAG_PINFO  (1<<1)	/* Success in calling proc_pidinfo for the PID */
 #define PROC_FLAG_THREAD (1<<2)	/* Given process structure represents a thread */
+#define PROC_FLAG_STUCK  (1<<3)	/* Has thread in TH_STATE_UNINTERRUPTIBLE */
 
 /*
  * Process metrics from kinfo_proc and libproc
  */
 typedef struct {
     int		id;	/* pid, hash key and internal instance id */
+    int		tgid;	/* thread group id (parent pid for threads) */
     int		flags;
 
     char	*psargs;   /* offset to start of process arguments in name */
@@ -56,6 +58,7 @@ typedef struct {
     uint32_t	suid;
     uint32_t	sgid;
     uint32_t	majflt;
+    uint32_t	minflt;
     uint32_t	threads;
     uint32_t	translated;
     uint32_t	fd_count;	/* open file descriptor count */

--- a/src/pmdas/darwin_proc/pmda.c
+++ b/src/pmdas/darwin_proc/pmda.c
@@ -158,6 +158,12 @@ static pmdaMetric metrictab[] = {
 /* proc.psinfo.usrpri */
   { NULL, { PMDA_PMID(CLUSTER_PROCS, 24), PM_TYPE_32, PROC_INDOM,
     PM_SEM_INSTANT, PMDA_PMUNITS(0,0,0,0,0,0) } },
+/* proc.psinfo.minflt */
+  { NULL, { PMDA_PMID(CLUSTER_PROCS, 25), PM_TYPE_U32, PROC_INDOM,
+    PM_SEM_COUNTER, PMDA_PMUNITS(0,0,1,0,0,PM_COUNT_ONE) } },
+/* proc.psinfo.tgid */
+  { NULL, { PMDA_PMID(CLUSTER_PROCS, 26), PM_TYPE_U32, PROC_INDOM,
+    PM_SEM_DISCRETE, PMDA_PMUNITS(0,0,0,0,0,0) } },
 
 /* proc.runq.runnable */
   { &run_queue.runnable,
@@ -222,10 +228,10 @@ static pmdaMetric metrictab[] = {
 
 /* proc.memory.size */
   { NULL, { PMDA_PMID(CLUSTER_PROC_MEM, 0), PM_TYPE_U64, PROC_INDOM,
-    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_BYTE,0,0) } },
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0) } },
 /* proc.memory.rss */
   { NULL, { PMDA_PMID(CLUSTER_PROC_MEM, 1), PM_TYPE_U64, PROC_INDOM,
-    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_BYTE,0,0) } },
+    PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_KBYTE,0,0) } },
 /* proc.memory.footprint */
   { NULL, { PMDA_PMID(CLUSTER_PROC_MEM, 2), PM_TYPE_U64, PROC_INDOM,
     PM_SEM_INSTANT, PMDA_PMUNITS(1,0,0,PM_SPACE_BYTE,0,0) } },
@@ -533,6 +539,12 @@ proc_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
 	case 24: /* proc.psinfo.usrpri */
 	    atom->l = proc->usrpri;
 	    break;
+	case 25: /* proc.psinfo.minflt */
+	    atom->ul = proc->minflt;
+	    break;
+	case 26: /* proc.psinfo.tgid */
+	    atom->ul = proc->tgid;
+	    break;
 	default:
 	    return PM_ERR_PMID;
 	}
@@ -555,7 +567,7 @@ proc_fetchCallBack(pmdaMetric *mdesc, unsigned int inst, pmAtomValue *atom)
 	    atom->ul = proc->suid;
 	    break;
 	case 3: /* proc.id.gid */
-	    atom->ul = proc->uid;
+	    atom->ul = proc->gid;
 	    break;
 	case 4: /* proc.id.uid_nm */
 	    atom->cp = proc_uidname_lookup(proc->uid);

--- a/src/pmdas/darwin_proc/rewrite.conf
+++ b/src/pmdas/darwin_proc/rewrite.conf
@@ -1,0 +1,8 @@
+# darwin_proc PMDA rewriting rules
+#
+
+# proc.memory.size and proc.memory.rss values have always been
+# stored in Kbytes; fix the metadata to match (was BYTE, now KBYTE)
+#
+metric proc.memory.size { units -> 1,0,0,KBYTE,0,0 }
+metric proc.memory.rss { units -> 1,0,0,KBYTE,0,0 }

--- a/src/pmdas/darwin_proc/root_proc
+++ b/src/pmdas/darwin_proc/root_proc
@@ -27,12 +27,16 @@ proc.psinfo {
     pid			PROC:1:1
     ppid		PROC:1:2
     pgid		PROC:1:3
+    pgrp		PROC:1:3
     tpgid		PROC:1:4
+    tty_pgrp		PROC:1:4
     cwd			PROC:1:5
     cmd			PROC:1:6
     exe			PROC:1:7
     nice		PROC:1:8
     majflt		PROC:1:9
+    maj_flt		PROC:1:9
+    minflt		PROC:1:25
     priority		PROC:1:10
     psargs		PROC:1:11
     sname		PROC:1:12
@@ -40,6 +44,7 @@ proc.psinfo {
     utime		PROC:1:14
     stime		PROC:1:15
     threads		PROC:1:16
+    tgid		PROC:1:26
     translated		PROC:1:17
     tty			PROC:1:18
     ttyname		PROC:1:19


### PR DESCRIPTION
Process state was only set inside darwin_process_set_taskinfo() which is skipped when proc_pidinfo() fails (e.g. insufficient privileges). Move initial state assignment into darwin_process_set_basic_fields() using p_stat from kinfo_proc so all processes get a valid state. Refine to RUNNING when taskinfo succeeds and pti_numrunning > 0. Map SIDL to 'I' (idle) instead of 'B' for pcp-htop compatibility. Propagate TH_STATE_UNINTERRUPTIBLE from threads to parent process as 'D' state, matching native htop behavior.

Fix proc.psinfo.start_time which stored absolute epoch seconds but declared PM_TIME_NSEC units, causing pcp-htop to mangle the value through its nanosecond-to-centisecond conversion.  Now stores nanoseconds since boot, consistent with the unit declaration and with what pcp-htop expects.

Fix proc.psinfo.majflt to use pti_pageins (actual disk page-ins) instead of pti_faults (total faults).  Add proc.psinfo.minflt as the difference (pti_faults - pti_pageins).

Fix proc.memory.size and proc.memory.rss unit declarations from PM_SPACE_BYTE to PM_SPACE_KBYTE to match the stored values (which are divided by 1024 before storage).

Fix proc.id.gid returning proc->uid instead of proc->gid.

Add PMNS aliases for Linux proc PMDA compatible metric names that pcp-htop requests: pgrp, tty_pgrp, maj_flt.  Add proc.psinfo.tgid (equals pid on macOS) needed by pcp-htop for thread grouping.