### PR TITLE
pcp-ps: optimize initial reporting and archive samples

### DIFF
--- a/qa/1987.out
+++ b/qa/1987.out
@@ -3,6 +3,262 @@ QA output created by 1987
 pcp-ps output : Display default output
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
 Timestamp        PID		TIME		CMD
+06:20:30         1       	00:00:01	systemd             
+06:20:30         2       	00:00:00	kthreadd            
+06:20:30         3       	00:00:00	rcu_gp              
+06:20:30         4       	00:00:00	rcu_par_gp          
+06:20:30         5       	00:00:00	kworker/0:0-cgroup_p
+06:20:30         6       	00:00:00	kworker/0:0H-events_
+06:20:30         7       	00:00:00	kworker/u8:0-events_
+06:20:30         8       	00:00:00	kworker/0:1H-events_
+06:20:30         9       	00:00:00	mm_percpu_wq        
+06:20:30         10      	00:00:00	ksoftirqd/0         
+06:20:30         11      	00:00:00	rcu_sched           
+06:20:30         12      	00:00:00	migration/0         
+06:20:30         13      	00:00:00	kworker/0:1-events  
+06:20:30         14      	00:00:00	cpuhp/0             
+06:20:30         15      	00:00:00	cpuhp/1             
+06:20:30         16      	00:00:00	migration/1         
+06:20:30         17      	00:00:00	ksoftirqd/1         
+06:20:30         18      	00:00:00	kworker/1:0-cgroup_p
+06:20:30         19      	00:00:00	kworker/1:0H-events_
+06:20:30         20      	00:00:00	cpuhp/2             
+06:20:30         21      	00:00:00	migration/2         
+06:20:30         22      	00:00:00	ksoftirqd/2         
+06:20:30         23      	00:00:00	kworker/2:0-events  
+06:20:30         24      	00:00:00	kworker/2:0H-events_
+06:20:30         25      	00:00:00	cpuhp/3             
+06:20:30         26      	00:00:00	migration/3         
+06:20:30         27      	00:00:00	ksoftirqd/3         
+06:20:30         28      	00:00:00	kworker/3:0-events  
+06:20:30         29      	00:00:00	kworker/3:0H-events_
+06:20:30         31      	00:00:00	kworker/u8:1-events_
+06:20:30         32      	00:00:00	kworker/u8:2-events_
+06:20:30         33      	00:00:00	kworker/u8:3-events_
+06:20:30         34      	00:00:00	kdevtmpfs           
+06:20:30         35      	00:00:00	netns               
+06:20:30         36      	00:00:00	kauditd             
+06:20:30         37      	00:00:00	khungtaskd          
+06:20:30         38      	00:00:00	oom_reaper          
+06:20:30         39      	00:00:00	writeback           
+06:20:30         40      	00:00:00	kcompactd0          
+06:20:30         41      	00:00:00	ksmd                
+06:20:30         42      	00:00:00	khugepaged          
+06:20:30         44      	00:00:00	kworker/3:1-events  
+06:20:30         97      	00:00:00	kintegrityd         
+06:20:30         98      	00:00:00	kblockd             
+06:20:30         99      	00:00:00	blkcg_punt_bio      
+06:20:30         100     	00:00:00	tpm_dev_wq          
+06:20:30         101     	00:00:00	md                  
+06:20:30         102     	00:00:00	edac-poller         
+06:20:30         103     	00:00:00	devfreq_wq          
+06:20:30         104     	00:00:00	watchdogd           
+06:20:30         105     	00:00:00	kworker/2:1-mm_percp
+06:20:30         107     	00:00:00	kswapd0:0           
+06:20:30         109     	00:00:00	kthrotld            
+06:20:30         110     	00:00:00	acpi_thermal_pm     
+06:20:30         111     	00:00:00	kmpath_rdacd        
+06:20:30         112     	00:00:00	kaluad              
+06:20:30         113     	00:00:00	kworker/3:1H-events_
+06:20:30         114     	00:00:00	bch_btree_io        
+06:20:30         115     	00:00:00	bcache              
+06:20:30         116     	00:00:00	bch_journal         
+06:20:30         117     	00:00:00	ipv6_addrconf       
+06:20:30         118     	00:00:00	dsa_ordered         
+06:20:30         119     	00:00:00	kworker/0:2-cgroup_p
+06:20:30         120     	00:00:00	kstrp               
+06:20:30         125     	00:00:00	kworker/u9:0        
+06:20:30         127     	00:00:00	kworker/1:1-ata_sff 
+06:20:30         135     	00:00:00	charger_manager     
+06:20:30         186     	00:00:00	kworker/3:2-events  
+06:20:30         189     	00:00:00	kworker/1:2-events  
+06:20:30         191     	00:00:00	kworker/1:3-cgroup_d
+06:20:30         194     	00:00:00	kworker/0:3-cgroup_p
+06:20:30         344     	00:00:00	iprt-VBoxWQueue     
+06:20:30         345     	00:00:00	kworker/2:1H-events_
+06:20:30         346     	00:00:00	ata_sff             
+06:20:30         347     	00:00:00	scsi_eh_0           
+06:20:30         351     	00:00:00	scsi_tmf_0          
+06:20:30         352     	00:00:00	scsi_eh_1           
+06:20:30         353     	00:00:00	scsi_tmf_1          
+06:20:30         366     	00:00:00	scsi_eh_2           
+06:20:30         367     	00:00:00	scsi_tmf_2          
+06:20:30         369     	00:00:00	kworker/1:1H-events_
+06:20:30         371     	00:00:00	irq/18-vmwgfx       
+06:20:30         372     	00:00:00	ttm_swap            
+06:20:30         441     	00:00:00	kdmflush            
+06:20:30         452     	00:00:00	kdmflush            
+06:20:30         467     	00:00:00	kworker/3:3-xfs-buf/
+06:20:30         473     	00:00:00	kworker/2:2-cgroup_p
+06:20:30         477     	00:00:00	kworker/2:3-cgroup_d
+06:20:30         478     	00:00:00	xfsalloc            
+06:20:30         479     	00:00:00	xfs_mru_cache       
+06:20:30         481     	00:00:00	xfs-buf/dm-0        
+06:20:30         482     	00:00:00	xfs-conv/dm-0       
+06:20:30         483     	00:00:00	xfs-cil/dm-0        
+06:20:30         484     	00:00:00	xfs-reclaim/dm-     
+06:20:30         485     	00:00:00	xfs-eofblocks/d     
+06:20:30         486     	00:00:00	xfs-log/dm-0        
+06:20:30         487     	00:00:00	xfsaild/dm-0        
+06:20:30         555     	00:00:00	kworker/2:4-events  
+06:20:30         585     	00:00:00	systemd-journal     
+06:20:30         624     	00:00:00	systemd-udevd       
+06:20:30         655     	00:00:00	cryptd              
+06:20:30         696     	00:00:00	kdmflush            
+06:20:30         751     	00:00:00	xfs-buf/dm-2        
+06:20:30         752     	00:00:00	xfs-conv/dm-2       
+06:20:30         753     	00:00:00	xfs-cil/dm-2        
+06:20:30         754     	00:00:00	xfs-buf/sda1        
+06:20:30         755     	00:00:00	xfs-conv/sda1       
+06:20:30         756     	00:00:00	xfs-reclaim/dm-     
+06:20:30         757     	00:00:00	xfs-cil/sda1        
+06:20:30         758     	00:00:00	xfs-eofblocks/d     
+06:20:30         759     	00:00:00	xfs-reclaim/sda     
+06:20:30         760     	00:00:00	xfs-eofblocks/s     
+06:20:30         761     	00:00:00	xfs-log/dm-2        
+06:20:30         762     	00:00:00	xfsaild/dm-2        
+06:20:30         763     	00:00:00	xfs-log/sda1        
+06:20:30         764     	00:00:00	xfsaild/sda1        
+06:20:30         786     	00:00:00	rpcbind             
+06:20:30         788     	00:00:00	auditd              
+06:20:30         790     	00:00:00	sedispatch          
+06:20:30         800     	00:00:00	rpciod              
+06:20:30         801     	00:00:00	xprtiod             
+06:20:30         816     	00:00:00	mcelog              
+06:20:30         818     	00:00:00	dbus-daemon         
+06:20:30         820     	00:00:00	polkitd             
+06:20:30         821     	00:00:00	irqbalance          
+06:20:30         826     	00:00:00	rtkit-daemon        
+06:20:30         827     	00:00:00	alsactl             
+06:20:30         829     	00:00:00	avahi-daemon        
+06:20:30         830     	00:00:00	lsmd                
+06:20:30         834     	00:00:00	systemd-machine     
+06:20:30         835     	00:00:00	udisksd             
+06:20:30         838     	00:00:00	sssd                
+06:20:30         840     	00:00:00	smartd              
+06:20:30         857     	00:00:00	chronyd             
+06:20:30         860     	00:00:00	ksmtuned            
+06:20:30         864     	00:00:00	vpnagentd           
+06:20:30         868     	00:00:00	avahi-daemon        
+06:20:30         877     	00:00:00	sssd_be             
+06:20:30         884     	00:00:00	firewalld           
+06:20:30         885     	00:00:00	ModemManager        
+06:20:30         897     	00:00:00	sssd_nss            
+06:20:30         941     	00:00:00	systemd-logind      
+06:20:30         946     	00:00:00	accounts-daemon     
+06:20:30         1106    	00:00:00	NetworkManager      
+06:20:30         1117    	00:00:00	sshd                
+06:20:30         1119    	00:00:00	cupsd               
+06:20:30         1120    	00:00:02	tuned               
+06:20:30         1125    	00:00:00	gssproxy            
+06:20:30         1150    	00:00:00	iscsid              
+06:20:30         1151    	00:00:00	rsyslogd            
+06:20:30         1176    	00:00:00	iscsi_eh            
+06:20:30         1192    	00:00:00	crond               
+06:20:30         1193    	00:00:00	kworker/0:4-cgroup_p
+06:20:30         1194    	00:00:00	atd                 
+06:20:30         1624    	00:00:00	pmcd                
+06:20:30         1633    	00:00:00	pmdaroot            
+06:20:30         1650    	00:00:00	pmdaproc            
+06:20:30         1666    	00:00:00	pmdaxfs             
+06:20:30         1682    	00:00:00	pmdalinux           
+06:20:30         1690    	00:00:00	python3             
+06:20:30         1754    	00:00:00	pmdakvm             
+06:20:30         1761    	00:00:00	pmdadm              
+06:20:30         1767    	00:00:00	python3             
+06:20:30         2407    	00:00:00	dnsmasq             
+06:20:30         2410    	00:00:00	dnsmasq             
+06:20:30         2501    	00:00:00	pmie                
+06:20:30         2508    	00:00:00	pmlogger            
+06:20:30         2516    	00:00:00	pmpause             
+06:20:30         2684    	00:00:00	pmpause             
+06:20:30         2937    	00:00:00	gdm                 
+06:20:30         2953    	00:00:00	VBoxService         
+06:20:30         4956    	00:00:00	upowerd             
+06:20:30         4964    	00:00:00	geoclue             
+06:20:30         4977    	00:00:00	wpa_supplicant      
+06:20:30         4978    	00:00:05	packagekitd         
+06:20:30         5059    	00:00:00	colord              
+06:20:30         5150    	00:00:00	kworker/3:4-cgroup_p
+06:20:30         5714    	00:00:00	gdm-session-wor     
+06:20:30         5729    	00:00:00	systemd             
+06:20:30         5731    	00:00:00	(sd-pam)            
+06:20:30         5757    	00:00:00	gnome-keyring-d     
+06:20:30         5764    	00:00:00	gdm-wayland-ses     
+06:20:30         5766    	00:00:00	dbus-daemon         
+06:20:30         5769    	00:00:00	gnome-session-b     
+06:20:30         5857    	00:00:07	gnome-shell         
+06:20:30         5901    	00:00:00	gvfsd               
+06:20:30         5908    	00:00:00	gvfsd-fuse          
+06:20:30         5916    	00:00:00	Xwayland            
+06:20:30         5927    	00:00:00	at-spi-bus-laun     
+06:20:30         5938    	00:00:00	dbus-daemon         
+06:20:30         5945    	00:00:00	at-spi2-registr     
+06:20:30         5963    	00:00:00	ibus-daemon         
+06:20:30         5967    	00:00:00	ibus-dconf          
+06:20:30         5968    	00:00:00	xdg-permission-     
+06:20:30         5970    	00:00:00	ibus-extension-     
+06:20:30         5976    	00:00:00	ibus-x11            
+06:20:30         5979    	00:00:00	ibus-portal         
+06:20:30         5993    	00:00:00	gnome-shell-cal     
+06:20:30         5999    	00:00:00	evolution-sourc     
+06:20:30         6005    	00:00:00	goa-daemon          
+06:20:30         6014    	00:00:00	gvfs-udisks2-vo     
+06:20:30         6023    	00:00:00	gvfs-mtp-volume     
+06:20:30         6030    	00:00:00	gvfs-gphoto2-vo     
+06:20:30         6034    	00:00:00	goa-identity-se     
+06:20:30         6042    	00:00:00	gvfs-goa-volume     
+06:20:30         6050    	00:00:00	gvfs-afc-volume     
+06:20:30         6055    	00:00:00	sssd_kcm            
+06:20:30         6057    	00:00:00	gsd-power           
+06:20:30         6058    	00:00:00	gsd-print-notif     
+06:20:30         6060    	00:00:00	gsd-rfkill          
+06:20:30         6062    	00:00:00	gsd-screensaver     
+06:20:30         6064    	00:00:00	gsd-sharing         
+06:20:30         6072    	00:00:00	gsd-sound           
+06:20:30         6078    	00:00:00	gsd-xsettings       
+06:20:30         6082    	00:00:00	gsd-wacom           
+06:20:30         6085    	00:00:00	evolution-calen     
+06:20:30         6087    	00:00:00	gsd-smartcard       
+06:20:30         6088    	00:00:00	gsd-account         
+06:20:30         6111    	00:00:00	gsd-a11y-settin     
+06:20:30         6113    	00:00:00	ibus-engine-sim     
+06:20:30         6115    	00:00:00	pulseaudio          
+06:20:30         6122    	00:00:00	gsd-clipboard       
+06:20:30         6126    	00:00:00	gsd-color           
+06:20:30         6128    	00:00:00	gsd-datetime        
+06:20:30         6131    	00:00:00	gsd-housekeepin     
+06:20:30         6132    	00:00:00	gsd-keyboard        
+06:20:30         6138    	00:00:00	gsd-media-keys      
+06:20:30         6142    	00:00:00	gsd-mouse           
+06:20:30         6188    	00:00:00	evolution-calen     
+06:20:30         6216    	00:00:00	evolution-addre     
+06:20:30         6217    	00:00:00	dconf-service       
+06:20:30         6219    	00:00:00	tracker-store       
+06:20:30         6224    	00:00:01	gnome-software      
+06:20:30         6230    	00:00:00	gsd-disk-utilit     
+06:20:30         6243    	00:00:00	tracker-miner-a     
+06:20:30         6252    	00:00:00	gsd-printer         
+06:20:30         6254    	00:00:00	tracker-miner-f     
+06:20:30         6288    	00:00:00	VBoxClient          
+06:20:30         6294    	00:00:00	evolution-addre     
+06:20:30         6297    	00:00:00	VBoxClient          
+06:20:30         6324    	00:00:00	VBoxClient          
+06:20:30         6325    	00:00:00	VBoxClient          
+06:20:30         6334    	00:00:00	VBoxClient          
+06:20:30         6335    	00:00:00	VBoxClient          
+06:20:30         6342    	00:00:00	VBoxClient          
+06:20:30         6343    	00:00:00	VBoxDRMClient       
+06:20:30         6432    	00:00:00	fwupd               
+06:20:30         6834    	00:00:00	gnome-terminal-     
+06:20:30         6839    	00:00:00	bash                
+06:20:30         6941    	00:00:00	kworker/1:4-cgroup_p
+06:20:30         8571    	00:00:00	gvfsd-metadata      
+06:20:30         9308    	00:00:00	sleep               
+06:20:30         9327    	00:00:00	mk.ps               
+06:20:30         9344    	00:00:00	pmlogger            
+06:20:30         9349    	00:00:00	tracker-extract     
+Timestamp        PID		TIME		CMD
 06:20:31         1       	00:00:01	systemd             
 06:20:31         2       	00:00:00	kthreadd            
 06:20:31         3       	00:00:00	rcu_gp              
@@ -19540,6 +19796,262 @@ Timestamp        PID		TIME		CMD
 pcp-ps output : Display all process and all archive data
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
 Timestamp        PID			TTY	TIME		CMD
+06:20:30         1       		?	00:00:01	/usr/lib/systemd/systemd --switched-root --system --deserialize 18
+06:20:30         2       		?	00:00:00	(kthreadd)
+06:20:30         3       		?	00:00:00	(rcu_gp)
+06:20:30         4       		?	00:00:00	(rcu_par_gp)
+06:20:30         5       		?	00:00:00	(kworker/0:0-cgroup_pidlist_destroy)
+06:20:30         6       		?	00:00:00	(kworker/0:0H-events_highpri)
+06:20:30         7       		?	00:00:00	(kworker/u8:0-events_unbound)
+06:20:30         8       		?	00:00:00	(kworker/0:1H-kblockd)
+06:20:30         9       		?	00:00:00	(mm_percpu_wq)
+06:20:30         10      		?	00:00:00	(ksoftirqd/0)
+06:20:30         11      		?	00:00:00	(rcu_sched)
+06:20:30         12      		?	00:00:00	(migration/0)
+06:20:30         13      		?	00:00:00	(kworker/0:1-xfs-buf/dm-0)
+06:20:30         14      		?	00:00:00	(cpuhp/0)
+06:20:30         15      		?	00:00:00	(cpuhp/1)
+06:20:30         16      		?	00:00:00	(migration/1)
+06:20:30         17      		?	00:00:00	(ksoftirqd/1)
+06:20:30         18      		?	00:00:00	(kworker/1:0-events)
+06:20:30         19      		?	00:00:00	(kworker/1:0H-events_highpri)
+06:20:30         20      		?	00:00:00	(cpuhp/2)
+06:20:30         21      		?	00:00:00	(migration/2)
+06:20:30         22      		?	00:00:00	(ksoftirqd/2)
+06:20:30         23      		?	00:00:00	(kworker/2:0-cgroup_pidlist_destroy)
+06:20:30         24      		?	00:00:00	(kworker/2:0H-events_highpri)
+06:20:30         25      		?	00:00:00	(cpuhp/3)
+06:20:30         26      		?	00:00:00	(migration/3)
+06:20:30         27      		?	00:00:00	(ksoftirqd/3)
+06:20:30         28      		?	00:00:00	(kworker/3:0-events)
+06:20:30         29      		?	00:00:00	(kworker/3:0H-events_highpri)
+06:20:30         31      		?	00:00:00	(kworker/u8:1-events_unbound)
+06:20:30         32      		?	00:00:00	(kworker/u8:2-events_unbound)
+06:20:30         33      		?	00:00:00	(kworker/u8:3)
+06:20:30         34      		?	00:00:00	(kdevtmpfs)
+06:20:30         35      		?	00:00:00	(netns)
+06:20:30         36      		?	00:00:00	(kauditd)
+06:20:30         37      		?	00:00:00	(khungtaskd)
+06:20:30         38      		?	00:00:00	(oom_reaper)
+06:20:30         39      		?	00:00:00	(writeback)
+06:20:30         40      		?	00:00:00	(kcompactd0)
+06:20:30         41      		?	00:00:00	(ksmd)
+06:20:30         42      		?	00:00:00	(khugepaged)
+06:20:30         44      		?	00:00:00	(kworker/3:1-events)
+06:20:30         97      		?	00:00:00	(kintegrityd)
+06:20:30         98      		?	00:00:00	(kblockd)
+06:20:30         99      		?	00:00:00	(blkcg_punt_bio)
+06:20:30         100     		?	00:00:00	(tpm_dev_wq)
+06:20:30         101     		?	00:00:00	(md)
+06:20:30         102     		?	00:00:00	(edac-poller)
+06:20:30         103     		?	00:00:00	(devfreq_wq)
+06:20:30         104     		?	00:00:00	(watchdogd)
+06:20:30         105     		?	00:00:00	(kworker/2:1-events)
+06:20:30         107     		?	00:00:00	(kswapd0:0)
+06:20:30         109     		?	00:00:00	(kthrotld)
+06:20:30         110     		?	00:00:00	(acpi_thermal_pm)
+06:20:30         111     		?	00:00:00	(kmpath_rdacd)
+06:20:30         112     		?	00:00:00	(kaluad)
+06:20:30         113     		?	00:00:00	(kworker/3:1H-events_highpri)
+06:20:30         114     		?	00:00:00	(bch_btree_io)
+06:20:30         115     		?	00:00:00	(bcache)
+06:20:30         116     		?	00:00:00	(bch_journal)
+06:20:30         117     		?	00:00:00	(ipv6_addrconf)
+06:20:30         118     		?	00:00:00	(dsa_ordered)
+06:20:30         119     		?	00:00:00	(kworker/0:2-events)
+06:20:30         120     		?	00:00:00	(kstrp)
+06:20:30         125     		?	00:00:00	(kworker/u9:0)
+06:20:30         127     		?	00:00:00	(kworker/1:1-events)
+06:20:30         135     		?	00:00:00	(charger_manager)
+06:20:30         186     		?	00:00:00	(kworker/3:2-cgroup_pidlist_destroy)
+06:20:30         189     		?	00:00:00	(kworker/1:2-events)
+06:20:30         191     		?	00:00:00	(kworker/1:3-events)
+06:20:30         194     		?	00:00:00	(kworker/0:3-events)
+06:20:30         344     		?	00:00:00	(iprt-VBoxWQueue)
+06:20:30         345     		?	00:00:00	(kworker/2:1H-xfs-log/dm-0)
+06:20:30         346     		?	00:00:00	(ata_sff)
+06:20:30         347     		?	00:00:00	(scsi_eh_0)
+06:20:30         351     		?	00:00:00	(scsi_tmf_0)
+06:20:30         352     		?	00:00:00	(scsi_eh_1)
+06:20:30         353     		?	00:00:00	(scsi_tmf_1)
+06:20:30         366     		?	00:00:00	(scsi_eh_2)
+06:20:30         367     		?	00:00:00	(scsi_tmf_2)
+06:20:30         369     		?	00:00:00	(kworker/1:1H-kblockd)
+06:20:30         371     		?	00:00:00	(irq/18-vmwgfx)
+06:20:30         372     		?	00:00:00	(ttm_swap)
+06:20:30         441     		?	00:00:00	(kdmflush)
+06:20:30         452     		?	00:00:00	(kdmflush)
+06:20:30         467     		?	00:00:00	(kworker/3:3-events)
+06:20:30         473     		?	00:00:00	(kworker/2:2-cgroup_pidlist_destroy)
+06:20:30         477     		?	00:00:00	(kworker/2:3-cgroup_destroy)
+06:20:30         478     		?	00:00:00	(xfsalloc)
+06:20:30         479     		?	00:00:00	(xfs_mru_cache)
+06:20:30         481     		?	00:00:00	(xfs-buf/dm-0)
+06:20:30         482     		?	00:00:00	(xfs-conv/dm-0)
+06:20:30         483     		?	00:00:00	(xfs-cil/dm-0)
+06:20:30         484     		?	00:00:00	(xfs-reclaim/dm-)
+06:20:30         485     		?	00:00:00	(xfs-eofblocks/d)
+06:20:30         486     		?	00:00:00	(xfs-log/dm-0)
+06:20:30         487     		?	00:00:00	(xfsaild/dm-0)
+06:20:30         555     		?	00:00:00	(kworker/2:4-events)
+06:20:30         585     		?	00:00:00	/usr/lib/systemd/systemd-journald
+06:20:30         624     		?	00:00:00	/usr/lib/systemd/systemd-udevd
+06:20:30         655     		?	00:00:00	(cryptd)
+06:20:30         696     		?	00:00:00	(kdmflush)
+06:20:30         751     		?	00:00:00	(xfs-buf/dm-2)
+06:20:30         752     		?	00:00:00	(xfs-conv/dm-2)
+06:20:30         753     		?	00:00:00	(xfs-cil/dm-2)
+06:20:30         754     		?	00:00:00	(xfs-buf/sda1)
+06:20:30         755     		?	00:00:00	(xfs-conv/sda1)
+06:20:30         756     		?	00:00:00	(xfs-reclaim/dm-)
+06:20:30         757     		?	00:00:00	(xfs-cil/sda1)
+06:20:30         758     		?	00:00:00	(xfs-eofblocks/d)
+06:20:30         759     		?	00:00:00	(xfs-reclaim/sda)
+06:20:30         760     		?	00:00:00	(xfs-eofblocks/s)
+06:20:30         761     		?	00:00:00	(xfs-log/dm-2)
+06:20:30         762     		?	00:00:00	(xfsaild/dm-2)
+06:20:30         763     		?	00:00:00	(xfs-log/sda1)
+06:20:30         764     		?	00:00:00	(xfsaild/sda1)
+06:20:30         786     		?	00:00:00	/usr/bin/rpcbind -w -f
+06:20:30         788     		?	00:00:00	/sbin/auditd
+06:20:30         790     		?	00:00:00	/usr/sbin/sedispatch
+06:20:30         800     		?	00:00:00	(rpciod)
+06:20:30         801     		?	00:00:00	(xprtiod)
+06:20:30         816     		?	00:00:00	/usr/sbin/mcelog --ignorenodev --daemon --foreground
+06:20:30         818     		?	00:00:00	/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
+06:20:30         820     		?	00:00:00	/usr/lib/polkit-1/polkitd --no-debug
+06:20:30         821     		?	00:00:00	/usr/sbin/irqbalance --foreground
+06:20:30         826     		?	00:00:00	/usr/libexec/rtkit-daemon
+06:20:30         827     		?	00:00:00	/usr/sbin/alsactl -s -n 19 -c -E ALSA_CONFIG_PATH=/etc/alsa/alsactl.conf --initfile=/lib/alsa/init/00main rdaemon
+06:20:30         829     		?	00:00:00	avahi-daemon: running [linux.local]
+06:20:30         830     		?	00:00:00	/usr/bin/lsmd -d
+06:20:30         834     		?	00:00:00	/usr/lib/systemd/systemd-machined
+06:20:30         835     		?	00:00:00	/usr/libexec/udisks2/udisksd
+06:20:30         838     		?	00:00:00	/usr/sbin/sssd -i --logger=files
+06:20:30         840     		?	00:00:00	/usr/sbin/smartd -n -q never
+06:20:30         857     		?	00:00:00	/usr/sbin/chronyd
+06:20:30         860     		?	00:00:00	/bin/bash /usr/sbin/ksmtuned
+06:20:30         864     		?	00:00:00	/opt/cisco/anyconnect/bin/vpnagentd -execv_instance
+06:20:30         868     		?	00:00:00	avahi-daemon: chroot helper
+06:20:30         877     		?	00:00:00	/usr/libexec/sssd/sssd_be --domain implicit_files --uid 0 --gid 0 --logger=files
+06:20:30         884     		?	00:00:00	/usr/libexec/platform-python -s /usr/sbin/firewalld --nofork --nopid
+06:20:30         885     		?	00:00:00	/usr/sbin/ModemManager
+06:20:30         897     		?	00:00:00	/usr/libexec/sssd/sssd_nss --uid 0 --gid 0 --logger=files
+06:20:30         941     		?	00:00:00	/usr/lib/systemd/systemd-logind
+06:20:30         946     		?	00:00:00	/usr/libexec/accounts-daemon
+06:20:30         1106    		?	00:00:00	/usr/sbin/NetworkManager --no-daemon
+06:20:30         1117    		?	00:00:00	/usr/sbin/sshd -D -oCiphers=aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr,aes256-cbc,aes128-gcm@openssh.com,aes128-ctr,aes128-cbc -oMACs=hmac-sha2-256-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha1,umac-128@openssh.com,hmac-sha2-512 -oGSSAPIKexAlgorithms=gss-curve25519-sha256-,gss-nistp256-sha256-,gss-group14-sha256-,gss-group16-sha512-,gss-gex-sha1-,gss-group14-sha1- -oKexAlgorithms=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1 -oHostKeyAlgorithms=ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ssh-rsa,ssh-rsa-cert-v01@openssh.com -oPubkeyAcceptedKeyTypes=ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ssh-rsa,ssh-rsa-cert-v01@openssh.com -oCASignatureAlgorithms=ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-256,rsa-sha2-512,ssh-rsa
+06:20:30         1119    		?	00:00:00	/usr/sbin/cupsd -l
+06:20:30         1120    		?	00:00:02	/usr/libexec/platform-python -Es /usr/sbin/tuned -l -P
+06:20:30         1125    		?	00:00:00	/usr/sbin/gssproxy -D
+06:20:30         1150    		?	00:00:00	/usr/sbin/iscsid -f -d2
+06:20:30         1151    		?	00:00:00	/usr/sbin/rsyslogd -n
+06:20:30         1176    		?	00:00:00	(iscsi_eh)
+06:20:30         1192    		?	00:00:00	/usr/sbin/crond -n
+06:20:30         1193    		?	00:00:00	(kworker/0:4-cgroup_pidlist_destroy)
+06:20:30         1194    		?	00:00:00	/usr/sbin/atd -f
+06:20:30         1624    		?	00:00:00	/usr/libexec/pcp/bin/pmcd -A
+06:20:30         1633    		?	00:00:00	/var/lib/pcp/pmdas/root/pmdaroot
+06:20:30         1650    		?	00:00:00	/var/lib/pcp/pmdas/proc/pmdaproc -A -d 3
+06:20:30         1666    		?	00:00:00	/var/lib/pcp/pmdas/xfs/pmdaxfs -d 11
+06:20:30         1682    		?	00:00:00	/var/lib/pcp/pmdas/linux/pmdalinux -A
+06:20:30         1690    		?	00:00:00	python3 /var/lib/pcp/pmdas/nfsclient/pmdanfsclient.python
+06:20:30         1754    		?	00:00:00	/var/lib/pcp/pmdas/kvm/pmdakvm -d 95
+06:20:30         1761    		?	00:00:00	/var/lib/pcp/pmdas/dm/pmdadm -d 129
+06:20:30         1767    		?	00:00:00	python3 /var/lib/pcp/pmdas/openmetrics/pmdaopenmetrics.python
+06:20:30         2407    		?	00:00:00	/usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/default.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper
+06:20:30         2410    		?	00:00:00	/usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/default.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper
+06:20:30         2501    		?	00:00:00	/usr/bin/pmie -b -F -P -l /var/log/pcp/pmie/localhost.localdomain/pmie.log -c config.default
+06:20:30         2508    		?	00:00:00	/usr/libexec/pcp/bin/pmlogger -N -P -r -T24h10m -c config.ora -v 100mb -m pmlogger_check %Y%m%d.%H.%M
+06:20:30         2516    		?	00:00:00	/usr/libexec/pcp/bin/pmpause
+06:20:30         2684    		?	00:00:00	/bin/sh /usr/libexec/pcp/bin/pmlogger_farm --skip-primary --quick
+06:20:30         2937    		?	00:00:00	/usr/sbin/gdm
+06:20:30         2953    		?	00:00:00	/usr/sbin/VBoxService --pidfile /var/run/vboxadd-service.sh
+06:20:30         4956    		?	00:00:00	/usr/libexec/upowerd
+06:20:30         4964    		?	00:00:00	/usr/libexec/geoclue
+06:20:30         4977    		?	00:00:00	/usr/sbin/wpa_supplicant -c /etc/wpa_supplicant/wpa_supplicant.conf -u -s
+06:20:30         4978    		?	00:00:05	/usr/libexec/packagekitd
+06:20:30         5059    		?	00:00:00	/usr/libexec/colord
+06:20:30         5150    		?	00:00:00	(kworker/3:4-cgroup_pidlist_destroy)
+06:20:30         5714    		?	00:00:00	gdm-session-worker [pam/gdm-password]
+06:20:30         5729    		?	00:00:00	/usr/lib/systemd/systemd --user
+06:20:30         5731    		?	00:00:00	(sd-pam)
+06:20:30         5757    		?	00:00:00	/usr/bin/gnome-keyring-daemon --daemonize --login
+06:20:30         5764    		tty2	00:00:00	/usr/libexec/gdm-wayland-session --register-session gnome-session
+06:20:30         5766    		?	00:00:00	/usr/bin/dbus-daemon --session --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
+06:20:30         5769    		tty2	00:00:00	/usr/libexec/gnome-session-binary
+06:20:30         5857    		tty2	00:00:07	/usr/bin/gnome-shell
+06:20:30         5901    		?	00:00:00	/usr/libexec/gvfsd
+06:20:30         5908    		?	00:00:00	/usr/libexec/gvfsd-fuse /run/user/0/gvfs -f -o big_writes
+06:20:30         5916    		tty2	00:00:00	/usr/bin/Xwayland :0 -rootless -terminate -accessx -core -auth /run/user/0/.mutter-Xwaylandauth.Q6AEX1 -listen 4 -listen 5 -displayfd 6
+06:20:30         5927    		?	00:00:00	/usr/libexec/at-spi-bus-launcher
+06:20:30         5938    		?	00:00:00	/usr/bin/dbus-daemon --config-file=/usr/share/defaults/at-spi2/accessibility.conf --nofork --print-address 3
+06:20:30         5945    		?	00:00:00	/usr/libexec/at-spi2-registryd --use-gnome-session
+06:20:30         5963    		tty2	00:00:00	ibus-daemon --xim --panel disable
+06:20:30         5967    		tty2	00:00:00	/usr/libexec/ibus-dconf
+06:20:30         5968    		?	00:00:00	/usr/libexec/xdg-permission-store
+06:20:30         5970    		tty2	00:00:00	/usr/libexec/ibus-extension-gtk3
+06:20:30         5976    		tty2	00:00:00	/usr/libexec/ibus-x11 --kill-daemon
+06:20:30         5979    		?	00:00:00	/usr/libexec/ibus-portal
+06:20:30         5993    		?	00:00:00	/usr/libexec/gnome-shell-calendar-server
+06:20:30         5999    		?	00:00:00	/usr/libexec/evolution-source-registry
+06:20:30         6005    		?	00:00:00	/usr/libexec/goa-daemon
+06:20:30         6014    		?	00:00:00	/usr/libexec/gvfs-udisks2-volume-monitor
+06:20:30         6023    		?	00:00:00	/usr/libexec/gvfs-mtp-volume-monitor
+06:20:30         6030    		?	00:00:00	/usr/libexec/gvfs-gphoto2-volume-monitor
+06:20:30         6034    		?	00:00:00	/usr/libexec/goa-identity-service
+06:20:30         6042    		?	00:00:00	/usr/libexec/gvfs-goa-volume-monitor
+06:20:30         6050    		?	00:00:00	/usr/libexec/gvfs-afc-volume-monitor
+06:20:30         6055    		?	00:00:00	/usr/libexec/sssd/sssd_kcm --uid 0 --gid 0 --logger=files
+06:20:30         6057    		tty2	00:00:00	/usr/libexec/gsd-power
+06:20:30         6058    		tty2	00:00:00	/usr/libexec/gsd-print-notifications
+06:20:30         6060    		tty2	00:00:00	/usr/libexec/gsd-rfkill
+06:20:30         6062    		tty2	00:00:00	/usr/libexec/gsd-screensaver-proxy
+06:20:30         6064    		tty2	00:00:00	/usr/libexec/gsd-sharing
+06:20:30         6072    		tty2	00:00:00	/usr/libexec/gsd-sound
+06:20:30         6078    		tty2	00:00:00	/usr/libexec/gsd-xsettings
+06:20:30         6082    		tty2	00:00:00	/usr/libexec/gsd-wacom
+06:20:30         6085    		?	00:00:00	/usr/libexec/evolution-calendar-factory
+06:20:30         6087    		tty2	00:00:00	/usr/libexec/gsd-smartcard
+06:20:30         6088    		tty2	00:00:00	/usr/libexec/gsd-account
+06:20:30         6111    		tty2	00:00:00	/usr/libexec/gsd-a11y-settings
+06:20:30         6113    		tty2	00:00:00	/usr/libexec/ibus-engine-simple
+06:20:30         6115    		?	00:00:00	/usr/bin/pulseaudio --start
+06:20:30         6122    		tty2	00:00:00	/usr/libexec/gsd-clipboard
+06:20:30         6126    		tty2	00:00:00	/usr/libexec/gsd-color
+06:20:30         6128    		tty2	00:00:00	/usr/libexec/gsd-datetime
+06:20:30         6131    		tty2	00:00:00	/usr/libexec/gsd-housekeeping
+06:20:30         6132    		tty2	00:00:00	/usr/libexec/gsd-keyboard
+06:20:30         6138    		tty2	00:00:00	/usr/libexec/gsd-media-keys
+06:20:30         6142    		tty2	00:00:00	/usr/libexec/gsd-mouse
+06:20:30         6188    		?	00:00:00	/usr/libexec/evolution-calendar-factory-subprocess --factory all --bus-name org.gnome.evolution.dataserver.Subprocess.Backend.Calendarx6085x2 --own-path /org/gnome/evolution/dataserver/Subprocess/Backend/Calendar/6085/2
+06:20:30         6216    		?	00:00:00	/usr/libexec/evolution-addressbook-factory
+06:20:30         6217    		?	00:00:00	/usr/libexec/dconf-service
+06:20:30         6219    		?	00:00:00	/usr/libexec/tracker-store
+06:20:30         6224    		tty2	00:00:01	/usr/bin/gnome-software --gapplication-service
+06:20:30         6230    		tty2	00:00:00	/usr/libexec/gsd-disk-utility-notify
+06:20:30         6243    		tty2	00:00:00	/usr/libexec/tracker-miner-apps
+06:20:30         6252    		tty2	00:00:00	/usr/libexec/gsd-printer
+06:20:30         6254    		tty2	00:00:00	/usr/libexec/tracker-miner-fs
+06:20:30         6288    		?	00:00:00	/usr/bin/VBoxClient --clipboard
+06:20:30         6294    		?	00:00:00	/usr/libexec/evolution-addressbook-factory-subprocess --factory all --bus-name org.gnome.evolution.dataserver.Subprocess.Backend.AddressBookx6216x2 --own-path /org/gnome/evolution/dataserver/Subprocess/Backend/AddressBook/6216/2
+06:20:30         6297    		?	00:00:00	/usr/bin/VBoxClient --clipboard
+06:20:30         6324    		?	00:00:00	/usr/bin/VBoxClient --seamless
+06:20:30         6325    		?	00:00:00	/usr/bin/VBoxClient --seamless
+06:20:30         6334    		?	00:00:00	/usr/bin/VBoxClient --draganddrop
+06:20:30         6335    		?	00:00:00	/usr/bin/VBoxClient --draganddrop
+06:20:30         6342    		?	00:00:00	/usr/bin/VBoxClient --vmsvga
+06:20:30         6343    		?	00:00:00	
+06:20:30         6432    		?	00:00:00	/usr/libexec/fwupd/fwupd
+06:20:30         6834    		?	00:00:00	/usr/libexec/gnome-terminal-server
+06:20:30         6839    		pts/0	00:00:00	bash
+06:20:30         6941    		?	00:00:00	(kworker/1:4-cgroup_pidlist_destroy)
+06:20:30         8571    		?	00:00:00	/usr/libexec/gvfsd-metadata
+06:20:30         9308    		?	00:00:00	sleep 60
+06:20:30         9327    		pts/0	00:00:00	/bin/sh ./mk.ps
+06:20:30         9344    		pts/0	00:00:00	pmlogger -s 10 -c /var/tmp/9327.config pcp-ps
+06:20:30         9349    		?	00:00:00	/usr/libexec/tracker-extract
+Timestamp        PID			TTY	TIME		CMD
 06:20:31         1       		?	00:00:01	/usr/lib/systemd/systemd --switched-root --system --deserialize 18
 06:20:31         2       		?	00:00:00	(kthreadd)
 06:20:31         3       		?	00:00:00	(rcu_gp)
