### PR TITLE
Fix qa failures introduced by pmsearch redevelopment

### DIFF
--- a/man/man1/newhelp.1
+++ b/man/man1/newhelp.1
@@ -52,13 +52,24 @@ in which case the
 .B \-o
 flag must be given.
 .PP
-If the output file name is determined to be
+In the normal mode of operation, if the output file name is determined to be
 .BR foo ,
 .B newhelp
 will create
 .B foo.dir
 and
 .BR foo.pag .
+When the
+.B \-S
+.RB ( \-\-search )
+option is given, no
+.B .dir
+or
+.B .pag
+files are created; instead the name given with the
+.B \-o
+option directly names the SQLite FTS5 database file used by
+.BR pmsearch (1).
 .PP
 The
 .B \-V

--- a/man/man1/newhelp.1
+++ b/man/man1/newhelp.1
@@ -18,7 +18,7 @@
 \f3newhelp\f1 \- generate a performance metrics help database
 .SH SYNOPSIS
 \f3$PCP_BINADM_DIR/newhelp\f1
-[\f3\-vV?\f1]
+[\f3\-SvV?\f1]
 [\f3\-D\f1 \f2debug\f1]
 [\f3\-n\f1 \f2pmnsfile\f1]
 [\f3\-o\f1 \f2outputfile\f1]
@@ -132,6 +132,13 @@ Load an alternative Performance Metrics Name Space
 .RB ( PMNS (5))
 from the file
 .IR pmnsfile .
+.TP
+\fB\-S\fR, \fB\-\-search\fR
+Build a search index rather than the usual help text database.
+In this mode the output file (which must be named with the
+.B \-o
+option) is a SQLite FTS5 database used by
+.BR pmsearch (1).
 .TP
 \fB\-v\fR \fIversion\fR, \fB\-\-version\fR=\fIversion\fR
 Set output version.

