### PR TITLE
macos: fix libpcp install_name for qmake-built Qt tools

### DIFF
--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -449,8 +449,27 @@ LINKER_MAKERULE = \
     for lib in `otool -L $@ | ${AWK} '/libpcp/ {print $$1}'`; do \
         install_name_tool -change $$lib $(PCP_LIB_DIR)/$$lib $@; \
     done
+
+# Same fixup as LINKER_MAKERULE above, but for qmake/QTMAKE-built binaries.
+# These are linked directly by qmake's generated Makefile, bypassing the
+# $(PROGTARGET)/$(LIBTARGET) rules in buildrules that invoke
+# LINKER_MAKERULE via $@, so without this the binary keeps a bare
+# "libpcp.N.dylib" dependency that dyld cannot resolve outside the build
+# tree. Call as $(call QT_LINKER_FIXUP,$(BINARY)) after $(LNMAKE).
+# Unlike the $(PROGTARGET)/$(LIBTARGET) rules, "build-me" has no mtime-based
+# prerequisites, so its recipe (and this fixup) can run again on an already-
+# fixed binary; skip anything already rooted at $(PCP_LIB_DIR) so repeat
+# invocations stay a no-op instead of nesting the prefix.
+QT_LINKER_FIXUP = \
+    for lib in `otool -L $(1) | ${AWK} '/libpcp/ {print $$1}'`; do \
+        case "$$lib" in \
+            $(PCP_LIB_DIR)/*) ;; \
+            *) install_name_tool -change $$lib $(PCP_LIB_DIR)/$$lib $(1) ;; \
+        esac; \
+    done
 else
 LINKER_MAKERULE =
+QT_LINKER_FIXUP =
 endif
 
 # prepare domain.h used during the PMDA build process for each PMDA

--- a/src/include/builddefs.in
+++ b/src/include/builddefs.in
@@ -458,12 +458,13 @@ LINKER_MAKERULE = \
 # tree. Call as $(call QT_LINKER_FIXUP,$(BINARY)) after $(LNMAKE).
 # Unlike the $(PROGTARGET)/$(LIBTARGET) rules, "build-me" has no mtime-based
 # prerequisites, so its recipe (and this fixup) can run again on an already-
-# fixed binary; skip anything already rooted at $(PCP_LIB_DIR) so repeat
-# invocations stay a no-op instead of nesting the prefix.
+# fixed binary; skip anything already absolute (not just already rooted at
+# $(PCP_LIB_DIR)) so repeat invocations stay a no-op instead of nesting the
+# prefix onto a path that is already usable.
 QT_LINKER_FIXUP = \
     for lib in `otool -L $(1) | ${AWK} '/libpcp/ {print $$1}'`; do \
         case "$$lib" in \
-            $(PCP_LIB_DIR)/*) ;; \
+            /*) ;; \
             *) install_name_tool -change $$lib $(PCP_LIB_DIR)/$$lib $(1) ;; \
         esac; \
     done

--- a/src/pmchart/GNUmakefile
+++ b/src/pmchart/GNUmakefile
@@ -32,6 +32,7 @@ ifeq "$(ENABLE_QT)" "true"
 build-me:: images wrappers
 	+$(QTMAKE)
 	$(LNMAKE)
+	$(call QT_LINKER_FIXUP,$(BINARY))
 
 build-me:: $(SUBDIRS)
 	$(SUBDIRS_MAKERULE)

--- a/src/pmdumptext/GNUmakefile
+++ b/src/pmdumptext/GNUmakefile
@@ -17,6 +17,7 @@ ifeq "$(ENABLE_QT)" "true"
 build-me:
 	+$(QTMAKE)
 	$(LNMAKE)
+	$(call QT_LINKER_FIXUP,$(BINARY))
 
 install: default
 ifeq ($(WINDOW),mac)

--- a/src/pmgadgets/GNUmakefile
+++ b/src/pmgadgets/GNUmakefile
@@ -20,6 +20,7 @@ ifeq "$(ENABLE_QT)" "true"
 build-me:: images wrappers
 	+$(QTMAKE)
 	$(LNMAKE)
+	$(call QT_LINKER_FIXUP,$(BINARY))
 
 build-me:: $(SUBDIRS)
 	$(SUBDIRS_MAKERULE)

--- a/src/pmquery/GNUmakefile
+++ b/src/pmquery/GNUmakefile
@@ -22,6 +22,7 @@ ifeq "$(ENABLE_QT)" "true"
 build-me:: images wrappers
 	+$(QTMAKE)
 	$(LNMAKE)
+	$(call QT_LINKER_FIXUP,$(BINARY))
 
 ifeq ($(WINDOW),mac)
 PKG_MAC_DIR = /usr/local/Cellar/pcp/$(PACKAGE_VERSION)/$(COMMAND).app/Contents

--- a/src/pmtime/GNUmakefile
+++ b/src/pmtime/GNUmakefile
@@ -24,6 +24,7 @@ ifeq "$(ENABLE_QT)" "true"
 build-me: images wrappers
 	+$(QTMAKE)
 	$(LNMAKE)
+	$(call QT_LINKER_FIXUP,$(BINARY))
 
 ifeq ($(WINDOW),mac)
 PKG_MAC_DIR = /usr/local/Cellar/pcp/$(PACKAGE_VERSION)/$(COMMAND).app/Contents

--- a/src/pmview/GNUmakefile
+++ b/src/pmview/GNUmakefile
@@ -37,6 +37,7 @@ ifeq "$(ENABLE_QT3D)" "true"
 build-me:: images wrappers $(GENERATED)
 	+$(QTMAKE)
 	$(LNMAKE)
+	$(call QT_LINKER_FIXUP,$(BINARY))
 
 build-me:: $(SUBDIRS)
 	$(SUBDIRS_MAKERULE)


### PR DESCRIPTION
pmchart, pmdumptext, pmtime, pmquery, pmgadgets and pmview are linked directly by qmake's generated Makefile via the QTMAKE build-me recipe, which bypasses the $(PROGTARGET)/$(LIBTARGET) rules in buildrules that invoke LINKER_MAKERULE after linking. On macOS that rule is what rewrites a binary's bare "libpcp.N.dylib" dependency into an absolute $(PCP_LIB_DIR) path, so without it these Qt tools keep the bare name and dyld fails to load them outside the build tree.

Add QT_LINKER_FIXUP, the same fixup parameterized on an explicit binary path (build-me has no mtime-based prerequisites, so $@ isn't available and the recipe can legitimately run more than once per build; the fixup skips paths already rooted at $(PCP_LIB_DIR) so repeat runs are a no-op instead of nesting the prefix), and call it after $(LNMAKE) in each affected GNUmakefile.

## Pull Request Description

## Related Issues
Fixes #

## Checklist
- [ ] ** Description **
_Why_ this PR exists. Reference all relevant information, including _background_, _issues_, _test failures_, etc
- [ ] ** Commmits **
_Commits_ are self contained and only do one thing
_Commits_ have a header of the form: `module: short description`
_Commits_ have a body (whenever relevant) containing a detailed description of the addressed problem and its solution
- [ ] Documentation updated
- [ ] Tests added/updated