@@ -19795,262 +20307,6 @@ Timestamp        PID			TTY	TIME		CMD
 06:20:31         9327    		pts/0	00:00:00	/bin/sh ./mk.ps
 06:20:31         9344    		pts/0	00:00:00	pmlogger -s 10 -c /var/tmp/9327.config pcp-ps
 06:20:31         9349    		?	00:00:00	/usr/libexec/tracker-extract
-Timestamp        PID			TTY	TIME		CMD
-06:20:32         1       		?	00:00:01	/usr/lib/systemd/systemd --switched-root --system --deserialize 18
-06:20:32         2       		?	00:00:00	(kthreadd)
-06:20:32         3       		?	00:00:00	(rcu_gp)
-06:20:32         4       		?	00:00:00	(rcu_par_gp)
-06:20:32         5       		?	00:00:00	(kworker/0:0-cgroup_pidlist_destroy)
-06:20:32         6       		?	00:00:00	(kworker/0:0H-events_highpri)
-06:20:32         7       		?	00:00:00	(kworker/u8:0-events_unbound)
-06:20:32         8       		?	00:00:00	(kworker/0:1H-kblockd)
-06:20:32         9       		?	00:00:00	(mm_percpu_wq)
-06:20:32         10      		?	00:00:00	(ksoftirqd/0)
-06:20:32         11      		?	00:00:00	(rcu_sched)
-06:20:32         12      		?	00:00:00	(migration/0)
-06:20:32         13      		?	00:00:00	(kworker/0:1-xfs-buf/dm-0)
-06:20:32         14      		?	00:00:00	(cpuhp/0)
-06:20:32         15      		?	00:00:00	(cpuhp/1)
-06:20:32         16      		?	00:00:00	(migration/1)
-06:20:32         17      		?	00:00:00	(ksoftirqd/1)
-06:20:32         18      		?	00:00:00	(kworker/1:0-events)
-06:20:32         19      		?	00:00:00	(kworker/1:0H-events_highpri)
-06:20:32         20      		?	00:00:00	(cpuhp/2)
-06:20:32         21      		?	00:00:00	(migration/2)
-06:20:32         22      		?	00:00:00	(ksoftirqd/2)
-06:20:32         23      		?	00:00:00	(kworker/2:0-cgroup_pidlist_destroy)
-06:20:32         24      		?	00:00:00	(kworker/2:0H-events_highpri)
-06:20:32         25      		?	00:00:00	(cpuhp/3)
-06:20:32         26      		?	00:00:00	(migration/3)
-06:20:32         27      		?	00:00:00	(ksoftirqd/3)
-06:20:32         28      		?	00:00:00	(kworker/3:0-events)
-06:20:32         29      		?	00:00:00	(kworker/3:0H-events_highpri)
-06:20:32         31      		?	00:00:00	(kworker/u8:1-events_unbound)
-06:20:32         32      		?	00:00:00	(kworker/u8:2-events_unbound)
-06:20:32         33      		?	00:00:00	(kworker/u8:3)
-06:20:32         34      		?	00:00:00	(kdevtmpfs)
-06:20:32         35      		?	00:00:00	(netns)
-06:20:32         36      		?	00:00:00	(kauditd)
-06:20:32         37      		?	00:00:00	(khungtaskd)
-06:20:32         38      		?	00:00:00	(oom_reaper)
-06:20:32         39      		?	00:00:00	(writeback)
-06:20:32         40      		?	00:00:00	(kcompactd0)
-06:20:32         41      		?	00:00:00	(ksmd)
-06:20:32         42      		?	00:00:00	(khugepaged)
-06:20:32         44      		?	00:00:00	(kworker/3:1-events)
-06:20:32         97      		?	00:00:00	(kintegrityd)
-06:20:32         98      		?	00:00:00	(kblockd)
-06:20:32         99      		?	00:00:00	(blkcg_punt_bio)
-06:20:32         100     		?	00:00:00	(tpm_dev_wq)
-06:20:32         101     		?	00:00:00	(md)
-06:20:32         102     		?	00:00:00	(edac-poller)
-06:20:32         103     		?	00:00:00	(devfreq_wq)
-06:20:32         104     		?	00:00:00	(watchdogd)
-06:20:32         105     		?	00:00:00	(kworker/2:1-events)
-06:20:32         107     		?	00:00:00	(kswapd0:0)
-06:20:32         109     		?	00:00:00	(kthrotld)
-06:20:32         110     		?	00:00:00	(acpi_thermal_pm)
-06:20:32         111     		?	00:00:00	(kmpath_rdacd)
-06:20:32         112     		?	00:00:00	(kaluad)
-06:20:32         113     		?	00:00:00	(kworker/3:1H-events_highpri)
-06:20:32         114     		?	00:00:00	(bch_btree_io)
-06:20:32         115     		?	00:00:00	(bcache)
-06:20:32         116     		?	00:00:00	(bch_journal)
-06:20:32         117     		?	00:00:00	(ipv6_addrconf)
-06:20:32         118     		?	00:00:00	(dsa_ordered)
-06:20:32         119     		?	00:00:00	(kworker/0:2-events)
-06:20:32         120     		?	00:00:00	(kstrp)
-06:20:32         125     		?	00:00:00	(kworker/u9:0)
-06:20:32         127     		?	00:00:00	(kworker/1:1-events)
-06:20:32         135     		?	00:00:00	(charger_manager)
-06:20:32         186     		?	00:00:00	(kworker/3:2-cgroup_pidlist_destroy)
-06:20:32         189     		?	00:00:00	(kworker/1:2-events)
-06:20:32         191     		?	00:00:00	(kworker/1:3-events)
-06:20:32         194     		?	00:00:00	(kworker/0:3-events)
-06:20:32         344     		?	00:00:00	(iprt-VBoxWQueue)
-06:20:32         345     		?	00:00:00	(kworker/2:1H-xfs-log/dm-0)
-06:20:32         346     		?	00:00:00	(ata_sff)
-06:20:32         347     		?	00:00:00	(scsi_eh_0)
-06:20:32         351     		?	00:00:00	(scsi_tmf_0)
-06:20:32         352     		?	00:00:00	(scsi_eh_1)
-06:20:32         353     		?	00:00:00	(scsi_tmf_1)
-06:20:32         366     		?	00:00:00	(scsi_eh_2)
-06:20:32         367     		?	00:00:00	(scsi_tmf_2)
-06:20:32         369     		?	00:00:00	(kworker/1:1H-kblockd)
-06:20:32         371     		?	00:00:00	(irq/18-vmwgfx)
-06:20:32         372     		?	00:00:00	(ttm_swap)
-06:20:32         441     		?	00:00:00	(kdmflush)
-06:20:32         452     		?	00:00:00	(kdmflush)
-06:20:32         467     		?	00:00:00	(kworker/3:3-events)
-06:20:32         473     		?	00:00:00	(kworker/2:2-cgroup_pidlist_destroy)
-06:20:32         477     		?	00:00:00	(kworker/2:3-cgroup_destroy)
-06:20:32         478     		?	00:00:00	(xfsalloc)
-06:20:32         479     		?	00:00:00	(xfs_mru_cache)
-06:20:32         481     		?	00:00:00	(xfs-buf/dm-0)
-06:20:32         482     		?	00:00:00	(xfs-conv/dm-0)
-06:20:32         483     		?	00:00:00	(xfs-cil/dm-0)
-06:20:32         484     		?	00:00:00	(xfs-reclaim/dm-)
-06:20:32         485     		?	00:00:00	(xfs-eofblocks/d)
-06:20:32         486     		?	00:00:00	(xfs-log/dm-0)
-06:20:32         487     		?	00:00:00	(xfsaild/dm-0)
-06:20:32         555     		?	00:00:00	(kworker/2:4-events)
-06:20:32         585     		?	00:00:00	/usr/lib/systemd/systemd-journald
-06:20:32         624     		?	00:00:00	/usr/lib/systemd/systemd-udevd
-06:20:32         655     		?	00:00:00	(cryptd)
-06:20:32         696     		?	00:00:00	(kdmflush)
-06:20:32         751     		?	00:00:00	(xfs-buf/dm-2)
-06:20:32         752     		?	00:00:00	(xfs-conv/dm-2)
-06:20:32         753     		?	00:00:00	(xfs-cil/dm-2)
-06:20:32         754     		?	00:00:00	(xfs-buf/sda1)
-06:20:32         755     		?	00:00:00	(xfs-conv/sda1)
-06:20:32         756     		?	00:00:00	(xfs-reclaim/dm-)
-06:20:32         757     		?	00:00:00	(xfs-cil/sda1)
-06:20:32         758     		?	00:00:00	(xfs-eofblocks/d)
-06:20:32         759     		?	00:00:00	(xfs-reclaim/sda)
-06:20:32         760     		?	00:00:00	(xfs-eofblocks/s)
-06:20:32         761     		?	00:00:00	(xfs-log/dm-2)
-06:20:32         762     		?	00:00:00	(xfsaild/dm-2)
-06:20:32         763     		?	00:00:00	(xfs-log/sda1)
-06:20:32         764     		?	00:00:00	(xfsaild/sda1)
-06:20:32         786     		?	00:00:00	/usr/bin/rpcbind -w -f
-06:20:32         788     		?	00:00:00	/sbin/auditd
-06:20:32         790     		?	00:00:00	/usr/sbin/sedispatch
-06:20:32         800     		?	00:00:00	(rpciod)
-06:20:32         801     		?	00:00:00	(xprtiod)
-06:20:32         816     		?	00:00:00	/usr/sbin/mcelog --ignorenodev --daemon --foreground
-06:20:32         818     		?	00:00:00	/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
-06:20:32         820     		?	00:00:00	/usr/lib/polkit-1/polkitd --no-debug
-06:20:32         821     		?	00:00:00	/usr/sbin/irqbalance --foreground
-06:20:32         826     		?	00:00:00	/usr/libexec/rtkit-daemon
-06:20:32         827     		?	00:00:00	/usr/sbin/alsactl -s -n 19 -c -E ALSA_CONFIG_PATH=/etc/alsa/alsactl.conf --initfile=/lib/alsa/init/00main rdaemon
-06:20:32         829     		?	00:00:00	avahi-daemon: running [linux.local]
-06:20:32         830     		?	00:00:00	/usr/bin/lsmd -d
-06:20:32         834     		?	00:00:00	/usr/lib/systemd/systemd-machined
-06:20:32         835     		?	00:00:00	/usr/libexec/udisks2/udisksd
-06:20:32         838     		?	00:00:00	/usr/sbin/sssd -i --logger=files
-06:20:32         840     		?	00:00:00	/usr/sbin/smartd -n -q never
-06:20:32         857     		?	00:00:00	/usr/sbin/chronyd
-06:20:32         860     		?	00:00:00	/bin/bash /usr/sbin/ksmtuned
-06:20:32         864     		?	00:00:00	/opt/cisco/anyconnect/bin/vpnagentd -execv_instance
-06:20:32         868     		?	00:00:00	avahi-daemon: chroot helper
-06:20:32         877     		?	00:00:00	/usr/libexec/sssd/sssd_be --domain implicit_files --uid 0 --gid 0 --logger=files
-06:20:32         884     		?	00:00:00	/usr/libexec/platform-python -s /usr/sbin/firewalld --nofork --nopid
-06:20:32         885     		?	00:00:00	/usr/sbin/ModemManager
-06:20:32         897     		?	00:00:00	/usr/libexec/sssd/sssd_nss --uid 0 --gid 0 --logger=files
-06:20:32         941     		?	00:00:00	/usr/lib/systemd/systemd-logind
-06:20:32         946     		?	00:00:00	/usr/libexec/accounts-daemon
-06:20:32         1106    		?	00:00:00	/usr/sbin/NetworkManager --no-daemon
-06:20:32         1117    		?	00:00:00	/usr/sbin/sshd -D -oCiphers=aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr,aes256-cbc,aes128-gcm@openssh.com,aes128-ctr,aes128-cbc -oMACs=hmac-sha2-256-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha1,umac-128@openssh.com,hmac-sha2-512 -oGSSAPIKexAlgorithms=gss-curve25519-sha256-,gss-nistp256-sha256-,gss-group14-sha256-,gss-group16-sha512-,gss-gex-sha1-,gss-group14-sha1- -oKexAlgorithms=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1 -oHostKeyAlgorithms=ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ssh-rsa,ssh-rsa-cert-v01@openssh.com -oPubkeyAcceptedKeyTypes=ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ssh-rsa,ssh-rsa-cert-v01@openssh.com -oCASignatureAlgorithms=ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-256,rsa-sha2-512,ssh-rsa
-06:20:32         1119    		?	00:00:00	/usr/sbin/cupsd -l
-06:20:32         1120    		?	00:00:02	/usr/libexec/platform-python -Es /usr/sbin/tuned -l -P
-06:20:32         1125    		?	00:00:00	/usr/sbin/gssproxy -D
-06:20:32         1150    		?	00:00:00	/usr/sbin/iscsid -f -d2
-06:20:32         1151    		?	00:00:00	/usr/sbin/rsyslogd -n
-06:20:32         1176    		?	00:00:00	(iscsi_eh)
-06:20:32         1192    		?	00:00:00	/usr/sbin/crond -n
-06:20:32         1193    		?	00:00:00	(kworker/0:4-cgroup_pidlist_destroy)
-06:20:32         1194    		?	00:00:00	/usr/sbin/atd -f
-06:20:32         1624    		?	00:00:00	/usr/libexec/pcp/bin/pmcd -A
-06:20:32         1633    		?	00:00:00	/var/lib/pcp/pmdas/root/pmdaroot
-06:20:32         1650    		?	00:00:00	/var/lib/pcp/pmdas/proc/pmdaproc -A -d 3
-06:20:32         1666    		?	00:00:00	/var/lib/pcp/pmdas/xfs/pmdaxfs -d 11
-06:20:32         1682    		?	00:00:00	/var/lib/pcp/pmdas/linux/pmdalinux -A
-06:20:32         1690    		?	00:00:00	python3 /var/lib/pcp/pmdas/nfsclient/pmdanfsclient.python
-06:20:32         1754    		?	00:00:00	/var/lib/pcp/pmdas/kvm/pmdakvm -d 95
-06:20:32         1761    		?	00:00:00	/var/lib/pcp/pmdas/dm/pmdadm -d 129
-06:20:32         1767    		?	00:00:00	python3 /var/lib/pcp/pmdas/openmetrics/pmdaopenmetrics.python
-06:20:32         2407    		?	00:00:00	/usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/default.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper
-06:20:32         2410    		?	00:00:00	/usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/default.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper
-06:20:32         2501    		?	00:00:00	/usr/bin/pmie -b -F -P -l /var/log/pcp/pmie/localhost.localdomain/pmie.log -c config.default
-06:20:32         2508    		?	00:00:00	/usr/libexec/pcp/bin/pmlogger -N -P -r -T24h10m -c config.ora -v 100mb -m pmlogger_check %Y%m%d.%H.%M
-06:20:32         2516    		?	00:00:00	/usr/libexec/pcp/bin/pmpause
-06:20:32         2684    		?	00:00:00	/bin/sh /usr/libexec/pcp/bin/pmlogger_farm --skip-primary --quick
-06:20:32         2937    		?	00:00:00	/usr/sbin/gdm
-06:20:32         2953    		?	00:00:00	/usr/sbin/VBoxService --pidfile /var/run/vboxadd-service.sh
-06:20:32         4956    		?	00:00:00	/usr/libexec/upowerd
-06:20:32         4964    		?	00:00:00	/usr/libexec/geoclue
-06:20:32         4977    		?	00:00:00	/usr/sbin/wpa_supplicant -c /etc/wpa_supplicant/wpa_supplicant.conf -u -s
-06:20:32         4978    		?	00:00:05	/usr/libexec/packagekitd
-06:20:32         5059    		?	00:00:00	/usr/libexec/colord
-06:20:32         5150    		?	00:00:00	(kworker/3:4-cgroup_pidlist_destroy)
-06:20:32         5714    		?	00:00:00	gdm-session-worker [pam/gdm-password]
-06:20:32         5729    		?	00:00:00	/usr/lib/systemd/systemd --user
-06:20:32         5731    		?	00:00:00	(sd-pam)
-06:20:32         5757    		?	00:00:00	/usr/bin/gnome-keyring-daemon --daemonize --login
-06:20:32         5764    		tty2	00:00:00	/usr/libexec/gdm-wayland-session --register-session gnome-session
-06:20:32         5766    		?	00:00:00	/usr/bin/dbus-daemon --session --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
-06:20:32         5769    		tty2	00:00:00	/usr/libexec/gnome-session-binary
-06:20:32         5857    		tty2	00:00:07	/usr/bin/gnome-shell
-06:20:32         5901    		?	00:00:00	/usr/libexec/gvfsd
-06:20:32         5908    		?	00:00:00	/usr/libexec/gvfsd-fuse /run/user/0/gvfs -f -o big_writes
-06:20:32         5916    		tty2	00:00:00	/usr/bin/Xwayland :0 -rootless -terminate -accessx -core -auth /run/user/0/.mutter-Xwaylandauth.Q6AEX1 -listen 4 -listen 5 -displayfd 6
-06:20:32         5927    		?	00:00:00	/usr/libexec/at-spi-bus-launcher
-06:20:32         5938    		?	00:00:00	/usr/bin/dbus-daemon --config-file=/usr/share/defaults/at-spi2/accessibility.conf --nofork --print-address 3
-06:20:32         5945    		?	00:00:00	/usr/libexec/at-spi2-registryd --use-gnome-session
-06:20:32         5963    		tty2	00:00:00	ibus-daemon --xim --panel disable
-06:20:32         5967    		tty2	00:00:00	/usr/libexec/ibus-dconf
-06:20:32         5968    		?	00:00:00	/usr/libexec/xdg-permission-store
-06:20:32         5970    		tty2	00:00:00	/usr/libexec/ibus-extension-gtk3
-06:20:32         5976    		tty2	00:00:00	/usr/libexec/ibus-x11 --kill-daemon
-06:20:32         5979    		?	00:00:00	/usr/libexec/ibus-portal
-06:20:32         5993    		?	00:00:00	/usr/libexec/gnome-shell-calendar-server
-06:20:32         5999    		?	00:00:00	/usr/libexec/evolution-source-registry
-06:20:32         6005    		?	00:00:00	/usr/libexec/goa-daemon
-06:20:32         6014    		?	00:00:00	/usr/libexec/gvfs-udisks2-volume-monitor
-06:20:32         6023    		?	00:00:00	/usr/libexec/gvfs-mtp-volume-monitor
-06:20:32         6030    		?	00:00:00	/usr/libexec/gvfs-gphoto2-volume-monitor
-06:20:32         6034    		?	00:00:00	/usr/libexec/goa-identity-service
-06:20:32         6042    		?	00:00:00	/usr/libexec/gvfs-goa-volume-monitor
-06:20:32         6050    		?	00:00:00	/usr/libexec/gvfs-afc-volume-monitor
-06:20:32         6055    		?	00:00:00	/usr/libexec/sssd/sssd_kcm --uid 0 --gid 0 --logger=files
-06:20:32         6057    		tty2	00:00:00	/usr/libexec/gsd-power
-06:20:32         6058    		tty2	00:00:00	/usr/libexec/gsd-print-notifications
-06:20:32         6060    		tty2	00:00:00	/usr/libexec/gsd-rfkill
-06:20:32         6062    		tty2	00:00:00	/usr/libexec/gsd-screensaver-proxy
-06:20:32         6064    		tty2	00:00:00	/usr/libexec/gsd-sharing
-06:20:32         6072    		tty2	00:00:00	/usr/libexec/gsd-sound
-06:20:32         6078    		tty2	00:00:00	/usr/libexec/gsd-xsettings
-06:20:32         6082    		tty2	00:00:00	/usr/libexec/gsd-wacom
-06:20:32         6085    		?	00:00:00	/usr/libexec/evolution-calendar-factory
-06:20:32         6087    		tty2	00:00:00	/usr/libexec/gsd-smartcard
-06:20:32         6088    		tty2	00:00:00	/usr/libexec/gsd-account
-06:20:32         6111    		tty2	00:00:00	/usr/libexec/gsd-a11y-settings
-06:20:32         6113    		tty2	00:00:00	/usr/libexec/ibus-engine-simple
-06:20:32         6115    		?	00:00:00	/usr/bin/pulseaudio --start
-06:20:32         6122    		tty2	00:00:00	/usr/libexec/gsd-clipboard
-06:20:32         6126    		tty2	00:00:00	/usr/libexec/gsd-color
-06:20:32         6128    		tty2	00:00:00	/usr/libexec/gsd-datetime
-06:20:32         6131    		tty2	00:00:00	/usr/libexec/gsd-housekeeping
-06:20:32         6132    		tty2	00:00:00	/usr/libexec/gsd-keyboard
-06:20:32         6138    		tty2	00:00:00	/usr/libexec/gsd-media-keys
-06:20:32         6142    		tty2	00:00:00	/usr/libexec/gsd-mouse
-06:20:32         6188    		?	00:00:00	/usr/libexec/evolution-calendar-factory-subprocess --factory all --bus-name org.gnome.evolution.dataserver.Subprocess.Backend.Calendarx6085x2 --own-path /org/gnome/evolution/dataserver/Subprocess/Backend/Calendar/6085/2
-06:20:32         6216    		?	00:00:00	/usr/libexec/evolution-addressbook-factory
-06:20:32         6217    		?	00:00:00	/usr/libexec/dconf-service
-06:20:32         6219    		?	00:00:00	/usr/libexec/tracker-store
-06:20:32         6224    		tty2	00:00:01	/usr/bin/gnome-software --gapplication-service
-06:20:32         6230    		tty2	00:00:00	/usr/libexec/gsd-disk-utility-notify
-06:20:32         6243    		tty2	00:00:00	/usr/libexec/tracker-miner-apps
-06:20:32         6252    		tty2	00:00:00	/usr/libexec/gsd-printer
-06:20:32         6254    		tty2	00:00:00	/usr/libexec/tracker-miner-fs
-06:20:32         6288    		?	00:00:00	/usr/bin/VBoxClient --clipboard
-06:20:32         6294    		?	00:00:00	/usr/libexec/evolution-addressbook-factory-subprocess --factory all --bus-name org.gnome.evolution.dataserver.Subprocess.Backend.AddressBookx6216x2 --own-path /org/gnome/evolution/dataserver/Subprocess/Backend/AddressBook/6216/2
-06:20:32         6297    		?	00:00:00	/usr/bin/VBoxClient --clipboard
-06:20:32         6324    		?	00:00:00	/usr/bin/VBoxClient --seamless
-06:20:32         6325    		?	00:00:00	/usr/bin/VBoxClient --seamless
-06:20:32         6334    		?	00:00:00	/usr/bin/VBoxClient --draganddrop
-06:20:32         6335    		?	00:00:00	/usr/bin/VBoxClient --draganddrop
-06:20:32         6342    		?	00:00:00	/usr/bin/VBoxClient --vmsvga
-06:20:32         6343    		?	00:00:00	
-06:20:32         6432    		?	00:00:00	/usr/libexec/fwupd/fwupd
-06:20:32         6834    		?	00:00:00	/usr/libexec/gnome-terminal-server
-06:20:32         6839    		pts/0	00:00:00	bash
-06:20:32         6941    		?	00:00:00	(kworker/1:4-cgroup_pidlist_destroy)
-06:20:32         8571    		?	00:00:00	/usr/libexec/gvfsd-metadata
-06:20:32         9308    		?	00:00:00	sleep 60
-06:20:32         9327    		pts/0	00:00:00	/bin/sh ./mk.ps
-06:20:32         9344    		pts/0	00:00:00	pmlogger -s 10 -c /var/tmp/9327.config pcp-ps
-06:20:32         9349    		?	00:00:00	/usr/libexec/tracker-extract
 
 pcp-ps output : Display the user oriented format
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
@@ -20570,6 +20826,262 @@ Timestamp        USERNAME	PID		%CPU	%MEM	VSZ	RSS	TTY	STAT	TIME		START		COMMAND
 pcp-ps output : Display the colum pid,ppid,tty,uname,wchan
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
 Timestamp	PID		PPID		TTY	USER		WCHAN				