--- a/src/libpcp_web/src/load.c
+++ b/src/libpcp_web/src/load.c
@@ -1100,8 +1100,6 @@ connect_keys_source_service(seriesLoadBaton *baton)
 	    baton->error = -ENOTSUP;
 	} else {
 	    flags = SLOTS_VERSION;
-	    if ((baton->flags & PM_SERIES_FLAG_TEXT))
-		flags |= SLOTS_SEARCH;
 	    baton->slots = data->slots =
 		&(keySlotsConnect(
 		    data->config, flags, baton->info,

--- a/src/libpcp_web/src/nosearch.c
+++ b/src/libpcp_web/src/nosearch.c
@@ -105,8 +105,6 @@ pmSearchClose(pmSearchModule *module)
 
 /* --- stubs for schema.c / keys.c compatibility --- */
 
-extern void keys_slots_end_phase(void *);
-
 void
 keysSearchInit(struct dict *config)
 {
@@ -116,12 +114,6 @@ keysSearchInit(struct dict *config)
 void
 keysSearchClose(void)
 {
-}
-
-void
-keys_load_search_schema(void *arg)
-{
-    keys_slots_end_phase(arg);
 }
 
 void

--- a/src/libpcp_web/src/schema.c
+++ b/src/libpcp_web/src/schema.c
@@ -1485,17 +1485,6 @@ keysSchemaLoad(keySlots *slots, keySlotsFlags flags,
 	baton->phases[i++].func = keys_load_version; /* v5 */
 	baton->phases[i++].func = keys_load_series_version;
     }
-    /* Register the pmsearch schema with RediSearch if needed */
-    if (flags & SLOTS_SEARCH) {
-	/* if we got a route update means we are in cluster mode */
-	if (slots->acc && slots->acc->cc.route_version > 0) {
-	    pmNotifyErr(LOG_INFO, "disabling search module "
-			"because it does not support cluster mode\n");
-	} else {
-	    baton->phases[i++].func = keys_load_search_schema;
-	}
-    }
-
     baton->phases[i++].func = keys_slots_finished;
     assert(i <= SLOTS_PHASES);
     seriesBatonPhases(baton->current, i, baton);
@@ -1733,10 +1722,6 @@ pmSeriesSetup(pmSeriesModule *module, void *arg)
 
 	/* establish an initial connection to key server instance(s) */
 	flags = SLOTS_VERSION;
-
-	option = pmIniFileLookup(data->config, "pmsearch", "enabled");
-	if (option && strcmp(option, "true") == 0)
-	    flags |= SLOTS_SEARCH;
 
 	data->slots = &(keySlotsConnect(
 			data->config, flags, module->on_info,

--- a/src/libpcp_web/src/search.c
+++ b/src/libpcp_web/src/search.c
@@ -867,8 +867,6 @@ pmSearchClose(pmSearchModule *module)
 
 /* --- stubs for schema.c / keys.c compatibility --- */
 
-extern void keys_slots_end_phase(void *);
-
 void
 keysSearchInit(struct dict *config)
 {
@@ -893,12 +891,6 @@ void
 keysSearchClose(void)
 {
     default_resultcount = 10;
-}
-
-void
-keys_load_search_schema(void *arg)
-{
-    keys_slots_end_phase(arg);
 }
 
 void

--- a/src/libpcp_web/src/search.h
+++ b/src/libpcp_web/src/search.h
@@ -30,7 +30,6 @@ struct keySlots;
 extern void keysSearchInit(struct dict *);
 extern void keysSearchClose(void);
 
-extern void keys_load_search_schema(void *);
 extern void keys_search_text_add(struct keySlots *, pmSearchTextType,
 		const char *, const char *, const char *, const char *, void *);
 

--- a/src/libpcp_web/src/slots.h
+++ b/src/libpcp_web/src/slots.h
@@ -22,13 +22,12 @@
 
 #define MAXSLOTS	(1 << 14)
 #define SLOTMASK	(MAXSLOTS-1)
-#define SLOTS_PHASES	5
+#define SLOTS_PHASES	4
 
 typedef enum keySlotsFlags {
     SLOTS_NONE		= 0,
     SLOTS_VERSION	= (1 << 0),
     SLOTS_KEYMAP	= (1 << 1),
-    SLOTS_SEARCH	= (1 << 2),
 } keySlotsFlags;
 
 enum {

--- a/src/pmproxy/src/keys.c
+++ b/src/pmproxy/src/keys.c
@@ -16,7 +16,6 @@
 
 #define KEY_SERVER_RECONNECT_INTERVAL 2
 
-static int search_queries;
 static int series_queries;
 static int key_server_resp;
 static int archive_discovery;
@@ -30,12 +29,6 @@ static pmDiscoverCallBacks key_server_series = {
     .on_values		= pmSeriesDiscoverValues,
     .on_indom		= pmSeriesDiscoverInDom,
     .on_text		= pmSeriesDiscoverText,
-};
-
-static pmDiscoverCallBacks key_server_search = {
-    .on_metric		= pmSearchDiscoverMetric,
-    .on_indom		= pmSearchDiscoverInDom,
-    .on_text		= pmSearchDiscoverText,
 };
 
 static pmDiscoverSettings key_server_discover = {
@@ -145,8 +138,6 @@ on_key_server_connected(void *arg)
     message = sdsnew("Key server slots");
     if (key_server_resp)
 	message = sdscat(message, ", command keys");
-    if ((search_queries = pmSearchEnabled(&proxy->slotsctx->slots)))
-	message = sdscat(message, ", search");
     if (series_queries)
 	message = sdscat(message, ", schema version");
     pmNotifyErr(LOG_INFO, "%s setup\n", message);
@@ -156,16 +147,10 @@ on_key_server_connected(void *arg)
     if (proxy->keys_setup == 1)
 	return;
 
-    if (series_queries) {
-	if (search_queries)
-	    key_server_series.next = &key_server_search;
+    if (series_queries)
 	key_server_discover.callbacks = key_server_series;
-    } else if (search_queries) {
-	key_server_discover.callbacks = key_server_search;
-    }
 
-    if ((archive_discovery || archive_push) &&
-	(series_queries || search_queries)) {
+    if ((archive_discovery || archive_push) && series_queries) {
 	mmv_registry_t	*registry = proxymetrics(proxy, METRICS_DISCOVER);
 
 	pmDiscoverSetEventLoop(&key_server_discover.module, proxy->events);
@@ -187,8 +172,6 @@ get_key_slots_flags()
 	flags |= SLOTS_KEYMAP;
     if (series_queries)
 	flags |= SLOTS_VERSION;
-    if (search_queries)
-	flags |= SLOTS_SEARCH;
 
     return flags;
 }
@@ -243,15 +226,13 @@ setup_keys_module(struct proxy *proxy)
 	key_server_resp = (strcmp(option, "true") == 0);
     if ((option = pmIniFileLookup(config, "pmseries", "enabled")))
 	series_queries = (strcmp(option, "true") == 0);
-    if ((option = pmIniFileLookup(config, "pmsearch", "enabled")))
-	search_queries = (strcmp(option, "true") == 0);
     if ((option = pmIniFileLookup(config, "discover", "enabled")))
 	archive_discovery = (strcmp(option, "true") == 0);
     if ((option = pmIniFileLookup(config, "pmlogger", "enabled")))
 	archive_push = (strcmp(option, "true") == 0);
 
     if (proxy->slotsctx == NULL &&
-	(key_server_resp || series_queries || search_queries ||
+	(key_server_resp || series_queries ||
 	 archive_discovery || archive_push)) {
 	mmv_registry_t	*registry = proxymetrics(proxy, METRICS_KEYS);
 	keySlotsFlags	flags = get_key_slots_flags();


### PR DESCRIPTION
Added the -S option to the newhelp man page.

Refactored areas of the code now that search functionality is not associated with the key server and instead uses a local sqlite database.