### PR TITLE
qa: big refactor for _service usage [Part 2 of 2 redo for commit 40641f731]

### DIFF
--- a/qa/041
+++ b/qa/041
@@ -85,12 +85,12 @@ $sudo cp $tmp.tmp $PCP_PMLOGGERCONTROL_PATH
 # I have no idea why this is required, but this test run
 # after 040 sometimes produces garbled messages unless
 # this is done!
-if ! _service pmlogger stop >$tmp.out 2>$tmp.err; then _exit 1; fi
+if ! _service pmlogger stop >$tmp.out 2>$tmp.err; then cat $tmp.err $tmp.out; _exit 1; fi
 _wait_pmlogger_end || _exit 1
 cat $tmp.out >>$seq_full
 _filter_pcp_stop <$tmp.out
 cat $tmp.err
-if ! _service pmcd stop >$tmp.out 2>$tmp.err; then _exit 1; fi
+if ! _service pmcd stop >$tmp.out 2>$tmp.err; then cat $tmp.err $tmp.out; _exit 1; fi
 _wait_pmcd_end || _exit 1
 cat $tmp.out >>$seq_full
 _filter_pcp_stop <$tmp.out

--- a/qa/1000
+++ b/qa/1000
@@ -77,11 +77,11 @@ pmdumptext -s 1 -h no.such.host.pcp.io 'proc.psinfo.utime[12345]'
 
 _stop_auto_restart pmcd
 _stop_auto_restart pmlogger
-if ! _service pmlogger stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmlogger_end || _exit 1
-if ! _service pmcd stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmcd_end || _exit 1
 echo
 echo "=== pmcd not running, default case ==="

--- a/qa/1034
+++ b/qa/1034
@@ -37,7 +37,8 @@ pmdanamed_install()
     # start from known starting points
     cd $PCP_PMDAS_DIR/named
     $sudo ./Remove >/dev/null 2>&1
-    if ! _service pmcd stop 2>&1; then _exit 1; fi | _filter_pcp_stop
+    if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+    _filter_pcp_stop <$tmp.tmp
 
     echo
     echo "=== named agent installation ==="

--- a/qa/1041
+++ b/qa/1041
@@ -36,7 +36,8 @@ $python -c "import lxml" >/dev/null 2>&1
 
 # start libvirtd
 #
-if ! _service libvirtd start >$seq_full 2>&1; then _exit 1; fi
+if ! _service libvirtd start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 [ -e /var/run/libvirt/libvirt-sock-ro ] || _notrun "no socket, libvirtd not running?"
 
 status=1	# failure is the default!

--- a/qa/1055
+++ b/qa/1055
@@ -66,11 +66,11 @@ PMDA_PMCD_PATH=$PCP_PMDAS_DIR/pmcd/pmda_pmcd.$DSO_SUFFIX
 cp $PCP_PMCDCONF_PATH $tmp.pmcd.conf
 
 # start from a known starting point
-if ! _service pmlogger stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmlogger_end || _exit 1
-if ! _service pmcd stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmcd_end || _exit 1
 
 cat <<End-of-File >$tmp.tmp
@@ -82,11 +82,11 @@ End-of-File
 $sudo cp $tmp.tmp $PCP_PMCDCONF_PATH
 
 _writable_primary_logger
-if ! _service pmcd restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmcd || _exit 1
-if ! _service pmlogger restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 
 # Reset pmlogger

--- a/qa/1060
+++ b/qa/1060
@@ -68,7 +68,8 @@ pmie_was_running=false
 if $pmie_was_running
 then
     _stop_auto_restart pmie
-    if ! _service pmie stop >>$seq_full 2>&1; then _exit 1; fi
+    if ! _service pmie stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+    cat $tmp.tmp >>$seq_full
 fi
 
 # real QA test starts here
@@ -81,8 +82,8 @@ LOCALHOSTNAME n n $tmp/pmie/myhost/2017/02/12 -c config.default
 End-of-File
 $sudo cp $tmp.tmp ${PCP_PMIECONTROL_PATH}.d/qa-$seq
 
-if ! _service pmie restart; then _exit 1; fi \
-| _filter_pmie_start | sed -e '/Warning: .* not permanently enabled/d'
+if ! _service pmie restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pmie_start <$tmp.tmp | sed -e '/Warning: .* not permanently enabled/d'
 
 sleep 3
 

--- a/qa/1083
+++ b/qa/1083
@@ -42,21 +42,24 @@ _stop_auto_restart pmlogger
 # get to a known starting point as far as systemd is concerned
 #
 date >>$seq_full 2>&1
-if ! _service pmcd restart >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 date >>$seq_full 2>&1
 _wait_for_pmcd || _exit 1
 date >>$seq_full 2>&1
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '/[p]mcd|[P]PID( |$)' >>$seq_full
 
 # real QA test starts here
-if ! _service pmcd stop >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_for_pmcd_stop || _exit 1
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '/[p]mcd|[P]PID( |$)' >>$seq_full
 
 echo "expect failure ..."
 pmprobe hinv.ncpu
 
-if ! _service pmcd start >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmcd start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_for_pmcd || _exit 1
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '/[p]mcd|[P]PID( |$)' >>$seq_full
 

--- a/qa/1090
+++ b/qa/1090
@@ -85,10 +85,11 @@ _get_metrics()
 }
 
 _stop_auto_restart pmproxy
-if ! _service pmproxy stop >/dev/null 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
-if ! _service pmproxy start; then _exit 1; fi \
-| _filter_pmproxy_start
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pmproxy_start <$tmp.tmp
 _wait_for_pmproxy $port || _exit 1
 
 # real QA test starts here
@@ -105,7 +106,8 @@ _get_metrics $ctx1
 
 # kill off pmcd
 echo "Killing off pmcd ..."
-if ! _service pmcd stop 2>&1; then _exit 1; fi | _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 
 echo "Retrying first context ..."
 _get_metrics $ctx1
@@ -126,7 +128,8 @@ fi
 
 # start pmcd
 echo "Restarting pmcd ..."
-if ! _service pmcd start 2>&1; then _exit 1; fi | _filter_pcp_start
+if ! _service pmcd start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmcd || _exit 1
 
 ctx3=`_get_context`

--- a/qa/1146
+++ b/qa/1146
@@ -29,8 +29,8 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 pid=`_get_primary_logger_pid`
 echo "+++ at the start primary pmlogger pid = $pid" >>$seq_full
 _stop_auto_restart pmlogger
-if ! _service pmlogger stop; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmlogger_end $pid || _exit 1
 
 PCPQA_SYSTEMD=no; export PCPQA_SYSTEMD

--- a/qa/1147
+++ b/qa/1147
@@ -44,8 +44,8 @@ then
     exit
 fi
 _stop_auto_restart pmlogger
