### PR TITLE
Fault injection testing outside libpcp - PoC for pmlogmv

### DIFF
--- a/man/man1/chkhelp.1
+++ b/man/man1/chkhelp.1
@@ -157,7 +157,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/collectl2pcp.1
+++ b/man/man1/collectl2pcp.1
@@ -76,7 +76,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/dbpmda.1
+++ b/man/man1/dbpmda.1
@@ -601,7 +601,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/ganglia2pcp.1
+++ b/man/man1/ganglia2pcp.1
@@ -131,7 +131,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/newhelp.1
+++ b/man/man1/newhelp.1
@@ -164,7 +164,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pcp.1
+++ b/man/man1/pcp.1
@@ -223,7 +223,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmcd.1
+++ b/man/man1/pmcd.1
@@ -1411,7 +1411,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmcd_wait.1
+++ b/man/man1/pmcd_wait.1
@@ -129,7 +129,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmchart.1
+++ b/man/man1/pmchart.1
@@ -740,7 +740,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmclient.1
+++ b/man/man1/pmclient.1
@@ -274,7 +274,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdaamdgpu.1
+++ b/man/man1/pmdaamdgpu.1
@@ -152,7 +152,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdaapache.1
+++ b/man/man1/pmdaapache.1
@@ -176,7 +176,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdabash.1
+++ b/man/man1/pmdabash.1
@@ -250,7 +250,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdacisco.1
+++ b/man/man1/pmdacisco.1
@@ -348,7 +348,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdakernel.1
+++ b/man/man1/pmdakernel.1
@@ -186,7 +186,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdalogger.1
+++ b/man/man1/pmdalogger.1
@@ -183,7 +183,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdamailq.1
+++ b/man/man1/pmdamailq.1
@@ -190,7 +190,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdammv.1
+++ b/man/man1/pmdammv.1
@@ -222,7 +222,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdamounts.1
+++ b/man/man1/pmdamounts.1
@@ -141,7 +141,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdanvidia.1
+++ b/man/man1/pmdanvidia.1
@@ -153,7 +153,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdaoverhead.1
+++ b/man/man1/pmdaoverhead.1
@@ -272,7 +272,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdapipe.1
+++ b/man/man1/pmdapipe.1
@@ -314,7 +314,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdaroot.1
+++ b/man/man1/pmdaroot.1
@@ -117,7 +117,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdasample.1
+++ b/man/man1/pmdasample.1
@@ -180,7 +180,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdasendmail.1
+++ b/man/man1/pmdasendmail.1
@@ -159,7 +159,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdashping.1
+++ b/man/man1/pmdashping.1
@@ -215,7 +215,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdasimple.1
+++ b/man/man1/pmdasimple.1
@@ -191,7 +191,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdasummary.1
+++ b/man/man1/pmdasummary.1
@@ -150,7 +150,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdatrace.1
+++ b/man/man1/pmdatrace.1
@@ -215,7 +215,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdatrivial.1
+++ b/man/man1/pmdatrivial.1
@@ -139,7 +139,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdatxmon.1
+++ b/man/man1/pmdatxmon.1
@@ -188,7 +188,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdaweblog.1
+++ b/man/man1/pmdaweblog.1
@@ -574,7 +574,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmdumptext.1
+++ b/man/man1/pmdumptext.1
@@ -531,7 +531,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmfind.1
+++ b/man/man1/pmfind.1
@@ -182,7 +182,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmgetopt.1
+++ b/man/man1/pmgetopt.1
@@ -213,7 +213,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmhostname.1
+++ b/man/man1/pmhostname.1
@@ -71,7 +71,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmie.1
+++ b/man/man1/pmie.1
@@ -1505,7 +1505,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pminfo.1
+++ b/man/man1/pminfo.1
@@ -332,7 +332,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmjson.1
+++ b/man/man1/pmjson.1
@@ -85,7 +85,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlc.1
+++ b/man/man1/pmlc.1
@@ -576,7 +576,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogbasename.1
+++ b/man/man1/pmlogbasename.1
@@ -84,7 +84,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogcheck.1
+++ b/man/man1/pmlogcheck.1
@@ -311,7 +311,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogconf.1
+++ b/man/man1/pmlogconf.1
@@ -533,22 +533,6 @@ with the
 .B \-l
 option to obtain
 a list of the available debugging options and their meaning.
