### PR TITLE
libpcp, qa: allow distinct client and server certificates

### DIFF
--- a/qa/712
+++ b/qa/712
@@ -122,22 +122,22 @@ PCP_SECURE_SOCKETS=1; export PCP_SECURE_SOCKETS
 yes | pminfo -h $hostname -f hinv.ncpu 2>&1 | tee -a $seq_full | _filter_tls
 
 # check mode where separate client/server certificates are used
-#cp $tmp.tls.orig $tmp.tls.conf
-#sed -i -e 's/pcp.key/server.key/g' $tmp.tls.conf
-#sed -i -e 's/pcp.crt/server.crt/g' $tmp.tls.conf
-#echo "tls-client-key-file = $here/tls.conf/client.key" >> $tmp.tls.conf
-#echo "tls-client-cert-file = $here/tls.conf/client.crt" >> $tmp.tls.conf
-#echo "tls-verify-clients = true" >> $tmp.tls.conf
-#$sudo cp $tmp.tls.conf $PCP_TLSCONF_PATH
+cp $tmp.tls.orig $tmp.tls.conf
+sed -i -e 's/pcp.key/server.key/g' $tmp.tls.conf
+sed -i -e 's/pcp.crt/server.crt/g' $tmp.tls.conf
+echo "tls-client-key-file = $tmp.tls/client.key" >> $tmp.tls.conf
+echo "tls-client-cert-file = $tmp.tls/client.crt" >> $tmp.tls.conf
+echo "tls-verify-clients = true" >> $tmp.tls.conf
+$sudo cp $tmp.tls.conf $PCP_TLSCONF_PATH
 
-#unset PCP_SECURE_SOCKETS
-#_service pmcd start | _filter_pcp_start
-#_wait_for_pmcd
+unset PCP_SECURE_SOCKETS
+_service pmcd start | _filter_pcp_start
+_wait_for_pmcd
 
-#echo
-#echo "checking both client and server certificates.  should pass..." | tee -a $seq_full
-#PCP_SECURE_SOCKETS=1; export PCP_SECURE_SOCKETS
-#yes | pminfo -h $hostname -f hinv.ncpu 2>&1 | tee -a $seq_full | _filter_tls
+echo
+echo "checking both client and server certificates.  should pass..." | tee -a $seq_full
+PCP_SECURE_SOCKETS=1; export PCP_SECURE_SOCKETS
+yes | pminfo -h $hostname -f hinv.ncpu 2>&1 | tee -a $seq_full | _filter_tls
 
 # success, all done
 status=0

--- a/qa/712.out
+++ b/qa/712.out
@@ -17,3 +17,8 @@ hinv.ncpu
 
 checking client, server certificate only.  should fail...
 Error: hinv.ncpu: IPC protocol failure
+
+checking both client and server certificates.  should pass...
+
+hinv.ncpu
+    value NUMBER

--- a/src/libpcp/src/secureconnect.c
+++ b/src/libpcp/src/secureconnect.c
@@ -610,6 +610,7 @@ __pmInitSecureClients(void)
     int	flags = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 |
 		SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1;
     int verify = SSL_VERIFY_NONE;
+    int use_client_cert;
 
     if (pmDebugOptions.tls)
 	fprintf(stderr, "%s: entered\n", "__pmInitSecureClients");
@@ -624,6 +625,14 @@ __pmInitSecureClients(void)
 
     /* load optional /etc/pcp/tls.conf configuration file contents */
     __pmGetSecureConfig(&tls.cfg);
+
+    if ((tls.cfg.clientcertfile == NULL) !=
+	(tls.cfg.clientkeyfile == NULL)) {
+	pmNotifyErr(LOG_ERR,
+		    "Client certificate and key must be configured together");
+	goto fail;
+    }
+    use_client_cert = tls.cfg.clientcertfile != NULL;
 
     tls.ctx = SSL_CTX_new(TLS_client_method());
     if (tls.ctx == NULL) {
@@ -659,7 +668,7 @@ __pmInitSecureClients(void)
 	}
     }
 