-if ! _service pmlogger stop; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmlogger_end $pid || _exit 1
 
 # real QA test starts here

--- a/qa/1148
+++ b/qa/1148
@@ -30,8 +30,8 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 pid=`_get_primary_logger_pid`
 echo "+++ before shutdown the primary pmlogger pid = $pid" >>$seq_full
 _stop_auto_restart pmlogger
-if ! _service pmlogger stop; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmlogger_end $pid || _exit 1
 pid=`_get_primary_logger_pid`
 echo "+++ after shutdown the primary pmlogger pid = $pid" >>$seq_full

--- a/qa/1196
+++ b/qa/1196
@@ -48,7 +48,8 @@ _cleanup()
 _fixup()
 {
     $sudo cp $PCP_PMCDCONF_PATH.$seq $PCP_PMCDCONF_PATH
-    if ! _service pmcd restart 2>&1; then _exit 1; fi | _filter_pcp_restart
+    if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+    _filter_pcp_restart <$tmp.tmp
     _wait_for_pmcd || _exit 1
 }
 

--- a/qa/1199
+++ b/qa/1199
@@ -24,7 +24,8 @@ status=1	# failure is the default!
 trap "_cleanup; exit \$status" 0 1 2 3 15
 
 _stop_auto_restart pmcd
-if ! _service pmcd restart 2>&1; then _exit 1; fi | _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 echo "initial pminfo ..." >>$seq_full
 pminfo -v -b 1000 >/dev/null 2>>$seq_full
 echo "done." >>$seq_full

--- a/qa/1200
+++ b/qa/1200
@@ -97,11 +97,11 @@ $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '/[p](mcd|mlogger)' >>$seq_full
 
 # stop pmcd, primary pmlogger
 #
-if ! _service pmlogger stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmlogger_end || _exit 1
-if ! _service pmcd stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmcd_end || _exit 1
 echo "pcp stop" >>$seq_full
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '/[p](mcd|mlogger)' >>$seq_full

--- a/qa/1201
+++ b/qa/1201
@@ -118,11 +118,11 @@ $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]PID|/[p](mcd|mlogger)' >>$seq_full
 # stop pmcd, and all pmloggers
 #
 echo "[`date`] pcp stop" >>$seq_full
-if ! _service pmlogger stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmlogger_end || _exit 1
-if ! _service pmcd stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmcd_end || _exit 1
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]PID|/[p](mcd|mlogger)' >>$seq_full
 

--- a/qa/1226
+++ b/qa/1226
@@ -104,7 +104,8 @@ _get_config pmie >$tmp.tmp || _exit 1
 pmie_state=`cat $tmp.tmp`
 rm -f $tmp.tmp
 [ "$pmie_state" = off ] && _change_config pmie on
-if ! _service pmie start >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmie start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
 # real QA test starts here
 

--- a/qa/1249
+++ b/qa/1249
@@ -140,7 +140,8 @@ _get_config pmie >$tmp.tmp || _exit 1
 pmie_state=`cat $tmp.tmp`
 rm -f $tmp.tmp
 [ "$pmie_state" = off ] && _change_config pmie on
-if ! _service pmie start >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmie start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
 # real QA test starts here
 echo '== -NV expect pmfind class to be used' | tee -a $seq_full

--- a/qa/1264
+++ b/qa/1264
@@ -4,6 +4,8 @@
 #
 # Copyright (c) 2024 Red Hat.
 #
+# check-group-exclude: ss pcp-ss
+#
 
 # 1286 is the bcc variant of this
 seq=`basename $0`

--- a/qa/1290
+++ b/qa/1290
@@ -235,7 +235,8 @@ End-of-File
 }
 
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]PID|/[p]mproxy( |$)' >>$seq_full
-if ! _service pmproxy stop >/dev/null 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 $sudo $signal -s KILL -a pmproxy >/dev/null 2>&1
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]PID|/[p]mproxy( |$)' >>$seq_full
 

--- a/qa/1295
+++ b/qa/1295
@@ -54,11 +54,11 @@ _filter()
 pminfo -f sample.dynamic >/dev/null 2>&1
 
 # real QA test starts here
-if ! _service pmcd restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmcd || _exit 1
-if ! _service pmlogger restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 
 

--- a/qa/1296
+++ b/qa/1296
@@ -56,9 +56,11 @@ PMCD_RECONNECT_TIMEOUT=1; export PMCD_RECONNECT_TIMEOUT
 pmie -c $tmp.config -l $tmp.log -U `id -un` >$tmp.out 2>&1 &
 pid=$!
 sleep 5
-if ! _service pmcd stop >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 sleep 5
-if ! _service pmcd restart >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 sleep 5
 kill -TERM $pid
 wait

--- a/qa/1304
+++ b/qa/1304
@@ -27,7 +27,8 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 
 # real QA test starts here
 _stop_auto_restart pmcd
-if ! _service pmcd stop 2>&1; then _exit 1; fi | _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmcd_end || _exit 1
 
 echo "Running pmstat in local context fallback mode"

--- a/qa/1362
+++ b/qa/1362
@@ -84,7 +84,8 @@ EOF
 
     $sudo mv $tmp.conf $CONF
     $sudo ./Remove >/dev/null 2>&1
-    if ! _service pmcd stop 2>&1; then _exit 1; fi | _filter_pcp_stop
+    if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+    _filter_pcp_stop <$tmp.tmp
 
     echo | tee -a $seq_full
     echo "=== postgresql agent installation ===" | tee -a $seq_full

--- a/qa/1369
+++ b/qa/1369
@@ -63,8 +63,8 @@ need_restore=true
 trap "_cleanup; exit \$status" 0 1 2 3 15
 
 _stop_auto_restart pmlogger
-if ! _service pmlogger stop; then _exit 1; fi \
-| _filter_pcp_stop \
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp \
 | sed -e '/pmlogger not running/d'
 
 # real QA test starts here

--- a/qa/1379
+++ b/qa/1379
@@ -131,8 +131,10 @@ echo "secure.enabled = true" >> $tmp.conf
 $sudo cp $tmp.conf $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 cat $tmp.conf >> $seq_full
 
-if ! _service pmproxy stop >/dev/null; then _exit 1; fi
-if ! _service pmproxy start >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_for_pmproxy || _exit 1
 cat $PCP_LOG_DIR/pmproxy/pmproxy.log >> $seq_full
 

--- a/qa/1388
+++ b/qa/1388
@@ -172,7 +172,7 @@ ls -l $tmp.passwd.db >>$seq_full
 $sudo -u $PCP_USER od -c $tmp.passwd.db >>$seq_full
 
 echo "Start pmcd with this shiny new sasldb"
