### PR TITLE
Fix of pcp-atop conflict with atop on Fedora

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -794,7 +794,7 @@ License: GPL-2.0-or-later
 Summary: Performance Co-Pilot (PCP) System and Monitoring Tools
 URL: https://pcp.io
 Requires: pcp = @package_version@ pcp-libs = @package_version@
-Requires: pcp-atop = @package_version@
+Recommends: pcp-atop = @package_version@
 Requires: pcp-htop = @package_version@
 Obsoletes: pcp-system-tools-debuginfo < @package_version@
 %if "@have_python@" == "true"
@@ -814,8 +814,6 @@ License: GPL-2.0-or-later
 Summary: Performance Co-Pilot (PCP) top-like system and process monitor
 URL: https://pcp.io
 Requires: pcp-libs = %{version}-%{release}
-Provides: atop = @package_version@
-Obsoletes: atop <= 2.12
 Conflicts: atop
 
 %description atop

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -3547,5 +3547,5 @@ fi
 %files zeroconf -f pcp-zeroconf-files.rpm
 
 %changelog
-* Wed Aug 07 2026 Jan Kurik <jkurik@redhat.com> - 7.2.0-2
+* Fri Aug 07 2026 Jan Kurik <jkurik@redhat.com> - 7.2.0-2
 - Fixed pcp-atop conflict with atop

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -1,6 +1,6 @@
 Name:    pcp
-Version: 7.2.1
-Release: 1%{?dist}
+Version: 7.2.0
+Release: 2%{?dist}
 Summary: System-level performance monitoring and performance management
 License: GPL-2.0-or-later AND LGPL-2.1-or-later AND CC-BY-3.0
 URL:     https://pcp.io
@@ -2163,7 +2163,7 @@ License: GPL-2.0-or-later
 Summary: Performance Co-Pilot (PCP) System and Monitoring Tools
 URL: https://pcp.io
 Requires: pcp = %{version}-%{release} pcp-libs = %{version}-%{release}
-Requires: pcp-atop = %{version}-%{release}
+Recommends: pcp-atop = %{version}-%{release}
 Requires: pcp-htop = %{version}-%{release}
 Obsoletes: pcp-system-tools-debuginfo < %{version}-%{release}
 %if !%{disable_python3}
@@ -2183,8 +2183,6 @@ License: GPL-2.0-or-later
 Summary: Performance Co-Pilot (PCP) top-like system and process monitor
 URL: https://pcp.io
 Requires: pcp-libs = %{version}-%{release}
-Provides: atop = %{version}-%{release}
-Obsoletes: atop <= 2.12
 Conflicts: atop
 
 %description atop
@@ -3549,5 +3547,5 @@ fi
 %files zeroconf -f pcp-zeroconf-files.rpm
 
 %changelog
-* Wed Sep 30 2026 Lauren Chilton <lchilton@redhat.com> - 7.2.1-1
-- Latest release.
+* Wed Aug 07 2026 Jan Kurik <jkurik@redhat.com> - 7.2.0-2
+- Fixed pcp-atop conflict with atop


### PR DESCRIPTION
Make pcp-atop as optional dependency on RPM based distributions to allow users with installed atop to update PCP while keeping the already installed atop.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2510602