### PR TITLE
libpcp_web: fix truncated timespec strings

### DIFF
--- a/src/libpcp_web/src/util.c
+++ b/src/libpcp_web/src/util.c
@@ -88,7 +88,7 @@ timespec_str(struct timespec *tvp, char *buffer, int buflen)
     time_t	now = (time_t)tvp->tv_sec;
 
     pmLocaltime(&now, &tmp);
-    pmsprintf(buffer, sizeof(buflen), "%02u:%02u:%02u.%09u",
+    pmsprintf(buffer, buflen, "%02u:%02u:%02u.%09u",
 	      tmp.tm_hour, tmp.tm_min, tmp.tm_sec, (unsigned int)tvp->tv_nsec);
     return buffer;
 }


### PR DESCRIPTION
Pass the caller-provided buffer length to pmsprintf instead of sizeof(buflen). Since buflen is an int, sizeof(buflen) is typically four bytes, limiting the output to three characters plus the null terminator.

For a minor change.