+06:20:30	1       	0       	?	root      	ep_poll                       
+06:20:30	2       	0       	?	root      	kthreadd                      
+06:20:30	3       	2       	?	root      	rescuer_thread                
+06:20:30	4       	2       	?	root      	rescuer_thread                
+06:20:30	5       	2       	?	root      	worker_thread                 
+06:20:30	6       	2       	?	root      	worker_thread                 
+06:20:30	7       	2       	?	root      	worker_thread                 
+06:20:30	8       	2       	?	root      	worker_thread                 
+06:20:30	9       	2       	?	root      	rescuer_thread                
+06:20:30	10      	2       	?	root      	smpboot_thread_fn             
+06:20:30	11      	2       	?	root      	rcu_gp_kthread                
+06:20:30	12      	2       	?	root      	smpboot_thread_fn             
+06:20:30	13      	2       	?	root      	worker_thread                 
+06:20:30	14      	2       	?	root      	smpboot_thread_fn             
+06:20:30	15      	2       	?	root      	smpboot_thread_fn             
+06:20:30	16      	2       	?	root      	smpboot_thread_fn             
+06:20:30	17      	2       	?	root      	smpboot_thread_fn             
+06:20:30	18      	2       	?	root      	worker_thread                 
+06:20:30	19      	2       	?	root      	worker_thread                 
+06:20:30	20      	2       	?	root      	smpboot_thread_fn             
+06:20:30	21      	2       	?	root      	smpboot_thread_fn             
+06:20:30	22      	2       	?	root      	smpboot_thread_fn             
+06:20:30	23      	2       	?	root      	worker_thread                 
+06:20:30	24      	2       	?	root      	worker_thread                 
+06:20:30	25      	2       	?	root      	smpboot_thread_fn             
+06:20:30	26      	2       	?	root      	smpboot_thread_fn             
+06:20:30	27      	2       	?	root      	smpboot_thread_fn             
+06:20:30	28      	2       	?	root      	worker_thread                 
+06:20:30	29      	2       	?	root      	worker_thread                 
+06:20:30	31      	2       	?	root      	worker_thread                 
+06:20:30	32      	2       	?	root      	worker_thread                 
+06:20:30	33      	2       	?	root      	worker_thread                 
+06:20:30	34      	2       	?	root      	devtmpfsd.part.5              
+06:20:30	35      	2       	?	root      	rescuer_thread                
+06:20:30	36      	2       	?	root      	kauditd_thread                
+06:20:30	37      	2       	?	root      	watchdog                      
+06:20:30	38      	2       	?	root      	oom_reaper                    
+06:20:30	39      	2       	?	root      	rescuer_thread                
+06:20:30	40      	2       	?	root      	kcompactd                     
+06:20:30	41      	2       	?	root      	ksm_scan_thread               
+06:20:30	42      	2       	?	root      	khugepaged                    
+06:20:30	44      	2       	?	root      	worker_thread                 
+06:20:30	97      	2       	?	root      	rescuer_thread                
+06:20:30	98      	2       	?	root      	rescuer_thread                
+06:20:30	99      	2       	?	root      	rescuer_thread                
+06:20:30	100     	2       	?	root      	rescuer_thread                
+06:20:30	101     	2       	?	root      	rescuer_thread                
+06:20:30	102     	2       	?	root      	rescuer_thread                
+06:20:30	103     	2       	?	root      	rescuer_thread                
+06:20:30	104     	2       	?	root      	kthread_worker_fn             
+06:20:30	105     	2       	?	root      	worker_thread                 
+06:20:30	107     	2       	?	root      	kswapd                        
+06:20:30	109     	2       	?	root      	rescuer_thread                
+06:20:30	110     	2       	?	root      	rescuer_thread                
+06:20:30	111     	2       	?	root      	rescuer_thread                
+06:20:30	112     	2       	?	root      	rescuer_thread                
+06:20:30	113     	2       	?	root      	worker_thread                 
+06:20:30	114     	2       	?	root      	rescuer_thread                
+06:20:30	115     	2       	?	root      	rescuer_thread                
+06:20:30	116     	2       	?	root      	rescuer_thread                
+06:20:30	117     	2       	?	root      	rescuer_thread                
+06:20:30	118     	2       	?	root      	rescuer_thread                
+06:20:30	119     	2       	?	root      	worker_thread                 
+06:20:30	120     	2       	?	root      	rescuer_thread                
+06:20:30	125     	2       	?	root      	worker_thread                 
+06:20:30	127     	2       	?	root      	worker_thread                 
+06:20:30	135     	2       	?	root      	rescuer_thread                
+06:20:30	186     	2       	?	root      	worker_thread                 
+06:20:30	189     	2       	?	root      	worker_thread                 
+06:20:30	191     	2       	?	root      	worker_thread                 
+06:20:30	194     	2       	?	root      	worker_thread                 
+06:20:30	344     	2       	?	root      	rescuer_thread                
+06:20:30	345     	2       	?	root      	worker_thread                 
+06:20:30	346     	2       	?	root      	rescuer_thread                
+06:20:30	347     	2       	?	root      	scsi_error_handler            
+06:20:30	351     	2       	?	root      	rescuer_thread                
+06:20:30	352     	2       	?	root      	scsi_error_handler            
+06:20:30	353     	2       	?	root      	rescuer_thread                
+06:20:30	366     	2       	?	root      	scsi_error_handler            
+06:20:30	367     	2       	?	root      	rescuer_thread                
+06:20:30	369     	2       	?	root      	worker_thread                 
+06:20:30	371     	2       	?	root      	irq_thread                    
+06:20:30	372     	2       	?	root      	rescuer_thread                
+06:20:30	441     	2       	?	root      	rescuer_thread                
+06:20:30	452     	2       	?	root      	rescuer_thread                
+06:20:30	467     	2       	?	root      	worker_thread                 
+06:20:30	473     	2       	?	root      	worker_thread                 
+06:20:30	477     	2       	?	root      	worker_thread                 
+06:20:30	478     	2       	?	root      	rescuer_thread                
+06:20:30	479     	2       	?	root      	rescuer_thread                
+06:20:30	481     	2       	?	root      	rescuer_thread                
+06:20:30	482     	2       	?	root      	rescuer_thread                
+06:20:30	483     	2       	?	root      	rescuer_thread                
+06:20:30	484     	2       	?	root      	rescuer_thread                
+06:20:30	485     	2       	?	root      	rescuer_thread                
+06:20:30	486     	2       	?	root      	rescuer_thread                
+06:20:30	487     	2       	?	root      	xfsaild                       
+06:20:30	555     	2       	?	root      	worker_thread                 
+06:20:30	585     	1       	?	root      	ep_poll                       
+06:20:30	624     	1       	?	root      	ep_poll                       
+06:20:30	655     	2       	?	root      	rescuer_thread                
+06:20:30	696     	2       	?	root      	rescuer_thread                
+06:20:30	751     	2       	?	root      	rescuer_thread                
+06:20:30	752     	2       	?	root      	rescuer_thread                
+06:20:30	753     	2       	?	root      	rescuer_thread                
+06:20:30	754     	2       	?	root      	rescuer_thread                
+06:20:30	755     	2       	?	root      	rescuer_thread                
+06:20:30	756     	2       	?	root      	rescuer_thread                
+06:20:30	757     	2       	?	root      	rescuer_thread                
+06:20:30	758     	2       	?	root      	rescuer_thread                
+06:20:30	759     	2       	?	root      	rescuer_thread                
+06:20:30	760     	2       	?	root      	rescuer_thread                
+06:20:30	761     	2       	?	root      	rescuer_thread                
+06:20:30	762     	2       	?	root      	xfsaild                       
+06:20:30	763     	2       	?	root      	rescuer_thread                
+06:20:30	764     	2       	?	root      	xfsaild                       
+06:20:30	786     	1       	?	rpc       	poll_schedule_timeout.constpro
+06:20:30	788     	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	790     	788     	?	root      	unix_stream_read_generic      
+06:20:30	800     	2       	?	root      	rescuer_thread                
+06:20:30	801     	2       	?	root      	rescuer_thread                
+06:20:30	816     	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	818     	1       	?	dbus      	ep_poll                       
+06:20:30	820     	1       	?	polkitd   	poll_schedule_timeout.constpro
+06:20:30	821     	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	826     	1       	?	rtkit     	poll_schedule_timeout.constpro
+06:20:30	827     	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	829     	1       	?	avahi     	poll_schedule_timeout.constpro
+06:20:30	830     	1       	?	libstorage	poll_schedule_timeout.constpro
+06:20:30	834     	1       	?	root      	ep_poll                       
+06:20:30	835     	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	838     	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	840     	1       	?	root      	hrtimer_nanosleep             
+06:20:30	857     	1       	?	chrony    	poll_schedule_timeout.constpro
+06:20:30	860     	1       	?	root      	do_wait                       
+06:20:30	864     	1       	?	root      	futex_wait_queue_me           
+06:20:30	868     	829     	?	avahi     	unix_stream_read_generic      
+06:20:30	877     	838     	?	root      	ep_poll                       
+06:20:30	884     	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	885     	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	897     	838     	?	root      	ep_poll                       
+06:20:30	941     	1       	?	root      	ep_poll                       
+06:20:30	946     	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	1106    	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	1117    	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	1119    	1       	?	root      	ep_poll                       
+06:20:30	1120    	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	1125    	1       	?	root      	ep_poll                       
+06:20:30	1150    	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	1151    	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	1176    	2       	?	root      	rescuer_thread                
+06:20:30	1192    	1       	?	root      	hrtimer_nanosleep             
+06:20:30	1193    	2       	?	root      	worker_thread                 
+06:20:30	1194    	1       	?	root      	__ia32_sys_pause              
+06:20:30	1624    	1       	?	pcp       	poll_schedule_timeout.constpro
+06:20:30	1633    	1624    	?	root      	poll_schedule_timeout.constpro
+06:20:30	1650    	1633    	?	root      	-                             
+06:20:30	1666    	1633    	?	root      	pipe_wait                     
+06:20:30	1682    	1633    	?	root      	pipe_wait                     
+06:20:30	1690    	1633    	?	root      	pipe_wait                     
+06:20:30	1754    	1633    	?	root      	pipe_wait                     
+06:20:30	1761    	1633    	?	root      	pipe_wait                     
+06:20:30	1767    	1633    	?	root      	pipe_wait                     
+06:20:30	2407    	1       	?	dnsmasq   	poll_schedule_timeout.constpro
+06:20:30	2410    	2407    	?	root      	pipe_wait                     
+06:20:30	2501    	1       	?	pcp       	hrtimer_nanosleep             
+06:20:30	2508    	1       	?	pcp       	poll_schedule_timeout.constpro
+06:20:30	2516    	1       	?	pcp       	__ia32_sys_pause              
+06:20:30	2684    	1       	?	pcp       	__ia32_sys_pause              
+06:20:30	2937    	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	2953    	1       	?	root      	do_sigtimedwait.isra.42       
+06:20:30	4956    	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	4964    	1       	?	geoclue   	poll_schedule_timeout.constpro
+06:20:30	4977    	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	4978    	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	5059    	1       	?	colord    	poll_schedule_timeout.constpro
+06:20:30	5150    	2       	?	root      	worker_thread                 
+06:20:30	5714    	2937    	?	root      	poll_schedule_timeout.constpro
+06:20:30	5729    	1       	?	root      	ep_poll                       
+06:20:30	5731    	5729    	?	root      	do_sigtimedwait.isra.42       
+06:20:30	5757    	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	5764    	5714    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	5766    	5729    	?	root      	ep_poll                       
+06:20:30	5769    	5764    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	5857    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	5901    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	5908    	5729    	?	root      	futex_wait_queue_me           
+06:20:30	5916    	5857    	tty2	root      	ep_poll                       
+06:20:30	5927    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	5938    	5927    	?	root      	ep_poll                       
+06:20:30	5945    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	5963    	5857    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	5967    	5963    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	5968    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	5970    	5963    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	5976    	1       	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	5979    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	5993    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	5999    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6005    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6014    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6023    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6030    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6034    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6042    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6050    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6055    	1       	?	root      	ep_poll                       
+06:20:30	6057    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6058    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6060    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6062    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6064    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6072    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6078    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6082    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6085    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6087    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6088    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6111    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6113    	5963    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6115    	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	6122    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6126    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6128    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6131    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6132    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6138    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6142    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6188    	6085    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6216    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6217    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6219    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6224    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6230    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6243    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6252    	1       	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6254    	5769    	tty2	root      	poll_schedule_timeout.constpro
+06:20:30	6288    	1       	?	root      	do_wait                       
+06:20:30	6294    	6216    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6297    	6288    	?	root      	rtR0SemEventMultiLnxWait.isra.
+06:20:30	6324    	1       	?	root      	do_wait                       
+06:20:30	6325    	6324    	?	root      	rtR0SemEventMultiLnxWait.isra.
+06:20:30	6334    	1       	?	root      	do_wait                       
+06:20:30	6335    	6334    	?	root      	futex_wait_queue_me           
+06:20:30	6342    	1       	?	root      	do_wait                       
+06:20:30	6343    	6342    	?	root      	rtR0SemEventMultiLnxWait.isra.
+06:20:30	6432    	1       	?	root      	poll_schedule_timeout.constpro
+06:20:30	6834    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	6839    	6834    	pts/0	root      	do_wait                       
+06:20:30	6941    	2       	?	root      	worker_thread                 
+06:20:30	8571    	5729    	?	root      	poll_schedule_timeout.constpro
+06:20:30	9308    	860     	?	root      	hrtimer_nanosleep             
+06:20:30	9327    	6839    	pts/0	root      	do_wait                       
+06:20:30	9344    	9327    	pts/0	root      	poll_schedule_timeout.constpro
+06:20:30	9349    	5729    	?	root      	-                             
+Timestamp	PID		PPID		TTY	USER		WCHAN				
 06:20:31	1       	0       	?	root      	ep_poll                       
 06:20:31	2       	0       	?	root      	kthreadd                      
 06:20:31	3       	2       	?	root      	rescuer_thread                
@@ -20825,274 +21337,193 @@ Timestamp	PID		PPID		TTY	USER		WCHAN
 06:20:31	9327    	6839    	pts/0	root      	do_wait                       
 06:20:31	9344    	9327    	pts/0	root      	poll_schedule_timeout.constpro
 06:20:31	9349    	5729    	?	root      	-                             
-Timestamp	PID		PPID		TTY	USER		WCHAN				
-06:20:32	1       	0       	?	root      	ep_poll                       
-06:20:32	2       	0       	?	root      	kthreadd                      
-06:20:32	3       	2       	?	root      	rescuer_thread                
-06:20:32	4       	2       	?	root      	rescuer_thread                
-06:20:32	5       	2       	?	root      	worker_thread                 
-06:20:32	6       	2       	?	root      	worker_thread                 
-06:20:32	7       	2       	?	root      	worker_thread                 
-06:20:32	8       	2       	?	root      	worker_thread                 
-06:20:32	9       	2       	?	root      	rescuer_thread                
-06:20:32	10      	2       	?	root      	smpboot_thread_fn             
-06:20:32	11      	2       	?	root      	rcu_gp_kthread                
-06:20:32	12      	2       	?	root      	smpboot_thread_fn             
-06:20:32	13      	2       	?	root      	worker_thread                 
-06:20:32	14      	2       	?	root      	smpboot_thread_fn             
-06:20:32	15      	2       	?	root      	smpboot_thread_fn             
-06:20:32	16      	2       	?	root      	smpboot_thread_fn             
-06:20:32	17      	2       	?	root      	smpboot_thread_fn             
-06:20:32	18      	2       	?	root      	worker_thread                 
-06:20:32	19      	2       	?	root      	worker_thread                 
-06:20:32	20      	2       	?	root      	smpboot_thread_fn             
-06:20:32	21      	2       	?	root      	smpboot_thread_fn             
-06:20:32	22      	2       	?	root      	smpboot_thread_fn             
-06:20:32	23      	2       	?	root      	worker_thread                 
-06:20:32	24      	2       	?	root      	worker_thread                 
-06:20:32	25      	2       	?	root      	smpboot_thread_fn             
-06:20:32	26      	2       	?	root      	smpboot_thread_fn             
-06:20:32	27      	2       	?	root      	smpboot_thread_fn             
-06:20:32	28      	2       	?	root      	worker_thread                 
-06:20:32	29      	2       	?	root      	worker_thread                 
-06:20:32	31      	2       	?	root      	worker_thread                 
-06:20:32	32      	2       	?	root      	worker_thread                 
-06:20:32	33      	2       	?	root      	worker_thread                 
-06:20:32	34      	2       	?	root      	devtmpfsd.part.5              
-06:20:32	35      	2       	?	root      	rescuer_thread                
-06:20:32	36      	2       	?	root      	kauditd_thread                
-06:20:32	37      	2       	?	root      	watchdog                      
-06:20:32	38      	2       	?	root      	oom_reaper                    
-06:20:32	39      	2       	?	root      	rescuer_thread                
-06:20:32	40      	2       	?	root      	kcompactd                     
-06:20:32	41      	2       	?	root      	ksm_scan_thread               
-06:20:32	42      	2       	?	root      	khugepaged                    
-06:20:32	44      	2       	?	root      	worker_thread                 
-06:20:32	97      	2       	?	root      	rescuer_thread                
-06:20:32	98      	2       	?	root      	rescuer_thread                
-06:20:32	99      	2       	?	root      	rescuer_thread                
-06:20:32	100     	2       	?	root      	rescuer_thread                
-06:20:32	101     	2       	?	root      	rescuer_thread                
-06:20:32	102     	2       	?	root      	rescuer_thread                
-06:20:32	103     	2       	?	root      	rescuer_thread                
-06:20:32	104     	2       	?	root      	kthread_worker_fn             
-06:20:32	105     	2       	?	root      	worker_thread                 
-06:20:32	107     	2       	?	root      	kswapd                        
-06:20:32	109     	2       	?	root      	rescuer_thread                
-06:20:32	110     	2       	?	root      	rescuer_thread                
-06:20:32	111     	2       	?	root      	rescuer_thread                
-06:20:32	112     	2       	?	root      	rescuer_thread                
-06:20:32	113     	2       	?	root      	worker_thread                 
-06:20:32	114     	2       	?	root      	rescuer_thread                
-06:20:32	115     	2       	?	root      	rescuer_thread                
-06:20:32	116     	2       	?	root      	rescuer_thread                
-06:20:32	117     	2       	?	root      	rescuer_thread                
-06:20:32	118     	2       	?	root      	rescuer_thread                
-06:20:32	119     	2       	?	root      	worker_thread                 
-06:20:32	120     	2       	?	root      	rescuer_thread                
-06:20:32	125     	2       	?	root      	worker_thread                 
-06:20:32	127     	2       	?	root      	worker_thread                 
-06:20:32	135     	2       	?	root      	rescuer_thread                
-06:20:32	186     	2       	?	root      	worker_thread                 
-06:20:32	189     	2       	?	root      	worker_thread                 
-06:20:32	191     	2       	?	root      	worker_thread                 
-06:20:32	194     	2       	?	root      	worker_thread                 
-06:20:32	344     	2       	?	root      	rescuer_thread                
-06:20:32	345     	2       	?	root      	worker_thread                 
-06:20:32	346     	2       	?	root      	rescuer_thread                
-06:20:32	347     	2       	?	root      	scsi_error_handler            
-06:20:32	351     	2       	?	root      	rescuer_thread                
-06:20:32	352     	2       	?	root      	scsi_error_handler            
-06:20:32	353     	2       	?	root      	rescuer_thread                
-06:20:32	366     	2       	?	root      	scsi_error_handler            
-06:20:32	367     	2       	?	root      	rescuer_thread                
-06:20:32	369     	2       	?	root      	worker_thread                 
-06:20:32	371     	2       	?	root      	irq_thread                    
-06:20:32	372     	2       	?	root      	rescuer_thread                
-06:20:32	441     	2       	?	root      	rescuer_thread                
-06:20:32	452     	2       	?	root      	rescuer_thread                
-06:20:32	467     	2       	?	root      	worker_thread                 
-06:20:32	473     	2       	?	root      	worker_thread                 
-06:20:32	477     	2       	?	root      	worker_thread                 
-06:20:32	478     	2       	?	root      	rescuer_thread                
-06:20:32	479     	2       	?	root      	rescuer_thread                
-06:20:32	481     	2       	?	root      	rescuer_thread                
-06:20:32	482     	2       	?	root      	rescuer_thread                
-06:20:32	483     	2       	?	root      	rescuer_thread                
-06:20:32	484     	2       	?	root      	rescuer_thread                
-06:20:32	485     	2       	?	root      	rescuer_thread                
-06:20:32	486     	2       	?	root      	rescuer_thread                
-06:20:32	487     	2       	?	root      	xfsaild                       
-06:20:32	555     	2       	?	root      	worker_thread                 
-06:20:32	585     	1       	?	root      	ep_poll                       
-06:20:32	624     	1       	?	root      	ep_poll                       
-06:20:32	655     	2       	?	root      	rescuer_thread                
-06:20:32	696     	2       	?	root      	rescuer_thread                
-06:20:32	751     	2       	?	root      	rescuer_thread                
-06:20:32	752     	2       	?	root      	rescuer_thread                
-06:20:32	753     	2       	?	root      	rescuer_thread                
-06:20:32	754     	2       	?	root      	rescuer_thread                
-06:20:32	755     	2       	?	root      	rescuer_thread                
-06:20:32	756     	2       	?	root      	rescuer_thread                
-06:20:32	757     	2       	?	root      	rescuer_thread                
-06:20:32	758     	2       	?	root      	rescuer_thread                
-06:20:32	759     	2       	?	root      	rescuer_thread                
-06:20:32	760     	2       	?	root      	rescuer_thread                
-06:20:32	761     	2       	?	root      	rescuer_thread                
-06:20:32	762     	2       	?	root      	xfsaild                       
-06:20:32	763     	2       	?	root      	rescuer_thread                
-06:20:32	764     	2       	?	root      	xfsaild                       
-06:20:32	786     	1       	?	rpc       	poll_schedule_timeout.constpro
-06:20:32	788     	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	790     	788     	?	root      	unix_stream_read_generic      
-06:20:32	800     	2       	?	root      	rescuer_thread                
-06:20:32	801     	2       	?	root      	rescuer_thread                
-06:20:32	816     	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	818     	1       	?	dbus      	ep_poll                       
-06:20:32	820     	1       	?	polkitd   	poll_schedule_timeout.constpro
-06:20:32	821     	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	826     	1       	?	rtkit     	poll_schedule_timeout.constpro
-06:20:32	827     	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	829     	1       	?	avahi     	poll_schedule_timeout.constpro
-06:20:32	830     	1       	?	libstorage	poll_schedule_timeout.constpro
-06:20:32	834     	1       	?	root      	ep_poll                       
-06:20:32	835     	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	838     	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	840     	1       	?	root      	hrtimer_nanosleep             
-06:20:32	857     	1       	?	chrony    	poll_schedule_timeout.constpro
-06:20:32	860     	1       	?	root      	do_wait                       
-06:20:32	864     	1       	?	root      	futex_wait_queue_me           
-06:20:32	868     	829     	?	avahi     	unix_stream_read_generic      
-06:20:32	877     	838     	?	root      	ep_poll                       
-06:20:32	884     	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	885     	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	897     	838     	?	root      	ep_poll                       
-06:20:32	941     	1       	?	root      	ep_poll                       
-06:20:32	946     	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	1106    	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	1117    	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	1119    	1       	?	root      	ep_poll                       
-06:20:32	1120    	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	1125    	1       	?	root      	ep_poll                       
-06:20:32	1150    	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	1151    	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	1176    	2       	?	root      	rescuer_thread                
-06:20:32	1192    	1       	?	root      	hrtimer_nanosleep             
-06:20:32	1193    	2       	?	root      	worker_thread                 
-06:20:32	1194    	1       	?	root      	__ia32_sys_pause              
-06:20:32	1624    	1       	?	pcp       	poll_schedule_timeout.constpro
-06:20:32	1633    	1624    	?	root      	poll_schedule_timeout.constpro
-06:20:32	1650    	1633    	?	root      	-                             
-06:20:32	1666    	1633    	?	root      	pipe_wait                     
-06:20:32	1682    	1633    	?	root      	pipe_wait                     
-06:20:32	1690    	1633    	?	root      	pipe_wait                     
-06:20:32	1754    	1633    	?	root      	pipe_wait                     
-06:20:32	1761    	1633    	?	root      	pipe_wait                     
-06:20:32	1767    	1633    	?	root      	pipe_wait                     
-06:20:32	2407    	1       	?	dnsmasq   	poll_schedule_timeout.constpro
-06:20:32	2410    	2407    	?	root      	pipe_wait                     
-06:20:32	2501    	1       	?	pcp       	hrtimer_nanosleep             
-06:20:32	2508    	1       	?	pcp       	poll_schedule_timeout.constpro
-06:20:32	2516    	1       	?	pcp       	__ia32_sys_pause              
-06:20:32	2684    	1       	?	pcp       	__ia32_sys_pause              
-06:20:32	2937    	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	2953    	1       	?	root      	do_sigtimedwait.isra.42       
-06:20:32	4956    	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	4964    	1       	?	geoclue   	poll_schedule_timeout.constpro
-06:20:32	4977    	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	4978    	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	5059    	1       	?	colord    	poll_schedule_timeout.constpro
-06:20:32	5150    	2       	?	root      	worker_thread                 
-06:20:32	5714    	2937    	?	root      	poll_schedule_timeout.constpro
-06:20:32	5729    	1       	?	root      	ep_poll                       
-06:20:32	5731    	5729    	?	root      	do_sigtimedwait.isra.42       
-06:20:32	5757    	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	5764    	5714    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	5766    	5729    	?	root      	ep_poll                       
-06:20:32	5769    	5764    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	5857    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	5901    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	5908    	5729    	?	root      	futex_wait_queue_me           
-06:20:32	5916    	5857    	tty2	root      	ep_poll                       
-06:20:32	5927    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	5938    	5927    	?	root      	ep_poll                       
-06:20:32	5945    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	5963    	5857    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	5967    	5963    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	5968    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	5970    	5963    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	5976    	1       	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	5979    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	5993    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	5999    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6005    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6014    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6023    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6030    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6034    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6042    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6050    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6055    	1       	?	root      	ep_poll                       
-06:20:32	6057    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6058    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6060    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6062    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6064    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6072    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6078    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6082    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6085    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6087    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6088    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6111    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6113    	5963    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6115    	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	6122    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6126    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6128    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6131    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6132    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6138    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6142    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6188    	6085    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6216    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6217    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6219    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6224    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6230    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6243    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6252    	1       	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6254    	5769    	tty2	root      	poll_schedule_timeout.constpro
-06:20:32	6288    	1       	?	root      	do_wait                       
-06:20:32	6294    	6216    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6297    	6288    	?	root      	rtR0SemEventMultiLnxWait.isra.
-06:20:32	6324    	1       	?	root      	do_wait                       
-06:20:32	6325    	6324    	?	root      	rtR0SemEventMultiLnxWait.isra.
-06:20:32	6334    	1       	?	root      	do_wait                       
-06:20:32	6335    	6334    	?	root      	futex_wait_queue_me           
-06:20:32	6342    	1       	?	root      	do_wait                       
-06:20:32	6343    	6342    	?	root      	rtR0SemEventMultiLnxWait.isra.
-06:20:32	6432    	1       	?	root      	poll_schedule_timeout.constpro
-06:20:32	6834    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	6839    	6834    	pts/0	root      	do_wait                       
-06:20:32	6941    	2       	?	root      	worker_thread                 
-06:20:32	8571    	5729    	?	root      	poll_schedule_timeout.constpro
-06:20:32	9308    	860     	?	root      	hrtimer_nanosleep             
-06:20:32	9327    	6839    	pts/0	root      	do_wait                       
-06:20:32	9344    	9327    	pts/0	root      	poll_schedule_timeout.constpro
-06:20:32	9349    	5729    	?	root      	-                             
 
 pcp-ps output : Display the selected process pid 1 and 2
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
 Timestamp        PID		PPID		TTY	TIME		CMD