-.SH DEBUGGING OPTIONS
-The
-.B \-D
-or
-.B \-\-debug
-option enables the output of additional diagnostics on
-.I stderr
-to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
-.I debug
-is a comma separated list of debugging options; use
-.BR pmdbg (1)
-with the
-.B \-l
-option to obtain
-a list of the available debugging options and their meaning.
 .PP
 Debugging options specific to
 .B pmlogconf

--- a/man/man1/pmlogconf.1
+++ b/man/man1/pmlogconf.1
@@ -525,7 +525,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogdump.1
+++ b/man/man1/pmlogdump.1
@@ -327,7 +327,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogextract.1
+++ b/man/man1/pmlogextract.1
@@ -688,7 +688,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogger.1
+++ b/man/man1/pmlogger.1
@@ -1327,7 +1327,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmloglabel.1
+++ b/man/man1/pmloglabel.1
@@ -151,7 +151,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogmv.1
+++ b/man/man1/pmlogmv.1
@@ -158,7 +158,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogpush.1
+++ b/man/man1/pmlogpush.1
@@ -111,7 +111,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogredact.1
+++ b/man/man1/pmlogredact.1
@@ -108,7 +108,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogreduce.1
+++ b/man/man1/pmlogreduce.1
@@ -308,7 +308,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogrewrite.1
+++ b/man/man1/pmlogrewrite.1
@@ -1760,7 +1760,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogsize.1
+++ b/man/man1/pmlogsize.1
@@ -96,7 +96,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmlogsummary.1
+++ b/man/man1/pmlogsummary.1
@@ -342,7 +342,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmnsdel.1
+++ b/man/man1/pmnsdel.1
@@ -104,7 +104,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmnsmerge.1
+++ b/man/man1/pmnsmerge.1
@@ -214,7 +214,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmpost.1
+++ b/man/man1/pmpost.1
@@ -79,7 +79,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmprobe.1
+++ b/man/man1/pmprobe.1
@@ -322,7 +322,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmproxy.1
+++ b/man/man1/pmproxy.1
@@ -555,7 +555,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmrepconf.1
+++ b/man/man1/pmrepconf.1
@@ -188,7 +188,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmsearch.1
+++ b/man/man1/pmsearch.1
@@ -169,7 +169,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmseries.1
+++ b/man/man1/pmseries.1
@@ -851,7 +851,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmstat.1
+++ b/man/man1/pmstat.1
@@ -448,7 +448,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmstore.1
+++ b/man/man1/pmstore.1
@@ -231,7 +231,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmtime.1
+++ b/man/man1/pmtime.1
@@ -88,7 +88,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmval.1
+++ b/man/man1/pmval.1
@@ -506,7 +506,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/pmview.1
+++ b/man/man1/pmview.1
@@ -563,7 +563,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/man/man1/runaspcp.1
+++ b/man/man1/runaspcp.1
@@ -73,7 +73,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/qa/1699
+++ b/qa/1699
@@ -1,0 +1,109 @@
+#!/bin/sh
+# PCP QA Test No. 1699
+# pmlogmv with fault injection for read() and write()
+#
+# Copyright (c) 2026 Ken McDonell.  All Rights Reserved.
+#
+
+if [ $# -eq 0 ]
+then
+    seq=`basename $0`
+    echo "QA output created by $seq"
+else
+    # use $seq from caller, unless not set
+    [ -n "$seq" ] || seq=`basename $0`
+    echo "QA output created by `basename $0` $*"
+fi
+
+# get standard environment, filters and checks
+. ./common.product
+. ./common.filter
+. ./common.check
+
+srcdir=$here/../src/pmlogmv
+[ -d "$srcdir" ] || _notrun "Not in a git tree with access to pmlogmv source"
+
+_cleanup()
+{
+    cd "$srcdir"
+    make clean >>$seq_full 2>&1
+    rm -f pmlogcp
+    cd $here
+    $sudo rm -rf $tmp $tmp.*
+}
+
+status=0	# success is the default!
+trap "_cleanup; exit \$status" 0 1 2 3 15
+
+_filter()
+{
+    sed \
+	-e "s@$tmp@TMP@g" \
+	-e "s@/privateTMP@TMP@g" \
+    # end
+}
+
+cd "$srcdir"
+make clean >>$seq_full 2>&1
+if LCFLAGS=-DPM_FAULT_INJECTION=1 PCPLIB=-lpcp_fault make >$tmp.tmp 2>&1
+then
+    cat $tmp.tmp >>$seq_full
+else
+    cat $tmp.tmp
+    echo "Arrgh make for fault-enabled pmlogmv failed"
+    _exit 1
+fi
+# really need pmlogcp, not pmlogmv
+#
+rm -f pmlogcp
+ln -s pmlogmv pmlogcp
+cd $here
+
+mkdir $tmp || _exit 1
+
+PM_FAULT_CONTROL=$tmp.control; export PM_FAULT_CONTROL
+
+# archives/rattle contains (in the order pmlogcp processes 'em)
+# this many BUFSIZ blocks
+#    1 data records
+#    1 temportal index records
+#    1 metadata records
+
+# real QA test starts here
+echo "read() fail for data volume ..."
+echo 'pmlogmv.c:read ==1' >$tmp.control
+"$srcdir"/pmlogcp archives/rattle $tmp/rattle 2>&1 | _filter
+echo $tmp/* | sed -e '/\/\*$/d'
+
+echo
+echo "read() fail for index ..."
+echo 'pmlogmv.c:read ==2' >$tmp.control
+"$srcdir"/pmlogcp archives/rattle $tmp/rattle 2>&1 | _filter
+echo $tmp/* | sed -e '/\/\*$/d'
+
+echo
+echo "read() fail for metadata volume ..."
+echo 'pmlogmv.c:read ==3' >$tmp.control
+"$srcdir"/pmlogcp archives/rattle $tmp/rattle 2>&1 | _filter
+echo $tmp/* | sed -e '/\/\*$/d'
+
+echo
+echo "write() fail for data volume ..."
+echo 'pmlogmv.c:write ==1' >$tmp.control
+"$srcdir"/pmlogcp archives/rattle $tmp/rattle 2>&1 | _filter
+echo $tmp/* | sed -e '/\/\*$/d'
+
+echo
+echo "write() fail for index ..."
+echo 'pmlogmv.c:write ==2' >$tmp.control
+"$srcdir"/pmlogcp archives/rattle $tmp/rattle 2>&1 | _filter
+echo $tmp/* | sed -e '/\/\*$/d'
+
+echo
+echo "write() fail for metadata volume ..."
+echo 'pmlogmv.c:write ==3' >$tmp.control
+"$srcdir"/pmlogcp archives/rattle $tmp/rattle 2>&1 | _filter
+echo $tmp/* | sed -e '/\/\*$/d'
+
+# success, all done
+exit

--- a/qa/1699.out
+++ b/qa/1699.out
@@ -1,0 +1,24 @@
+QA output created by 1699
+read() fail for data volume ...
+pmlogcp: read from archives/rattle.0 failed: Bad address
+pmlogcp: copy archives/rattle.0 -> TMP/rattle.0 failed
+
+read() fail for index ...
+pmlogcp: read from archives/rattle.index failed: Bad address
+pmlogcp: copy archives/rattle.index -> TMP/rattle.index failed
+
+read() fail for metadata volume ...
+pmlogcp: read from archives/rattle.meta failed: Bad address
+pmlogcp: copy archives/rattle.meta -> TMP/rattle.meta failed
+
+write() fail for data volume ...
+pmlogcp: write to TMP/rattle.0 failed: Bad address
+pmlogcp: copy archives/rattle.0 -> TMP/rattle.0 failed
+
+write() fail for index ...
+pmlogcp: write to TMP/rattle.index failed: Bad address
+pmlogcp: copy archives/rattle.index -> TMP/rattle.index failed
+
+write() fail for metadata volume ...
+pmlogcp: write to TMP/rattle.meta failed: Bad address
+pmlogcp: copy archives/rattle.meta -> TMP/rattle.meta failed

--- a/qa/group
+++ b/qa/group
@@ -2252,6 +2252,7 @@ suse
 1696 pmproxy valgrind local
 1697 pmproxy valgrind local pmjson
 1698 logutil local pmlogger_daily
+1699 logmv fault local
 1700 pmda.bpftrace local python pmjson
 1701 pmda.bpftrace local python
 1702 pmda.bpftrace local python

--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -898,7 +898,12 @@ PCP_GROUP_INSTALL = @pcp_group_install@
 # systemd service type for logutil scripts
 SD_SERVICE_TYPE=@sd_service_type@
 
+# can set PCPLIB from Makefile to get something different,
+# e.g. -lpcp_fault
+#
+ifeq "$(PCPLIB)" ""
 PCPLIB = -lpcp
+endif
 PCPLIB_EXTRAS = $(LIB_FOR_MATH) $(LIB_FOR_PTHREADS) $(LIB_FOR_DLOPEN) $(LIB_FOR_RT)
 ifneq "$(PCPLIB)" "$(LIB_FOR_BASENAME)"
 PCPLIB_EXTRAS += $(LIB_FOR_BASENAME)

--- a/src/libpcp/src/install-dev
+++ b/src/libpcp/src/install-dev
@@ -51,6 +51,13 @@ fi
 . ../../../src/include/pcp.env
 
 iam="`pwd | sed -e 's;/src$;;' -e's;.*/\(.*\);\1;'`"
+case "$iam"
+in
+    libpcp_fault)	pkg_lib=libpcp
+    			;;
+    *)			pkg_lib="$iam"
+    			;;
+esac
 
 if ! make
 then