-if ! _service pmcd restart 2>&1; then _exit 1; fi | tee -a $seq_full >$tmp.out
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi | tee -a $seq_full >$tmp.out
 _wait_for_pmcd || _exit 1
 
 if [ "$PCPQA_SYSTEMD" = yes ]
@@ -181,8 +181,10 @@ then
 fi
 
 echo "Start pmproxy with mandatory authentication"
-if ! _service pmproxy stop >/dev/null; then _exit 1; fi
-if ! _service pmproxy start >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
 echo "Start test Python PMDA to check if username is in per-context state"
 cd pmdas/test_python

--- a/qa/1388
+++ b/qa/1388
@@ -172,7 +172,8 @@ ls -l $tmp.passwd.db >>$seq_full
 $sudo -u $PCP_USER od -c $tmp.passwd.db >>$seq_full
 
 echo "Start pmcd with this shiny new sasldb"
-if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi | tee -a $seq_full >$tmp.out
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_for_pmcd || _exit 1
 
 if [ "$PCPQA_SYSTEMD" = yes ]

--- a/qa/1391
+++ b/qa/1391
@@ -170,7 +170,7 @@ ls -l $tmp.passwd.db >>$seq_full
 $sudo -u $PCP_USER od -c $tmp.passwd.db >>$seq_full
 
 echo "Start pmcd with this shiny new sasldb"
-if ! _service pmcd restart 2>&1; then _exit 1; fi | tee -a $seq_full >$tmp.out
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi | tee -a $seq_full >$tmp.out
 _wait_for_pmcd || _exit 1
 
 if [ "$PCPQA_SYSTEMD" = yes ]
@@ -179,8 +179,10 @@ then
 fi
 
 echo "Start pmproxy with mandatory authentication"
-if ! _service pmproxy stop >/dev/null; then _exit 1; fi
-if ! _service pmproxy start >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
 echo "Start test Python PMDA to check if username is in per-context state"
 cd pmdas/test_python

--- a/qa/1391
+++ b/qa/1391
@@ -170,7 +170,8 @@ ls -l $tmp.passwd.db >>$seq_full
 $sudo -u $PCP_USER od -c $tmp.passwd.db >>$seq_full
 
 echo "Start pmcd with this shiny new sasldb"
-if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi | tee -a $seq_full >$tmp.out
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_for_pmcd || _exit 1
 
 if [ "$PCPQA_SYSTEMD" = yes ]

--- a/qa/1401
+++ b/qa/1401
@@ -55,8 +55,10 @@ _filter_fetch()
 }
 
 # real QA test starts here
-if ! _service pmproxy stop >/dev/null; then _exit 1; fi
-if ! _service pmproxy start >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_for_pmproxy || _exit 1
 
 # curl maintains a connection when given multiple URLs

--- a/qa/1424
+++ b/qa/1424
@@ -100,8 +100,8 @@ _filter()
 $sudo cp $tmp.control $PCP_ETC_DIR/pcp/pmlogger/control.d/$seq
 cat $PCP_ETC_DIR/pcp/pmlogger/control.d/$seq >>$seq_full
 
-if ! _service pmlogger restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 
 # _wait_for_pmlogger does not quite cut the mustard here ... we

--- a/qa/1433
+++ b/qa/1433
@@ -49,15 +49,18 @@ echo "# Option added by PCP QA test $seq" > $tmp.local
 echo --timeseries >> $tmp.local
 $sudo cp $tmp.local $PCP_PMPROXYOPTIONS_PATH
 
-if ! _service pmproxy stop >/dev/null 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_pmproxy_end || _exit 1
 # give any running pmproxy a chance to shutdown cleanly
 #
 sleep 2
-if ! _service pmproxy start 2>&1; then _exit 1; fi | _filter_pmproxy_start
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pmproxy_start <$tmp.tmp
 _wait_for_pmproxy || _exit 1
 
-if ! _service pmproxy stop 2>&1; then _exit 1; fi | _filter_pmproxy_start
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pmproxy_start <$tmp.tmp
 _wait_pmproxy_end || _exit 1
 _filter_pmproxy_log < $PCP_LOG_DIR/pmproxy/pmproxy.log
 

--- a/qa/1441
+++ b/qa/1441
@@ -338,7 +338,8 @@ qa.heartbeat = hinv.ncpu > 0
    shell "echo \$(expr `cat /tmp/pmie-hb` + 1) >/tmp/pmie-hb";
 End-of-File
 $sudo cp $tmp.config $config
-if ! _service pmie restart >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmie restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_for_pmie || _exit 1
 
 if [ -f $PCP_RUN_DIR/pmie.pid ]

--- a/qa/1453
+++ b/qa/1453
@@ -64,7 +64,8 @@ _filter()
 
 if $pmie_was_running
 then
-    if ! _service pmie stop >>$seq_full 2>&1; then _exit 1; fi
+    if ! _service pmie stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 fi
 
 cd $PCP_LOG_DIR/pmie/`hostname`
@@ -90,8 +91,8 @@ $sudo chown $PCP_USER:$PCP_GROUP pmie.log
 echo "--- before ---" >>$seq_full
 ls -li >>$seq_full
 
-if ! _service pmie start 2>&1; then _exit 1; fi \
-| tee -a $seq_full \
+if ! _service pmie start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+tee -a $seq_full <$tmp.tmp \
 | _filter_pmie_start
 
 echo "--- after ---" >>$seq_full

--- a/qa/1466
+++ b/qa/1466
@@ -29,7 +29,8 @@ status=1	# failure is the default!
 trap "_cleanup; exit \$status" 0 1 2 3 15
 
 # real QA test starts here
-if ! _service pmcd restart 2>&1; then cat $tmp.tmp; _exit 1; fi >>$seq_full
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 # in a known clean systemd service state now
 _wait_for_pmcd || _exit 1
 pmcdpid=`_get_pids_by_name pmcd`

--- a/qa/1466
+++ b/qa/1466
@@ -29,7 +29,7 @@ status=1	# failure is the default!
 trap "_cleanup; exit \$status" 0 1 2 3 15
 
 # real QA test starts here
-if ! _service pmcd restart 2>&1; then _exit 1; fi >>$seq_full
+if ! _service pmcd restart 2>&1; then cat $tmp.tmp; _exit 1; fi >>$seq_full
 # in a known clean systemd service state now
 _wait_for_pmcd || _exit 1
 pmcdpid=`_get_pids_by_name pmcd`

--- a/qa/1482
+++ b/qa/1482
@@ -80,7 +80,8 @@ do
     case "$svc"
     in
 	pmcd)
-	    if ! _service $svc stop >>$seq_full 2>&1; then _exit 1; fi
+	    if ! _service $svc stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+	    cat $tmp.tmp >>$seq_full
 	    _wait_pmcd_end || _exit 1
 	    ;;
 