+06:20:30         1       	0       	?	00:00:01	systemd             
+06:20:30         2       	0       	?	00:00:00	kthreadd            
+Timestamp        PID		PPID		TTY	TIME		CMD
 06:20:31         1       	0       	?	00:00:01	systemd             
 06:20:31         2       	0       	?	00:00:00	kthreadd            
-Timestamp        PID		PPID		TTY	TIME		CMD
-06:20:32         1       	0       	?	00:00:01	systemd             
-06:20:32         2       	0       	?	00:00:00	kthreadd            
 
 pcp-ps output : Display the selected process ppid 1,2,3,4 and 5
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
+Timestamp        PID		PPID		TTY	TIME		CMD
+06:20:30         3       	2       	?	00:00:00	rcu_gp              
+06:20:30         4       	2       	?	00:00:00	rcu_par_gp          
+06:20:30         5       	2       	?	00:00:00	kworker/0:0-cgroup_p
+06:20:30         6       	2       	?	00:00:00	kworker/0:0H-events_
+06:20:30         7       	2       	?	00:00:00	kworker/u8:0-events_
+06:20:30         8       	2       	?	00:00:00	kworker/0:1H-events_
+06:20:30         9       	2       	?	00:00:00	mm_percpu_wq        
+06:20:30         10      	2       	?	00:00:00	ksoftirqd/0         
+06:20:30         11      	2       	?	00:00:00	rcu_sched           
+06:20:30         12      	2       	?	00:00:00	migration/0         
+06:20:30         13      	2       	?	00:00:00	kworker/0:1-events  
+06:20:30         14      	2       	?	00:00:00	cpuhp/0             
+06:20:30         15      	2       	?	00:00:00	cpuhp/1             
+06:20:30         16      	2       	?	00:00:00	migration/1         
+06:20:30         17      	2       	?	00:00:00	ksoftirqd/1         
+06:20:30         18      	2       	?	00:00:00	kworker/1:0-cgroup_p
+06:20:30         19      	2       	?	00:00:00	kworker/1:0H-events_
+06:20:30         20      	2       	?	00:00:00	cpuhp/2             
+06:20:30         21      	2       	?	00:00:00	migration/2         
+06:20:30         22      	2       	?	00:00:00	ksoftirqd/2         
+06:20:30         23      	2       	?	00:00:00	kworker/2:0-events  
+06:20:30         24      	2       	?	00:00:00	kworker/2:0H-events_
+06:20:30         25      	2       	?	00:00:00	cpuhp/3             
+06:20:30         26      	2       	?	00:00:00	migration/3         
+06:20:30         27      	2       	?	00:00:00	ksoftirqd/3         
+06:20:30         28      	2       	?	00:00:00	kworker/3:0-events  
+06:20:30         29      	2       	?	00:00:00	kworker/3:0H-events_
+06:20:30         31      	2       	?	00:00:00	kworker/u8:1-events_
+06:20:30         32      	2       	?	00:00:00	kworker/u8:2-events_
+06:20:30         33      	2       	?	00:00:00	kworker/u8:3-events_
+06:20:30         34      	2       	?	00:00:00	kdevtmpfs           
+06:20:30         35      	2       	?	00:00:00	netns               
+06:20:30         36      	2       	?	00:00:00	kauditd             
+06:20:30         37      	2       	?	00:00:00	khungtaskd          
+06:20:30         38      	2       	?	00:00:00	oom_reaper          
+06:20:30         39      	2       	?	00:00:00	writeback           
+06:20:30         40      	2       	?	00:00:00	kcompactd0          
+06:20:30         41      	2       	?	00:00:00	ksmd                
+06:20:30         42      	2       	?	00:00:00	khugepaged          
+06:20:30         44      	2       	?	00:00:00	kworker/3:1-events  
+06:20:30         97      	2       	?	00:00:00	kintegrityd         
+06:20:30         98      	2       	?	00:00:00	kblockd             
+06:20:30         99      	2       	?	00:00:00	blkcg_punt_bio      
+06:20:30         100     	2       	?	00:00:00	tpm_dev_wq          
+06:20:30         101     	2       	?	00:00:00	md                  
+06:20:30         102     	2       	?	00:00:00	edac-poller         
+06:20:30         103     	2       	?	00:00:00	devfreq_wq          
+06:20:30         104     	2       	?	00:00:00	watchdogd           
+06:20:30         105     	2       	?	00:00:00	kworker/2:1-mm_percp
+06:20:30         107     	2       	?	00:00:00	kswapd0:0           
+06:20:30         109     	2       	?	00:00:00	kthrotld            
+06:20:30         110     	2       	?	00:00:00	acpi_thermal_pm     
+06:20:30         111     	2       	?	00:00:00	kmpath_rdacd        
+06:20:30         112     	2       	?	00:00:00	kaluad              
+06:20:30         113     	2       	?	00:00:00	kworker/3:1H-events_
+06:20:30         114     	2       	?	00:00:00	bch_btree_io        
+06:20:30         115     	2       	?	00:00:00	bcache              
+06:20:30         116     	2       	?	00:00:00	bch_journal         
+06:20:30         117     	2       	?	00:00:00	ipv6_addrconf       
+06:20:30         118     	2       	?	00:00:00	dsa_ordered         
+06:20:30         119     	2       	?	00:00:00	kworker/0:2-cgroup_p
+06:20:30         120     	2       	?	00:00:00	kstrp               
+06:20:30         125     	2       	?	00:00:00	kworker/u9:0        
+06:20:30         127     	2       	?	00:00:00	kworker/1:1-ata_sff 
+06:20:30         135     	2       	?	00:00:00	charger_manager     
+06:20:30         186     	2       	?	00:00:00	kworker/3:2-events  
+06:20:30         189     	2       	?	00:00:00	kworker/1:2-events  
+06:20:30         191     	2       	?	00:00:00	kworker/1:3-cgroup_d
+06:20:30         194     	2       	?	00:00:00	kworker/0:3-cgroup_p
+06:20:30         344     	2       	?	00:00:00	iprt-VBoxWQueue     
+06:20:30         345     	2       	?	00:00:00	kworker/2:1H-events_
+06:20:30         346     	2       	?	00:00:00	ata_sff             
+06:20:30         347     	2       	?	00:00:00	scsi_eh_0           
+06:20:30         351     	2       	?	00:00:00	scsi_tmf_0          
+06:20:30         352     	2       	?	00:00:00	scsi_eh_1           
+06:20:30         353     	2       	?	00:00:00	scsi_tmf_1          
+06:20:30         366     	2       	?	00:00:00	scsi_eh_2           
+06:20:30         367     	2       	?	00:00:00	scsi_tmf_2          
+06:20:30         369     	2       	?	00:00:00	kworker/1:1H-events_
+06:20:30         371     	2       	?	00:00:00	irq/18-vmwgfx       
+06:20:30         372     	2       	?	00:00:00	ttm_swap            
+06:20:30         441     	2       	?	00:00:00	kdmflush            
+06:20:30         452     	2       	?	00:00:00	kdmflush            
+06:20:30         467     	2       	?	00:00:00	kworker/3:3-xfs-buf/
+06:20:30         473     	2       	?	00:00:00	kworker/2:2-cgroup_p
+06:20:30         477     	2       	?	00:00:00	kworker/2:3-cgroup_d
+06:20:30         478     	2       	?	00:00:00	xfsalloc            
+06:20:30         479     	2       	?	00:00:00	xfs_mru_cache       
+06:20:30         481     	2       	?	00:00:00	xfs-buf/dm-0        
+06:20:30         482     	2       	?	00:00:00	xfs-conv/dm-0       
+06:20:30         483     	2       	?	00:00:00	xfs-cil/dm-0        
+06:20:30         484     	2       	?	00:00:00	xfs-reclaim/dm-     
+06:20:30         485     	2       	?	00:00:00	xfs-eofblocks/d     
+06:20:30         486     	2       	?	00:00:00	xfs-log/dm-0        
+06:20:30         487     	2       	?	00:00:00	xfsaild/dm-0        
+06:20:30         555     	2       	?	00:00:00	kworker/2:4-events  
+06:20:30         585     	1       	?	00:00:00	systemd-journal     
+06:20:30         624     	1       	?	00:00:00	systemd-udevd       
+06:20:30         655     	2       	?	00:00:00	cryptd              
+06:20:30         696     	2       	?	00:00:00	kdmflush            
+06:20:30         751     	2       	?	00:00:00	xfs-buf/dm-2        
+06:20:30         752     	2       	?	00:00:00	xfs-conv/dm-2       
+06:20:30         753     	2       	?	00:00:00	xfs-cil/dm-2        
+06:20:30         754     	2       	?	00:00:00	xfs-buf/sda1        
+06:20:30         755     	2       	?	00:00:00	xfs-conv/sda1       
+06:20:30         756     	2       	?	00:00:00	xfs-reclaim/dm-     
+06:20:30         757     	2       	?	00:00:00	xfs-cil/sda1        
+06:20:30         758     	2       	?	00:00:00	xfs-eofblocks/d     
+06:20:30         759     	2       	?	00:00:00	xfs-reclaim/sda     
+06:20:30         760     	2       	?	00:00:00	xfs-eofblocks/s     
+06:20:30         761     	2       	?	00:00:00	xfs-log/dm-2        
+06:20:30         762     	2       	?	00:00:00	xfsaild/dm-2        
+06:20:30         763     	2       	?	00:00:00	xfs-log/sda1        
+06:20:30         764     	2       	?	00:00:00	xfsaild/sda1        
+06:20:30         786     	1       	?	00:00:00	rpcbind             
+06:20:30         788     	1       	?	00:00:00	auditd              
+06:20:30         800     	2       	?	00:00:00	rpciod              
+06:20:30         801     	2       	?	00:00:00	xprtiod             
+06:20:30         816     	1       	?	00:00:00	mcelog              
+06:20:30         818     	1       	?	00:00:00	dbus-daemon         
+06:20:30         820     	1       	?	00:00:00	polkitd             
+06:20:30         821     	1       	?	00:00:00	irqbalance          
+06:20:30         826     	1       	?	00:00:00	rtkit-daemon        
+06:20:30         827     	1       	?	00:00:00	alsactl             
+06:20:30         829     	1       	?	00:00:00	avahi-daemon        
+06:20:30         830     	1       	?	00:00:00	lsmd                
+06:20:30         834     	1       	?	00:00:00	systemd-machine     
+06:20:30         835     	1       	?	00:00:00	udisksd             
+06:20:30         838     	1       	?	00:00:00	sssd                
+06:20:30         840     	1       	?	00:00:00	smartd              
+06:20:30         857     	1       	?	00:00:00	chronyd             
+06:20:30         860     	1       	?	00:00:00	ksmtuned            
+06:20:30         864     	1       	?	00:00:00	vpnagentd           
+06:20:30         884     	1       	?	00:00:00	firewalld           
+06:20:30         885     	1       	?	00:00:00	ModemManager        
+06:20:30         941     	1       	?	00:00:00	systemd-logind      
+06:20:30         946     	1       	?	00:00:00	accounts-daemon     
+06:20:30         1106    	1       	?	00:00:00	NetworkManager      
+06:20:30         1117    	1       	?	00:00:00	sshd                
+06:20:30         1119    	1       	?	00:00:00	cupsd               
+06:20:30         1120    	1       	?	00:00:02	tuned               
+06:20:30         1125    	1       	?	00:00:00	gssproxy            
+06:20:30         1150    	1       	?	00:00:00	iscsid              
+06:20:30         1151    	1       	?	00:00:00	rsyslogd            
+06:20:30         1176    	2       	?	00:00:00	iscsi_eh            
+06:20:30         1192    	1       	?	00:00:00	crond               
+06:20:30         1193    	2       	?	00:00:00	kworker/0:4-cgroup_p
+06:20:30         1194    	1       	?	00:00:00	atd                 
+06:20:30         1624    	1       	?	00:00:00	pmcd                
+06:20:30         2407    	1       	?	00:00:00	dnsmasq             
+06:20:30         2501    	1       	?	00:00:00	pmie                
+06:20:30         2508    	1       	?	00:00:00	pmlogger            
+06:20:30         2516    	1       	?	00:00:00	pmpause             
+06:20:30         2684    	1       	?	00:00:00	pmpause             
+06:20:30         2937    	1       	?	00:00:00	gdm                 
+06:20:30         2953    	1       	?	00:00:00	VBoxService         
+06:20:30         4956    	1       	?	00:00:00	upowerd             
+06:20:30         4964    	1       	?	00:00:00	geoclue             
+06:20:30         4977    	1       	?	00:00:00	wpa_supplicant      
+06:20:30         4978    	1       	?	00:00:05	packagekitd         
+06:20:30         5059    	1       	?	00:00:00	colord              
+06:20:30         5150    	2       	?	00:00:00	kworker/3:4-cgroup_p
+06:20:30         5729    	1       	?	00:00:00	systemd             
+06:20:30         5757    	1       	?	00:00:00	gnome-keyring-d     
+06:20:30         5976    	1       	tty2	00:00:00	ibus-x11            
+06:20:30         6055    	1       	?	00:00:00	sssd_kcm            
+06:20:30         6115    	1       	?	00:00:00	pulseaudio          
+06:20:30         6252    	1       	tty2	00:00:00	gsd-printer         
+06:20:30         6288    	1       	?	00:00:00	VBoxClient          
+06:20:30         6324    	1       	?	00:00:00	VBoxClient          
+06:20:30         6334    	1       	?	00:00:00	VBoxClient          
+06:20:30         6342    	1       	?	00:00:00	VBoxClient          
+06:20:30         6432    	1       	?	00:00:00	fwupd               
+06:20:30         6941    	2       	?	00:00:00	kworker/1:4-cgroup_p
 Timestamp        PID		PPID		TTY	TIME		CMD
 06:20:31         3       	2       	?	00:00:00	rcu_gp              
 06:20:31         4       	2       	?	00:00:00	rcu_par_gp          
@@ -21268,190 +21699,15 @@ Timestamp        PID		PPID		TTY	TIME		CMD
 06:20:31         6342    	1       	?	00:00:00	VBoxClient          
 06:20:31         6432    	1       	?	00:00:00	fwupd               
 06:20:31         6941    	2       	?	00:00:00	kworker/1:4-cgroup_p
-Timestamp        PID		PPID		TTY	TIME		CMD
-06:20:32         3       	2       	?	00:00:00	rcu_gp              
-06:20:32         4       	2       	?	00:00:00	rcu_par_gp          
-06:20:32         5       	2       	?	00:00:00	kworker/0:0-cgroup_p
-06:20:32         6       	2       	?	00:00:00	kworker/0:0H-events_
-06:20:32         7       	2       	?	00:00:00	kworker/u8:0-events_
-06:20:32         8       	2       	?	00:00:00	kworker/0:1H-events_
-06:20:32         9       	2       	?	00:00:00	mm_percpu_wq        
-06:20:32         10      	2       	?	00:00:00	ksoftirqd/0         
-06:20:32         11      	2       	?	00:00:00	rcu_sched           
-06:20:32         12      	2       	?	00:00:00	migration/0         
-06:20:32         13      	2       	?	00:00:00	kworker/0:1-events  
-06:20:32         14      	2       	?	00:00:00	cpuhp/0             
-06:20:32         15      	2       	?	00:00:00	cpuhp/1             
-06:20:32         16      	2       	?	00:00:00	migration/1         
-06:20:32         17      	2       	?	00:00:00	ksoftirqd/1         
-06:20:32         18      	2       	?	00:00:00	kworker/1:0-cgroup_p
-06:20:32         19      	2       	?	00:00:00	kworker/1:0H-events_
-06:20:32         20      	2       	?	00:00:00	cpuhp/2             
-06:20:32         21      	2       	?	00:00:00	migration/2         
-06:20:32         22      	2       	?	00:00:00	ksoftirqd/2         
-06:20:32         23      	2       	?	00:00:00	kworker/2:0-events  
-06:20:32         24      	2       	?	00:00:00	kworker/2:0H-events_
-06:20:32         25      	2       	?	00:00:00	cpuhp/3             
-06:20:32         26      	2       	?	00:00:00	migration/3         
-06:20:32         27      	2       	?	00:00:00	ksoftirqd/3         
-06:20:32         28      	2       	?	00:00:00	kworker/3:0-events  
-06:20:32         29      	2       	?	00:00:00	kworker/3:0H-events_
-06:20:32         31      	2       	?	00:00:00	kworker/u8:1-events_
-06:20:32         32      	2       	?	00:00:00	kworker/u8:2-events_
-06:20:32         33      	2       	?	00:00:00	kworker/u8:3-events_
-06:20:32         34      	2       	?	00:00:00	kdevtmpfs           
-06:20:32         35      	2       	?	00:00:00	netns               
-06:20:32         36      	2       	?	00:00:00	kauditd             
-06:20:32         37      	2       	?	00:00:00	khungtaskd          
-06:20:32         38      	2       	?	00:00:00	oom_reaper          
-06:20:32         39      	2       	?	00:00:00	writeback           
-06:20:32         40      	2       	?	00:00:00	kcompactd0          
-06:20:32         41      	2       	?	00:00:00	ksmd                
-06:20:32         42      	2       	?	00:00:00	khugepaged          
-06:20:32         44      	2       	?	00:00:00	kworker/3:1-events  
-06:20:32         97      	2       	?	00:00:00	kintegrityd         
-06:20:32         98      	2       	?	00:00:00	kblockd             
-06:20:32         99      	2       	?	00:00:00	blkcg_punt_bio      
-06:20:32         100     	2       	?	00:00:00	tpm_dev_wq          
-06:20:32         101     	2       	?	00:00:00	md                  
-06:20:32         102     	2       	?	00:00:00	edac-poller         
-06:20:32         103     	2       	?	00:00:00	devfreq_wq          
-06:20:32         104     	2       	?	00:00:00	watchdogd           
-06:20:32         105     	2       	?	00:00:00	kworker/2:1-mm_percp
-06:20:32         107     	2       	?	00:00:00	kswapd0:0           
-06:20:32         109     	2       	?	00:00:00	kthrotld            
-06:20:32         110     	2       	?	00:00:00	acpi_thermal_pm     
-06:20:32         111     	2       	?	00:00:00	kmpath_rdacd        
-06:20:32         112     	2       	?	00:00:00	kaluad              
-06:20:32         113     	2       	?	00:00:00	kworker/3:1H-events_
-06:20:32         114     	2       	?	00:00:00	bch_btree_io        
-06:20:32         115     	2       	?	00:00:00	bcache              
-06:20:32         116     	2       	?	00:00:00	bch_journal         
-06:20:32         117     	2       	?	00:00:00	ipv6_addrconf       
-06:20:32         118     	2       	?	00:00:00	dsa_ordered         
-06:20:32         119     	2       	?	00:00:00	kworker/0:2-cgroup_p
-06:20:32         120     	2       	?	00:00:00	kstrp               
-06:20:32         125     	2       	?	00:00:00	kworker/u9:0        
-06:20:32         127     	2       	?	00:00:00	kworker/1:1-ata_sff 
-06:20:32         135     	2       	?	00:00:00	charger_manager     
-06:20:32         186     	2       	?	00:00:00	kworker/3:2-events  
-06:20:32         189     	2       	?	00:00:00	kworker/1:2-events  
-06:20:32         191     	2       	?	00:00:00	kworker/1:3-cgroup_d
-06:20:32         194     	2       	?	00:00:00	kworker/0:3-cgroup_p
-06:20:32         344     	2       	?	00:00:00	iprt-VBoxWQueue     
-06:20:32         345     	2       	?	00:00:00	kworker/2:1H-events_
-06:20:32         346     	2       	?	00:00:00	ata_sff             
-06:20:32         347     	2       	?	00:00:00	scsi_eh_0           
-06:20:32         351     	2       	?	00:00:00	scsi_tmf_0          
-06:20:32         352     	2       	?	00:00:00	scsi_eh_1           
-06:20:32         353     	2       	?	00:00:00	scsi_tmf_1          
-06:20:32         366     	2       	?	00:00:00	scsi_eh_2           
-06:20:32         367     	2       	?	00:00:00	scsi_tmf_2          
-06:20:32         369     	2       	?	00:00:00	kworker/1:1H-events_
-06:20:32         371     	2       	?	00:00:00	irq/18-vmwgfx       
-06:20:32         372     	2       	?	00:00:00	ttm_swap            
-06:20:32         441     	2       	?	00:00:00	kdmflush            
-06:20:32         452     	2       	?	00:00:00	kdmflush            
-06:20:32         467     	2       	?	00:00:00	kworker/3:3-xfs-buf/
-06:20:32         473     	2       	?	00:00:00	kworker/2:2-cgroup_p
-06:20:32         477     	2       	?	00:00:00	kworker/2:3-cgroup_d
-06:20:32         478     	2       	?	00:00:00	xfsalloc            
-06:20:32         479     	2       	?	00:00:00	xfs_mru_cache       
-06:20:32         481     	2       	?	00:00:00	xfs-buf/dm-0        
-06:20:32         482     	2       	?	00:00:00	xfs-conv/dm-0       
-06:20:32         483     	2       	?	00:00:00	xfs-cil/dm-0        
-06:20:32         484     	2       	?	00:00:00	xfs-reclaim/dm-     
-06:20:32         485     	2       	?	00:00:00	xfs-eofblocks/d     
-06:20:32         486     	2       	?	00:00:00	xfs-log/dm-0        
-06:20:32         487     	2       	?	00:00:00	xfsaild/dm-0        
-06:20:32         555     	2       	?	00:00:00	kworker/2:4-events  
-06:20:32         585     	1       	?	00:00:00	systemd-journal     
-06:20:32         624     	1       	?	00:00:00	systemd-udevd       
-06:20:32         655     	2       	?	00:00:00	cryptd              
-06:20:32         696     	2       	?	00:00:00	kdmflush            
-06:20:32         751     	2       	?	00:00:00	xfs-buf/dm-2        
-06:20:32         752     	2       	?	00:00:00	xfs-conv/dm-2       
-06:20:32         753     	2       	?	00:00:00	xfs-cil/dm-2        
-06:20:32         754     	2       	?	00:00:00	xfs-buf/sda1        
-06:20:32         755     	2       	?	00:00:00	xfs-conv/sda1       
-06:20:32         756     	2       	?	00:00:00	xfs-reclaim/dm-     
-06:20:32         757     	2       	?	00:00:00	xfs-cil/sda1        
-06:20:32         758     	2       	?	00:00:00	xfs-eofblocks/d     
-06:20:32         759     	2       	?	00:00:00	xfs-reclaim/sda     
-06:20:32         760     	2       	?	00:00:00	xfs-eofblocks/s     
-06:20:32         761     	2       	?	00:00:00	xfs-log/dm-2        
-06:20:32         762     	2       	?	00:00:00	xfsaild/dm-2        
-06:20:32         763     	2       	?	00:00:00	xfs-log/sda1        
-06:20:32         764     	2       	?	00:00:00	xfsaild/sda1        
-06:20:32         786     	1       	?	00:00:00	rpcbind             
-06:20:32         788     	1       	?	00:00:00	auditd              
-06:20:32         800     	2       	?	00:00:00	rpciod              
-06:20:32         801     	2       	?	00:00:00	xprtiod             
-06:20:32         816     	1       	?	00:00:00	mcelog              
-06:20:32         818     	1       	?	00:00:00	dbus-daemon         
-06:20:32         820     	1       	?	00:00:00	polkitd             
-06:20:32         821     	1       	?	00:00:00	irqbalance          
-06:20:32         826     	1       	?	00:00:00	rtkit-daemon        
-06:20:32         827     	1       	?	00:00:00	alsactl             
-06:20:32         829     	1       	?	00:00:00	avahi-daemon        
-06:20:32         830     	1       	?	00:00:00	lsmd                
-06:20:32         834     	1       	?	00:00:00	systemd-machine     
-06:20:32         835     	1       	?	00:00:00	udisksd             
-06:20:32         838     	1       	?	00:00:00	sssd                
-06:20:32         840     	1       	?	00:00:00	smartd              
-06:20:32         857     	1       	?	00:00:00	chronyd             
-06:20:32         860     	1       	?	00:00:00	ksmtuned            
-06:20:32         864     	1       	?	00:00:00	vpnagentd           
-06:20:32         884     	1       	?	00:00:00	firewalld           
-06:20:32         885     	1       	?	00:00:00	ModemManager        
-06:20:32         941     	1       	?	00:00:00	systemd-logind      
-06:20:32         946     	1       	?	00:00:00	accounts-daemon     
-06:20:32         1106    	1       	?	00:00:00	NetworkManager      
-06:20:32         1117    	1       	?	00:00:00	sshd                
-06:20:32         1119    	1       	?	00:00:00	cupsd               
-06:20:32         1120    	1       	?	00:00:02	tuned               
-06:20:32         1125    	1       	?	00:00:00	gssproxy            
-06:20:32         1150    	1       	?	00:00:00	iscsid              
-06:20:32         1151    	1       	?	00:00:00	rsyslogd            
-06:20:32         1176    	2       	?	00:00:00	iscsi_eh            
-06:20:32         1192    	1       	?	00:00:00	crond               
-06:20:32         1193    	2       	?	00:00:00	kworker/0:4-cgroup_p
-06:20:32         1194    	1       	?	00:00:00	atd                 
-06:20:32         1624    	1       	?	00:00:00	pmcd                
-06:20:32         2407    	1       	?	00:00:00	dnsmasq             
-06:20:32         2501    	1       	?	00:00:00	pmie                
-06:20:32         2508    	1       	?	00:00:00	pmlogger            
-06:20:32         2516    	1       	?	00:00:00	pmpause             
-06:20:32         2684    	1       	?	00:00:00	pmpause             
-06:20:32         2937    	1       	?	00:00:00	gdm                 
-06:20:32         2953    	1       	?	00:00:00	VBoxService         
-06:20:32         4956    	1       	?	00:00:00	upowerd             
-06:20:32         4964    	1       	?	00:00:00	geoclue             
-06:20:32         4977    	1       	?	00:00:00	wpa_supplicant      
-06:20:32         4978    	1       	?	00:00:05	packagekitd         
-06:20:32         5059    	1       	?	00:00:00	colord              
-06:20:32         5150    	2       	?	00:00:00	kworker/3:4-cgroup_p
-06:20:32         5729    	1       	?	00:00:00	systemd             
-06:20:32         5757    	1       	?	00:00:00	gnome-keyring-d     
-06:20:32         5976    	1       	tty2	00:00:00	ibus-x11            
-06:20:32         6055    	1       	?	00:00:00	sssd_kcm            
-06:20:32         6115    	1       	?	00:00:00	pulseaudio          
-06:20:32         6252    	1       	tty2	00:00:00	gsd-printer         
-06:20:32         6288    	1       	?	00:00:00	VBoxClient          
-06:20:32         6324    	1       	?	00:00:00	VBoxClient          
-06:20:32         6334    	1       	?	00:00:00	VBoxClient          
-06:20:32         6342    	1       	?	00:00:00	VBoxClient          
-06:20:32         6432    	1       	?	00:00:00	fwupd               
-06:20:32         6941    	2       	?	00:00:00	kworker/1:4-cgroup_p
 
 pcp-ps output : Display only user selected process command
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
 Timestamp        PID		PPID		TTY	TIME		CMD
+06:20:30         1       	0       	?	00:00:01	systemd             
+06:20:30         5729    	1       	?	00:00:00	systemd             
+Timestamp        PID		PPID		TTY	TIME		CMD
 06:20:31         1       	0       	?	00:00:01	systemd             
 06:20:31         5729    	1       	?	00:00:00	systemd             
