### PR TITLE
pmdalmsensors, qa/1480: handle sensor read failures gracefully

### DIFF
--- a/qa/1480
+++ b/qa/1480
@@ -93,7 +93,7 @@ END				{ print int(sum+0.5) }'`
 echo "pminfo -f lmsensors output:" >> $seq_full
 
 PMDA=`pminfo -f lmsensors | tee -a $seq_full | grep '^  *value ' | \
-	awk '{ sum += $2 } END { print sum }'`
+	awk '{ sum += $2 } END { print sum+0 }'`
 
 if _within_tolerance "Expecting $SENS +- 10%" $PMDA $SENS 10%; then
     echo -n "The output of the 'sensors -u' values differs not more than 10% "

--- a/src/pmdas/lmsensors/pmdalmsensors.python
+++ b/src/pmdas/lmsensors/pmdalmsensors.python
@@ -53,7 +53,13 @@ def lmsensors_get(chip=None):
             if chip:
                 cmd.append(chip)
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=devnull)
-            output = json.loads(re.sub("[0-9]_", "_", p.communicate()[0].decode("utf-8")))
+            raw = p.communicate()[0].decode("utf-8")
+            try:
+                output = json.loads(re.sub("[0-9]_", "_", raw))
+            except (json.JSONDecodeError, ValueError):
+                if chip:
+                    return
+                raise
 
         if args.debug_value and args.debug_value >= 0:
             print("function lmsensors_get(), json object after removing redundant naming:\n", output)


### PR DESCRIPTION
When sensors -j is called for a specific chip (e.g. NVMe) and the device returns EAGAIN, the empty or invalid output causes json.loads() to raise an exception, crashing the fetch callback. Catch JSON parse errors during fetch and preserve the last known sensor values instead.

At init time (no chip filter), re-raise the exception so the PMDA fails loudly rather than silently starting with zero metrics.

Also harden the QA test: ensure the awk sum is always numeric so _within_tolerance does not receive empty arguments.

Relates: #2665