@@ -78,10 +85,10 @@ then
     echo "Arrgh: sudo make install failed"
 fi
 
-$debug && echo "Debug: iam=$iam dso_ver=$dso_ver"
+$debug && echo "Debug: iam=$iam dso_ver=$dso_ver pkg_lib=$pkg_lib"
 $debug && echo "Debug: PCP build libdir: $PCP_LIB_DIR"
 
-pkg_dir="`pkg-config --variable=libdir $iam 2>/dev/null`"
+pkg_dir="`pkg-config --variable=libdir $pkg_lib 2>/dev/null`"
 $debug && echo "Debug: pkg-config libdir: $pkg_dir"
 if [ -z "$pkg_dir" ]
 then

--- a/src/libpcp_fault/README
+++ b/src/libpcp_fault/README
@@ -30,9 +30,9 @@ libpcp_fault, e.g.
 
 The mechanisms for defining fault injection points and controlling
 the triggering of fault injection is described in the brief "man"
-page found in the this directory.  Review with
+page. Review with
 
-    $ man ./pmfault.3
+    $ man ../../man/man3i/pmfault.3
 
 Lock debugging is activated with -D options on the command line for
 standard PCP applications:

--- a/src/libpcp_fault/src/mk.exports
+++ b/src/libpcp_fault/src/mk.exports
@@ -16,5 +16,6 @@ BEGIN			{ onetrip = 1 }
 onetrip == 1 && $1 == "global:"	{ print "    __pmFault_malloc;"
 		  print "    __pmFault_realloc;"
 		  print "    __pmFault_strdup;"
+		  print "    __pmFault_arm;"
 		  onetrip = 0;
 		}'