-Timestamp        PID		PPID		TTY	TIME		CMD
-06:20:32         1       	0       	?	00:00:01	systemd             
-06:20:32         5729    	1       	?	00:00:00	systemd             
 
 pcp-ps output : Display only selected user process
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
@@ -21951,6 +22207,262 @@ Timestamp        USERNAME	PID		%CPU	%MEM	VSZ	RSS	TTY	STAT	TIME		START		COMMAND
 pcp-ps output : Display the colum args in between of -o option colum list
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
 Timestamp	PID		PPID		Command				TTY	WCHAN				
+06:20:30	1       	0       	/usr/lib/systemd/systemd --swi	?	ep_poll                       
+06:20:30	2       	0       	(kthreadd)                    	?	kthreadd                      
+06:20:30	3       	2       	(rcu_gp)                      	?	rescuer_thread                
+06:20:30	4       	2       	(rcu_par_gp)                  	?	rescuer_thread                
+06:20:30	5       	2       	(kworker/0:0-cgroup_pidlist_de	?	worker_thread                 
+06:20:30	6       	2       	(kworker/0:0H-events_highpri) 	?	worker_thread                 
+06:20:30	7       	2       	(kworker/u8:0-events_unbound) 	?	worker_thread                 
+06:20:30	8       	2       	(kworker/0:1H-kblockd)        	?	worker_thread                 
+06:20:30	9       	2       	(mm_percpu_wq)                	?	rescuer_thread                
+06:20:30	10      	2       	(ksoftirqd/0)                 	?	smpboot_thread_fn             
+06:20:30	11      	2       	(rcu_sched)                   	?	rcu_gp_kthread                
+06:20:30	12      	2       	(migration/0)                 	?	smpboot_thread_fn             
+06:20:30	13      	2       	(kworker/0:1-xfs-buf/dm-0)    	?	worker_thread                 
+06:20:30	14      	2       	(cpuhp/0)                     	?	smpboot_thread_fn             
+06:20:30	15      	2       	(cpuhp/1)                     	?	smpboot_thread_fn             
+06:20:30	16      	2       	(migration/1)                 	?	smpboot_thread_fn             
+06:20:30	17      	2       	(ksoftirqd/1)                 	?	smpboot_thread_fn             
+06:20:30	18      	2       	(kworker/1:0-events)          	?	worker_thread                 
+06:20:30	19      	2       	(kworker/1:0H-events_highpri) 	?	worker_thread                 
+06:20:30	20      	2       	(cpuhp/2)                     	?	smpboot_thread_fn             
+06:20:30	21      	2       	(migration/2)                 	?	smpboot_thread_fn             
+06:20:30	22      	2       	(ksoftirqd/2)                 	?	smpboot_thread_fn             
+06:20:30	23      	2       	(kworker/2:0-cgroup_pidlist_de	?	worker_thread                 
+06:20:30	24      	2       	(kworker/2:0H-events_highpri) 	?	worker_thread                 
+06:20:30	25      	2       	(cpuhp/3)                     	?	smpboot_thread_fn             
+06:20:30	26      	2       	(migration/3)                 	?	smpboot_thread_fn             
+06:20:30	27      	2       	(ksoftirqd/3)                 	?	smpboot_thread_fn             
+06:20:30	28      	2       	(kworker/3:0-events)          	?	worker_thread                 
+06:20:30	29      	2       	(kworker/3:0H-events_highpri) 	?	worker_thread                 
+06:20:30	31      	2       	(kworker/u8:1-events_unbound) 	?	worker_thread                 
+06:20:30	32      	2       	(kworker/u8:2-events_unbound) 	?	worker_thread                 
+06:20:30	33      	2       	(kworker/u8:3)                	?	worker_thread                 
+06:20:30	34      	2       	(kdevtmpfs)                   	?	devtmpfsd.part.5              
+06:20:30	35      	2       	(netns)                       	?	rescuer_thread                
+06:20:30	36      	2       	(kauditd)                     	?	kauditd_thread                
+06:20:30	37      	2       	(khungtaskd)                  	?	watchdog                      
+06:20:30	38      	2       	(oom_reaper)                  	?	oom_reaper                    
+06:20:30	39      	2       	(writeback)                   	?	rescuer_thread                
+06:20:30	40      	2       	(kcompactd0)                  	?	kcompactd                     
+06:20:30	41      	2       	(ksmd)                        	?	ksm_scan_thread               
+06:20:30	42      	2       	(khugepaged)                  	?	khugepaged                    
+06:20:30	44      	2       	(kworker/3:1-events)          	?	worker_thread                 
+06:20:30	97      	2       	(kintegrityd)                 	?	rescuer_thread                
+06:20:30	98      	2       	(kblockd)                     	?	rescuer_thread                
+06:20:30	99      	2       	(blkcg_punt_bio)              	?	rescuer_thread                
+06:20:30	100     	2       	(tpm_dev_wq)                  	?	rescuer_thread                
+06:20:30	101     	2       	(md)                          	?	rescuer_thread                
+06:20:30	102     	2       	(edac-poller)                 	?	rescuer_thread                
+06:20:30	103     	2       	(devfreq_wq)                  	?	rescuer_thread                
+06:20:30	104     	2       	(watchdogd)                   	?	kthread_worker_fn             
+06:20:30	105     	2       	(kworker/2:1-events)          	?	worker_thread                 
+06:20:30	107     	2       	(kswapd0:0)                   	?	kswapd                        
+06:20:30	109     	2       	(kthrotld)                    	?	rescuer_thread                
+06:20:30	110     	2       	(acpi_thermal_pm)             	?	rescuer_thread                
+06:20:30	111     	2       	(kmpath_rdacd)                	?	rescuer_thread                
+06:20:30	112     	2       	(kaluad)                      	?	rescuer_thread                
+06:20:30	113     	2       	(kworker/3:1H-events_highpri) 	?	worker_thread                 
+06:20:30	114     	2       	(bch_btree_io)                	?	rescuer_thread                
+06:20:30	115     	2       	(bcache)                      	?	rescuer_thread                
+06:20:30	116     	2       	(bch_journal)                 	?	rescuer_thread                
+06:20:30	117     	2       	(ipv6_addrconf)               	?	rescuer_thread                
+06:20:30	118     	2       	(dsa_ordered)                 	?	rescuer_thread                
+06:20:30	119     	2       	(kworker/0:2-events)          	?	worker_thread                 
+06:20:30	120     	2       	(kstrp)                       	?	rescuer_thread                
+06:20:30	125     	2       	(kworker/u9:0)                	?	worker_thread                 
+06:20:30	127     	2       	(kworker/1:1-events)          	?	worker_thread                 
+06:20:30	135     	2       	(charger_manager)             	?	rescuer_thread                
+06:20:30	186     	2       	(kworker/3:2-cgroup_pidlist_de	?	worker_thread                 
+06:20:30	189     	2       	(kworker/1:2-events)          	?	worker_thread                 
+06:20:30	191     	2       	(kworker/1:3-events)          	?	worker_thread                 
+06:20:30	194     	2       	(kworker/0:3-events)          	?	worker_thread                 
+06:20:30	344     	2       	(iprt-VBoxWQueue)             	?	rescuer_thread                
+06:20:30	345     	2       	(kworker/2:1H-xfs-log/dm-0)   	?	worker_thread                 
+06:20:30	346     	2       	(ata_sff)                     	?	rescuer_thread                
+06:20:30	347     	2       	(scsi_eh_0)                   	?	scsi_error_handler            
+06:20:30	351     	2       	(scsi_tmf_0)                  	?	rescuer_thread                
+06:20:30	352     	2       	(scsi_eh_1)                   	?	scsi_error_handler            
+06:20:30	353     	2       	(scsi_tmf_1)                  	?	rescuer_thread                
+06:20:30	366     	2       	(scsi_eh_2)                   	?	scsi_error_handler            
+06:20:30	367     	2       	(scsi_tmf_2)                  	?	rescuer_thread                
+06:20:30	369     	2       	(kworker/1:1H-kblockd)        	?	worker_thread                 
+06:20:30	371     	2       	(irq/18-vmwgfx)               	?	irq_thread                    
+06:20:30	372     	2       	(ttm_swap)                    	?	rescuer_thread                
+06:20:30	441     	2       	(kdmflush)                    	?	rescuer_thread                
+06:20:30	452     	2       	(kdmflush)                    	?	rescuer_thread                
+06:20:30	467     	2       	(kworker/3:3-events)          	?	worker_thread                 
+06:20:30	473     	2       	(kworker/2:2-cgroup_pidlist_de	?	worker_thread                 
+06:20:30	477     	2       	(kworker/2:3-cgroup_destroy)  	?	worker_thread                 
+06:20:30	478     	2       	(xfsalloc)                    	?	rescuer_thread                
+06:20:30	479     	2       	(xfs_mru_cache)               	?	rescuer_thread                
+06:20:30	481     	2       	(xfs-buf/dm-0)                	?	rescuer_thread                
+06:20:30	482     	2       	(xfs-conv/dm-0)               	?	rescuer_thread                
+06:20:30	483     	2       	(xfs-cil/dm-0)                	?	rescuer_thread                
+06:20:30	484     	2       	(xfs-reclaim/dm-)             	?	rescuer_thread                
+06:20:30	485     	2       	(xfs-eofblocks/d)             	?	rescuer_thread                
+06:20:30	486     	2       	(xfs-log/dm-0)                	?	rescuer_thread                
+06:20:30	487     	2       	(xfsaild/dm-0)                	?	xfsaild                       
+06:20:30	555     	2       	(kworker/2:4-events)          	?	worker_thread                 
+06:20:30	585     	1       	/usr/lib/systemd/systemd-journ	?	ep_poll                       
+06:20:30	624     	1       	/usr/lib/systemd/systemd-udevd	?	ep_poll                       
+06:20:30	655     	2       	(cryptd)                      	?	rescuer_thread                
+06:20:30	696     	2       	(kdmflush)                    	?	rescuer_thread                
+06:20:30	751     	2       	(xfs-buf/dm-2)                	?	rescuer_thread                
+06:20:30	752     	2       	(xfs-conv/dm-2)               	?	rescuer_thread                
+06:20:30	753     	2       	(xfs-cil/dm-2)                	?	rescuer_thread                
+06:20:30	754     	2       	(xfs-buf/sda1)                	?	rescuer_thread                
+06:20:30	755     	2       	(xfs-conv/sda1)               	?	rescuer_thread                
+06:20:30	756     	2       	(xfs-reclaim/dm-)             	?	rescuer_thread                
+06:20:30	757     	2       	(xfs-cil/sda1)                	?	rescuer_thread                
+06:20:30	758     	2       	(xfs-eofblocks/d)             	?	rescuer_thread                
+06:20:30	759     	2       	(xfs-reclaim/sda)             	?	rescuer_thread                
+06:20:30	760     	2       	(xfs-eofblocks/s)             	?	rescuer_thread                
+06:20:30	761     	2       	(xfs-log/dm-2)                	?	rescuer_thread                
+06:20:30	762     	2       	(xfsaild/dm-2)                	?	xfsaild                       
+06:20:30	763     	2       	(xfs-log/sda1)                	?	rescuer_thread                
+06:20:30	764     	2       	(xfsaild/sda1)                	?	xfsaild                       
+06:20:30	786     	1       	/usr/bin/rpcbind -w -f        	?	poll_schedule_timeout.constpro
+06:20:30	788     	1       	/sbin/auditd                  	?	poll_schedule_timeout.constpro
+06:20:30	790     	788     	/usr/sbin/sedispatch          	?	unix_stream_read_generic      
+06:20:30	800     	2       	(rpciod)                      	?	rescuer_thread                
+06:20:30	801     	2       	(xprtiod)                     	?	rescuer_thread                
+06:20:30	816     	1       	/usr/sbin/mcelog --ignorenodev	?	poll_schedule_timeout.constpro
+06:20:30	818     	1       	/usr/bin/dbus-daemon --system 	?	ep_poll                       
+06:20:30	820     	1       	/usr/lib/polkit-1/polkitd --no	?	poll_schedule_timeout.constpro
+06:20:30	821     	1       	/usr/sbin/irqbalance --foregro	?	poll_schedule_timeout.constpro
+06:20:30	826     	1       	/usr/libexec/rtkit-daemon     	?	poll_schedule_timeout.constpro
+06:20:30	827     	1       	/usr/sbin/alsactl -s -n 19 -c 	?	poll_schedule_timeout.constpro
+06:20:30	829     	1       	avahi-daemon: running [linux.l	?	poll_schedule_timeout.constpro
+06:20:30	830     	1       	/usr/bin/lsmd -d              	?	poll_schedule_timeout.constpro
+06:20:30	834     	1       	/usr/lib/systemd/systemd-machi	?	ep_poll                       
+06:20:30	835     	1       	/usr/libexec/udisks2/udisksd  	?	poll_schedule_timeout.constpro
+06:20:30	838     	1       	/usr/sbin/sssd -i --logger=fil	?	poll_schedule_timeout.constpro
+06:20:30	840     	1       	/usr/sbin/smartd -n -q never  	?	hrtimer_nanosleep             
+06:20:30	857     	1       	/usr/sbin/chronyd             	?	poll_schedule_timeout.constpro
+06:20:30	860     	1       	/bin/bash /usr/sbin/ksmtuned  	?	do_wait                       
+06:20:30	864     	1       	/opt/cisco/anyconnect/bin/vpna	?	futex_wait_queue_me           
+06:20:30	868     	829     	avahi-daemon: chroot helper   	?	unix_stream_read_generic      
+06:20:30	877     	838     	/usr/libexec/sssd/sssd_be --do	?	ep_poll                       
+06:20:30	884     	1       	/usr/libexec/platform-python -	?	poll_schedule_timeout.constpro
+06:20:30	885     	1       	/usr/sbin/ModemManager        	?	poll_schedule_timeout.constpro
+06:20:30	897     	838     	/usr/libexec/sssd/sssd_nss --u	?	ep_poll                       
+06:20:30	941     	1       	/usr/lib/systemd/systemd-login	?	ep_poll                       
+06:20:30	946     	1       	/usr/libexec/accounts-daemon  	?	poll_schedule_timeout.constpro
+06:20:30	1106    	1       	/usr/sbin/NetworkManager --no-	?	poll_schedule_timeout.constpro
+06:20:30	1117    	1       	/usr/sbin/sshd -D -oCiphers=ae	?	poll_schedule_timeout.constpro
+06:20:30	1119    	1       	/usr/sbin/cupsd -l            	?	ep_poll                       
+06:20:30	1120    	1       	/usr/libexec/platform-python -	?	poll_schedule_timeout.constpro
+06:20:30	1125    	1       	/usr/sbin/gssproxy -D         	?	ep_poll                       
+06:20:30	1150    	1       	/usr/sbin/iscsid -f -d2       	?	poll_schedule_timeout.constpro
+06:20:30	1151    	1       	/usr/sbin/rsyslogd -n         	?	poll_schedule_timeout.constpro
+06:20:30	1176    	2       	(iscsi_eh)                    	?	rescuer_thread                
+06:20:30	1192    	1       	/usr/sbin/crond -n            	?	hrtimer_nanosleep             
+06:20:30	1193    	2       	(kworker/0:4-cgroup_pidlist_de	?	worker_thread                 
+06:20:30	1194    	1       	/usr/sbin/atd -f              	?	__ia32_sys_pause              
+06:20:30	1624    	1       	/usr/libexec/pcp/bin/pmcd -A  	?	poll_schedule_timeout.constpro
+06:20:30	1633    	1624    	/var/lib/pcp/pmdas/root/pmdaro	?	poll_schedule_timeout.constpro
+06:20:30	1650    	1633    	/var/lib/pcp/pmdas/proc/pmdapr	?	-                             
+06:20:30	1666    	1633    	/var/lib/pcp/pmdas/xfs/pmdaxfs	?	pipe_wait                     
+06:20:30	1682    	1633    	/var/lib/pcp/pmdas/linux/pmdal	?	pipe_wait                     
+06:20:30	1690    	1633    	python3 /var/lib/pcp/pmdas/nfs	?	pipe_wait                     
+06:20:30	1754    	1633    	/var/lib/pcp/pmdas/kvm/pmdakvm	?	pipe_wait                     
+06:20:30	1761    	1633    	/var/lib/pcp/pmdas/dm/pmdadm -	?	pipe_wait                     
+06:20:30	1767    	1633    	python3 /var/lib/pcp/pmdas/ope	?	pipe_wait                     
+06:20:30	2407    	1       	/usr/sbin/dnsmasq --conf-file=	?	poll_schedule_timeout.constpro
+06:20:30	2410    	2407    	/usr/sbin/dnsmasq --conf-file=	?	pipe_wait                     
+06:20:30	2501    	1       	/usr/bin/pmie -b -F -P -l /var	?	hrtimer_nanosleep             
+06:20:30	2508    	1       	/usr/libexec/pcp/bin/pmlogger 	?	poll_schedule_timeout.constpro
+06:20:30	2516    	1       	/usr/libexec/pcp/bin/pmpause  	?	__ia32_sys_pause              
+06:20:30	2684    	1       	/bin/sh /usr/libexec/pcp/bin/p	?	__ia32_sys_pause              
+06:20:30	2937    	1       	/usr/sbin/gdm                 	?	poll_schedule_timeout.constpro
+06:20:30	2953    	1       	/usr/sbin/VBoxService --pidfil	?	do_sigtimedwait.isra.42       
+06:20:30	4956    	1       	/usr/libexec/upowerd          	?	poll_schedule_timeout.constpro
+06:20:30	4964    	1       	/usr/libexec/geoclue          	?	poll_schedule_timeout.constpro
+06:20:30	4977    	1       	/usr/sbin/wpa_supplicant -c /e	?	poll_schedule_timeout.constpro
+06:20:30	4978    	1       	/usr/libexec/packagekitd      	?	poll_schedule_timeout.constpro
+06:20:30	5059    	1       	/usr/libexec/colord           	?	poll_schedule_timeout.constpro
+06:20:30	5150    	2       	(kworker/3:4-cgroup_pidlist_de	?	worker_thread                 
+06:20:30	5714    	2937    	gdm-session-worker [pam/gdm-pa	?	poll_schedule_timeout.constpro
+06:20:30	5729    	1       	/usr/lib/systemd/systemd --use	?	ep_poll                       
+06:20:30	5731    	5729    	(sd-pam)                      	?	do_sigtimedwait.isra.42       
+06:20:30	5757    	1       	/usr/bin/gnome-keyring-daemon 	?	poll_schedule_timeout.constpro
+06:20:30	5764    	5714    	/usr/libexec/gdm-wayland-sessi	tty2	poll_schedule_timeout.constpro
+06:20:30	5766    	5729    	/usr/bin/dbus-daemon --session	?	ep_poll                       
+06:20:30	5769    	5764    	/usr/libexec/gnome-session-bin	tty2	poll_schedule_timeout.constpro
+06:20:30	5857    	5769    	/usr/bin/gnome-shell          	tty2	poll_schedule_timeout.constpro
+06:20:30	5901    	5729    	/usr/libexec/gvfsd            	?	poll_schedule_timeout.constpro
+06:20:30	5908    	5729    	/usr/libexec/gvfsd-fuse /run/u	?	futex_wait_queue_me           
+06:20:30	5916    	5857    	/usr/bin/Xwayland :0 -rootless	tty2	ep_poll                       
+06:20:30	5927    	5729    	/usr/libexec/at-spi-bus-launch	?	poll_schedule_timeout.constpro
+06:20:30	5938    	5927    	/usr/bin/dbus-daemon --config-	?	ep_poll                       
+06:20:30	5945    	5729    	/usr/libexec/at-spi2-registryd	?	poll_schedule_timeout.constpro
+06:20:30	5963    	5857    	ibus-daemon --xim --panel disa	tty2	poll_schedule_timeout.constpro
+06:20:30	5967    	5963    	/usr/libexec/ibus-dconf       	tty2	poll_schedule_timeout.constpro
+06:20:30	5968    	5729    	/usr/libexec/xdg-permission-st	?	poll_schedule_timeout.constpro
+06:20:30	5970    	5963    	/usr/libexec/ibus-extension-gt	tty2	poll_schedule_timeout.constpro
+06:20:30	5976    	1       	/usr/libexec/ibus-x11 --kill-d	tty2	poll_schedule_timeout.constpro
+06:20:30	5979    	5729    	/usr/libexec/ibus-portal      	?	poll_schedule_timeout.constpro
+06:20:30	5993    	5729    	/usr/libexec/gnome-shell-calen	?	poll_schedule_timeout.constpro
+06:20:30	5999    	5729    	/usr/libexec/evolution-source-	?	poll_schedule_timeout.constpro
+06:20:30	6005    	5729    	/usr/libexec/goa-daemon       	?	poll_schedule_timeout.constpro
+06:20:30	6014    	5729    	/usr/libexec/gvfs-udisks2-volu	?	poll_schedule_timeout.constpro
+06:20:30	6023    	5729    	/usr/libexec/gvfs-mtp-volume-m	?	poll_schedule_timeout.constpro
+06:20:30	6030    	5729    	/usr/libexec/gvfs-gphoto2-volu	?	poll_schedule_timeout.constpro
+06:20:30	6034    	5729    	/usr/libexec/goa-identity-serv	?	poll_schedule_timeout.constpro
+06:20:30	6042    	5729    	/usr/libexec/gvfs-goa-volume-m	?	poll_schedule_timeout.constpro
+06:20:30	6050    	5729    	/usr/libexec/gvfs-afc-volume-m	?	poll_schedule_timeout.constpro
+06:20:30	6055    	1       	/usr/libexec/sssd/sssd_kcm --u	?	ep_poll                       
+06:20:30	6057    	5769    	/usr/libexec/gsd-power        	tty2	poll_schedule_timeout.constpro
+06:20:30	6058    	5769    	/usr/libexec/gsd-print-notific	tty2	poll_schedule_timeout.constpro
+06:20:30	6060    	5769    	/usr/libexec/gsd-rfkill       	tty2	poll_schedule_timeout.constpro
+06:20:30	6062    	5769    	/usr/libexec/gsd-screensaver-p	tty2	poll_schedule_timeout.constpro
+06:20:30	6064    	5769    	/usr/libexec/gsd-sharing      	tty2	poll_schedule_timeout.constpro
+06:20:30	6072    	5769    	/usr/libexec/gsd-sound        	tty2	poll_schedule_timeout.constpro
+06:20:30	6078    	5769    	/usr/libexec/gsd-xsettings    	tty2	poll_schedule_timeout.constpro
+06:20:30	6082    	5769    	/usr/libexec/gsd-wacom        	tty2	poll_schedule_timeout.constpro
+06:20:30	6085    	5729    	/usr/libexec/evolution-calenda	?	poll_schedule_timeout.constpro
+06:20:30	6087    	5769    	/usr/libexec/gsd-smartcard    	tty2	poll_schedule_timeout.constpro
+06:20:30	6088    	5769    	/usr/libexec/gsd-account      	tty2	poll_schedule_timeout.constpro
+06:20:30	6111    	5769    	/usr/libexec/gsd-a11y-settings	tty2	poll_schedule_timeout.constpro
+06:20:30	6113    	5963    	/usr/libexec/ibus-engine-simpl	tty2	poll_schedule_timeout.constpro
+06:20:30	6115    	1       	/usr/bin/pulseaudio --start   	?	poll_schedule_timeout.constpro
+06:20:30	6122    	5769    	/usr/libexec/gsd-clipboard    	tty2	poll_schedule_timeout.constpro
+06:20:30	6126    	5769    	/usr/libexec/gsd-color        	tty2	poll_schedule_timeout.constpro
+06:20:30	6128    	5769    	/usr/libexec/gsd-datetime     	tty2	poll_schedule_timeout.constpro
+06:20:30	6131    	5769    	/usr/libexec/gsd-housekeeping 	tty2	poll_schedule_timeout.constpro
+06:20:30	6132    	5769    	/usr/libexec/gsd-keyboard     	tty2	poll_schedule_timeout.constpro
+06:20:30	6138    	5769    	/usr/libexec/gsd-media-keys   	tty2	poll_schedule_timeout.constpro
+06:20:30	6142    	5769    	/usr/libexec/gsd-mouse        	tty2	poll_schedule_timeout.constpro
+06:20:30	6188    	6085    	/usr/libexec/evolution-calenda	?	poll_schedule_timeout.constpro
+06:20:30	6216    	5729    	/usr/libexec/evolution-address	?	poll_schedule_timeout.constpro
+06:20:30	6217    	5729    	/usr/libexec/dconf-service    	?	poll_schedule_timeout.constpro
+06:20:30	6219    	5729    	/usr/libexec/tracker-store    	?	poll_schedule_timeout.constpro
+06:20:30	6224    	5769    	/usr/bin/gnome-software --gapp	tty2	poll_schedule_timeout.constpro
+06:20:30	6230    	5769    	/usr/libexec/gsd-disk-utility-	tty2	poll_schedule_timeout.constpro
+06:20:30	6243    	5769    	/usr/libexec/tracker-miner-app	tty2	poll_schedule_timeout.constpro
+06:20:30	6252    	1       	/usr/libexec/gsd-printer      	tty2	poll_schedule_timeout.constpro
+06:20:30	6254    	5769    	/usr/libexec/tracker-miner-fs 	tty2	poll_schedule_timeout.constpro
+06:20:30	6288    	1       	/usr/bin/VBoxClient --clipboar	?	do_wait                       
+06:20:30	6294    	6216    	/usr/libexec/evolution-address	?	poll_schedule_timeout.constpro
+06:20:30	6297    	6288    	/usr/bin/VBoxClient --clipboar	?	rtR0SemEventMultiLnxWait.isra.
+06:20:30	6324    	1       	/usr/bin/VBoxClient --seamless	?	do_wait                       
+06:20:30	6325    	6324    	/usr/bin/VBoxClient --seamless	?	rtR0SemEventMultiLnxWait.isra.
+06:20:30	6334    	1       	/usr/bin/VBoxClient --dragandd	?	do_wait                       
+06:20:30	6335    	6334    	/usr/bin/VBoxClient --dragandd	?	futex_wait_queue_me           
+06:20:30	6342    	1       	/usr/bin/VBoxClient --vmsvga  	?	do_wait                       
+06:20:30	6343    	6342    	                              	?	rtR0SemEventMultiLnxWait.isra.
+06:20:30	6432    	1       	/usr/libexec/fwupd/fwupd      	?	poll_schedule_timeout.constpro
+06:20:30	6834    	5729    	/usr/libexec/gnome-terminal-se	?	poll_schedule_timeout.constpro
+06:20:30	6839    	6834    	bash                          	pts/0	do_wait                       
+06:20:30	6941    	2       	(kworker/1:4-cgroup_pidlist_de	?	worker_thread                 
+06:20:30	8571    	5729    	/usr/libexec/gvfsd-metadata   	?	poll_schedule_timeout.constpro
+06:20:30	9308    	860     	sleep 60                      	?	hrtimer_nanosleep             
+06:20:30	9327    	6839    	/bin/sh ./mk.ps               	pts/0	do_wait                       
+06:20:30	9344    	9327    	pmlogger -s 10 -c /var/tmp/932	pts/0	poll_schedule_timeout.constpro
+06:20:30	9349    	5729    	/usr/libexec/tracker-extract  	?	-                             
+Timestamp	PID		PPID		Command				TTY	WCHAN				
 06:20:31	1       	0       	/usr/lib/systemd/systemd --swi	?	ep_poll                       
 06:20:31	2       	0       	(kthreadd)                    	?	kthreadd                      
 06:20:31	3       	2       	(rcu_gp)                      	?	rescuer_thread                
@@ -22206,265 +22718,265 @@ Timestamp	PID		PPID		Command				TTY	WCHAN
 06:20:31	9327    	6839    	/bin/sh ./mk.ps               	pts/0	do_wait                       
 06:20:31	9344    	9327    	pmlogger -s 10 -c /var/tmp/932	pts/0	poll_schedule_timeout.constpro
 06:20:31	9349    	5729    	/usr/libexec/tracker-extract  	?	-                             
-Timestamp	PID		PPID		Command				TTY	WCHAN				
-06:20:32	1       	0       	/usr/lib/systemd/systemd --swi	?	ep_poll                       
-06:20:32	2       	0       	(kthreadd)                    	?	kthreadd                      
-06:20:32	3       	2       	(rcu_gp)                      	?	rescuer_thread                
-06:20:32	4       	2       	(rcu_par_gp)                  	?	rescuer_thread                
-06:20:32	5       	2       	(kworker/0:0-cgroup_pidlist_de	?	worker_thread                 
-06:20:32	6       	2       	(kworker/0:0H-events_highpri) 	?	worker_thread                 
-06:20:32	7       	2       	(kworker/u8:0-events_unbound) 	?	worker_thread                 
-06:20:32	8       	2       	(kworker/0:1H-kblockd)        	?	worker_thread                 
-06:20:32	9       	2       	(mm_percpu_wq)                	?	rescuer_thread                
-06:20:32	10      	2       	(ksoftirqd/0)                 	?	smpboot_thread_fn             
-06:20:32	11      	2       	(rcu_sched)                   	?	rcu_gp_kthread                
-06:20:32	12      	2       	(migration/0)                 	?	smpboot_thread_fn             
-06:20:32	13      	2       	(kworker/0:1-xfs-buf/dm-0)    	?	worker_thread                 
-06:20:32	14      	2       	(cpuhp/0)                     	?	smpboot_thread_fn             
-06:20:32	15      	2       	(cpuhp/1)                     	?	smpboot_thread_fn             
-06:20:32	16      	2       	(migration/1)                 	?	smpboot_thread_fn             
-06:20:32	17      	2       	(ksoftirqd/1)                 	?	smpboot_thread_fn             
-06:20:32	18      	2       	(kworker/1:0-events)          	?	worker_thread                 
-06:20:32	19      	2       	(kworker/1:0H-events_highpri) 	?	worker_thread                 
-06:20:32	20      	2       	(cpuhp/2)                     	?	smpboot_thread_fn             
-06:20:32	21      	2       	(migration/2)                 	?	smpboot_thread_fn             
-06:20:32	22      	2       	(ksoftirqd/2)                 	?	smpboot_thread_fn             
-06:20:32	23      	2       	(kworker/2:0-cgroup_pidlist_de	?	worker_thread                 
-06:20:32	24      	2       	(kworker/2:0H-events_highpri) 	?	worker_thread                 
-06:20:32	25      	2       	(cpuhp/3)                     	?	smpboot_thread_fn             
-06:20:32	26      	2       	(migration/3)                 	?	smpboot_thread_fn             
-06:20:32	27      	2       	(ksoftirqd/3)                 	?	smpboot_thread_fn             
-06:20:32	28      	2       	(kworker/3:0-events)          	?	worker_thread                 
-06:20:32	29      	2       	(kworker/3:0H-events_highpri) 	?	worker_thread                 
-06:20:32	31      	2       	(kworker/u8:1-events_unbound) 	?	worker_thread                 
-06:20:32	32      	2       	(kworker/u8:2-events_unbound) 	?	worker_thread                 
-06:20:32	33      	2       	(kworker/u8:3)                	?	worker_thread                 
-06:20:32	34      	2       	(kdevtmpfs)                   	?	devtmpfsd.part.5              
-06:20:32	35      	2       	(netns)                       	?	rescuer_thread                
-06:20:32	36      	2       	(kauditd)                     	?	kauditd_thread                
-06:20:32	37      	2       	(khungtaskd)                  	?	watchdog                      
-06:20:32	38      	2       	(oom_reaper)                  	?	oom_reaper                    
-06:20:32	39      	2       	(writeback)                   	?	rescuer_thread                
-06:20:32	40      	2       	(kcompactd0)                  	?	kcompactd                     
-06:20:32	41      	2       	(ksmd)                        	?	ksm_scan_thread               
-06:20:32	42      	2       	(khugepaged)                  	?	khugepaged                    
-06:20:32	44      	2       	(kworker/3:1-events)          	?	worker_thread                 
-06:20:32	97      	2       	(kintegrityd)                 	?	rescuer_thread                
-06:20:32	98      	2       	(kblockd)                     	?	rescuer_thread                
-06:20:32	99      	2       	(blkcg_punt_bio)              	?	rescuer_thread                
-06:20:32	100     	2       	(tpm_dev_wq)                  	?	rescuer_thread                
-06:20:32	101     	2       	(md)                          	?	rescuer_thread                
-06:20:32	102     	2       	(edac-poller)                 	?	rescuer_thread                
-06:20:32	103     	2       	(devfreq_wq)                  	?	rescuer_thread                
-06:20:32	104     	2       	(watchdogd)                   	?	kthread_worker_fn             
-06:20:32	105     	2       	(kworker/2:1-events)          	?	worker_thread                 
-06:20:32	107     	2       	(kswapd0:0)                   	?	kswapd                        
-06:20:32	109     	2       	(kthrotld)                    	?	rescuer_thread                
-06:20:32	110     	2       	(acpi_thermal_pm)             	?	rescuer_thread                
-06:20:32	111     	2       	(kmpath_rdacd)                	?	rescuer_thread                
-06:20:32	112     	2       	(kaluad)                      	?	rescuer_thread                
-06:20:32	113     	2       	(kworker/3:1H-events_highpri) 	?	worker_thread                 
-06:20:32	114     	2       	(bch_btree_io)                	?	rescuer_thread                
-06:20:32	115     	2       	(bcache)                      	?	rescuer_thread                
-06:20:32	116     	2       	(bch_journal)                 	?	rescuer_thread                
-06:20:32	117     	2       	(ipv6_addrconf)               	?	rescuer_thread                
-06:20:32	118     	2       	(dsa_ordered)                 	?	rescuer_thread                
-06:20:32	119     	2       	(kworker/0:2-events)          	?	worker_thread                 
-06:20:32	120     	2       	(kstrp)                       	?	rescuer_thread                
-06:20:32	125     	2       	(kworker/u9:0)                	?	worker_thread                 
-06:20:32	127     	2       	(kworker/1:1-events)          	?	worker_thread                 
-06:20:32	135     	2       	(charger_manager)             	?	rescuer_thread                
-06:20:32	186     	2       	(kworker/3:2-cgroup_pidlist_de	?	worker_thread                 
-06:20:32	189     	2       	(kworker/1:2-events)          	?	worker_thread                 
-06:20:32	191     	2       	(kworker/1:3-events)          	?	worker_thread                 
-06:20:32	194     	2       	(kworker/0:3-events)          	?	worker_thread                 
-06:20:32	344     	2       	(iprt-VBoxWQueue)             	?	rescuer_thread                
-06:20:32	345     	2       	(kworker/2:1H-xfs-log/dm-0)   	?	worker_thread                 
-06:20:32	346     	2       	(ata_sff)                     	?	rescuer_thread                
-06:20:32	347     	2       	(scsi_eh_0)                   	?	scsi_error_handler            
-06:20:32	351     	2       	(scsi_tmf_0)                  	?	rescuer_thread                
-06:20:32	352     	2       	(scsi_eh_1)                   	?	scsi_error_handler            
-06:20:32	353     	2       	(scsi_tmf_1)                  	?	rescuer_thread                
-06:20:32	366     	2       	(scsi_eh_2)                   	?	scsi_error_handler            
-06:20:32	367     	2       	(scsi_tmf_2)                  	?	rescuer_thread                
-06:20:32	369     	2       	(kworker/1:1H-kblockd)        	?	worker_thread                 
-06:20:32	371     	2       	(irq/18-vmwgfx)               	?	irq_thread                    
-06:20:32	372     	2       	(ttm_swap)                    	?	rescuer_thread                
-06:20:32	441     	2       	(kdmflush)                    	?	rescuer_thread                
-06:20:32	452     	2       	(kdmflush)                    	?	rescuer_thread                
-06:20:32	467     	2       	(kworker/3:3-events)          	?	worker_thread                 
-06:20:32	473     	2       	(kworker/2:2-cgroup_pidlist_de	?	worker_thread                 
-06:20:32	477     	2       	(kworker/2:3-cgroup_destroy)  	?	worker_thread                 
-06:20:32	478     	2       	(xfsalloc)                    	?	rescuer_thread                
-06:20:32	479     	2       	(xfs_mru_cache)               	?	rescuer_thread                
-06:20:32	481     	2       	(xfs-buf/dm-0)                	?	rescuer_thread                
-06:20:32	482     	2       	(xfs-conv/dm-0)               	?	rescuer_thread                
-06:20:32	483     	2       	(xfs-cil/dm-0)                	?	rescuer_thread                
-06:20:32	484     	2       	(xfs-reclaim/dm-)             	?	rescuer_thread                
-06:20:32	485     	2       	(xfs-eofblocks/d)             	?	rescuer_thread                
-06:20:32	486     	2       	(xfs-log/dm-0)                	?	rescuer_thread                
-06:20:32	487     	2       	(xfsaild/dm-0)                	?	xfsaild                       
-06:20:32	555     	2       	(kworker/2:4-events)          	?	worker_thread                 
-06:20:32	585     	1       	/usr/lib/systemd/systemd-journ	?	ep_poll                       
-06:20:32	624     	1       	/usr/lib/systemd/systemd-udevd	?	ep_poll                       
-06:20:32	655     	2       	(cryptd)                      	?	rescuer_thread                
-06:20:32	696     	2       	(kdmflush)                    	?	rescuer_thread                
-06:20:32	751     	2       	(xfs-buf/dm-2)                	?	rescuer_thread                
-06:20:32	752     	2       	(xfs-conv/dm-2)               	?	rescuer_thread                
-06:20:32	753     	2       	(xfs-cil/dm-2)                	?	rescuer_thread                
-06:20:32	754     	2       	(xfs-buf/sda1)                	?	rescuer_thread                
-06:20:32	755     	2       	(xfs-conv/sda1)               	?	rescuer_thread                
-06:20:32	756     	2       	(xfs-reclaim/dm-)             	?	rescuer_thread                
-06:20:32	757     	2       	(xfs-cil/sda1)                	?	rescuer_thread                
-06:20:32	758     	2       	(xfs-eofblocks/d)             	?	rescuer_thread                
-06:20:32	759     	2       	(xfs-reclaim/sda)             	?	rescuer_thread                
-06:20:32	760     	2       	(xfs-eofblocks/s)             	?	rescuer_thread                
-06:20:32	761     	2       	(xfs-log/dm-2)                	?	rescuer_thread                
-06:20:32	762     	2       	(xfsaild/dm-2)                	?	xfsaild                       
-06:20:32	763     	2       	(xfs-log/sda1)                	?	rescuer_thread                
-06:20:32	764     	2       	(xfsaild/sda1)                	?	xfsaild                       
-06:20:32	786     	1       	/usr/bin/rpcbind -w -f        	?	poll_schedule_timeout.constpro
-06:20:32	788     	1       	/sbin/auditd                  	?	poll_schedule_timeout.constpro
-06:20:32	790     	788     	/usr/sbin/sedispatch          	?	unix_stream_read_generic      
-06:20:32	800     	2       	(rpciod)                      	?	rescuer_thread                
-06:20:32	801     	2       	(xprtiod)                     	?	rescuer_thread                
-06:20:32	816     	1       	/usr/sbin/mcelog --ignorenodev	?	poll_schedule_timeout.constpro
-06:20:32	818     	1       	/usr/bin/dbus-daemon --system 	?	ep_poll                       
-06:20:32	820     	1       	/usr/lib/polkit-1/polkitd --no	?	poll_schedule_timeout.constpro
-06:20:32	821     	1       	/usr/sbin/irqbalance --foregro	?	poll_schedule_timeout.constpro
-06:20:32	826     	1       	/usr/libexec/rtkit-daemon     	?	poll_schedule_timeout.constpro
-06:20:32	827     	1       	/usr/sbin/alsactl -s -n 19 -c 	?	poll_schedule_timeout.constpro
-06:20:32	829     	1       	avahi-daemon: running [linux.l	?	poll_schedule_timeout.constpro
-06:20:32	830     	1       	/usr/bin/lsmd -d              	?	poll_schedule_timeout.constpro
-06:20:32	834     	1       	/usr/lib/systemd/systemd-machi	?	ep_poll                       
-06:20:32	835     	1       	/usr/libexec/udisks2/udisksd  	?	poll_schedule_timeout.constpro
-06:20:32	838     	1       	/usr/sbin/sssd -i --logger=fil	?	poll_schedule_timeout.constpro
-06:20:32	840     	1       	/usr/sbin/smartd -n -q never  	?	hrtimer_nanosleep             
-06:20:32	857     	1       	/usr/sbin/chronyd             	?	poll_schedule_timeout.constpro
-06:20:32	860     	1       	/bin/bash /usr/sbin/ksmtuned  	?	do_wait                       
-06:20:32	864     	1       	/opt/cisco/anyconnect/bin/vpna	?	futex_wait_queue_me           
-06:20:32	868     	829     	avahi-daemon: chroot helper   	?	unix_stream_read_generic      
-06:20:32	877     	838     	/usr/libexec/sssd/sssd_be --do	?	ep_poll                       
-06:20:32	884     	1       	/usr/libexec/platform-python -	?	poll_schedule_timeout.constpro
-06:20:32	885     	1       	/usr/sbin/ModemManager        	?	poll_schedule_timeout.constpro
-06:20:32	897     	838     	/usr/libexec/sssd/sssd_nss --u	?	ep_poll                       
-06:20:32	941     	1       	/usr/lib/systemd/systemd-login	?	ep_poll                       
-06:20:32	946     	1       	/usr/libexec/accounts-daemon  	?	poll_schedule_timeout.constpro
-06:20:32	1106    	1       	/usr/sbin/NetworkManager --no-	?	poll_schedule_timeout.constpro
-06:20:32	1117    	1       	/usr/sbin/sshd -D -oCiphers=ae	?	poll_schedule_timeout.constpro
-06:20:32	1119    	1       	/usr/sbin/cupsd -l            	?	ep_poll                       
-06:20:32	1120    	1       	/usr/libexec/platform-python -	?	poll_schedule_timeout.constpro
-06:20:32	1125    	1       	/usr/sbin/gssproxy -D         	?	ep_poll                       
-06:20:32	1150    	1       	/usr/sbin/iscsid -f -d2       	?	poll_schedule_timeout.constpro
-06:20:32	1151    	1       	/usr/sbin/rsyslogd -n         	?	poll_schedule_timeout.constpro
-06:20:32	1176    	2       	(iscsi_eh)                    	?	rescuer_thread                
-06:20:32	1192    	1       	/usr/sbin/crond -n            	?	hrtimer_nanosleep             
-06:20:32	1193    	2       	(kworker/0:4-cgroup_pidlist_de	?	worker_thread                 
-06:20:32	1194    	1       	/usr/sbin/atd -f              	?	__ia32_sys_pause              
-06:20:32	1624    	1       	/usr/libexec/pcp/bin/pmcd -A  	?	poll_schedule_timeout.constpro
-06:20:32	1633    	1624    	/var/lib/pcp/pmdas/root/pmdaro	?	poll_schedule_timeout.constpro
-06:20:32	1650    	1633    	/var/lib/pcp/pmdas/proc/pmdapr	?	-                             
-06:20:32	1666    	1633    	/var/lib/pcp/pmdas/xfs/pmdaxfs	?	pipe_wait                     
-06:20:32	1682    	1633    	/var/lib/pcp/pmdas/linux/pmdal	?	pipe_wait                     
-06:20:32	1690    	1633    	python3 /var/lib/pcp/pmdas/nfs	?	pipe_wait                     
-06:20:32	1754    	1633    	/var/lib/pcp/pmdas/kvm/pmdakvm	?	pipe_wait                     
-06:20:32	1761    	1633    	/var/lib/pcp/pmdas/dm/pmdadm -	?	pipe_wait                     
-06:20:32	1767    	1633    	python3 /var/lib/pcp/pmdas/ope	?	pipe_wait                     
-06:20:32	2407    	1       	/usr/sbin/dnsmasq --conf-file=	?	poll_schedule_timeout.constpro
-06:20:32	2410    	2407    	/usr/sbin/dnsmasq --conf-file=	?	pipe_wait                     
-06:20:32	2501    	1       	/usr/bin/pmie -b -F -P -l /var	?	hrtimer_nanosleep             
-06:20:32	2508    	1       	/usr/libexec/pcp/bin/pmlogger 	?	poll_schedule_timeout.constpro
-06:20:32	2516    	1       	/usr/libexec/pcp/bin/pmpause  	?	__ia32_sys_pause              
-06:20:32	2684    	1       	/bin/sh /usr/libexec/pcp/bin/p	?	__ia32_sys_pause              
-06:20:32	2937    	1       	/usr/sbin/gdm                 	?	poll_schedule_timeout.constpro
-06:20:32	2953    	1       	/usr/sbin/VBoxService --pidfil	?	do_sigtimedwait.isra.42       
-06:20:32	4956    	1       	/usr/libexec/upowerd          	?	poll_schedule_timeout.constpro
-06:20:32	4964    	1       	/usr/libexec/geoclue          	?	poll_schedule_timeout.constpro
-06:20:32	4977    	1       	/usr/sbin/wpa_supplicant -c /e	?	poll_schedule_timeout.constpro
-06:20:32	4978    	1       	/usr/libexec/packagekitd      	?	poll_schedule_timeout.constpro
-06:20:32	5059    	1       	/usr/libexec/colord           	?	poll_schedule_timeout.constpro
-06:20:32	5150    	2       	(kworker/3:4-cgroup_pidlist_de	?	worker_thread                 
-06:20:32	5714    	2937    	gdm-session-worker [pam/gdm-pa	?	poll_schedule_timeout.constpro
-06:20:32	5729    	1       	/usr/lib/systemd/systemd --use	?	ep_poll                       
-06:20:32	5731    	5729    	(sd-pam)                      	?	do_sigtimedwait.isra.42       
-06:20:32	5757    	1       	/usr/bin/gnome-keyring-daemon 	?	poll_schedule_timeout.constpro
-06:20:32	5764    	5714    	/usr/libexec/gdm-wayland-sessi	tty2	poll_schedule_timeout.constpro
-06:20:32	5766    	5729    	/usr/bin/dbus-daemon --session	?	ep_poll                       
-06:20:32	5769    	5764    	/usr/libexec/gnome-session-bin	tty2	poll_schedule_timeout.constpro
-06:20:32	5857    	5769    	/usr/bin/gnome-shell          	tty2	poll_schedule_timeout.constpro
-06:20:32	5901    	5729    	/usr/libexec/gvfsd            	?	poll_schedule_timeout.constpro
-06:20:32	5908    	5729    	/usr/libexec/gvfsd-fuse /run/u	?	futex_wait_queue_me           
-06:20:32	5916    	5857    	/usr/bin/Xwayland :0 -rootless	tty2	ep_poll                       
-06:20:32	5927    	5729    	/usr/libexec/at-spi-bus-launch	?	poll_schedule_timeout.constpro
-06:20:32	5938    	5927    	/usr/bin/dbus-daemon --config-	?	ep_poll                       
-06:20:32	5945    	5729    	/usr/libexec/at-spi2-registryd	?	poll_schedule_timeout.constpro
-06:20:32	5963    	5857    	ibus-daemon --xim --panel disa	tty2	poll_schedule_timeout.constpro
-06:20:32	5967    	5963    	/usr/libexec/ibus-dconf       	tty2	poll_schedule_timeout.constpro
-06:20:32	5968    	5729    	/usr/libexec/xdg-permission-st	?	poll_schedule_timeout.constpro
-06:20:32	5970    	5963    	/usr/libexec/ibus-extension-gt	tty2	poll_schedule_timeout.constpro
-06:20:32	5976    	1       	/usr/libexec/ibus-x11 --kill-d	tty2	poll_schedule_timeout.constpro
-06:20:32	5979    	5729    	/usr/libexec/ibus-portal      	?	poll_schedule_timeout.constpro
-06:20:32	5993    	5729    	/usr/libexec/gnome-shell-calen	?	poll_schedule_timeout.constpro
-06:20:32	5999    	5729    	/usr/libexec/evolution-source-	?	poll_schedule_timeout.constpro
-06:20:32	6005    	5729    	/usr/libexec/goa-daemon       	?	poll_schedule_timeout.constpro
-06:20:32	6014    	5729    	/usr/libexec/gvfs-udisks2-volu	?	poll_schedule_timeout.constpro
-06:20:32	6023    	5729    	/usr/libexec/gvfs-mtp-volume-m	?	poll_schedule_timeout.constpro
-06:20:32	6030    	5729    	/usr/libexec/gvfs-gphoto2-volu	?	poll_schedule_timeout.constpro
-06:20:32	6034    	5729    	/usr/libexec/goa-identity-serv	?	poll_schedule_timeout.constpro
-06:20:32	6042    	5729    	/usr/libexec/gvfs-goa-volume-m	?	poll_schedule_timeout.constpro
-06:20:32	6050    	5729    	/usr/libexec/gvfs-afc-volume-m	?	poll_schedule_timeout.constpro
-06:20:32	6055    	1       	/usr/libexec/sssd/sssd_kcm --u	?	ep_poll                       
-06:20:32	6057    	5769    	/usr/libexec/gsd-power        	tty2	poll_schedule_timeout.constpro
-06:20:32	6058    	5769    	/usr/libexec/gsd-print-notific	tty2	poll_schedule_timeout.constpro
-06:20:32	6060    	5769    	/usr/libexec/gsd-rfkill       	tty2	poll_schedule_timeout.constpro
-06:20:32	6062    	5769    	/usr/libexec/gsd-screensaver-p	tty2	poll_schedule_timeout.constpro
-06:20:32	6064    	5769    	/usr/libexec/gsd-sharing      	tty2	poll_schedule_timeout.constpro
-06:20:32	6072    	5769    	/usr/libexec/gsd-sound        	tty2	poll_schedule_timeout.constpro
-06:20:32	6078    	5769    	/usr/libexec/gsd-xsettings    	tty2	poll_schedule_timeout.constpro
-06:20:32	6082    	5769    	/usr/libexec/gsd-wacom        	tty2	poll_schedule_timeout.constpro
-06:20:32	6085    	5729    	/usr/libexec/evolution-calenda	?	poll_schedule_timeout.constpro
-06:20:32	6087    	5769    	/usr/libexec/gsd-smartcard    	tty2	poll_schedule_timeout.constpro
-06:20:32	6088    	5769    	/usr/libexec/gsd-account      	tty2	poll_schedule_timeout.constpro
-06:20:32	6111    	5769    	/usr/libexec/gsd-a11y-settings	tty2	poll_schedule_timeout.constpro
-06:20:32	6113    	5963    	/usr/libexec/ibus-engine-simpl	tty2	poll_schedule_timeout.constpro
-06:20:32	6115    	1       	/usr/bin/pulseaudio --start   	?	poll_schedule_timeout.constpro
-06:20:32	6122    	5769    	/usr/libexec/gsd-clipboard    	tty2	poll_schedule_timeout.constpro
-06:20:32	6126    	5769    	/usr/libexec/gsd-color        	tty2	poll_schedule_timeout.constpro
-06:20:32	6128    	5769    	/usr/libexec/gsd-datetime     	tty2	poll_schedule_timeout.constpro
-06:20:32	6131    	5769    	/usr/libexec/gsd-housekeeping 	tty2	poll_schedule_timeout.constpro
-06:20:32	6132    	5769    	/usr/libexec/gsd-keyboard     	tty2	poll_schedule_timeout.constpro
-06:20:32	6138    	5769    	/usr/libexec/gsd-media-keys   	tty2	poll_schedule_timeout.constpro
-06:20:32	6142    	5769    	/usr/libexec/gsd-mouse        	tty2	poll_schedule_timeout.constpro
-06:20:32	6188    	6085    	/usr/libexec/evolution-calenda	?	poll_schedule_timeout.constpro
-06:20:32	6216    	5729    	/usr/libexec/evolution-address	?	poll_schedule_timeout.constpro
-06:20:32	6217    	5729    	/usr/libexec/dconf-service    	?	poll_schedule_timeout.constpro
-06:20:32	6219    	5729    	/usr/libexec/tracker-store    	?	poll_schedule_timeout.constpro
-06:20:32	6224    	5769    	/usr/bin/gnome-software --gapp	tty2	poll_schedule_timeout.constpro
-06:20:32	6230    	5769    	/usr/libexec/gsd-disk-utility-	tty2	poll_schedule_timeout.constpro
-06:20:32	6243    	5769    	/usr/libexec/tracker-miner-app	tty2	poll_schedule_timeout.constpro
-06:20:32	6252    	1       	/usr/libexec/gsd-printer      	tty2	poll_schedule_timeout.constpro
-06:20:32	6254    	5769    	/usr/libexec/tracker-miner-fs 	tty2	poll_schedule_timeout.constpro
-06:20:32	6288    	1       	/usr/bin/VBoxClient --clipboar	?	do_wait                       
-06:20:32	6294    	6216    	/usr/libexec/evolution-address	?	poll_schedule_timeout.constpro
-06:20:32	6297    	6288    	/usr/bin/VBoxClient --clipboar	?	rtR0SemEventMultiLnxWait.isra.
-06:20:32	6324    	1       	/usr/bin/VBoxClient --seamless	?	do_wait                       
-06:20:32	6325    	6324    	/usr/bin/VBoxClient --seamless	?	rtR0SemEventMultiLnxWait.isra.
-06:20:32	6334    	1       	/usr/bin/VBoxClient --dragandd	?	do_wait                       
-06:20:32	6335    	6334    	/usr/bin/VBoxClient --dragandd	?	futex_wait_queue_me           
-06:20:32	6342    	1       	/usr/bin/VBoxClient --vmsvga  	?	do_wait                       
-06:20:32	6343    	6342    	                              	?	rtR0SemEventMultiLnxWait.isra.
-06:20:32	6432    	1       	/usr/libexec/fwupd/fwupd      	?	poll_schedule_timeout.constpro
-06:20:32	6834    	5729    	/usr/libexec/gnome-terminal-se	?	poll_schedule_timeout.constpro
-06:20:32	6839    	6834    	bash                          	pts/0	do_wait                       
-06:20:32	6941    	2       	(kworker/1:4-cgroup_pidlist_de	?	worker_thread                 
-06:20:32	8571    	5729    	/usr/libexec/gvfsd-metadata   	?	poll_schedule_timeout.constpro
-06:20:32	9308    	860     	sleep 60                      	?	hrtimer_nanosleep             
-06:20:32	9327    	6839    	/bin/sh ./mk.ps               	pts/0	do_wait                       
-06:20:32	9344    	9327    	pmlogger -s 10 -c /var/tmp/932	pts/0	poll_schedule_timeout.constpro
-06:20:32	9349    	5729    	/usr/libexec/tracker-extract  	?	-                             
 
 pcp-ps output : Display the colum args in the end of -o option colum list
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
+Timestamp	PID		PPID		TTY	Command				
+06:20:30	1       	0       	?	/usr/lib/systemd/systemd --switched-root --system --deserialize 18
+06:20:30	2       	0       	?	(kthreadd)
+06:20:30	3       	2       	?	(rcu_gp)
+06:20:30	4       	2       	?	(rcu_par_gp)
+06:20:30	5       	2       	?	(kworker/0:0-cgroup_pidlist_destroy)
+06:20:30	6       	2       	?	(kworker/0:0H-events_highpri)
+06:20:30	7       	2       	?	(kworker/u8:0-events_unbound)
+06:20:30	8       	2       	?	(kworker/0:1H-kblockd)
+06:20:30	9       	2       	?	(mm_percpu_wq)
+06:20:30	10      	2       	?	(ksoftirqd/0)
+06:20:30	11      	2       	?	(rcu_sched)
+06:20:30	12      	2       	?	(migration/0)
+06:20:30	13      	2       	?	(kworker/0:1-xfs-buf/dm-0)
+06:20:30	14      	2       	?	(cpuhp/0)
+06:20:30	15      	2       	?	(cpuhp/1)
+06:20:30	16      	2       	?	(migration/1)
+06:20:30	17      	2       	?	(ksoftirqd/1)
+06:20:30	18      	2       	?	(kworker/1:0-events)
+06:20:30	19      	2       	?	(kworker/1:0H-events_highpri)
+06:20:30	20      	2       	?	(cpuhp/2)
+06:20:30	21      	2       	?	(migration/2)
+06:20:30	22      	2       	?	(ksoftirqd/2)
+06:20:30	23      	2       	?	(kworker/2:0-cgroup_pidlist_destroy)
+06:20:30	24      	2       	?	(kworker/2:0H-events_highpri)
+06:20:30	25      	2       	?	(cpuhp/3)
+06:20:30	26      	2       	?	(migration/3)
+06:20:30	27      	2       	?	(ksoftirqd/3)
+06:20:30	28      	2       	?	(kworker/3:0-events)
+06:20:30	29      	2       	?	(kworker/3:0H-events_highpri)
+06:20:30	31      	2       	?	(kworker/u8:1-events_unbound)
+06:20:30	32      	2       	?	(kworker/u8:2-events_unbound)
+06:20:30	33      	2       	?	(kworker/u8:3)
+06:20:30	34      	2       	?	(kdevtmpfs)
+06:20:30	35      	2       	?	(netns)
+06:20:30	36      	2       	?	(kauditd)
+06:20:30	37      	2       	?	(khungtaskd)
+06:20:30	38      	2       	?	(oom_reaper)
+06:20:30	39      	2       	?	(writeback)
+06:20:30	40      	2       	?	(kcompactd0)
+06:20:30	41      	2       	?	(ksmd)
+06:20:30	42      	2       	?	(khugepaged)
+06:20:30	44      	2       	?	(kworker/3:1-events)
+06:20:30	97      	2       	?	(kintegrityd)
+06:20:30	98      	2       	?	(kblockd)
+06:20:30	99      	2       	?	(blkcg_punt_bio)
+06:20:30	100     	2       	?	(tpm_dev_wq)
+06:20:30	101     	2       	?	(md)
+06:20:30	102     	2       	?	(edac-poller)
+06:20:30	103     	2       	?	(devfreq_wq)
+06:20:30	104     	2       	?	(watchdogd)
+06:20:30	105     	2       	?	(kworker/2:1-events)
+06:20:30	107     	2       	?	(kswapd0:0)
+06:20:30	109     	2       	?	(kthrotld)
+06:20:30	110     	2       	?	(acpi_thermal_pm)
+06:20:30	111     	2       	?	(kmpath_rdacd)
+06:20:30	112     	2       	?	(kaluad)
+06:20:30	113     	2       	?	(kworker/3:1H-events_highpri)
+06:20:30	114     	2       	?	(bch_btree_io)
+06:20:30	115     	2       	?	(bcache)
+06:20:30	116     	2       	?	(bch_journal)
+06:20:30	117     	2       	?	(ipv6_addrconf)
+06:20:30	118     	2       	?	(dsa_ordered)
+06:20:30	119     	2       	?	(kworker/0:2-events)
+06:20:30	120     	2       	?	(kstrp)
+06:20:30	125     	2       	?	(kworker/u9:0)
+06:20:30	127     	2       	?	(kworker/1:1-events)
+06:20:30	135     	2       	?	(charger_manager)
+06:20:30	186     	2       	?	(kworker/3:2-cgroup_pidlist_destroy)
+06:20:30	189     	2       	?	(kworker/1:2-events)
+06:20:30	191     	2       	?	(kworker/1:3-events)
+06:20:30	194     	2       	?	(kworker/0:3-events)
+06:20:30	344     	2       	?	(iprt-VBoxWQueue)
+06:20:30	345     	2       	?	(kworker/2:1H-xfs-log/dm-0)
+06:20:30	346     	2       	?	(ata_sff)
+06:20:30	347     	2       	?	(scsi_eh_0)
+06:20:30	351     	2       	?	(scsi_tmf_0)
+06:20:30	352     	2       	?	(scsi_eh_1)
+06:20:30	353     	2       	?	(scsi_tmf_1)
+06:20:30	366     	2       	?	(scsi_eh_2)
+06:20:30	367     	2       	?	(scsi_tmf_2)
+06:20:30	369     	2       	?	(kworker/1:1H-kblockd)
+06:20:30	371     	2       	?	(irq/18-vmwgfx)
+06:20:30	372     	2       	?	(ttm_swap)
+06:20:30	441     	2       	?	(kdmflush)
+06:20:30	452     	2       	?	(kdmflush)
+06:20:30	467     	2       	?	(kworker/3:3-events)
+06:20:30	473     	2       	?	(kworker/2:2-cgroup_pidlist_destroy)
+06:20:30	477     	2       	?	(kworker/2:3-cgroup_destroy)
+06:20:30	478     	2       	?	(xfsalloc)
+06:20:30	479     	2       	?	(xfs_mru_cache)
+06:20:30	481     	2       	?	(xfs-buf/dm-0)
+06:20:30	482     	2       	?	(xfs-conv/dm-0)
+06:20:30	483     	2       	?	(xfs-cil/dm-0)
+06:20:30	484     	2       	?	(xfs-reclaim/dm-)
+06:20:30	485     	2       	?	(xfs-eofblocks/d)
+06:20:30	486     	2       	?	(xfs-log/dm-0)
+06:20:30	487     	2       	?	(xfsaild/dm-0)
+06:20:30	555     	2       	?	(kworker/2:4-events)
+06:20:30	585     	1       	?	/usr/lib/systemd/systemd-journald
+06:20:30	624     	1       	?	/usr/lib/systemd/systemd-udevd
+06:20:30	655     	2       	?	(cryptd)
+06:20:30	696     	2       	?	(kdmflush)
+06:20:30	751     	2       	?	(xfs-buf/dm-2)
+06:20:30	752     	2       	?	(xfs-conv/dm-2)
+06:20:30	753     	2       	?	(xfs-cil/dm-2)
+06:20:30	754     	2       	?	(xfs-buf/sda1)
+06:20:30	755     	2       	?	(xfs-conv/sda1)
+06:20:30	756     	2       	?	(xfs-reclaim/dm-)
+06:20:30	757     	2       	?	(xfs-cil/sda1)
+06:20:30	758     	2       	?	(xfs-eofblocks/d)
+06:20:30	759     	2       	?	(xfs-reclaim/sda)
+06:20:30	760     	2       	?	(xfs-eofblocks/s)
+06:20:30	761     	2       	?	(xfs-log/dm-2)
+06:20:30	762     	2       	?	(xfsaild/dm-2)
+06:20:30	763     	2       	?	(xfs-log/sda1)
+06:20:30	764     	2       	?	(xfsaild/sda1)
+06:20:30	786     	1       	?	/usr/bin/rpcbind -w -f
+06:20:30	788     	1       	?	/sbin/auditd
+06:20:30	790     	788     	?	/usr/sbin/sedispatch
+06:20:30	800     	2       	?	(rpciod)
+06:20:30	801     	2       	?	(xprtiod)
+06:20:30	816     	1       	?	/usr/sbin/mcelog --ignorenodev --daemon --foreground
+06:20:30	818     	1       	?	/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
+06:20:30	820     	1       	?	/usr/lib/polkit-1/polkitd --no-debug
+06:20:30	821     	1       	?	/usr/sbin/irqbalance --foreground
+06:20:30	826     	1       	?	/usr/libexec/rtkit-daemon
+06:20:30	827     	1       	?	/usr/sbin/alsactl -s -n 19 -c -E ALSA_CONFIG_PATH=/etc/alsa/alsactl.conf --initfile=/lib/alsa/init/00main rdaemon
+06:20:30	829     	1       	?	avahi-daemon: running [linux.local]
+06:20:30	830     	1       	?	/usr/bin/lsmd -d
+06:20:30	834     	1       	?	/usr/lib/systemd/systemd-machined
+06:20:30	835     	1       	?	/usr/libexec/udisks2/udisksd
+06:20:30	838     	1       	?	/usr/sbin/sssd -i --logger=files
+06:20:30	840     	1       	?	/usr/sbin/smartd -n -q never
+06:20:30	857     	1       	?	/usr/sbin/chronyd
+06:20:30	860     	1       	?	/bin/bash /usr/sbin/ksmtuned
+06:20:30	864     	1       	?	/opt/cisco/anyconnect/bin/vpnagentd -execv_instance
+06:20:30	868     	829     	?	avahi-daemon: chroot helper
+06:20:30	877     	838     	?	/usr/libexec/sssd/sssd_be --domain implicit_files --uid 0 --gid 0 --logger=files
+06:20:30	884     	1       	?	/usr/libexec/platform-python -s /usr/sbin/firewalld --nofork --nopid
+06:20:30	885     	1       	?	/usr/sbin/ModemManager
+06:20:30	897     	838     	?	/usr/libexec/sssd/sssd_nss --uid 0 --gid 0 --logger=files
+06:20:30	941     	1       	?	/usr/lib/systemd/systemd-logind
+06:20:30	946     	1       	?	/usr/libexec/accounts-daemon
+06:20:30	1106    	1       	?	/usr/sbin/NetworkManager --no-daemon
+06:20:30	1117    	1       	?	/usr/sbin/sshd -D -oCiphers=aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr,aes256-cbc,aes128-gcm@openssh.com,aes128-ctr,aes128-cbc -oMACs=hmac-sha2-256-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha1,umac-128@openssh.com,hmac-sha2-512 -oGSSAPIKexAlgorithms=gss-curve25519-sha256-,gss-nistp256-sha256-,gss-group14-sha256-,gss-group16-sha512-,gss-gex-sha1-,gss-group14-sha1- -oKexAlgorithms=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1 -oHostKeyAlgorithms=ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ssh-rsa,ssh-rsa-cert-v01@openssh.com -oPubkeyAcceptedKeyTypes=ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ssh-rsa,ssh-rsa-cert-v01@openssh.com -oCASignatureAlgorithms=ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-256,rsa-sha2-512,ssh-rsa
+06:20:30	1119    	1       	?	/usr/sbin/cupsd -l
+06:20:30	1120    	1       	?	/usr/libexec/platform-python -Es /usr/sbin/tuned -l -P
+06:20:30	1125    	1       	?	/usr/sbin/gssproxy -D
+06:20:30	1150    	1       	?	/usr/sbin/iscsid -f -d2
+06:20:30	1151    	1       	?	/usr/sbin/rsyslogd -n
+06:20:30	1176    	2       	?	(iscsi_eh)
+06:20:30	1192    	1       	?	/usr/sbin/crond -n
+06:20:30	1193    	2       	?	(kworker/0:4-cgroup_pidlist_destroy)
+06:20:30	1194    	1       	?	/usr/sbin/atd -f
+06:20:30	1624    	1       	?	/usr/libexec/pcp/bin/pmcd -A
+06:20:30	1633    	1624    	?	/var/lib/pcp/pmdas/root/pmdaroot
+06:20:30	1650    	1633    	?	/var/lib/pcp/pmdas/proc/pmdaproc -A -d 3
+06:20:30	1666    	1633    	?	/var/lib/pcp/pmdas/xfs/pmdaxfs -d 11
+06:20:30	1682    	1633    	?	/var/lib/pcp/pmdas/linux/pmdalinux -A
+06:20:30	1690    	1633    	?	python3 /var/lib/pcp/pmdas/nfsclient/pmdanfsclient.python
+06:20:30	1754    	1633    	?	/var/lib/pcp/pmdas/kvm/pmdakvm -d 95
+06:20:30	1761    	1633    	?	/var/lib/pcp/pmdas/dm/pmdadm -d 129
+06:20:30	1767    	1633    	?	python3 /var/lib/pcp/pmdas/openmetrics/pmdaopenmetrics.python
+06:20:30	2407    	1       	?	/usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/default.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper
+06:20:30	2410    	2407    	?	/usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/default.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper
+06:20:30	2501    	1       	?	/usr/bin/pmie -b -F -P -l /var/log/pcp/pmie/localhost.localdomain/pmie.log -c config.default
+06:20:30	2508    	1       	?	/usr/libexec/pcp/bin/pmlogger -N -P -r -T24h10m -c config.ora -v 100mb -m pmlogger_check %Y%m%d.%H.%M
+06:20:30	2516    	1       	?	/usr/libexec/pcp/bin/pmpause
+06:20:30	2684    	1       	?	/bin/sh /usr/libexec/pcp/bin/pmlogger_farm --skip-primary --quick
+06:20:30	2937    	1       	?	/usr/sbin/gdm
+06:20:30	2953    	1       	?	/usr/sbin/VBoxService --pidfile /var/run/vboxadd-service.sh
+06:20:30	4956    	1       	?	/usr/libexec/upowerd
+06:20:30	4964    	1       	?	/usr/libexec/geoclue
+06:20:30	4977    	1       	?	/usr/sbin/wpa_supplicant -c /etc/wpa_supplicant/wpa_supplicant.conf -u -s
+06:20:30	4978    	1       	?	/usr/libexec/packagekitd
+06:20:30	5059    	1       	?	/usr/libexec/colord
+06:20:30	5150    	2       	?	(kworker/3:4-cgroup_pidlist_destroy)
+06:20:30	5714    	2937    	?	gdm-session-worker [pam/gdm-password]
+06:20:30	5729    	1       	?	/usr/lib/systemd/systemd --user
+06:20:30	5731    	5729    	?	(sd-pam)
+06:20:30	5757    	1       	?	/usr/bin/gnome-keyring-daemon --daemonize --login
+06:20:30	5764    	5714    	tty2	/usr/libexec/gdm-wayland-session --register-session gnome-session
+06:20:30	5766    	5729    	?	/usr/bin/dbus-daemon --session --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
+06:20:30	5769    	5764    	tty2	/usr/libexec/gnome-session-binary
+06:20:30	5857    	5769    	tty2	/usr/bin/gnome-shell
+06:20:30	5901    	5729    	?	/usr/libexec/gvfsd
+06:20:30	5908    	5729    	?	/usr/libexec/gvfsd-fuse /run/user/0/gvfs -f -o big_writes
+06:20:30	5916    	5857    	tty2	/usr/bin/Xwayland :0 -rootless -terminate -accessx -core -auth /run/user/0/.mutter-Xwaylandauth.Q6AEX1 -listen 4 -listen 5 -displayfd 6
+06:20:30	5927    	5729    	?	/usr/libexec/at-spi-bus-launcher
+06:20:30	5938    	5927    	?	/usr/bin/dbus-daemon --config-file=/usr/share/defaults/at-spi2/accessibility.conf --nofork --print-address 3
+06:20:30	5945    	5729    	?	/usr/libexec/at-spi2-registryd --use-gnome-session
+06:20:30	5963    	5857    	tty2	ibus-daemon --xim --panel disable
+06:20:30	5967    	5963    	tty2	/usr/libexec/ibus-dconf
+06:20:30	5968    	5729    	?	/usr/libexec/xdg-permission-store
+06:20:30	5970    	5963    	tty2	/usr/libexec/ibus-extension-gtk3
+06:20:30	5976    	1       	tty2	/usr/libexec/ibus-x11 --kill-daemon
+06:20:30	5979    	5729    	?	/usr/libexec/ibus-portal
+06:20:30	5993    	5729    	?	/usr/libexec/gnome-shell-calendar-server
+06:20:30	5999    	5729    	?	/usr/libexec/evolution-source-registry
+06:20:30	6005    	5729    	?	/usr/libexec/goa-daemon
+06:20:30	6014    	5729    	?	/usr/libexec/gvfs-udisks2-volume-monitor
+06:20:30	6023    	5729    	?	/usr/libexec/gvfs-mtp-volume-monitor
+06:20:30	6030    	5729    	?	/usr/libexec/gvfs-gphoto2-volume-monitor
+06:20:30	6034    	5729    	?	/usr/libexec/goa-identity-service
+06:20:30	6042    	5729    	?	/usr/libexec/gvfs-goa-volume-monitor
+06:20:30	6050    	5729    	?	/usr/libexec/gvfs-afc-volume-monitor
+06:20:30	6055    	1       	?	/usr/libexec/sssd/sssd_kcm --uid 0 --gid 0 --logger=files
+06:20:30	6057    	5769    	tty2	/usr/libexec/gsd-power
+06:20:30	6058    	5769    	tty2	/usr/libexec/gsd-print-notifications
+06:20:30	6060    	5769    	tty2	/usr/libexec/gsd-rfkill
+06:20:30	6062    	5769    	tty2	/usr/libexec/gsd-screensaver-proxy
+06:20:30	6064    	5769    	tty2	/usr/libexec/gsd-sharing
+06:20:30	6072    	5769    	tty2	/usr/libexec/gsd-sound
+06:20:30	6078    	5769    	tty2	/usr/libexec/gsd-xsettings
+06:20:30	6082    	5769    	tty2	/usr/libexec/gsd-wacom
+06:20:30	6085    	5729    	?	/usr/libexec/evolution-calendar-factory
+06:20:30	6087    	5769    	tty2	/usr/libexec/gsd-smartcard
+06:20:30	6088    	5769    	tty2	/usr/libexec/gsd-account
+06:20:30	6111    	5769    	tty2	/usr/libexec/gsd-a11y-settings
+06:20:30	6113    	5963    	tty2	/usr/libexec/ibus-engine-simple
+06:20:30	6115    	1       	?	/usr/bin/pulseaudio --start
+06:20:30	6122    	5769    	tty2	/usr/libexec/gsd-clipboard
+06:20:30	6126    	5769    	tty2	/usr/libexec/gsd-color
+06:20:30	6128    	5769    	tty2	/usr/libexec/gsd-datetime
+06:20:30	6131    	5769    	tty2	/usr/libexec/gsd-housekeeping
+06:20:30	6132    	5769    	tty2	/usr/libexec/gsd-keyboard
+06:20:30	6138    	5769    	tty2	/usr/libexec/gsd-media-keys
+06:20:30	6142    	5769    	tty2	/usr/libexec/gsd-mouse
+06:20:30	6188    	6085    	?	/usr/libexec/evolution-calendar-factory-subprocess --factory all --bus-name org.gnome.evolution.dataserver.Subprocess.Backend.Calendarx6085x2 --own-path /org/gnome/evolution/dataserver/Subprocess/Backend/Calendar/6085/2
+06:20:30	6216    	5729    	?	/usr/libexec/evolution-addressbook-factory
+06:20:30	6217    	5729    	?	/usr/libexec/dconf-service
+06:20:30	6219    	5729    	?	/usr/libexec/tracker-store
+06:20:30	6224    	5769    	tty2	/usr/bin/gnome-software --gapplication-service
+06:20:30	6230    	5769    	tty2	/usr/libexec/gsd-disk-utility-notify
+06:20:30	6243    	5769    	tty2	/usr/libexec/tracker-miner-apps
+06:20:30	6252    	1       	tty2	/usr/libexec/gsd-printer
+06:20:30	6254    	5769    	tty2	/usr/libexec/tracker-miner-fs
+06:20:30	6288    	1       	?	/usr/bin/VBoxClient --clipboard
+06:20:30	6294    	6216    	?	/usr/libexec/evolution-addressbook-factory-subprocess --factory all --bus-name org.gnome.evolution.dataserver.Subprocess.Backend.AddressBookx6216x2 --own-path /org/gnome/evolution/dataserver/Subprocess/Backend/AddressBook/6216/2
+06:20:30	6297    	6288    	?	/usr/bin/VBoxClient --clipboard
+06:20:30	6324    	1       	?	/usr/bin/VBoxClient --seamless
+06:20:30	6325    	6324    	?	/usr/bin/VBoxClient --seamless
+06:20:30	6334    	1       	?	/usr/bin/VBoxClient --draganddrop
+06:20:30	6335    	6334    	?	/usr/bin/VBoxClient --draganddrop
+06:20:30	6342    	1       	?	/usr/bin/VBoxClient --vmsvga
+06:20:30	6343    	6342    	?	
+06:20:30	6432    	1       	?	/usr/libexec/fwupd/fwupd
+06:20:30	6834    	5729    	?	/usr/libexec/gnome-terminal-server
+06:20:30	6839    	6834    	pts/0	bash
+06:20:30	6941    	2       	?	(kworker/1:4-cgroup_pidlist_destroy)
+06:20:30	8571    	5729    	?	/usr/libexec/gvfsd-metadata
+06:20:30	9308    	860     	?	sleep 60
+06:20:30	9327    	6839    	pts/0	/bin/sh ./mk.ps
+06:20:30	9344    	9327    	pts/0	pmlogger -s 10 -c /var/tmp/9327.config pcp-ps
+06:20:30	9349    	5729    	?	/usr/libexec/tracker-extract
 Timestamp	PID		PPID		TTY	Command				
 06:20:31	1       	0       	?	/usr/lib/systemd/systemd --switched-root --system --deserialize 18
 06:20:31	2       	0       	?	(kthreadd)
@@ -22721,262 +23233,6 @@ Timestamp	PID		PPID		TTY	Command
 06:20:31	9327    	6839    	pts/0	/bin/sh ./mk.ps
 06:20:31	9344    	9327    	pts/0	pmlogger -s 10 -c /var/tmp/9327.config pcp-ps
 06:20:31	9349    	5729    	?	/usr/libexec/tracker-extract
-Timestamp	PID		PPID		TTY	Command				
-06:20:32	1       	0       	?	/usr/lib/systemd/systemd --switched-root --system --deserialize 18
-06:20:32	2       	0       	?	(kthreadd)
-06:20:32	3       	2       	?	(rcu_gp)
-06:20:32	4       	2       	?	(rcu_par_gp)
-06:20:32	5       	2       	?	(kworker/0:0-cgroup_pidlist_destroy)
-06:20:32	6       	2       	?	(kworker/0:0H-events_highpri)
-06:20:32	7       	2       	?	(kworker/u8:0-events_unbound)
-06:20:32	8       	2       	?	(kworker/0:1H-kblockd)
-06:20:32	9       	2       	?	(mm_percpu_wq)
-06:20:32	10      	2       	?	(ksoftirqd/0)
-06:20:32	11      	2       	?	(rcu_sched)
-06:20:32	12      	2       	?	(migration/0)
-06:20:32	13      	2       	?	(kworker/0:1-xfs-buf/dm-0)
-06:20:32	14      	2       	?	(cpuhp/0)
-06:20:32	15      	2       	?	(cpuhp/1)
-06:20:32	16      	2       	?	(migration/1)
-06:20:32	17      	2       	?	(ksoftirqd/1)
-06:20:32	18      	2       	?	(kworker/1:0-events)
-06:20:32	19      	2       	?	(kworker/1:0H-events_highpri)
-06:20:32	20      	2       	?	(cpuhp/2)
-06:20:32	21      	2       	?	(migration/2)
-06:20:32	22      	2       	?	(ksoftirqd/2)
-06:20:32	23      	2       	?	(kworker/2:0-cgroup_pidlist_destroy)
-06:20:32	24      	2       	?	(kworker/2:0H-events_highpri)
-06:20:32	25      	2       	?	(cpuhp/3)
-06:20:32	26      	2       	?	(migration/3)
-06:20:32	27      	2       	?	(ksoftirqd/3)
-06:20:32	28      	2       	?	(kworker/3:0-events)
-06:20:32	29      	2       	?	(kworker/3:0H-events_highpri)
-06:20:32	31      	2       	?	(kworker/u8:1-events_unbound)
-06:20:32	32      	2       	?	(kworker/u8:2-events_unbound)
-06:20:32	33      	2       	?	(kworker/u8:3)
-06:20:32	34      	2       	?	(kdevtmpfs)
-06:20:32	35      	2       	?	(netns)
-06:20:32	36      	2       	?	(kauditd)
-06:20:32	37      	2       	?	(khungtaskd)
-06:20:32	38      	2       	?	(oom_reaper)
-06:20:32	39      	2       	?	(writeback)
-06:20:32	40      	2       	?	(kcompactd0)
-06:20:32	41      	2       	?	(ksmd)
-06:20:32	42      	2       	?	(khugepaged)
-06:20:32	44      	2       	?	(kworker/3:1-events)
-06:20:32	97      	2       	?	(kintegrityd)
-06:20:32	98      	2       	?	(kblockd)
-06:20:32	99      	2       	?	(blkcg_punt_bio)
-06:20:32	100     	2       	?	(tpm_dev_wq)
-06:20:32	101     	2       	?	(md)
-06:20:32	102     	2       	?	(edac-poller)
-06:20:32	103     	2       	?	(devfreq_wq)
-06:20:32	104     	2       	?	(watchdogd)
-06:20:32	105     	2       	?	(kworker/2:1-events)
-06:20:32	107     	2       	?	(kswapd0:0)
-06:20:32	109     	2       	?	(kthrotld)
-06:20:32	110     	2       	?	(acpi_thermal_pm)
-06:20:32	111     	2       	?	(kmpath_rdacd)
-06:20:32	112     	2       	?	(kaluad)
-06:20:32	113     	2       	?	(kworker/3:1H-events_highpri)
-06:20:32	114     	2       	?	(bch_btree_io)
-06:20:32	115     	2       	?	(bcache)
-06:20:32	116     	2       	?	(bch_journal)
-06:20:32	117     	2       	?	(ipv6_addrconf)
-06:20:32	118     	2       	?	(dsa_ordered)
-06:20:32	119     	2       	?	(kworker/0:2-events)
-06:20:32	120     	2       	?	(kstrp)
-06:20:32	125     	2       	?	(kworker/u9:0)
-06:20:32	127     	2       	?	(kworker/1:1-events)
-06:20:32	135     	2       	?	(charger_manager)
-06:20:32	186     	2       	?	(kworker/3:2-cgroup_pidlist_destroy)
-06:20:32	189     	2       	?	(kworker/1:2-events)
-06:20:32	191     	2       	?	(kworker/1:3-events)
-06:20:32	194     	2       	?	(kworker/0:3-events)
-06:20:32	344     	2       	?	(iprt-VBoxWQueue)
-06:20:32	345     	2       	?	(kworker/2:1H-xfs-log/dm-0)
-06:20:32	346     	2       	?	(ata_sff)
-06:20:32	347     	2       	?	(scsi_eh_0)
-06:20:32	351     	2       	?	(scsi_tmf_0)
-06:20:32	352     	2       	?	(scsi_eh_1)
-06:20:32	353     	2       	?	(scsi_tmf_1)
-06:20:32	366     	2       	?	(scsi_eh_2)
-06:20:32	367     	2       	?	(scsi_tmf_2)
-06:20:32	369     	2       	?	(kworker/1:1H-kblockd)
-06:20:32	371     	2       	?	(irq/18-vmwgfx)
-06:20:32	372     	2       	?	(ttm_swap)
-06:20:32	441     	2       	?	(kdmflush)
-06:20:32	452     	2       	?	(kdmflush)
-06:20:32	467     	2       	?	(kworker/3:3-events)
-06:20:32	473     	2       	?	(kworker/2:2-cgroup_pidlist_destroy)
-06:20:32	477     	2       	?	(kworker/2:3-cgroup_destroy)
-06:20:32	478     	2       	?	(xfsalloc)
-06:20:32	479     	2       	?	(xfs_mru_cache)
-06:20:32	481     	2       	?	(xfs-buf/dm-0)
-06:20:32	482     	2       	?	(xfs-conv/dm-0)
-06:20:32	483     	2       	?	(xfs-cil/dm-0)
-06:20:32	484     	2       	?	(xfs-reclaim/dm-)
-06:20:32	485     	2       	?	(xfs-eofblocks/d)
-06:20:32	486     	2       	?	(xfs-log/dm-0)
-06:20:32	487     	2       	?	(xfsaild/dm-0)
-06:20:32	555     	2       	?	(kworker/2:4-events)
-06:20:32	585     	1       	?	/usr/lib/systemd/systemd-journald
-06:20:32	624     	1       	?	/usr/lib/systemd/systemd-udevd
-06:20:32	655     	2       	?	(cryptd)
-06:20:32	696     	2       	?	(kdmflush)
-06:20:32	751     	2       	?	(xfs-buf/dm-2)
-06:20:32	752     	2       	?	(xfs-conv/dm-2)
-06:20:32	753     	2       	?	(xfs-cil/dm-2)
-06:20:32	754     	2       	?	(xfs-buf/sda1)
-06:20:32	755     	2       	?	(xfs-conv/sda1)
-06:20:32	756     	2       	?	(xfs-reclaim/dm-)
-06:20:32	757     	2       	?	(xfs-cil/sda1)
-06:20:32	758     	2       	?	(xfs-eofblocks/d)
-06:20:32	759     	2       	?	(xfs-reclaim/sda)
-06:20:32	760     	2       	?	(xfs-eofblocks/s)
-06:20:32	761     	2       	?	(xfs-log/dm-2)
-06:20:32	762     	2       	?	(xfsaild/dm-2)
-06:20:32	763     	2       	?	(xfs-log/sda1)
-06:20:32	764     	2       	?	(xfsaild/sda1)
-06:20:32	786     	1       	?	/usr/bin/rpcbind -w -f
-06:20:32	788     	1       	?	/sbin/auditd
-06:20:32	790     	788     	?	/usr/sbin/sedispatch
-06:20:32	800     	2       	?	(rpciod)
-06:20:32	801     	2       	?	(xprtiod)
-06:20:32	816     	1       	?	/usr/sbin/mcelog --ignorenodev --daemon --foreground
-06:20:32	818     	1       	?	/usr/bin/dbus-daemon --system --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
-06:20:32	820     	1       	?	/usr/lib/polkit-1/polkitd --no-debug
-06:20:32	821     	1       	?	/usr/sbin/irqbalance --foreground
-06:20:32	826     	1       	?	/usr/libexec/rtkit-daemon
-06:20:32	827     	1       	?	/usr/sbin/alsactl -s -n 19 -c -E ALSA_CONFIG_PATH=/etc/alsa/alsactl.conf --initfile=/lib/alsa/init/00main rdaemon
-06:20:32	829     	1       	?	avahi-daemon: running [linux.local]
-06:20:32	830     	1       	?	/usr/bin/lsmd -d
-06:20:32	834     	1       	?	/usr/lib/systemd/systemd-machined
-06:20:32	835     	1       	?	/usr/libexec/udisks2/udisksd
-06:20:32	838     	1       	?	/usr/sbin/sssd -i --logger=files
-06:20:32	840     	1       	?	/usr/sbin/smartd -n -q never
-06:20:32	857     	1       	?	/usr/sbin/chronyd
-06:20:32	860     	1       	?	/bin/bash /usr/sbin/ksmtuned
-06:20:32	864     	1       	?	/opt/cisco/anyconnect/bin/vpnagentd -execv_instance
-06:20:32	868     	829     	?	avahi-daemon: chroot helper
-06:20:32	877     	838     	?	/usr/libexec/sssd/sssd_be --domain implicit_files --uid 0 --gid 0 --logger=files
-06:20:32	884     	1       	?	/usr/libexec/platform-python -s /usr/sbin/firewalld --nofork --nopid
-06:20:32	885     	1       	?	/usr/sbin/ModemManager
-06:20:32	897     	838     	?	/usr/libexec/sssd/sssd_nss --uid 0 --gid 0 --logger=files
-06:20:32	941     	1       	?	/usr/lib/systemd/systemd-logind
-06:20:32	946     	1       	?	/usr/libexec/accounts-daemon
-06:20:32	1106    	1       	?	/usr/sbin/NetworkManager --no-daemon
-06:20:32	1117    	1       	?	/usr/sbin/sshd -D -oCiphers=aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr,aes256-cbc,aes128-gcm@openssh.com,aes128-ctr,aes128-cbc -oMACs=hmac-sha2-256-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha1,umac-128@openssh.com,hmac-sha2-512 -oGSSAPIKexAlgorithms=gss-curve25519-sha256-,gss-nistp256-sha256-,gss-group14-sha256-,gss-group16-sha512-,gss-gex-sha1-,gss-group14-sha1- -oKexAlgorithms=curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1 -oHostKeyAlgorithms=ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ssh-rsa,ssh-rsa-cert-v01@openssh.com -oPubkeyAcceptedKeyTypes=ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-512-cert-v01@openssh.com,ssh-rsa,ssh-rsa-cert-v01@openssh.com -oCASignatureAlgorithms=ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-256,rsa-sha2-512,ssh-rsa
-06:20:32	1119    	1       	?	/usr/sbin/cupsd -l
-06:20:32	1120    	1       	?	/usr/libexec/platform-python -Es /usr/sbin/tuned -l -P
-06:20:32	1125    	1       	?	/usr/sbin/gssproxy -D
-06:20:32	1150    	1       	?	/usr/sbin/iscsid -f -d2
-06:20:32	1151    	1       	?	/usr/sbin/rsyslogd -n
-06:20:32	1176    	2       	?	(iscsi_eh)
-06:20:32	1192    	1       	?	/usr/sbin/crond -n
-06:20:32	1193    	2       	?	(kworker/0:4-cgroup_pidlist_destroy)
-06:20:32	1194    	1       	?	/usr/sbin/atd -f
-06:20:32	1624    	1       	?	/usr/libexec/pcp/bin/pmcd -A
-06:20:32	1633    	1624    	?	/var/lib/pcp/pmdas/root/pmdaroot
-06:20:32	1650    	1633    	?	/var/lib/pcp/pmdas/proc/pmdaproc -A -d 3
-06:20:32	1666    	1633    	?	/var/lib/pcp/pmdas/xfs/pmdaxfs -d 11
-06:20:32	1682    	1633    	?	/var/lib/pcp/pmdas/linux/pmdalinux -A
-06:20:32	1690    	1633    	?	python3 /var/lib/pcp/pmdas/nfsclient/pmdanfsclient.python
-06:20:32	1754    	1633    	?	/var/lib/pcp/pmdas/kvm/pmdakvm -d 95
-06:20:32	1761    	1633    	?	/var/lib/pcp/pmdas/dm/pmdadm -d 129
-06:20:32	1767    	1633    	?	python3 /var/lib/pcp/pmdas/openmetrics/pmdaopenmetrics.python
-06:20:32	2407    	1       	?	/usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/default.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper
-06:20:32	2410    	2407    	?	/usr/sbin/dnsmasq --conf-file=/var/lib/libvirt/dnsmasq/default.conf --leasefile-ro --dhcp-script=/usr/libexec/libvirt_leaseshelper
-06:20:32	2501    	1       	?	/usr/bin/pmie -b -F -P -l /var/log/pcp/pmie/localhost.localdomain/pmie.log -c config.default
-06:20:32	2508    	1       	?	/usr/libexec/pcp/bin/pmlogger -N -P -r -T24h10m -c config.ora -v 100mb -m pmlogger_check %Y%m%d.%H.%M
-06:20:32	2516    	1       	?	/usr/libexec/pcp/bin/pmpause
-06:20:32	2684    	1       	?	/bin/sh /usr/libexec/pcp/bin/pmlogger_farm --skip-primary --quick
-06:20:32	2937    	1       	?	/usr/sbin/gdm
-06:20:32	2953    	1       	?	/usr/sbin/VBoxService --pidfile /var/run/vboxadd-service.sh
-06:20:32	4956    	1       	?	/usr/libexec/upowerd
-06:20:32	4964    	1       	?	/usr/libexec/geoclue
-06:20:32	4977    	1       	?	/usr/sbin/wpa_supplicant -c /etc/wpa_supplicant/wpa_supplicant.conf -u -s
-06:20:32	4978    	1       	?	/usr/libexec/packagekitd
-06:20:32	5059    	1       	?	/usr/libexec/colord
-06:20:32	5150    	2       	?	(kworker/3:4-cgroup_pidlist_destroy)
-06:20:32	5714    	2937    	?	gdm-session-worker [pam/gdm-password]
-06:20:32	5729    	1       	?	/usr/lib/systemd/systemd --user
-06:20:32	5731    	5729    	?	(sd-pam)
-06:20:32	5757    	1       	?	/usr/bin/gnome-keyring-daemon --daemonize --login
-06:20:32	5764    	5714    	tty2	/usr/libexec/gdm-wayland-session --register-session gnome-session
-06:20:32	5766    	5729    	?	/usr/bin/dbus-daemon --session --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
-06:20:32	5769    	5764    	tty2	/usr/libexec/gnome-session-binary
-06:20:32	5857    	5769    	tty2	/usr/bin/gnome-shell
-06:20:32	5901    	5729    	?	/usr/libexec/gvfsd
-06:20:32	5908    	5729    	?	/usr/libexec/gvfsd-fuse /run/user/0/gvfs -f -o big_writes
-06:20:32	5916    	5857    	tty2	/usr/bin/Xwayland :0 -rootless -terminate -accessx -core -auth /run/user/0/.mutter-Xwaylandauth.Q6AEX1 -listen 4 -listen 5 -displayfd 6
-06:20:32	5927    	5729    	?	/usr/libexec/at-spi-bus-launcher
-06:20:32	5938    	5927    	?	/usr/bin/dbus-daemon --config-file=/usr/share/defaults/at-spi2/accessibility.conf --nofork --print-address 3
-06:20:32	5945    	5729    	?	/usr/libexec/at-spi2-registryd --use-gnome-session
-06:20:32	5963    	5857    	tty2	ibus-daemon --xim --panel disable
-06:20:32	5967    	5963    	tty2	/usr/libexec/ibus-dconf
-06:20:32	5968    	5729    	?	/usr/libexec/xdg-permission-store
-06:20:32	5970    	5963    	tty2	/usr/libexec/ibus-extension-gtk3
-06:20:32	5976    	1       	tty2	/usr/libexec/ibus-x11 --kill-daemon
-06:20:32	5979    	5729    	?	/usr/libexec/ibus-portal
-06:20:32	5993    	5729    	?	/usr/libexec/gnome-shell-calendar-server
-06:20:32	5999    	5729    	?	/usr/libexec/evolution-source-registry
-06:20:32	6005    	5729    	?	/usr/libexec/goa-daemon
-06:20:32	6014    	5729    	?	/usr/libexec/gvfs-udisks2-volume-monitor
-06:20:32	6023    	5729    	?	/usr/libexec/gvfs-mtp-volume-monitor
-06:20:32	6030    	5729    	?	/usr/libexec/gvfs-gphoto2-volume-monitor
-06:20:32	6034    	5729    	?	/usr/libexec/goa-identity-service
-06:20:32	6042    	5729    	?	/usr/libexec/gvfs-goa-volume-monitor
-06:20:32	6050    	5729    	?	/usr/libexec/gvfs-afc-volume-monitor
-06:20:32	6055    	1       	?	/usr/libexec/sssd/sssd_kcm --uid 0 --gid 0 --logger=files
-06:20:32	6057    	5769    	tty2	/usr/libexec/gsd-power
-06:20:32	6058    	5769    	tty2	/usr/libexec/gsd-print-notifications
-06:20:32	6060    	5769    	tty2	/usr/libexec/gsd-rfkill
-06:20:32	6062    	5769    	tty2	/usr/libexec/gsd-screensaver-proxy
-06:20:32	6064    	5769    	tty2	/usr/libexec/gsd-sharing
-06:20:32	6072    	5769    	tty2	/usr/libexec/gsd-sound
-06:20:32	6078    	5769    	tty2	/usr/libexec/gsd-xsettings
-06:20:32	6082    	5769    	tty2	/usr/libexec/gsd-wacom
-06:20:32	6085    	5729    	?	/usr/libexec/evolution-calendar-factory
-06:20:32	6087    	5769    	tty2	/usr/libexec/gsd-smartcard
-06:20:32	6088    	5769    	tty2	/usr/libexec/gsd-account
-06:20:32	6111    	5769    	tty2	/usr/libexec/gsd-a11y-settings
-06:20:32	6113    	5963    	tty2	/usr/libexec/ibus-engine-simple
-06:20:32	6115    	1       	?	/usr/bin/pulseaudio --start
-06:20:32	6122    	5769    	tty2	/usr/libexec/gsd-clipboard
-06:20:32	6126    	5769    	tty2	/usr/libexec/gsd-color
-06:20:32	6128    	5769    	tty2	/usr/libexec/gsd-datetime
-06:20:32	6131    	5769    	tty2	/usr/libexec/gsd-housekeeping
-06:20:32	6132    	5769    	tty2	/usr/libexec/gsd-keyboard
-06:20:32	6138    	5769    	tty2	/usr/libexec/gsd-media-keys
-06:20:32	6142    	5769    	tty2	/usr/libexec/gsd-mouse
-06:20:32	6188    	6085    	?	/usr/libexec/evolution-calendar-factory-subprocess --factory all --bus-name org.gnome.evolution.dataserver.Subprocess.Backend.Calendarx6085x2 --own-path /org/gnome/evolution/dataserver/Subprocess/Backend/Calendar/6085/2
-06:20:32	6216    	5729    	?	/usr/libexec/evolution-addressbook-factory
-06:20:32	6217    	5729    	?	/usr/libexec/dconf-service
-06:20:32	6219    	5729    	?	/usr/libexec/tracker-store
-06:20:32	6224    	5769    	tty2	/usr/bin/gnome-software --gapplication-service
-06:20:32	6230    	5769    	tty2	/usr/libexec/gsd-disk-utility-notify
-06:20:32	6243    	5769    	tty2	/usr/libexec/tracker-miner-apps
-06:20:32	6252    	1       	tty2	/usr/libexec/gsd-printer
-06:20:32	6254    	5769    	tty2	/usr/libexec/tracker-miner-fs
-06:20:32	6288    	1       	?	/usr/bin/VBoxClient --clipboard
-06:20:32	6294    	6216    	?	/usr/libexec/evolution-addressbook-factory-subprocess --factory all --bus-name org.gnome.evolution.dataserver.Subprocess.Backend.AddressBookx6216x2 --own-path /org/gnome/evolution/dataserver/Subprocess/Backend/AddressBook/6216/2
-06:20:32	6297    	6288    	?	/usr/bin/VBoxClient --clipboard
-06:20:32	6324    	1       	?	/usr/bin/VBoxClient --seamless
-06:20:32	6325    	6324    	?	/usr/bin/VBoxClient --seamless
-06:20:32	6334    	1       	?	/usr/bin/VBoxClient --draganddrop
-06:20:32	6335    	6334    	?	/usr/bin/VBoxClient --draganddrop
-06:20:32	6342    	1       	?	/usr/bin/VBoxClient --vmsvga
-06:20:32	6343    	6342    	?	
-06:20:32	6432    	1       	?	/usr/libexec/fwupd/fwupd
-06:20:32	6834    	5729    	?	/usr/libexec/gnome-terminal-server
-06:20:32	6839    	6834    	pts/0	bash
-06:20:32	6941    	2       	?	(kworker/1:4-cgroup_pidlist_destroy)
-06:20:32	8571    	5729    	?	/usr/libexec/gvfsd-metadata
-06:20:32	9308    	860     	?	sleep 60
-06:20:32	9327    	6839    	pts/0	/bin/sh ./mk.ps
-06:20:32	9344    	9327    	pts/0	pmlogger -s 10 -c /var/tmp/9327.config pcp-ps
-06:20:32	9349    	5729    	?	/usr/libexec/tracker-extract
 
 pcp-ps output : Display the value as per %cpu sorted
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
@@ -23017,14 +23273,14 @@ Timestamp        USERNAME	PID		%CPU	%MEM	VSZ	RSS	TTY	STAT	TIME		START		COMMAND
 pcp-ps output : Display the value as per %mem in user selected format
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
 Timestamp	PID		PPID		TTY	Command				%MEM	
-06:20:31	4978    	1       	?	/usr/libexec/packagekitd      	2.25
-06:20:31	5857    	5769    	tty2	/usr/bin/gnome-shell          	2.16
-06:20:31	6224    	5769    	tty2	/usr/bin/gnome-software --gapp	1.01
-06:20:31	5976    	1       	tty2	/usr/libexec/ibus-x11 --kill-d	0.45
-06:20:31	5916    	5857    	tty2	/usr/bin/Xwayland :0 -rootless	0.37
-06:20:31	6219    	5729    	?	/usr/libexec/tracker-store    	0.36
-06:20:31	6834    	5729    	?	/usr/libexec/gnome-terminal-se	0.35
-06:20:31	884     	1       	?	/usr/libexec/platform-python -	0.31
+06:20:30	4978    	1       	?	/usr/libexec/packagekitd      	2.25
+06:20:30	5857    	5769    	tty2	/usr/bin/gnome-shell          	2.16
+06:20:30	6224    	5769    	tty2	/usr/bin/gnome-software --gapp	1.01
+06:20:30	5976    	1       	tty2	/usr/libexec/ibus-x11 --kill-d	0.45
+06:20:30	5916    	5857    	tty2	/usr/bin/Xwayland :0 -rootless	0.37
+06:20:30	6219    	5729    	?	/usr/libexec/tracker-store    	0.36
+06:20:30	6834    	5729    	?	/usr/libexec/gnome-terminal-se	0.35
+06:20:30	884     	1       	?	/usr/libexec/platform-python -	0.31
 
 pcp-ps output : Display the value as per %cpu in user selected format
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
@@ -23155,14 +23411,14 @@ Timestamp	PID		%CPU	Command
 pcp-ps output : Display user format using --sort (long option)
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)
 Timestamp	PID		%MEM	Command				
-06:20:31	4978    	2.25	/usr/libexec/packagekitd
-06:20:31	5857    	2.16	/usr/bin/gnome-shell
-06:20:31	6224    	1.01	/usr/bin/gnome-software --gapplication-service
-06:20:31	5976    	0.45	/usr/libexec/ibus-x11 --kill-daemon
-06:20:31	5916    	0.37	/usr/bin/Xwayland :0 -rootless -terminate -accessx -core -auth /run/user/0/.mutter-Xwaylandauth.Q6AEX1 -listen 4 -listen 5 -displayfd 6
-06:20:31	6219    	0.36	/usr/libexec/tracker-store
-06:20:31	6834    	0.35	/usr/libexec/gnome-terminal-server
-06:20:31	884     	0.31	/usr/libexec/platform-python -s /usr/sbin/firewalld --nofork --nopid
+06:20:30	4978    	2.25	/usr/libexec/packagekitd
+06:20:30	5857    	2.16	/usr/bin/gnome-shell
+06:20:30	6224    	1.01	/usr/bin/gnome-software --gapplication-service
+06:20:30	5976    	0.45	/usr/libexec/ibus-x11 --kill-daemon
+06:20:30	5916    	0.37	/usr/bin/Xwayland :0 -rootless -terminate -accessx -core -auth /run/user/0/.mutter-Xwaylandauth.Q6AEX1 -listen 4 -listen 5 -displayfd 6
+06:20:30	6219    	0.36	/usr/libexec/tracker-store
+06:20:30	6834    	0.35	/usr/libexec/gnome-terminal-server
+06:20:30	884     	0.31	/usr/libexec/platform-python -s /usr/sbin/firewalld --nofork --nopid
 
 pcp-ps output : Display user format with --sort on missing column (negative test, should error)
 Linux  5.4.17-2136.313.6.el8uek.x86_64  (localhost.localdomain)  12/14/22  x86_64    (4 CPU)

--- a/src/pcp/ps/pcp-ps.py
+++ b/src/pcp/ps/pcp-ps.py
@@ -281,11 +281,11 @@ class ProcessStatusUtil:
 
 
     def total_time(self):
-        c_usertime = self.__get_value('proc.psinfo.stime', self.instance)
-        p_guesttime = self.__get_previous_value('proc.psinfo.utime', self.instance)
+        c_usertime = self.__get_value('proc.psinfo.utime', self.instance)
+        c_systemtime = self.__get_value('proc.psinfo.stime', self.instance)
         timefmt = "%H:%M:%S"
-        if c_usertime and p_guesttime is not None:
-            total_time = (c_usertime / 1000) + (p_guesttime / 1000)
+        if c_usertime is not None and c_systemtime is not None:
+            total_time = (c_usertime + c_systemtime) / 1000
         else:
             total_time = 0
         return time.strftime(timefmt, time.gmtime(total_time))
@@ -456,7 +456,7 @@ class ProcessStatusReporter:
             "pid": "Timestamp" + header_indentation + "PID\t\tPPID\t\tTTY\tTIME\t\tCMD",
             "ppid": "Timestamp" + header_indentation + "PID\t\tPPID\t\tTTY\tTIME\t\tCMD",
             "username": "Timestamp" + header_indentation + "USERNAME\t\tPID\t\t%CPU\t%MEM\tVSZ\tRSS\t" +
-                         "TTY\tSTAT\t\tTIME\t\tSTART\t\tCOMMAND",
+                        "TTY\tSTAT\t\tTIME\t\tSTART\t\tCOMMAND",
             "command": "Timestamp" + header_indentation + "PID\t\tPPID\t\tTTY\tTIME\t\tCMD"
         }
         selected_flag = self.processStatOptions.universal_flag
@@ -526,14 +526,14 @@ class ProcessStatusReporter:
                                  "please remove sorting flag or choose another flag for output")
             if self.processStatOptions.sorting_order == '%cpu':
                 output_rows.sort(
-                key=lambda x: float(x.split()[cpu_idx]) if x.split()[cpu_idx].replace('.', '', 1).isdigit()
-                else float('-inf'),
-                reverse=True)
+                    key=lambda x: float(x.split()[cpu_idx]) if x.split()[cpu_idx].replace('.', '', 1).isdigit()
+                    else float('-inf'),
+                    reverse=True)
             elif self.processStatOptions.sorting_order == '%mem':
                 output_rows.sort(
-                key=lambda x: float(x.split()[mem_idx]) if x.split()[mem_idx].replace('.', '', 1).isdigit()
-                else float('-inf'),
-                reverse=True)
+                    key=lambda x: float(x.split()[mem_idx]) if x.split()[mem_idx].replace('.', '', 1).isdigit()
+                    else float('-inf'),
+                    reverse=True)
         if output_rows:
             self.printer(header)
             self.printer('\n'.join(output_rows))
@@ -576,8 +576,9 @@ class ProcessStatReport(pmcc.MetricGroupPrinter):
         process_filter = ProcessFilter(self.processStatOptions)
         stdout = StdoutPrinter()
         printdecorator = NoneHandlingPrinterDecorator(stdout)
-        report = ProcessStatusReporter(process_report, process_filter, interval_in_seconds,
-                                        printdecorator.Print, self.processStatOptions)
+        report = ProcessStatusReporter(
+            process_report, process_filter, interval_in_seconds,
+            printdecorator.Print, self.processStatOptions)
         report.print_report(timestamp, header_indentation, value_indentation)
     def __print_dynamic_report(self, manager,timestamp, header_indentation, value_indentation,interval_in_seconds):
         if self.processStatOptions.debug_mode:
@@ -595,9 +596,16 @@ class ProcessStatReport(pmcc.MetricGroupPrinter):
         timestamp = time.strftime(self.processStatOptions.timefmt, ts.struct_time())
         return timestamp
 
+    def __needs_previous_values(self):
+        if self.processStatOptions.universal_flag in ('user', 'username'):
+            return True
+        return (self.processStatOptions.selective_colum_flag and
+                '%cpu' in self.processStatOptions.column_list)
+
     def report(self, manager):
         try:
-            if self.group['proc.psinfo.utime'].netPrevValues is None:
+            if (self.__needs_previous_values() and
+                    self.group['proc.psinfo.utime'].netPrevValues is None):
                 return False  # Not ready, skip increment
             if not self.group['hinv.ncpu'].netValues or not self.group['kernel.uname.sysname'].netValues:
                 return False
@@ -612,12 +620,11 @@ class ProcessStatReport(pmcc.MetricGroupPrinter):
             if self.processStatOptions.debug_mode:
                 print("Starting report generation")
                 print("Need to print samples: %s" % self.processStatOptions.print_count)
-            if self.processStatOptions.print_count == 0:
-                if self.processStatOptions.debug_mode:
-                    print("Print count exhausted, exiting")
-                sys.exit(0)
             timestamp = self.__get_timestamp()
-            interval_in_seconds = self.timeStampDelta()
+            try:
+                interval_in_seconds = self.timeStampDelta()
+            except AttributeError:
+                interval_in_seconds = 0
             header_indentation = "        " if len(timestamp) < 9 else (len(timestamp) - 7) * " "
             value_indentation = ((len(header_indentation) + 9) - len(timestamp)) * " "
 
@@ -635,6 +642,8 @@ class ProcessStatReport(pmcc.MetricGroupPrinter):
                 self.__print_report(manager,timestamp, header_indentation, value_indentation, interval_in_seconds)
             if self.processStatOptions.context is not PM_CONTEXT_ARCHIVE:
                 self.processStatOptions.print_count -= 1
+                if self.processStatOptions.print_count == 0:
+                    sys.exit(0)
             return True  # Data was printed
         finally:
             sys.stdout.flush()
@@ -733,13 +742,11 @@ class ProcessStatOptions(pmapi.pmOptions):
         self.pmSetLongOptionText(
             "\twchan\tWCHAN \tname of the kernel function in which the process is sleeping"
         )
-        self.pmSetLongOption("", 0, 'u', "",
-                             "Display user-oriented format"
-        )
+        self.pmSetLongOption(
+            "", 0, 'u', "", "Display user-oriented format")
         self.pmSetLongOption(
             "sort", 1, "O", "%cpu,%mem",
-            "sort the process list by %cpu or %mem values "
-        )
+            "sort the process list by %cpu or %mem values ")
         self.pmSetLongOption("", 0, "d", "", "enable debug mode")
         self.pmSetLongOptionVersion()
         self.pmSetLongOptionTimeZone()
@@ -893,6 +900,11 @@ if __name__ == "__main__":
         opts = ProcessStatOptions()
         manager = pmcc.MetricGroupManager.builder(opts, sys.argv)
         ProcessStatOptions.context = manager.type
+        if manager.type is PM_CONTEXT_ARCHIVE:
+            samples = opts.pmGetOptionSamples()
+            if samples is not None:
+                # Counter-based process metrics need one previous archive record.
+                opts.pmSetOptionSamples(str(samples + 1))
         if not opts.checkOptions():
             raise pmapi.pmUsageErr
         missing = manager.checkMissingMetrics(PSSTAT_METRICS)

--- a/src/pcp/ps/pcp-ps.py
+++ b/src/pcp/ps/pcp-ps.py
@@ -39,6 +39,12 @@ PSSTAT_METRICS = ['kernel.uname.nodename', 'kernel.uname.release', 'kernel.uname
 SCHED_POLICY = ['NORMAL', 'FIFO', 'RR', 'BATCH', '', 'IDLE', 'DEADLINE']
 
 
+def needs_previous_values(options):
+    if options.universal_flag in ('user', 'username'):
+        return True
+    return options.selective_colum_flag and '%cpu' in options.column_list
+
+
 class StdoutPrinter:
     def Print(self, args):
         print(args)
@@ -596,15 +602,9 @@ class ProcessStatReport(pmcc.MetricGroupPrinter):
         timestamp = time.strftime(self.processStatOptions.timefmt, ts.struct_time())
         return timestamp
 
-    def __needs_previous_values(self):
-        if self.processStatOptions.universal_flag in ('user', 'username'):
-            return True
-        return (self.processStatOptions.selective_colum_flag and
-                '%cpu' in self.processStatOptions.column_list)
-
     def report(self, manager):
         try:
-            if (self.__needs_previous_values() and
+            if (needs_previous_values(self.processStatOptions) and
                     self.group['proc.psinfo.utime'].netPrevValues is None):
                 return False  # Not ready, skip increment
             if not self.group['hinv.ncpu'].netValues or not self.group['kernel.uname.sysname'].netValues:
@@ -903,7 +903,7 @@ if __name__ == "__main__":
         if manager.type is PM_CONTEXT_ARCHIVE:
             samples = opts.pmGetOptionSamples()
             if samples is not None:
-                # Counter-based process metrics need one previous archive record.
+                # The manager's initial archive fetch precedes its report loop.
                 opts.pmSetOptionSamples(str(samples + 1))
         if not opts.checkOptions():
             raise pmapi.pmUsageErr

--- a/src/pcp/ps/pcp-ps.py
+++ b/src/pcp/ps/pcp-ps.py
@@ -40,9 +40,9 @@ SCHED_POLICY = ['NORMAL', 'FIFO', 'RR', 'BATCH', '', 'IDLE', 'DEADLINE']
 
 
 def needs_previous_values(options):
-    if options.universal_flag in ('user', 'username'):
-        return True
-    return options.selective_colum_flag and '%cpu' in options.column_list
+    if options.selective_colum_flag:
+        return '%cpu' in options.column_list
+    return options.universal_flag in ('user', 'username')
 
 
 class StdoutPrinter:
@@ -605,7 +605,7 @@ class ProcessStatReport(pmcc.MetricGroupPrinter):
     def report(self, manager):
         try:
             if (needs_previous_values(self.processStatOptions) and
-                    self.group['proc.psinfo.utime'].netPrevValues is None):
+                    self.group['proc.psinfo.stime'].netPrevValues is None):
                 return False  # Not ready, skip increment
             if not self.group['hinv.ncpu'].netValues or not self.group['kernel.uname.sysname'].netValues:
                 return False
@@ -900,7 +900,7 @@ if __name__ == "__main__":
         opts = ProcessStatOptions()
         manager = pmcc.MetricGroupManager.builder(opts, sys.argv)
         ProcessStatOptions.context = manager.type
-        if manager.type is PM_CONTEXT_ARCHIVE:
+        if manager.type is PM_CONTEXT_ARCHIVE and needs_previous_values(opts):
             samples = opts.pmGetOptionSamples()
             if samples is not None:
                 # The manager's initial archive fetch precedes its report loop.

--- a/src/pcp/ps/test/process_stat_report_test.py
+++ b/src/pcp/ps/test/process_stat_report_test.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env pmpython
+
+import unittest
+from unittest.mock import ANY, MagicMock, Mock, patch
+
+from pcp_ps import PM_CONTEXT_ARCHIVE, ProcessStatReport
+
+
+class TestProcessStatReport(unittest.TestCase):
+    def _report(self, options, previous_values):
+        group = MagicMock()
+        group.__getitem__.return_value.netPrevValues = previous_values
+        group.__getitem__.return_value.netValues = [object()]
+        report = ProcessStatReport(group, options)
+        report.Machine_info_count = 1
+        return report
+
+    def test_default_report_does_not_wait_for_previous_values(self):
+        options = Mock(context=None, debug_mode=False, print_count=1,
+                       selective_colum_flag=False, universal_flag='all')
+        report = self._report(options, None)
+
+        with patch.object(report, '_ProcessStatReport__get_timestamp', return_value='00:00:00'), \
+             patch.object(report, 'timeStampDelta', side_effect=AttributeError), \
+             patch.object(report, '_ProcessStatReport__print_report') as print_report, \
+             self.assertRaises(SystemExit):
+            report.report(Mock())
+
+        print_report.assert_called_once_with(ANY, '00:00:00', '        ', '         ', 0)
+
+    def test_user_report_waits_for_previous_values(self):
+        options = Mock(context=None, debug_mode=False, print_count=1,
+                       selective_colum_flag=False, universal_flag='user')
+        report = self._report(options, None)
+
+        self.assertFalse(report.report(Mock()))
+
+    def test_archive_report_does_not_decrement_print_count(self):
+        options = Mock(context=PM_CONTEXT_ARCHIVE, debug_mode=False,
+                       print_count=1, selective_colum_flag=False,
+                       universal_flag='all')
+        report = self._report(options, object())
+
+        with patch.object(report, '_ProcessStatReport__get_timestamp', return_value='00:00:00'), \
+             patch.object(report, 'timeStampDelta', return_value=1.0), \
+             patch.object(report, '_ProcessStatReport__print_report') as print_report:
+            self.assertTrue(report.report(Mock()))
+
+        self.assertEqual(options.print_count, 1)
+        print_report.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/pcp/ps/test/process_stat_report_test.py
+++ b/src/pcp/ps/test/process_stat_report_test.py
@@ -3,7 +3,7 @@
 import unittest
 from unittest.mock import ANY, MagicMock, Mock, patch
 
-from pcp_ps import PM_CONTEXT_ARCHIVE, ProcessStatReport
+from pcp_ps import PM_CONTEXT_ARCHIVE, ProcessStatReport, needs_previous_values
 
 
 class TestProcessStatReport(unittest.TestCase):
@@ -48,6 +48,16 @@ class TestProcessStatReport(unittest.TestCase):
 
         self.assertEqual(options.print_count, 1)
         print_report.assert_called_once()
+
+    def test_previous_values_are_only_needed_for_cpu_reports(self):
+        default = Mock(universal_flag='all', selective_colum_flag=False)
+        user = Mock(universal_flag='user', selective_colum_flag=False)
+        columns = Mock(universal_flag='all', selective_colum_flag=True,
+                       column_list=['pid', '%cpu'])
+
+        self.assertFalse(needs_previous_values(default))
+        self.assertTrue(needs_previous_values(user))
+        self.assertTrue(needs_previous_values(columns))
 
 
 if __name__ == '__main__':

--- a/src/pcp/ps/test/process_stat_report_test.py
+++ b/src/pcp/ps/test/process_stat_report_test.py
@@ -7,10 +7,15 @@ from pcp_ps import PM_CONTEXT_ARCHIVE, ProcessStatReport, needs_previous_values
 
 
 class TestProcessStatReport(unittest.TestCase):
-    def _report(self, options, previous_values):
+    def _report(self, options, utime_previous_values, stime_previous_values):
         group = MagicMock()
-        group.__getitem__.return_value.netPrevValues = previous_values
-        group.__getitem__.return_value.netValues = [object()]
+        utime = MagicMock(netPrevValues=utime_previous_values, netValues=[object()])
+        stime = MagicMock(netPrevValues=stime_previous_values, netValues=[object()])
+        metric = MagicMock(netValues=[object()])
+        group.__getitem__.side_effect = lambda name: {
+            'proc.psinfo.utime': utime,
+            'proc.psinfo.stime': stime,
+        }.get(name, metric)
         report = ProcessStatReport(group, options)
         report.Machine_info_count = 1
         return report
@@ -18,7 +23,7 @@ class TestProcessStatReport(unittest.TestCase):
     def test_default_report_does_not_wait_for_previous_values(self):
         options = Mock(context=None, debug_mode=False, print_count=1,
                        selective_colum_flag=False, universal_flag='all')
-        report = self._report(options, None)
+        report = self._report(options, None, None)
 
         with patch.object(report, '_ProcessStatReport__get_timestamp', return_value='00:00:00'), \
              patch.object(report, 'timeStampDelta', side_effect=AttributeError), \
@@ -31,7 +36,7 @@ class TestProcessStatReport(unittest.TestCase):
     def test_user_report_waits_for_previous_values(self):
         options = Mock(context=None, debug_mode=False, print_count=1,
                        selective_colum_flag=False, universal_flag='user')
-        report = self._report(options, None)
+        report = self._report(options, object(), None)
 
         self.assertFalse(report.report(Mock()))
 
@@ -39,7 +44,7 @@ class TestProcessStatReport(unittest.TestCase):
         options = Mock(context=PM_CONTEXT_ARCHIVE, debug_mode=False,
                        print_count=1, selective_colum_flag=False,
                        universal_flag='all')
-        report = self._report(options, object())
+        report = self._report(options, object(), object())
 
         with patch.object(report, '_ProcessStatReport__get_timestamp', return_value='00:00:00'), \
              patch.object(report, 'timeStampDelta', return_value=1.0), \
@@ -54,10 +59,13 @@ class TestProcessStatReport(unittest.TestCase):
         user = Mock(universal_flag='user', selective_colum_flag=False)
         columns = Mock(universal_flag='all', selective_colum_flag=True,
                        column_list=['pid', '%cpu'])
+        non_cpu_columns = Mock(universal_flag='user', selective_colum_flag=True,
+                               column_list=['pid', 'args'])
 
         self.assertFalse(needs_previous_values(default))
         self.assertTrue(needs_previous_values(user))
         self.assertTrue(needs_previous_values(columns))
+        self.assertFalse(needs_previous_values(non_cpu_columns))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Print non-CPU reports from the first sample, while retaining the
previous-sample wait for %CPU output. Compute TIME from current user
and system CPU time, exit live one-shot reports immediately, and add
an archive warm-up fetch so -s N prints N reports.