@@ -88,7 +89,8 @@ do
 	    if [ -f $PCP_RUN_DIR/pmlogger.pid ]
 	    then
 		pid=`cat $PCP_RUN_DIR/pmlogger.pid`
-		if ! _service $svc stop >>$seq_full 2>&1; then _exit 1; fi
+		if ! _service $svc stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+		cat $tmp.tmp >>$seq_full
 		_wait_pmlogger_end $pid || _exit 1
 	    fi
 	    ;;
@@ -97,7 +99,8 @@ do
 	    if [ -f $PCP_RUN_DIR/pmie.pid ]
 	    then
 		pmie_was_running=true
-		if ! _service $svc stop >>$seq_full 2>&1; then _exit 1; fi
+		if ! _service $svc stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+		cat $tmp.tmp >>$seq_full
 		_wait_pmie_end || _exit 1
 	    fi
 	    ;;
@@ -106,7 +109,8 @@ do
 	    if [ -f $PCP_RUN_DIR/pmproxy.pid ]
 	    then
 		pmproxy_was_running=true
-		if ! _service $svc stop >>$seq_full 2>&1; then _exit 1; fi
+		if ! _service $svc stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+		cat $tmp.tmp >>$seq_full
 		_wait_pmproxy_end || _exit 1
 	    fi
 	    ;;
@@ -119,22 +123,26 @@ do
     case "$svc"
     in
 	pmcd)
-	    if ! _service $svc start >>$seq_full 2>&1; then _exit 1; fi
+	    if ! _service $svc start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+	    cat $tmp.tmp >>$seq_full
 	    _wait_for_pmcd || _exit 1
 		;;
 
 	pmlogger)
-	    if ! _service $svc start >>$seq_full 2>&1; then _exit 1; fi
+	    if ! _service $svc start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+	    cat $tmp.tmp >>$seq_full
 	    _wait_for_pmlogger || _exit 1
 	    ;;
 
 	pmie)
-	    if ! _service $svc start >>$seq_full 2>&1; then _exit 1; fi
+	    if ! _service $svc start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+	    cat $tmp.tmp >>$seq_full
 	    _wait_for_pmie || _exit 1
 	    ;;
 
 	pmproxy)
-	    if ! _service $svc start >>$seq_full 2>&1; then _exit 1; fi
+	    if ! _service $svc start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+	    cat $tmp.tmp >>$seq_full
 	    _wait_for_pmproxy || _exit 1
 	    ;;
     esac
@@ -150,7 +158,8 @@ do
 	pmie)
 	    if $pmie_was_running
 	    then
-		if ! _service pmie start >>$seq_full 2>&1; then _exit 1; fi
+		if ! _service pmie start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+		cat $tmp.tmp >>$seq_full
 		_wait_for_pmie || _exit 1
 		pmie_was_running=false
 	    fi
@@ -159,7 +168,8 @@ do
 	pmproxy)
 	    if $pmproxy_was_running
 	    then
-		if ! _service pmproxy start >>$seq_full 2>&1; then _exit 1; fi
+		if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+		cat $tmp.tmp >>$seq_full
 		_wait_for_pmproxy || _exit 1
 		pmproxy_was_running=false
 	    fi

--- a/qa/1511
+++ b/qa/1511
@@ -49,7 +49,8 @@ PMDA_PMCD_PATH=$PCP_PMDAS_DIR/pmcd/pmda_pmcd.$DSO_SUFFIX
 
 _stop_auto_restart pmcd
 _stop_auto_restart pmlogger
-if ! _service pmcd stop >/dev/null 2>&1; then _exit 1; fi
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
 _save_config $PCP_PMCDCONF_PATH
 $sudo rm -f $PCP_PMCDCONF_PATH $PCP_PMCDCONF_PATH.access
@@ -68,8 +69,8 @@ disallow user $username : store;
 End-of-File
 $sudo cp $tmp.access $PCP_PMCDCONF_PATH.access
 
-if ! _service pmcd start; then _exit 1; fi \
-| _filter_pcp_start
+if ! _service pmcd start >$tmp.tmp 2>&1; then _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmcd 10 unix: || _exit 1
 
 cat $PCP_LOG_DIR/pmcd/pmcd.log >> $seq_full

--- a/qa/1511
+++ b/qa/1511
@@ -69,7 +69,7 @@ disallow user $username : store;
 End-of-File
 $sudo cp $tmp.access $PCP_PMCDCONF_PATH.access
 
-if ! _service pmcd start >$tmp.tmp 2>&1; then _exit 1; fi
+if ! _service pmcd start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
 _filter_pcp_start <$tmp.tmp
 _wait_for_pmcd 10 unix: || _exit 1
 

--- a/qa/1543
+++ b/qa/1543
@@ -204,8 +204,10 @@ echo "http.enabled = true" >> $tmp.conf
 $sudo cp $tmp.conf $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 
 _stop_auto_restart pmproxy
-if ! _service pmproxy stop >/dev/null; then _exit 1; fi
-if ! _service pmproxy start >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_for_pmproxy || _exit 1
 
 echo "After initial _service start ..." >>$seq_full

--- a/qa/1544
+++ b/qa/1544
@@ -70,8 +70,10 @@ echo "pmproxy_was_running=$pmproxy_was_running" >>$seq_full
 
 # real QA test starts here
 # start pmproxy
-if ! _service pmproxy stop >/dev/null; then _exit 1; fi
-if ! _service pmproxy start >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 port=44322
 
 # start test Python PMDA

--- a/qa/1562
+++ b/qa/1562
@@ -66,7 +66,8 @@ cp $PCP_PMCDCONF_PATH $tmp.pmcd.conf
 echo "# Installed by PCP QA test $seq on `date`" >$tmp.tmp
 sed -e '/^sample[ 	]/s/^/#/' <$PCP_PMCDCONF_PATH >>$tmp.tmp
 $sudo cp $tmp.tmp $PCP_PMCDCONF_PATH
-if ! _service pmcd restart 2>&1; then _exit 1; fi | _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 
 # real QA test starts here
 

--- a/qa/1573
+++ b/qa/1573
@@ -73,7 +73,8 @@ echo "[pmseries]" >> $tmp.conf
 echo "enabled = false" >> $tmp.conf
 $sudo cp $tmp.conf $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 
-if ! _service pmlogger stop >/dev/null; then _exit 1; fi
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
 # move aside existing logs so we can measure base memory footprint
 [ -d $PCP_LOG_DIR/pmlogger.$seq ] && $sudo mv $PCP_LOG_DIR/pmlogger.$seq $PCP_LOG_DIR/pmlogger.$seq.saved