--- a/src/pcp/atop/pcp-atop.1
+++ b/src/pcp/atop/pcp-atop.1
@@ -2591,7 +2591,7 @@ or
 pcp option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp/atop/pcp-atopsar.1
+++ b/src/pcp/atop/pcp-atopsar.1
@@ -1325,7 +1325,7 @@ or
 pcp option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp/iostat/pcp-iostat.1
+++ b/src/pcp/iostat/pcp-iostat.1
@@ -288,7 +288,7 @@ or
 pcp option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp/tapestat/pcp-tapestat.1
+++ b/src/pcp/tapestat/pcp-tapestat.1
@@ -274,7 +274,7 @@ or
 pcp option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp/verify/pcp-verify.1
+++ b/src/pcp/verify/pcp-verify.1
@@ -79,7 +79,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp2arrow/pcp2arrow.1
+++ b/src/pcp2arrow/pcp2arrow.1
@@ -432,7 +432,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp2elasticsearch/pcp2elasticsearch.1
+++ b/src/pcp2elasticsearch/pcp2elasticsearch.1
@@ -686,7 +686,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp2graphite/pcp2graphite.1
+++ b/src/pcp2graphite/pcp2graphite.1
@@ -636,7 +636,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp2influxdb/pcp2influxdb.1
+++ b/src/pcp2influxdb/pcp2influxdb.1
@@ -633,7 +633,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp2json/pcp2json.1
+++ b/src/pcp2json/pcp2json.1
@@ -701,7 +701,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp2openmetrics/pcp2openmetrics.1
+++ b/src/pcp2openmetrics/pcp2openmetrics.1
@@ -703,7 +703,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp2opentelemetry/pcp2opentelemetry.1
+++ b/src/pcp2opentelemetry/pcp2opentelemetry.1
@@ -665,7 +665,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp2spark/pcp2spark.1
+++ b/src/pcp2spark/pcp2spark.1
@@ -645,7 +645,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp2template/pcp2template.1
+++ b/src/pcp2template/pcp2template.1
@@ -620,7 +620,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp2xml/pcp2xml.1
+++ b/src/pcp2xml/pcp2xml.1
@@ -638,7 +638,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pcp2zabbix/pcp2zabbix.1
+++ b/src/pcp2zabbix/pcp2zabbix.1
@@ -672,7 +672,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/bpf/pmdabpf.1
+++ b/src/pmdas/bpf/pmdabpf.1
@@ -114,7 +114,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/btrfs/pmdabtrfs.1
+++ b/src/pmdas/btrfs/pmdabtrfs.1
@@ -96,7 +96,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/cifs/pmdacifs.1
+++ b/src/pmdas/cifs/pmdacifs.1
@@ -80,7 +80,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/darwin/pmdadarwin.1
+++ b/src/pmdas/darwin/pmdadarwin.1
@@ -134,7 +134,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/denki/pmdadenki.1
+++ b/src/pmdas/denki/pmdadenki.1
@@ -121,7 +121,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/dm/pmdadm.1
+++ b/src/pmdas/dm/pmdadm.1
@@ -226,7 +226,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/docker/pmdadocker.1
+++ b/src/pmdas/docker/pmdadocker.1
@@ -156,7 +156,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/farm/pmdafarm.1
+++ b/src/pmdas/farm/pmdafarm.1
@@ -85,7 +85,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/gfs2/pmdagfs2.1
+++ b/src/pmdas/gfs2/pmdagfs2.1
@@ -101,7 +101,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/hacluster/pmdahacluster.1
+++ b/src/pmdas/hacluster/pmdahacluster.1
@@ -85,7 +85,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/infiniband/pmdaib.1
+++ b/src/pmdas/infiniband/pmdaib.1
@@ -110,7 +110,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/jbd2/pmdajbd2.1
+++ b/src/pmdas/jbd2/pmdajbd2.1
@@ -162,7 +162,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/kvm/pmdakvm.1
+++ b/src/pmdas/kvm/pmdakvm.1
@@ -96,7 +96,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/linux_proc/pmdaproc.1
+++ b/src/pmdas/linux_proc/pmdaproc.1
@@ -402,7 +402,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/linux_sockets/pmdasockets.1
+++ b/src/pmdas/linux_sockets/pmdasockets.1
@@ -154,7 +154,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/linux_xfs/pmdaxfs.1
+++ b/src/pmdas/linux_xfs/pmdaxfs.1
@@ -143,7 +143,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/linux_zfs/pmdazfs.1
+++ b/src/pmdas/linux_zfs/pmdazfs.1
@@ -85,7 +85,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/lustrecomm/pmdalustrecomm.1
+++ b/src/pmdas/lustrecomm/pmdalustrecomm.1
@@ -142,7 +142,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/opentelemetry/pmdaopentelemetry.1
+++ b/src/pmdas/opentelemetry/pmdaopentelemetry.1
@@ -656,7 +656,7 @@ by default (see also
 .B \-l
 above),
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/podman/pmdapodman.1
+++ b/src/pmdas/podman/pmdapodman.1
@@ -140,7 +140,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/resctrl/pmdaresctrl.1
+++ b/src/pmdas/resctrl/pmdaresctrl.1
@@ -112,7 +112,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/smart/pmdasmart.1
+++ b/src/pmdas/smart/pmdasmart.1
@@ -85,7 +85,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/statsd/pmdastatsd.1
+++ b/src/pmdas/statsd/pmdastatsd.1
@@ -599,7 +599,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmdas/systemd/pmdasystemd.1
+++ b/src/pmdas/systemd/pmdasystemd.1
@@ -173,7 +173,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)

