### PR TITLE
selinux: pcp-import policy fixes from runtime AVC testing

### DIFF
--- a/src/selinux/import/pcp-import.if
+++ b/src/selinux/import/pcp-import.if
@@ -20,6 +20,25 @@ ifndef(`kernel_read_psi',`
 
 ########################################
 ## <summary>
+##	Dummy acct_search_data() for platforms without it.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+ifndef(`acct_search_data',`
+	interface(`acct_search_data',`
+		gen_require(`
+			type acct_data_t;
+		')
+		search_dirs_pattern($1, acct_data_t, acct_data_t)
+	')
+')
+
+########################################
+## <summary>
 ##	Read pcp_import log files (PCP archives).
 ## </summary>
 ## <param name="domain">

--- a/src/selinux/import/pcp-import.te
+++ b/src/selinux/import/pcp-import.te
@@ -55,6 +55,7 @@ allow pcp_import_t var_lib_t:file { execute execute_no_trans map };
 optional_policy(`
     gen_require(`
         type pcp_var_lib_t;
+        type pcp_var_run_t;
         type pcp_pmcd_t;
     ')
     read_files_pattern(pcp_import_t, pcp_var_lib_t, pcp_var_lib_t)
@@ -62,7 +63,9 @@ optional_policy(`
     read_lnk_files_pattern(pcp_import_t, pcp_var_lib_t, pcp_var_lib_t)
     exec_files_pattern(pcp_import_t, pcp_var_lib_t, pcp_var_lib_t)
     allow pcp_import_t pcp_var_lib_t:file { map write append };
+    allow pcp_import_t pcp_var_lib_t:dir write;
     allow pcp_import_t pcp_var_lib_t:sock_file write;
+    allow pcp_import_t pcp_var_run_t:sock_file write;
     allow pcp_import_t pcp_pmcd_t:unix_stream_socket connectto;
 ')
 
@@ -115,8 +118,12 @@ corecmd_exec_bin(pcp_import_t)
 corecmd_exec_shell(pcp_import_t)
 can_exec(pcp_import_t, pcp_import_exec_t)
 
-# Network (hostname resolution only)
+# Process accounting data (/var/account)
+acct_search_data(pcp_import_t)
+
+# Network (hostname resolution and optional pmcd TCP connection)
 sysnet_read_config(pcp_import_t)
+corenet_tcp_connect_all_ephemeral_ports(pcp_import_t)
 
 # TLS certs (libpcp, even if unused in local mode)
 miscfiles_read_generic_certs(pcp_import_t)


### PR DESCRIPTION
Add permissions discovered during sustained pcp-atop testing:
- dac_override and sys_pacct capabilities (process accounting)
- debugfs read access (linux PMDA extfrag metrics)
- kernel ipc_info (shared memory metrics)
- pcp_var_lib_t file write/append and dir write (process accounting)
- pmcd unix socket connectto and TCP ephemeral port connect
- pcp_var_run_t sock_file write (pmcd.socket in /run/pcp)
- acct_data_t dir search (process accounting data)
- dummy acct_search_data() interface for older platforms
- all pmcd-related rules consolidated into single optional_policy block