@@ -82,7 +83,8 @@ $sudo mkdir -p $PCP_LOG_DIR/pmlogger
 $sudo chmod 775 $PCP_LOG_DIR/pmlogger
 $sudo chown $PCP_USER:$PCP_USER $PCP_LOG_DIR/pmlogger
 
-if ! _service pmproxy restart >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmproxy restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_for_pmproxy || _exit 1
 
 pmproxy_pid=`_get_pids_by_name -a pmproxy`
@@ -100,7 +102,8 @@ then
 fi
 
 echo === restarting pmlogger # primary only
-if ! _service pmlogger restart 2>&1; then _exit 1; fi | _filter_pcp_restart
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 
 echo === wait for pmproxy to process filesystem events

--- a/qa/1602
+++ b/qa/1602
@@ -65,7 +65,8 @@ _filter_key_server_err()
 }
 
 _stop_auto_restart pmproxy
-if ! _service pmproxy stop >/dev/null 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_pmproxy_end || _exit 1
 
 # real QA test starts here

--- a/qa/1608
+++ b/qa/1608
@@ -46,7 +46,8 @@ _webapi_failure_filter()
 }
 
 # real QA test starts here
-if ! _service pmproxy restart >/dev/null 2>&1; then _exit 1; fi
+if ! _service pmproxy restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
 url="http://localhost:44322/pmapi/context"
 aaa=`head -c 10000 < /dev/zero | tr '\0' '\141'`

--- a/qa/1611
+++ b/qa/1611
@@ -82,7 +82,8 @@ date +TIME:%X.%N >>$seq_full
 _save_config $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 
 _stop_auto_restart pmproxy
-if ! _service pmproxy stop >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
 $sudo rm -fr $archive_path $archive_botch
 
@@ -101,7 +102,8 @@ enabled = false
 End-Of-File
 $sudo cp $tmp.conf $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 
-if ! _service pmproxy start 2>&1; then _exit 1; fi | _filter_pmproxy_start
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pmproxy_start <$tmp.tmp
 _wait_for_pmproxy || _exit 1
 
 PCP_DERIVED_CONFIG=""; export PCP_DERIVED_CONFIG

--- a/qa/1615
+++ b/qa/1615
@@ -95,7 +95,8 @@ echo "pmproxy_was_running=$pmproxy_was_running" >>$seq_full
 _save_config $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 
 _stop_auto_restart pmproxy
-if ! _service pmproxy stop >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
 cat >$tmp.local << End-Of-File
 # Installed by PCP QA test $seq on `date`
@@ -110,7 +111,8 @@ enabled = false
 End-Of-File
 $sudo cp $tmp.local $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 
-if ! _service pmproxy start 2>&1; then _exit 1; fi | _filter_pmproxy_start
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pmproxy_start <$tmp.tmp
 _wait_for_pmproxy || _exit 1
 
 if $do_valgrind

--- a/qa/1619
+++ b/qa/1619
@@ -36,7 +36,8 @@ echo Inode0: $inode0 >> $seq_full
 cp $PCP_PMCDCONF_PATH $tmp.save
 cat $PCP_PMCDCONF_PATH >> $seq_full
 
-if ! _service pmcd restart 2>&1; then _exit 1; fi | _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmcd || _exit 1
 _wait_for_pmlogger || _exit 1
 

--- a/qa/1620
+++ b/qa/1620
@@ -90,7 +90,8 @@ echo "pmproxy_was_running=$pmproxy_was_running" >>$seq_full
 _save_config $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 
 _stop_auto_restart pmproxy
-if ! _service pmproxy stop >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
 $sudo rm -fr $archive_path $archive_botch
 
@@ -109,7 +110,8 @@ enabled = false
 End-Of-File
 $sudo cp $tmp.conf $PCP_SYSCONF_DIR/pmproxy/pmproxy.conf
 
-if ! _service pmproxy start 2>&1; then _exit 1; fi | _filter_pmproxy_start
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pmproxy_start <$tmp.tmp
 _wait_for_pmproxy || _exit 1
 pmproxy_pid=`cat $PCP_RUN_DIR/pmproxy.pid`
 

--- a/qa/1624
+++ b/qa/1624
@@ -33,18 +33,18 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 
 echo "Silence is golden ..."
 
-if ! _service pmlogger stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmlogger_end || _exit 1
-if ! _service pmcd stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmcd_end || _exit 1
 
-if ! _service pmcd start 2>&1; then _exit 1; fi \
-| _filter_pcp_start
+if ! _service pmcd start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmcd || _exit 1
-if ! _service pmlogger start 2>&1; then _exit 1; fi \
-| _filter_pcp_start
+if ! _service pmlogger start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 
 # success, all done

--- a/qa/1626
+++ b/qa/1626
@@ -69,9 +69,11 @@ $sudo cp $tmp.options $PCP_SYSCONF_DIR/pmproxy/pmproxy.options
 status=0
 
 # need a fresh pmproxy service
-if ! _service pmproxy stop >/dev/null 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_pmproxy_end || _exit 1
-if ! _service pmproxy start 2>&1; then _exit 1; fi | _filter_pmproxy_start
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pmproxy_start <$tmp.tmp
 _wait_for_pmproxy || _exit 1
 
 echo == wait for pmproxy server metrics | tee -a $seq_full

--- a/qa/1661
+++ b/qa/1661
@@ -105,10 +105,12 @@ LOCALHOST=`hostname`
 # only want the primary logger running
 _save_config $PCP_ETC_DIR/pcp/pmlogger
 _restore_pmlogger_control
-if ! _service pmlogger stop 2>&1; then _exit 1; fi | _filter_pcp_stop
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 
 _full_log === restarting pmproxy service to ensure sane starting condition 
-if ! _service pmproxy restart 2>&1; then _exit 1; fi | _filter_pcp_restart
+if ! _service pmproxy restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmproxy || _exit 1
 
 pmproxy_pid=`_get_pids_by_name -a pmproxy`
@@ -171,7 +173,8 @@ done
 src/time_stamp $tmp.stamp 'compression' >>$seq_full
 
 _full_log === restarting pmlogger # primary only
-if ! _service pmlogger restart 2>&1; then _exit 1; fi | _filter_pcp_restart
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 src/time_stamp $tmp.stamp 'restart pmcd & pmlogger' >>$seq_full
 
@@ -261,7 +264,8 @@ fi
 src/time_stamp $tmp.stamp 'found new volume #' >>$seq_full
 
 _full_log === checking pmproxy survives pmlogger restart
-if ! _service pmlogger restart 2>&1; then _exit 1; fi | _filter_pcp_restart
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 $sudo [ ! -d /proc/$pmproxy_pid/fd/ ] && echo FAIL && exit
 echo passed