--- a/src/pmlogmv/pmlogmv.c
+++ b/src/pmlogmv/pmlogmv.c
@@ -94,6 +94,25 @@ static char	**sufftab;
  */
 #define MAX_CHECKSUM	64
 
+#ifdef PM_FAULT_INJECTION
+#include "fault.h"
+/*
+ * fault-injection helper
+ * if fault fires, store -1 in *ret and set errno to EFAULT
+ */
+static int
+fault_me(ssize_t *ret)
+{
+    if (PM_FAULT_CHECK) {
+	PM_FAULT_CLEAR;
+	*ret = -1;
+	setoserror(EFAULT);
+	return 1;
+    }
+    return 0;
+}
+#endif
+
 static int
 myoverrides(int opt, pmOptions *optsp)
 {
@@ -284,8 +303,16 @@ copy_file(const char *src, const char *dst)
     }
     while ((nread = read(sfd, buf, sizeof(buf))) > 0) {
 	char	*p = buf;
+#ifdef PM_FAULT_INJECTION
+	PM_FAULT_POINT(__FILE__ ":read", PM_FAULT_MISC);
+	if (fault_me(&nread)) break;
+#endif
 	while (nread > 0) {
 	    nwritten = write(dfd, p, nread);
+#ifdef PM_FAULT_INJECTION
+	    PM_FAULT_POINT(__FILE__ ":write", PM_FAULT_MISC);
+	    fault_me(&nwritten);
+#endif
 	    if (nwritten < 0) {
 		fprintf(stderr, "%s: write to %s failed: %s\n", progname, dst, strerror(errno));
 		close(sfd);

--- a/src/pmrep/pmrep.1
+++ b/src/pmrep/pmrep.1
@@ -1254,7 +1254,7 @@ or
 option enables the output of additional diagnostics on
 .I stderr
 to help triage problems, although the information is sometimes cryptic and
-primarily intended to provide guidance for developers rather end-users.
+primarily intended to provide guidance for developers rather than for end-users.
 .I debug
 is a comma separated list of debugging options; use
 .BR pmdbg (1)


### PR DESCRIPTION
In copy_file() it is important that we handle errors from read() and write() in ways that don't compromise the input archive and don't leave turds in the filesystem.

This is also a Proof of Concept for using libpcp_fault for fault injection testing outside libpcp.

But it needed some "extra" steps:
    
1. a change to builddefs so that $(PCPLIB) can be set in a makefile and not clobbered here, allowing libpcp_fault to be used in place of libpcp when building an instrumented application
2. the symbol __pmFault_Arm needs to be exported from libpcp_fault as the PCP_FAULT_* macros reference this variable (which is a static inside libpcp_fault)
3. changes to pmlogmv.c to conditionally include "fault.h" and add the fault insertion points
4. a new qa/1699 to trigger the fault injections and test the results
5. fixup for install-dev because for libpcp_fault the library is really  libpcp_fault, but the pkg-config libdir can only be found using libpcp