### PR TITLE
libpcp_web: fix double-free in pmwebapi_labelsetdup

### DIFF
--- a/src/libpcp_web/src/util.c
+++ b/src/libpcp_web/src/util.c
@@ -883,6 +883,7 @@ pmwebapi_labelsetdup(pmLabelSet *lp)
     dup->hash = NULL;
     dup->compound = 0;
     if (lp->nlabels <= 0 || lp->json == NULL) {
+	dup->nlabels = 0;
 	dup->json = NULL;
 	dup->jsonlen = 0;
 	dup->labels = NULL;

--- a/src/libpcp_web/src/util.c
+++ b/src/libpcp_web/src/util.c
@@ -880,8 +880,14 @@ pmwebapi_labelsetdup(pmLabelSet *lp)
     if ((dup = calloc(1, sizeof(pmLabelSet))) == NULL)
 	return NULL;
     *dup = *lp;
-    if (lp->nlabels <= 0)
+    dup->hash = NULL;
+    dup->compound = 0;
+    if (lp->nlabels <= 0 || lp->json == NULL) {
+	dup->json = NULL;
+	dup->jsonlen = 0;
+	dup->labels = NULL;
 	return dup;
+    }
     if ((json = strdup(lp->json)) == NULL) {
 	free(dup);
 	return NULL;


### PR DESCRIPTION
pmwebapi_labelsetdup() performs a shallow struct copy (*dup = *lp) and then selectively deep-copies json and labels — but only when nlabels > 0.  Two problems:

1. When nlabels <= 0 (or json is NULL), the dup shares the json pointer with the source.  When pmDiscoverInvokeLabelsCallBacks frees the source labelset after invoking callbacks, the stored duplicate retains the dangling pointer.  The next label discovery cycle frees the old duplicate, double-freeing the json allocation.

2. The compound flag and hash pointer were never handled — if set, the dup shares the opaque hash with the source, again leading to a double-free via pmFreeLabelSets.

Fix both by clearing compound/hash immediately after the struct copy and, for the nlabels <= 0 / NULL-json case, NULLing json, jsonlen and labels before returning.  This matches what __pmDupLabelSets in libpcp already does correctly for the same cases.

Resolves a pmproxy SIGABRT (double-free) in archive discovery:
  pmFreeLabelSets ← pmSeriesDiscoverLabels ← pmDiscoverInvokeLabelsCallBacks

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Fixes: #2686 