--- a/qa/1672
+++ b/qa/1672
@@ -114,11 +114,11 @@ ls -l $tmp.passwd.db >>$seq_full
 $sudo -u $PCP_USER od -c $tmp.passwd.db >>$seq_full
 
 echo "Start pmcd with this shiny new sasldb"
-if ! _service pmcd restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmcd || _exit 1
-if ! _service pmlogger restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 
 for method in $mechanisms

--- a/qa/1680
+++ b/qa/1680
@@ -39,8 +39,8 @@ pmdaopenvswitch_install()
     # start from known starting points
     cd $PCP_PMDAS_DIR/openvswitch
     $sudo ./Remove >/dev/null 2>&1
-    if ! _service pmcd stop; then _exit 1; fi \
-    | _filter_pcp_stop
+    if ! _service pmcd stop >$tmp.tmp 2>&1; then _exit 1; fi
+    _filter_pcp_stop <$tmp.tmp
 
     echo
     echo "=== openvswitch agent installation ==="

--- a/qa/1680
+++ b/qa/1680
@@ -39,7 +39,7 @@ pmdaopenvswitch_install()
     # start from known starting points
     cd $PCP_PMDAS_DIR/openvswitch
     $sudo ./Remove >/dev/null 2>&1
-    if ! _service pmcd stop >$tmp.tmp 2>&1; then _exit 1; fi
+    if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
     _filter_pcp_stop <$tmp.tmp
 
     echo

--- a/qa/1727
+++ b/qa/1727
@@ -24,7 +24,8 @@ then
     pmproxy_was_running=true
 else
     pmproxy_was_running=false
-    if ! _service pmproxy start >>$seq_full 2>&1; then _exit 1; fi
+    if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+    cat $tmp.tmp >>$seq_full
 fi
 echo "pmproxy_was_running=$pmproxy_was_running" >>$seq_full
 

--- a/qa/1770
+++ b/qa/1770
@@ -177,12 +177,15 @@ EOF
 
 echo "Start pmcd with this shiny new sasldb and no access"
 $sudo cp $tmp.nobody $PCP_SYSCONF_DIR/proc/access.conf
-if ! _service pmcd restart 2>&1; then _exit 1; fi | tee -a $seq_full >$tmp.out
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_for_pmcd || _exit 1
 
 echo "Start pmproxy with mandatory authentication"
-if ! _service pmproxy stop >/dev/null; then _exit 1; fi
-if ! _service pmproxy start >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
+if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
 test "$PCPQA_SYSTEMD" = yes && $sudo systemctl daemon-reload
 
@@ -197,7 +200,8 @@ echo
 
 echo "Restart pmcd with this sasldb and remote auth mode"
 $sudo cp $tmp.remote $PCP_SYSCONF_DIR/proc/access.conf
-if ! _service pmcd restart 2>&1; then _exit 1; fi | tee -a $seq_full >$tmp.out
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_for_pmcd || _exit 1
 
 _test_log "Establish context for authenticated local user"
@@ -220,7 +224,8 @@ echo
 
 echo "Restart pmcd with this sasldb and mapped auth mode"
 $sudo cp $tmp.mapped $PCP_SYSCONF_DIR/proc/access.conf
-if ! _service pmcd restart 2>&1; then _exit 1; fi | tee -a $seq_full >$tmp.out
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 _wait_for_pmcd || _exit 1
 
 _test_log "Establish context for authenticated user"

--- a/qa/1837
+++ b/qa/1837
@@ -40,7 +40,8 @@ _cleanup()
 }
 
 # real QA test starts here
-if ! _service pmproxy restart >/dev/null 2>&1; then _exit 1; fi
+if ! _service pmproxy restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 
 echo; echo "=== OPTIONS"
 curl -isS -X OPTIONS --request-target "*" http://localhost:44322 \

--- a/qa/1843
+++ b/qa/1843
@@ -51,8 +51,8 @@ sed < $PCP_PMCDCONF_PATH \
         -e "/^$iam.*/s/$/ -R 1/" \
         > $tmp.conf
 $sudo cp $tmp.conf $PCP_PMCDCONF_PATH
-if ! _service pmcd restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 sleep 2
 
 if ! _pmdaopentelemetry_wait_for_metric opentelemetry.simplemetric

--- a/qa/1855
+++ b/qa/1855
@@ -34,8 +34,8 @@ pmdarabbitmq_install()
     # start from known starting points
     cd $PCP_PMDAS_DIR/rabbitmq
     $sudo ./Remove >/dev/null 2>&1
-    if ! _service pmcd stop; then _exit 1; fi \
-    | _filter_pcp_stop
+    if ! _service pmcd stop >$tmp.tmp 2>&1; then _exit 1; fi
+    _filter_pcp_stop <$tmp.tmp
 
     echo
     echo "=== rabbitmq agent installation ==="

--- a/qa/1855
+++ b/qa/1855
@@ -34,7 +34,7 @@ pmdarabbitmq_install()
     # start from known starting points
     cd $PCP_PMDAS_DIR/rabbitmq
     $sudo ./Remove >/dev/null 2>&1
-    if ! _service pmcd stop >$tmp.tmp 2>&1; then _exit 1; fi
+    if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
     _filter_pcp_stop <$tmp.tmp
 
     echo

--- a/qa/1889
+++ b/qa/1889
@@ -50,8 +50,8 @@ echo "=== disable pmlogger.service" | tee -a $seq_full
 $sudo systemctl disable pmlogger.service >>$seq_full 2>&1
 
 echo === start primary logger whilst disabled ===
