### PR TITLE
Fixes for macOS pmlogger/pmie service start

### DIFF
--- a/build/mac/installer-resources/postinstall
+++ b/build/mac/installer-resources/postinstall
@@ -76,11 +76,8 @@ then
     dscl . append /Groups/pcp GroupMembership pcp
 fi
 
-chown -R pcp:pcp /var/log/pcp/pmcd 2>/dev/null
-chown -R pcp:pcp /var/log/pcp/pmlogger 2>/dev/null
-chown -R pcp:pcp /var/log/pcp/sa 2>/dev/null
-chown -R pcp:pcp /var/log/pcp/pmie 2>/dev/null
-chown -R pcp:pcp /var/log/pcp/pmproxy 2>/dev/null
+chown -R pcp:pcp /var/log/pcp 2>/dev/null
+chown -R pcp:pcp /var/lib/pcp/config 2>/dev/null
 
 # https://github.com/performancecopilot/pcp/issues/20
 defaults write io.pcp.pmtime NSAppSleepDisabled -bool YES

--- a/build/mac/installer-resources/postupgrade
+++ b/build/mac/installer-resources/postupgrade
@@ -135,11 +135,8 @@ then
     dscl . append /Groups/pcp GroupMembership pcp
 fi
 
-chown -R pcp:pcp /var/log/pcp/pmcd 2>/dev/null
-chown -R pcp:pcp /var/log/pcp/pmlogger 2>/dev/null
-chown -R pcp:pcp /var/log/pcp/sa 2>/dev/null
-chown -R pcp:pcp /var/log/pcp/pmie 2>/dev/null
-chown -R pcp:pcp /var/log/pcp/pmproxy 2>/dev/null
+chown -R pcp:pcp /var/log/pcp 2>/dev/null
+chown -R pcp:pcp /var/lib/pcp/config 2>/dev/null
 
 # https://github.com/performancecopilot/pcp/issues/20
 defaults write io.pcp.pmtime NSAppSleepDisabled -bool YES

--- a/build/mac/io.pcp.pmie.plist
+++ b/build/mac/io.pcp.pmie.plist
@@ -6,21 +6,22 @@
         <string>io.pcp.pmie</string>
         <key>ProgramArguments</key>
         <array>
-            <string>/etc/init.d/pmie</string>
-            <string>start</string>
+            <string>/usr/local/libexec/pcp/bin/pmie_farm</string>
         </array>
         <key>Disabled</key>
         <false/>
         <key>UserName</key>
-        <string>root</string>
-        <key>UserGroup</key>
-        <string>wheel</string>
+        <string>pcp</string>
+        <key>GroupName</key>
+        <string>pcp</string>
         <key>KeepAlive</key>
-        <false/>
+        <true/>
         <key>ThrottleInterval</key>
         <integer>30</integer>
         <key>RunAtLoad</key>
         <true/>
+        <key>WorkingDirectory</key>
+        <string>/var/lib/pcp</string>
         <key>StandardErrorPath</key>
         <string>/var/log/pcp/pmie/plist.stderr</string>
         <key>StandardOutPath</key>

--- a/build/mac/io.pcp.pmie_check.plist
+++ b/build/mac/io.pcp.pmie_check.plist
@@ -30,6 +30,6 @@
         <key>StandardOutPath</key>
         <string>/var/log/pcp/pmie/pmie_check.stdout</string>
         <key>WorkingDirectory</key>
-        <string>/private/var/lib/pcp</string>
+        <string>/var/lib/pcp</string>
     </dict>
 </plist>

--- a/build/mac/io.pcp.pmie_daily.plist
+++ b/build/mac/io.pcp.pmie_daily.plist
@@ -26,6 +26,6 @@
         <key>StandardOutPath</key>
         <string>/var/log/pcp/pmie/pmie_daily.stdout</string>
         <key>WorkingDirectory</key>
-        <string>/private/var/lib/pcp</string>
+        <string>/var/lib/pcp</string>
     </dict>
 </plist>

--- a/build/mac/io.pcp.pmie_farm_check.plist
+++ b/build/mac/io.pcp.pmie_farm_check.plist
@@ -33,6 +33,6 @@
         <key>StandardOutPath</key>
         <string>/var/log/pcp/pmie/pmie_farm_check.stdout</string>
         <key>WorkingDirectory</key>
-        <string>/private/var/lib/pcp</string>
+        <string>/var/lib/pcp</string>
     </dict>
 </plist>

--- a/build/mac/io.pcp.pmlogger.plist
+++ b/build/mac/io.pcp.pmlogger.plist
@@ -6,21 +6,23 @@
         <string>io.pcp.pmlogger</string>
         <key>ProgramArguments</key>
         <array>
-            <string>/etc/init.d/pmlogger</string>
-            <string>start</string>
+            <string>/usr/local/libexec/pcp/bin/pmlogger_farm</string>
+            <string>--quick</string>
         </array>
         <key>Disabled</key>
         <false/>
         <key>UserName</key>
-        <string>root</string>
-        <key>UserGroup</key>
-        <string>wheel</string>
+        <string>pcp</string>
+        <key>GroupName</key>
+        <string>pcp</string>
         <key>KeepAlive</key>
-        <false/>
+        <true/>
         <key>ThrottleInterval</key>
         <integer>30</integer>
         <key>RunAtLoad</key>
         <true/>
