### PR TITLE
Fix build on older RHEL and CentOS release

### DIFF
--- a/build/rpm/pcp.spec.in
+++ b/build/rpm/pcp.spec.in
@@ -794,7 +794,9 @@ License: GPL-2.0-or-later
 Summary: Performance Co-Pilot (PCP) System and Monitoring Tools
 URL: https://pcp.io
 Requires: pcp = @package_version@ pcp-libs = @package_version@
+%if 0%{?rhel} == 0 || 0%{?rhel} > 7
 Recommends: pcp-atop = @package_version@
+%endif
 Requires: pcp-htop = @package_version@
 Obsoletes: pcp-system-tools-debuginfo < @package_version@
 %if "@have_python@" == "true"

--- a/build/rpm/redhat.spec
+++ b/build/rpm/redhat.spec
@@ -1,6 +1,6 @@
 Name:    pcp
-Version: 7.2.0
-Release: 2%{?dist}
+Version: 7.2.1
+Release: 1%{?dist}
 Summary: System-level performance monitoring and performance management
 License: GPL-2.0-or-later AND LGPL-2.1-or-later AND CC-BY-3.0
 URL:     https://pcp.io
@@ -2163,7 +2163,9 @@ License: GPL-2.0-or-later
 Summary: Performance Co-Pilot (PCP) System and Monitoring Tools
 URL: https://pcp.io
 Requires: pcp = %{version}-%{release} pcp-libs = %{version}-%{release}
+%if 0%{?rhel} == 0 || 0%{?rhel} > 7
 Recommends: pcp-atop = %{version}-%{release}
+%endif
 Requires: pcp-htop = %{version}-%{release}
 Obsoletes: pcp-system-tools-debuginfo < %{version}-%{release}
 %if !%{disable_python3}
@@ -3547,5 +3549,5 @@ fi
 %files zeroconf -f pcp-zeroconf-files.rpm
 
 %changelog
-* Fri Aug 07 2026 Jan Kurik <jkurik@redhat.com> - 7.2.0-2
-- Fixed pcp-atop conflict with atop
+* Fri Aug 14 2026 Jan Kurik <jkurik@redhat.com> - 7.2.1-1
+- Update to the latest upstream release


### PR DESCRIPTION
Older RHEL and CentOS releases do not support `Recommends` directive.