-    if (tls.cfg.clientcertfile &&
+    if (use_client_cert &&
 	!SSL_CTX_use_certificate_chain_file(tls.ctx, tls.cfg.clientcertfile)) {
 	pmNotifyErr(LOG_ERR, "Cannot load client certificate chain from %s",
 		    tls.cfg.clientcertfile);
@@ -667,7 +676,7 @@ __pmInitSecureClients(void)
 	    ERR_print_errors_fp(stderr);
 	goto fail;
     }
-    else if (tls.cfg.certfile &&
+    else if (!use_client_cert && tls.cfg.certfile &&
 	!SSL_CTX_use_certificate_chain_file(tls.ctx, tls.cfg.certfile)) {
 	pmNotifyErr(LOG_ERR, "Cannot load certificate chain from %s",
 		    tls.cfg.certfile);
@@ -676,7 +685,7 @@ __pmInitSecureClients(void)
 	goto fail;
     }
 
-    if (tls.cfg.clientcertfile && tls.cfg.clientkeyfile &&
+    if (use_client_cert &&
 	!SSL_CTX_use_PrivateKey_file(tls.ctx,
 			    tls.cfg.clientkeyfile, SSL_FILETYPE_PEM)) {
 	pmNotifyErr(LOG_ERR, "Cannot load client private key from %s",
@@ -685,7 +694,7 @@ __pmInitSecureClients(void)
 	    ERR_print_errors_fp(stderr);
 	goto fail;
     }
-    else if (tls.cfg.certfile && tls.cfg.keyfile &&
+    else if (!use_client_cert && tls.cfg.certfile && tls.cfg.keyfile &&
 	!SSL_CTX_use_PrivateKey_file(tls.ctx,
 			    tls.cfg.keyfile, SSL_FILETYPE_PEM)) {
 	pmNotifyErr(LOG_ERR, "Cannot load private key from %s",

--- a/src/libpcp3/src/secureconnect.c
+++ b/src/libpcp3/src/secureconnect.c
@@ -610,6 +610,7 @@ __pmInitSecureClients(void)
     int	flags = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 |
 		SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1;
     int verify = SSL_VERIFY_NONE;
+    int use_client_cert;
 
     if (pmDebugOptions.tls)
 	fprintf(stderr, "%s: entered\n", "__pmInitSecureClients");
@@ -624,6 +625,14 @@ __pmInitSecureClients(void)
 
     /* load optional /etc/pcp/tls.conf configuration file contents */
     __pmGetSecureConfig(&tls.cfg);
+
+    if ((tls.cfg.clientcertfile == NULL) !=
+	(tls.cfg.clientkeyfile == NULL)) {
+	pmNotifyErr(LOG_ERR,
+		    "Client certificate and key must be configured together");
+	goto fail;
+    }
+    use_client_cert = tls.cfg.clientcertfile != NULL;
 
     tls.ctx = SSL_CTX_new(TLS_client_method());
     if (tls.ctx == NULL) {
@@ -659,7 +668,7 @@ __pmInitSecureClients(void)
 	}
     }
 
-    if (tls.cfg.clientcertfile &&
+    if (use_client_cert &&
 	!SSL_CTX_use_certificate_chain_file(tls.ctx, tls.cfg.clientcertfile)) {
 	pmNotifyErr(LOG_ERR, "Cannot load client certificate chain from %s",
 		    tls.cfg.clientcertfile);
@@ -667,7 +676,7 @@ __pmInitSecureClients(void)
 	    ERR_print_errors_fp(stderr);
 	goto fail;
     }
-    else if (tls.cfg.certfile &&
+    else if (!use_client_cert && tls.cfg.certfile &&
 	!SSL_CTX_use_certificate_chain_file(tls.ctx, tls.cfg.certfile)) {
 	pmNotifyErr(LOG_ERR, "Cannot load certificate chain from %s",
 		    tls.cfg.certfile);
@@ -676,7 +685,7 @@ __pmInitSecureClients(void)
 	goto fail;
     }
 
-    if (tls.cfg.clientcertfile && tls.cfg.clientkeyfile &&
+    if (use_client_cert &&
 	!SSL_CTX_use_PrivateKey_file(tls.ctx,
 			    tls.cfg.clientkeyfile, SSL_FILETYPE_PEM)) {
 	pmNotifyErr(LOG_ERR, "Cannot load client private key from %s",
@@ -685,7 +694,7 @@ __pmInitSecureClients(void)
 	    ERR_print_errors_fp(stderr);
 	goto fail;
     }
-    else if (tls.cfg.certfile && tls.cfg.keyfile &&
+    else if (!use_client_cert && tls.cfg.certfile && tls.cfg.keyfile &&
 	!SSL_CTX_use_PrivateKey_file(tls.ctx,
 			    tls.cfg.keyfile, SSL_FILETYPE_PEM)) {
 	pmNotifyErr(LOG_ERR, "Cannot load private key from %s",


### PR DESCRIPTION
The OpenSSL migration in 3e8b61a left the client certificate
selection in an else-if chain. When client-specific files were
configured, the generic server certificate could still be loaded,
causing the subsequent client key to fail the certificate/key match.

Commit fe8e9f8 later commented out QA 712 coverage for separate
client and server certificates without documenting the reason.

This change restores that coverage and selects the client certificate
and key as a pair. Reject partial client-specific configuration.

Tested with QA 712 on macOS in Tart.

## Related Issues
#1633 , #662 , fe8e9f8, 3e8b61a
