### PR TITLE
pmproxy: release the X509 reference in the CERT_REQD check

### DIFF
--- a/src/pmproxy/src/http.c
+++ b/src/pmproxy/src/http.c
@@ -1132,10 +1132,15 @@ on_headers_complete(http_parser *request)
     /* client certificate required for all servlets */
     if (__pmServerHasFeature(PM_SERVER_FEATURE_CERT_REQD)) {
 #ifdef HAVE_OPENSSL
-	if (!client->stream.secure ||
-	    !client->secure.ssl ||
-	    SSL_get_peer_certificate(client->secure.ssl) == NULL) {
+	if (!client->stream.secure || !client->secure.ssl) {
 	    client->u.http.parser.status_code = HTTP_STATUS_FORBIDDEN;
+	} else {
+	    X509	*cert = SSL_get_peer_certificate(client->secure.ssl);
+
+	    if (cert == NULL)
+		client->u.http.parser.status_code = HTTP_STATUS_FORBIDDEN;
+	    else
+		X509_free(cert);
 	}
 #else
 	/* no TLS support compiled in, reject all connections */


### PR DESCRIPTION
`SSL_get_peer_certificate()` returns a certificate whose reference count has been
incremented, so the caller owns that reference and must release it with `X509_free()`.
On OpenSSL 3.x the name is a compatibility macro for `SSL_get1_peer_certificate()`,
which has the same owning semantics.

81a9efe96db6 ("pmproxy: enforce -Q (CERT_REQD) for REST API connections") called it
inline in the NULL test and discarded the result:

```c
	if (!client->stream.secure ||
	    !client->secure.ssl ||
	    SSL_get_peer_certificate(client->secure.ssl) == NULL) {
	    client->u.http.parser.status_code = HTTP_STATUS_FORBIDDEN;
	}
```

Because of the short-circuit order the reference is only taken when the connection is
TLS and an SSL object exists, and it is leaked precisely when a certificate **is**
present — that is, on the path where the request is allowed through. The rejection paths
do not leak. `on_headers_complete()` runs once per request, so a `pmproxy` started with
`-Q` accumulates one `X509` per authenticated REST request for the lifetime of the
daemon.

This only affects deployments that have opted into client-certificate enforcement; `-Q`
is not enabled by the shipped `pmproxy.conf`. It is a reliability defect rather than a
security issue, since reaching it requires a client certificate that already passed
validation.

The fix captures the reference and frees it, leaving the accept/reject logic unchanged.
`SSL_get0_peer_certificate()` would avoid taking a reference at all, but it is not
available on the older OpenSSL versions pcp still supports, so `X509_free()` is the
portable form.

Found while backporting 81a9efe96db6 to pcp 6.3.7 and 6.0.1 (OpenSSL 3.2.2). Verified
against current `main` (55365f2e): the block is unchanged there, this commit introduces
the only call to `SSL_get_peer_certificate()` under `src/`, and there is no other
`X509_free()` in the tree — so nothing else was releasing it.

## Related Issues

Fixes #2693