-if ! _service pmlogger start; then _exit 1; fi \
-| _filter_pcp_start
+if ! _service pmlogger start >$tmp.tmp 2>&1; then _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 
 newpid=`$PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep '/[p]mlogger.*-P' | \

--- a/qa/1889
+++ b/qa/1889
@@ -50,7 +50,7 @@ echo "=== disable pmlogger.service" | tee -a $seq_full
 $sudo systemctl disable pmlogger.service >>$seq_full 2>&1
 
 echo === start primary logger whilst disabled ===
-if ! _service pmlogger start >$tmp.tmp 2>&1; then _exit 1; fi
+if ! _service pmlogger start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
 _filter_pcp_start <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 

--- a/qa/1890
+++ b/qa/1890
@@ -24,7 +24,8 @@ then
     pmproxy_was_running=true
 else
     pmproxy_was_running=false
-    if ! _service pmproxy start >>$seq_full 2>&1; then _exit 1; fi
+    if ! _service pmproxy start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+    cat $tmp.tmp >>$seq_full
 fi
 echo "pmproxy_was_running=$pmproxy_was_running" >>$seq_full
 

--- a/qa/1956
+++ b/qa/1956
@@ -34,7 +34,8 @@ _save_config $PCP_PMCDCONF_PATH
 
 # append -A option to the pmdalinux line
 $sudo sed -i -e '/^\(linux.*pmdalinux.*\)$/s//\1 -A/' $PCP_PMCDCONF_PATH
-if ! _service pmcd restart 2>&1; then _exit 1; fi | _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmcd || _exit 1
 
 # check access, stash for later

--- a/qa/1976
+++ b/qa/1976
@@ -51,8 +51,8 @@ sed < $PCP_PMCDCONF_PATH \
         -e "/^$iam.*/s/$/ -R 1/" \
         > $tmp.conf
 $sudo cp $tmp.conf $PCP_PMCDCONF_PATH
-if ! _service pmcd restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 sleep 2
 
 if ! _pmdaopenmetrics_wait_for_metric openmetrics.thermostat

--- a/qa/1992
+++ b/qa/1992
@@ -48,8 +48,8 @@ pmdauwsgi_install()
     # start from known starting points
     cd $PCP_PMDAS_DIR/$iam
     $sudo ./Remove >/dev/null 2>&1
-    if ! _service pmcd stop; then _exit 1; fi \
-    | _filter_pcp_stop
+    if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+    _filter_pcp_stop <$tmp.tmp
 
     echo
     echo "=== $iam check post-install ==="

--- a/qa/510
+++ b/qa/510
@@ -83,14 +83,16 @@ echo "Stop/start at beginning ... " `date` >>$seq_full
 _check_pmlogger_lock
 _remove_job_scheduler $tmp.cron $tmp.systemd $sudo
 _check_pmlogger_lock
-if ! _service pmlogger stop >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 echo "Stop/start done " `date` >>$seq_full
 
 sed -e '/^LOCALHOSTNAME/s/$/ -Dlog/' < $control >$tmp.control
 _save_config $control
 $sudo cp $tmp.control $control
 _writable_primary_logger
-if ! _service pmlogger start 2>&1; then _exit 1; fi | _filter_pcp_start
+if ! _service pmlogger start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 _check_pmlogger_lock
 

--- a/qa/522
+++ b/qa/522
@@ -29,11 +29,11 @@ _stop_auto_restart pmlogger
 # real QA test starts here
 $sudo rm -f "$PCP_TMPFILE_DIR"/*.pmcheck
 _change_config pmlogger on || _exit 1
-if ! _service pmcd restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmcd || _exit 1
-if ! _service pmlogger restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 
 # and wait some more for other pmloggers and stuff pmlogger_check will

--- a/qa/535
+++ b/qa/535
@@ -31,11 +31,11 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 
 # real QA test starts here
 
-if ! _service pmcd restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmcd || _exit 1
-if ! _service pmlogger restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 
 # prime the sample PMDA to refresh the dynamic indom

--- a/qa/541
+++ b/qa/541
@@ -35,11 +35,11 @@ trap "_cleanup; exit \$status" 0 1 2 3 15
 
 [ -f $control ] && $sudo mv $control $control.$seq
 
-if ! _service pmcd restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmcd || _exit 1
-if ! _service pmlogger restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 
 # prime the sample PMDA to refresh the dynamic indom

--- a/qa/557
+++ b/qa/557
@@ -25,11 +25,11 @@ HOST=`hostname`
 
 # real QA test starts here
 
-if ! _service pmlogger stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmlogger_end || _exit 1
-if ! _service pmcd stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmcd_end || _exit 1
 
 pmie -t 1sec $DEBUG << End-of-File >$tmp.log 2>&1 &
@@ -38,11 +38,11 @@ pmcd.numclients > 0
 End-of-File
 
 sleep 3
-if ! _service pmcd restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmcd || _exit 1
-if ! _service pmlogger restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 
 sleep 10

--- a/qa/558
+++ b/qa/558
@@ -47,19 +47,19 @@ some_host
 End-of-File
 
 sleep 3
-if ! _service pmlogger stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmlogger_end || _exit 1
-if ! _service pmcd stop 2>&1; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 _wait_pmcd_end || _exit 1
 
 sleep 10
-if ! _service pmcd start 2>&1; then _exit 1; fi \
-| _filter_pcp_start
+if ! _service pmcd start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmcd || _exit 1
-if ! _service pmlogger start 2>&1; then _exit 1; fi \
-| _filter_pcp_start
+if ! _service pmlogger start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 sleep 12
 $signal -s TERM $!

--- a/qa/572
+++ b/qa/572
@@ -101,12 +101,12 @@ cp $rootconf $tmp.root.bak
 needclean=true
 $sudo cp $tmp.pmcd.conf $pmcdconf 
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]PID|/[p]mcd( |$)' >>$seq_full
-if ! _service pmcd restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmcd || _exit 1
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]PID|/[p]mcd( |$)' >>$seq_full
-if ! _service pmlogger restart 2>&1; then _exit 1; fi \
-| _filter_pcp_restart
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 $PCP_PS_PROG $PCP_PS_ALL_FLAGS | grep -E '[P]PID|/[p]mcd( |$)' >>$seq_full
 

--- a/qa/575
+++ b/qa/575
@@ -42,7 +42,8 @@ then
     pmie_was_running=true
     echo "Found pmie PID `cat $PCP_RUN_DIR/pmie.pid` running @ start" >>$seq_full
     _stop_auto_restart pmie
-    if ! _service pmie stop >>$seq_full 2>&1; then _exit 1; fi
+    if ! _service pmie stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+    cat $tmp.tmp >>$seq_full
 fi
 $sudo $signal -a pmie >/dev/null 2>&1
 _wait_pmie_end || _exit 1
@@ -56,15 +57,15 @@ _change_config pmie on || _exit 1
 # And the "Waiting for pmie process(es) to terminate ..." message
 # depends on the platform and the state of the system.
 #
-if ! _service pmie stop; then _exit 1; fi \
-| _filter_pmie_stop \
+if ! _service pmie stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pmie_stop <$tmp.tmp \
 | sed \
     -e '/pmie not running/d' \
     -e '/Waiting for pmie process/d' \
 # end
 
-if ! _service pmie start; then _exit 1; fi \
-| _filter_pmie_start
+if ! _service pmie start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pmie_start <$tmp.tmp
 
 # success, all done
 status=0

--- a/qa/578
+++ b/qa/578
@@ -157,16 +157,18 @@ export PMCD_PORT
 # don't want these guys trying to connect to pmcd either ...
 #
 _stop_auto_restart pmlogger
-if ! _service pmlogger stop >>$seq_full 2>&1; then _exit 1; fi
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 if $pmie_was_running
 then
     _stop_auto_restart pmie
-    if ! _service pmie stop >>$seq_full 2>&1; then _exit 1; fi
+    if ! _service pmie stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+    cat $tmp.tmp >>$seq_full
 fi
 
 # and we're starting a new pmcd ...
-if ! _service pmcd stop; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 
 # Build simple agent
 #

--- a/qa/581
+++ b/qa/581
@@ -98,9 +98,10 @@ $sudo cp $tmp.indom $control
 _stop_auto_restart pmcd
 _stop_auto_restart pmlogger
 _disable_loggers || _exit 1
-if ! _service pmlogger stop; then _exit 1; fi \
-| _filter_pcp_stop
-if ! _service pmcd restart 2>&1; then _exit 1; fi | _filter_pcp_restart
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_restart <$tmp.tmp
 _wait_for_pmcd || _exit 1
 pminfo -f sample.dynamic.instant | _filter
 echo
@@ -118,10 +119,11 @@ sleep_stop=5
 # and again with the same instances
 #
 sleep $sleep_stop
-if ! _service pmcd stop; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 sleep $sleep_start
-if ! _service pmcd start 2>&1; then _exit 1; fi | _filter_pcp_start
+if ! _service pmcd start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmcd || _exit 1
 pminfo -f sample.dynamic.instant |_filter
 echo
@@ -129,8 +131,8 @@ echo
 # instances - mk II
 #
 sleep $sleep_stop
-if ! _service pmcd stop; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 cat >$tmp.indom <<End-of-File
 20 twenty
 25 twenty-five
@@ -143,7 +145,8 @@ cat >$tmp.indom <<End-of-File
 End-of-File
 $sudo cp $tmp.indom $control
 sleep $sleep_start
-if ! _service pmcd start 2>&1; then _exit 1; fi | _filter_pcp_start
+if ! _service pmcd start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmcd || _exit 1
 pminfo -f sample.dynamic.instant |_filter
 echo
@@ -151,8 +154,8 @@ echo
 # instances - mk III
 #
 sleep $sleep_stop
-if ! _service pmcd stop; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 cat >$tmp.indom <<End-of-File
 07 seven
 08 eight
@@ -163,7 +166,8 @@ cat >$tmp.indom <<End-of-File
 End-of-File
 $sudo cp $tmp.indom $control
 sleep $sleep_start
-if ! _service pmcd start 2>&1; then _exit 1; fi | _filter_pcp_start
+if ! _service pmcd start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmcd || _exit 1
 pminfo -f sample.dynamic.instant |_filter
 echo
@@ -171,13 +175,14 @@ echo
 # instances - mk IV
 #
 sleep $sleep_stop
-if ! _service pmcd stop; then _exit 1; fi \
-| _filter_pcp_stop
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_stop <$tmp.tmp
 cat >$tmp.indom <<End-of-File
 End-of-File
 $sudo cp $tmp.indom $control
 sleep $sleep_start
-if ! _service pmcd start 2>&1; then _exit 1; fi | _filter_pcp_start
+if ! _service pmcd start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmcd || _exit 1
 pminfo -f sample.dynamic.instant |_filter
 echo

--- a/qa/583
+++ b/qa/583
@@ -111,9 +111,9 @@ fi
 $sudo rm -f core* $seq.core*
 
 if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
-_filter_pcp_start <$tmp.tmp
+_filter_pcp_stop <$tmp.tmp
 if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
-_filter_pcp_start <$tmp.tmp
+_filter_pcp_stop <$tmp.tmp
 _wait_pmcd_end || _exit 1
 
 # note the following is time sensitive, run it too long

--- a/qa/583
+++ b/qa/583
@@ -110,9 +110,10 @@ fi
 # real QA test starts here
 $sudo rm -f core* $seq.core*
 
-if ! _service pmcd stop 2>&1; then _exit 1; fi | _filter_pcp_start
-if ! _service pmlogger stop; then _exit 1; fi \
-| _filter_pcp_start
+if ! _service pmcd stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
+if ! _service pmlogger stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_pmcd_end || _exit 1
 
 # note the following is time sensitive, run it too long
@@ -138,10 +139,11 @@ pmie -t 1sec >$tmp.out 2>$tmp.err <$tmp.in &
 pmie_pid=$!
 
 sleep 5
-if ! _service pmcd start 2>&1; then _exit 1; fi | _filter_pcp_start
+if ! _service pmcd start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmcd || _exit 1
-if ! _service pmlogger start; then _exit 1; fi \
-| _filter_pcp_start
+if ! _service pmlogger start >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+_filter_pcp_start <$tmp.tmp
 _wait_for_pmlogger || _exit 1
 
 sleep 15

--- a/qa/587
+++ b/qa/587
@@ -134,14 +134,14 @@ esac
 _save_config $PCP_PMCDCONF_PATH
 $sudo cp $tmp.conf $PCP_PMCDCONF_PATH
 echo "=== initial restart pmcd" >>$seq_full
-if ! _service pmcd restart 2>&1; then _exit 1; fi \
-| tee -a $seq_full \
+if ! _service pmcd restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+tee -a $seq_full <$tmp.tmp \
 | _filter_pcp_restart \
 | _filter
 _wait_for_pmcd || _exit 1
 echo "=== initial restart pmlogger" >>$seq_full
-if ! _service pmlogger restart 2>&1; then _exit 1; fi \
-| tee -a $seq_full \
+if ! _service pmlogger restart >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+tee -a $seq_full <$tmp.tmp \
 | _filter_pcp_restart \
 | _filter
 _wait_for_pmlogger || _exit 1

--- a/qa/713
+++ b/qa/713
@@ -60,7 +60,8 @@ _filter_pcp_stop <$tmp.tmp
 _wait_pmcd_end || _exit 1
 
 # pmcd is now secure.  next, pmproxy...
-if ! _service pmproxy stop >/dev/null 2>&1; then cat $tmp.tmp; _exit 1; fi
+if ! _service pmproxy stop >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
+cat $tmp.tmp >>$seq_full
 $sudo $signal -a pmproxy >/dev/null 2>&1
 
 _filter_tls()


### PR DESCRIPTION
@coderrabbitai noticed an issue with one of my qa test changes as an "outside scope of diff" issue.  In a nutshell we (me?)  had this sort of thing:
    if ! _service ... | _some_filter; then _exit 1; fi
which is 100% broken because the _exit 1 only happens if _some_filter has non-zero exit, and the return value from _service is ignored.

The only thing that saved the ship from sinking is that _service only fails when a much bigger wheel has fallen off and that very rarely happens and is most unlikely to go unnoticed.

This should be something like:
    if ! _service >$tmp.tmp 2>&1; then cat $tmp.tmp; _exit 1; fi
    _some_filter <$tmp.tmp