+        <key>WorkingDirectory</key>
+        <string>/var/lib/pcp</string>
         <key>StandardErrorPath</key>
         <string>/var/log/pcp/pmlogger/plist.stderr</string>
         <key>StandardOutPath</key>

--- a/build/mac/io.pcp.pmlogger_check.plist
+++ b/build/mac/io.pcp.pmlogger_check.plist
@@ -31,6 +31,6 @@
         <key>StandardOutPath</key>
         <string>/var/log/pcp/pmlogger/pmlogger_check.stdout</string>
         <key>WorkingDirectory</key>
-        <string>/private/var/lib/pcp</string>
+        <string>/var/lib/pcp</string>
     </dict>
 </plist>

--- a/build/mac/io.pcp.pmlogger_daily.plist
+++ b/build/mac/io.pcp.pmlogger_daily.plist
@@ -28,6 +28,6 @@
         <key>StandardOutPath</key>
         <string>/var/log/pcp/pmlogger/pmlogger_daily.stdout</string>
         <key>WorkingDirectory</key>
-        <string>/private/var/lib/pcp</string>
+        <string>/var/lib/pcp</string>
     </dict>
 </plist>

--- a/build/mac/io.pcp.pmlogger_farm_check.plist
+++ b/build/mac/io.pcp.pmlogger_farm_check.plist
@@ -33,6 +33,6 @@
         <key>StandardOutPath</key>
         <string>/var/log/pcp/pmlogger/pmlogger_farm_check.stdout</string>
         <key>WorkingDirectory</key>
-        <string>/private/var/lib/pcp</string>
+        <string>/var/lib/pcp</string>
     </dict>
 </plist>

--- a/src/pmdas/openmetrics/pmdaopenmetrics.python
+++ b/src/pmdas/openmetrics/pmdaopenmetrics.python
@@ -33,7 +33,10 @@ import sys
 from ctypes import c_int
 from socket import gethostname
 from stat import ST_MODE, S_IXUSR
-import requests
+try:
+    import requests
+except ImportError:
+    requests = None
 
 from pcp.pmapi import pmUnits, pmContext
 from pcp.pmda import PMDA, pmdaMetric, pmdaIndom, pmdaInstid
@@ -1044,7 +1047,11 @@ class OpenMetricsPMDA(PMDA):
         self.timeout = timeout
 
         # a single central Session that all our sources can concurrently reuse
-        self.requests = requests.Session() # allow persistent connections
+        if requests is not None:
+            self.requests = requests.Session()
+        else:
+            self.requests = None
+            self.err('Python "requests" module is not installed, URL sources will not work')
 
         # the list of configured sources
         self.source_by_name = {}

--- a/src/pmdas/opentelemetry/pmdaopentelemetry.python
+++ b/src/pmdas/opentelemetry/pmdaopentelemetry.python
@@ -35,7 +35,10 @@ import subprocess
 from ctypes import c_int
 from socket import gethostname
 from stat import ST_MODE, S_IXUSR
-import requests
+try:
+    import requests
+except ImportError:
+    requests = None
 import json
 
 from pcp.pmapi import pmUnits, pmContext
@@ -1003,7 +1006,11 @@ class OpenTelemetryPMDA(PMDA):
         self.timeout = timeout
 
         # a single central Session that all our sources can concurrently reuse
-        self.requests = requests.Session() # allow persistent connections
+        if requests is not None:
+            self.requests = requests.Session()
+        else:
+            self.requests = None
+            self.err('Python "requests" module is not installed, URL sources will not work')
 
         # the list of configured sources
         self.source_by_name = {}
@@ -1590,8 +1597,8 @@ if __name__ == '__main__':
     parser.add_argument(
         '-u', '--user',
         type=str,
-        default=None,
-        help='set the username to run under (default is current user)')
+        default='pcp',
+        help='set the username to run under (default is the pcp account)')
 
     args = parser.parse_args()
     if args.nosort:


### PR DESCRIPTION
Fix pcp user permissions
- The macOS postinstall/postupgrade scripts chowned five subdirectories under /var/log/pcp but not the parent itself, and missed /var/lib/pcp/config. The pcp user (not in wheel) couldn't write NOTICES or create pmlogger's config.default, so pmlogger failed silently at startup. Fixed by chowning /var/log/pcp and /var/lib/pcp/config directly.

Defer requests import in Python PMDAs
- Both openmetrics and opentelemetry PMDAs do import requests at the top level. Since requests is a build dependency not bundled in the .pkg, this kills the Install process — including the PCP_PYTHON_DOMAIN path that only needs to emit a one-line #define. Wrapped the import in try/except and guarded requests.Session() so Install succeeds without it; URL sources log an error at runtime if still missing. Also changed opentelemetry's default user from None (root) to pcp to match openmetrics.

Fix pmlogger/pmie launchd lifecycle
- The pmlogger and pmie plists ran /etc/init.d/<service> start, which forks daemons into the background and exits. launchd then tears down the job scope, sending SIGTERM ~1s later. Switched both to use pmlogger_farm/pmie_farm (which run *_check then exec pmpause), matching the Linux systemd farm pattern. Set KeepAlive=true, run as pcp:pcp, and cleaned up /private prefixes across all periodic plists.
